### PR TITLE
Remove trust from processor and output doc tree

### DIFF
--- a/internal/testing/ingestor/simpledoc/simpledoc.go
+++ b/internal/testing/ingestor/simpledoc/simpledoc.go
@@ -94,22 +94,6 @@ func validateSimpleDoc(pd SimpleDoc) error {
 	return nil
 }
 
-func (dp *SimpleDocProc) ValidateTrustInformation(d *processor.Document) (map[string]interface{}, error) {
-	var p SimpleDoc
-	if err := json.Unmarshal(d.Blob, &p); err != nil {
-		return nil, err
-	}
-
-	trustInfo := map[string]interface{}{}
-	if d.TrustInformation.IssuerUri != nil {
-		if p.Issuer != *d.TrustInformation.IssuerUri {
-			return nil, fmt.Errorf("trust information not valid issuer doesn't match")
-		}
-		trustInfo["issuer"] = d.TrustInformation.IssuerUri
-	}
-	return trustInfo, nil
-}
-
 func (dp *SimpleDocProc) Unpack(d *processor.Document) ([]*processor.Document, error) {
 	var p SimpleDoc
 	if err := json.Unmarshal(d.Blob, &p); err != nil {
@@ -123,10 +107,9 @@ func (dp *SimpleDocProc) Unpack(d *processor.Document) ([]*processor.Document, e
 			return nil, err
 		}
 		retDocs[i] = &processor.Document{
-			Blob:             b,
-			Type:             SimpleDocType,
-			Format:           processor.FormatJSON,
-			TrustInformation: d.TrustInformation,
+			Blob:   b,
+			Type:   SimpleDocType,
+			Format: processor.FormatJSON,
 		}
 	}
 

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -15,13 +15,9 @@
 
 package processor
 
-import (
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-)
-
 type DocumentProcessor interface {
+	// ValidateSchema validates the schema of the document
 	ValidateSchema(i *Document) error
-	ValidateTrustInformation(i *Document) (map[string]interface{}, error)
 
 	// Unpack takes in the document and tries to unpack it
 	// if there is a valid decomposition of sub-documents.
@@ -38,8 +34,17 @@ type Document struct {
 	Blob              []byte
 	Type              DocumentType
 	Format            FormatType
-	TrustInformation  TrustInformation
 	SourceInformation SourceInformation
+}
+
+// DocumentTree describes the output of a document tree that resulted from
+// processing a node
+type DocumentTree *DocumentNode
+
+// DocumentNode describes a node of a DocumentTree
+type DocumentNode struct {
+	Document *Document
+	Children []*DocumentNode
 }
 
 // DocumentType describes the type of the document contents for schema checks
@@ -47,9 +52,10 @@ type DocumentType string
 
 // Document* is the enumerables of DocumentType
 const (
-	DocumentSLSA DocumentType = "SLSA"
-	DocumentITE6              = "ITE6"
-	DocumentDSSE              = "DSSE"
+	DocumentSLSA    DocumentType = "SLSA"
+	DocumentITE6                 = "ITE6"
+	DocumentDSSE                 = "DSSE"
+	DocumentUnknown              = "UNKNOWN"
 )
 
 // FormatType describes the document format for malform checks
@@ -57,18 +63,11 @@ type FormatType string
 
 // Format* is the enumerables of FormatType
 const (
-	FormatJSON FormatType = "JSON"
+	FormatJSON    FormatType = "JSON"
+	FormatUnknown            = "UNKNOWN"
 )
 
-// TrustInformation provides additional information about how to verify the document
-type TrustInformation struct {
-	DSSE      *dsse.Envelope
-	IssuerUri *string
-	// TODO: Figure out how to handle log verification trust
-	// LogVerification *rtype.LogEntryAnonVerification
-}
-
-// TrustInformation provides additional information about where the document comes from
+// SourceInformation provides additional information about where the document comes from
 type SourceInformation struct {
 	// Collector describes the name of the collector providing this information
 	Collector string


### PR DESCRIPTION
As discussed removing trust information from processor and outputting a document tree instead. The implementation is complete but the testing is not yet.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>