### PR TITLE
Add collector cmd example

### DIFF
--- a/cmd/collector/cmd/example.go
+++ b/cmd/collector/cmd/example.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The AFF Authors.
+// Copyright 2022 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/collector/cmd/example.go
+++ b/cmd/collector/cmd/example.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2022 The AFF Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/guacsec/guac/cmd/collector/cmd/mockcollector"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var exampleCmd = &cobra.Command{
+	Use:   "example",
+	Short: "example collector using a mocked collector for GUAC",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Do Stuff Here
+		fmt.Println("GUAC example mock collector, it will emit 5 documents within 5 second intervals")
+
+		ctx := context.Background()
+
+		// Register collector
+		// We create our own MockCollector and register it
+		mc := mockcollector.NewMockCollector()
+		collector.RegisterDocumentCollector(mc, mc.Type())
+
+		// Collect
+		docChan, errChan, numCollectors, err := collector.Collect(ctx)
+		if err != nil {
+			logrus.Error(err)
+			os.Exit(1)
+		}
+
+		collectorsDone := 0
+		for collectorsDone < numCollectors {
+			select {
+			case d := <-docChan:
+				emit(d)
+				logrus.Infof("emitted document: %+v", d)
+			case err = <-errChan:
+				if err != nil {
+					logrus.Errorf("collector ended with error: %v", err)
+				} else {
+					logrus.Info("collector ended gracefully")
+				}
+				collectorsDone += 1
+			}
+		}
+
+		// Drain anything left in document channel
+		for len(docChan) > 0 {
+			d := <-docChan
+			emit(d)
+			logrus.Infof("emitted document: %+v", d)
+		}
+	},
+}
+
+func emit(d *processor.Document) {
+	// does nothing right now
+}

--- a/cmd/collector/cmd/mockcollector/mock_collector.go
+++ b/cmd/collector/cmd/mockcollector/mock_collector.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The AFF Authors.
+// Copyright 2022 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/collector/cmd/mockcollector/mock_collector.go
+++ b/cmd/collector/cmd/mockcollector/mock_collector.go
@@ -1,0 +1,54 @@
+//
+// Copyright 2022 The AFF Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockcollector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+func NewMockCollector() *mockCollector {
+	return &mockCollector{}
+}
+
+type mockCollector struct{}
+
+func (m *mockCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	for i := 0; i < 5; i++ {
+		docChannel <- mockDoc(i)
+		time.Sleep(5 * time.Second)
+	}
+	return nil
+}
+
+func (m *mockCollector) Type() string {
+	return "mock-collector"
+}
+
+func mockDoc(i int) *processor.Document {
+	return &processor.Document{
+		Blob:   []byte(fmt.Sprintf("doc-%d", i)),
+		Type:   processor.DocumentUnknown,
+		Format: processor.FormatUnknown,
+		SourceInformation: processor.SourceInformation{
+			Collector: "mock-collector",
+			Source:    "generated",
+		},
+	}
+}

--- a/cmd/collector/cmd/root.go
+++ b/cmd/collector/cmd/root.go
@@ -19,24 +19,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/guacsec/guac/pkg/handler/collector"
-	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	rootCmd.AddCommand(exampleCmd)
+}
+
 var rootCmd = &cobra.Command{
-	Use:   "ingestor",
-	Short: "ingestor is a ingestor cmdline for GUAC",
-	Run: func(cmd *cobra.Command, args []string) {
-		// Do Stuff Here
-		var (
-			collector collector.Collector
-			processor processor.DocumentProcessor
-		)
-		fmt.Println("GUAC")
-		_ = collector
-		_ = processor
-	},
+	Use:   "collector",
+	Short: "collector is an collector cmdline for GUAC",
 }
 
 func Execute() {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -16,7 +16,7 @@
 package main
 
 import (
-	"github.com/guacsec/guac/cmd/ingestor/cmd"
+	"github.com/guacsec/guac/cmd/collector/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Add the collector command example to show how a collector binary would be able to run a collector, currently emit is not implemented due to undecided mechanism between collector and processor.