### PR TITLE
added makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ci: lint test ## Run all the tests and code checks
 
 .PHONY: build
 build: ## Build a version
-	go build -ldflags ${LDFLAGS} -o bin/ingestor cmd/ingestor/main.go
+	go build -ldflags ${LDFLAGS} -o bin/collector cmd/collector/main.go
 
 .PHONY: clean
 clean: ## Remove temporary files

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,8 @@ PKG=github.com/guacsec/guac
 LDFLAGS="-X $(PKG).version=$(VERSION) -X $(PKG).commit=$(COMMIT) -X $(PKG).date=$(BUILD)"
 
 .PHONY: all
-all: setup test cover fmt lint ci build
+all: test cover fmt lint ci build
     
-.PHONY: setup
-setup: ## TODO Install all the build and lint dependencies
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
-
 
 .PHONY: test
 test: ## Run all the tests

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ LDFLAGS="-X $(PKG).version=$(VERSION) -X $(PKG).commit=$(COMMIT) -X $(PKG).date=
 all: setup test cover fmt lint ci build
     
 .PHONY: setup
-setup: ## Install all the build and lint dependencies
-	curl -L https://git.io/vp6lP | sh
+setup: ## TODO Install all the build and lint dependencies
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
 
 .PHONY: test
@@ -24,28 +24,18 @@ cover: test ## Run all the tests and opens the coverage report
 
 .PHONY: fmt
 fmt: ## Run goimports on all go files
-	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done
+	find . -name '*.go' -not -wholename './vendor/*' -exec goimports -w {} \;
 
 .PHONY: lint
-lint: ## Run all the linters
-	gometalinter --vendor --disable-all \
-		--enable=deadcode \
-		--enable=ineffassign \
-		--enable=gofmt \
-		--enable=goimports \
-		--enable=misspell \
-		--enable=errcheck \
-		--enable=vet \
-		--enable=vetshadow \
-		--deadline=10m \
-		./...
+lint: ## TODO Run all the linters
+	golangci-lint run ./...
 
 .PHONY: ci
 ci: lint test ## Run all the tests and code checks
 
 .PHONY: build
 build: ## Build a version
-	go build -ldflags ${LDFLAGS} -o ingestor cmd/ingestor/main.go
+	go build -ldflags ${LDFLAGS} -o bin/ingestor cmd/ingestor/main.go
 
 .PHONY: clean
 clean: ## Remove temporary files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+VERSION=$(shell git describe --tags --always)
+COMMIT=$(shell git rev-parse HEAD)
+BUILD=$(shell date +%FT%T%z)
+PKG=github.com/guacsec/guac
+
+LDFLAGS="-X $(PKG).version=$(VERSION) -X $(PKG).commit=$(COMMIT) -X $(PKG).date=$(BUILD)"
+
+.PHONY: all
+all: setup test cover fmt lint ci build
+    
+.PHONY: setup
+setup: ## Install all the build and lint dependencies
+	curl -L https://git.io/vp6lP | sh
+
+
+.PHONY: test
+test: ## Run all the tests
+	echo 'mode: atomic' > coverage.txt && go test -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=30s ./...
+
+
+.PHONY: cover
+cover: test ## Run all the tests and opens the coverage report
+	go tool cover -html=coverage.txt
+
+.PHONY: fmt
+fmt: ## Run goimports on all go files
+	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done
+
+.PHONY: lint
+lint: ## Run all the linters
+	gometalinter --vendor --disable-all \
+		--enable=deadcode \
+		--enable=ineffassign \
+		--enable=gofmt \
+		--enable=goimports \
+		--enable=misspell \
+		--enable=errcheck \
+		--enable=vet \
+		--enable=vetshadow \
+		--deadline=10m \
+		./...
+
+.PHONY: ci
+ci: lint test ## Run all the tests and code checks
+
+.PHONY: build
+build: ## Build a version
+	go build -ldflags ${LDFLAGS} -o ingestor cmd/ingestor/main.go
+
+.PHONY: clean
+clean: ## Remove temporary files
+	go clean
+
+# Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := build


### PR DESCRIPTION
Signed-off-by: Shripad Nadgowda <shri.nadgowda@gmail.com>

Issue/task reference #24 

I just updated my template makefile I use for my go-project.

```
$ make help
setup                          Install all the build and lint dependencies
test                           Run all the tests
cover                          Run all the tests and opens the coverage report
fmt                            Run goimports on all go files
lint                           Run all the linters
ci                             Run all the tests and code checks
build                          Build a version
clean                          Remove temporary files
```

Just to build the project binary
```
$ make build
go build -ldflags "-X github.com/guacsec/guac.version=b12f018 -X github.com/guacsec/guac.commit=b12f018181505dd6b3e5355566af830419842231 -X github.com/guacsec/guac.date=2022-08-24T15:34:09-0400" -o ingestor cmd/ingestor/main.go
```

Run test
```
$ make test
echo 'mode: atomic' > coverage.txt && go test -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=30s ./...
?       github.com/guacsec/guac/cmd/ingestor    [no test files]
?       github.com/guacsec/guac/cmd/ingestor/cmd        [no test files]
?       github.com/guacsec/guac/internal/testing/ingestor/simpledoc     [no test files]
?       github.com/guacsec/guac/pkg/assembler   [no test files]
?       github.com/guacsec/guac/pkg/handler/collector   [no test files]
?       github.com/guacsec/guac/pkg/handler/processor   [no test files]
=== RUN   Test_SimpleDocProcessTest
=== RUN   Test_SimpleDocProcessTest/simple_test
=== RUN   Test_SimpleDocProcessTest/unpack_test
=== RUN   Test_SimpleDocProcessTest/unpack_twice_test
=== RUN   Test_SimpleDocProcessTest/unpack_assymetric_test
=== RUN   Test_SimpleDocProcessTest/bad_format
=== RUN   Test_SimpleDocProcessTest/bad_format_type
=== RUN   Test_SimpleDocProcessTest/bad_document_schema
=== RUN   Test_SimpleDocProcessTest/bad_schema_type
=== RUN   Test_SimpleDocProcessTest/propagate_source_info
=== RUN   Test_SimpleDocProcessTest/propagate_nested_source_info
--- PASS: Test_SimpleDocProcessTest (0.01s)
    --- PASS: Test_SimpleDocProcessTest/simple_test (0.00s)
    --- PASS: Test_SimpleDocProcessTest/unpack_test (0.00s)
    --- PASS: Test_SimpleDocProcessTest/unpack_twice_test (0.00s)
    --- PASS: Test_SimpleDocProcessTest/unpack_assymetric_test (0.00s)
    --- PASS: Test_SimpleDocProcessTest/bad_format (0.00s)
    --- PASS: Test_SimpleDocProcessTest/bad_format_type (0.00s)
    --- PASS: Test_SimpleDocProcessTest/bad_document_schema (0.00s)
    --- PASS: Test_SimpleDocProcessTest/bad_schema_type (0.00s)
    --- PASS: Test_SimpleDocProcessTest/propagate_source_info (0.00s)
    --- PASS: Test_SimpleDocProcessTest/propagate_nested_source_info (0.00s)
PASS
coverage: 88.4% of statements
ok      github.com/guacsec/guac/pkg/handler/processor/process   0.030s  coverage: 88.4% of statements

```

Run lint/fmt/vet/misspell  and few more

```
$ make lint
gometalinter --vendor --disable-all \
        --enable=deadcode \
        --enable=ineffassign \
        --enable=gofmt \
        --enable=goimports \
        --enable=misspell \
        --enable=errcheck \
        --enable=vet \
        --enable=vetshadow \
        --deadline=10m \
        ./...
pkg/assembler/assembler.go:18:1:warning: assembler is unused (deadcode)
pkg/handler/processor/process/process_test.go:208:16:warning: "assymetric" is a misspelling of "asymmetric" (misspell)
make: *** [Makefile:31: lint] Error 1
```

or just do `make all`