### PR TITLE
Replace logging library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.dll
+*.dylib
+*.exe
+*.exe~
+*.out
+*.so
+*.test
+bin/
+coverage.txt
+go.work

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
+	go.uber.org/zap v1.23.0
 	google.golang.org/api v0.94.0
 )
 
@@ -27,12 +28,18 @@ require (
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pkg/xattr v0.4.8 // indirect
+	github.com/shibumi/go-pathspec v1.3.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -49,7 +56,6 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20220723181115-27de4befb95e // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/theupdateframework/go-tuf v0.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
@@ -58,9 +64,6 @@ require (
 )
 
 require (
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/sigstore/rekor v0.11.0
 	github.com/sigstore/sigstore v1.4.0
-	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -264,6 +265,7 @@ github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/xattr v0.4.8 h1:3QwVADT+4oUm3zg7MXO/2i/lqnKkQ9viNY8pl5egRDE=
 github.com/pkg/xattr v0.4.8/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -295,6 +297,7 @@ github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJ
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -323,6 +326,14 @@ go.opentelemetry.io/contrib/propagators v0.19.0 h1:HrixVNZYFjUl/Db+Tr3DhqzLsVW9G
 go.opentelemetry.io/otel v0.19.0 h1:Lenfy7QHRXPZVsw/12CWpxX6d/JkrX8wrx2vO8G80Ng=
 go.opentelemetry.io/otel/trace v0.19.0 h1:1ucYlenXIDA1OlHVLDZKX0ObXV5RLaq06DtUKz5e5zc=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
+go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/zap v1.23.0 h1:OjGQ5KQDEUawVHxNwQgPpiypGHOxo2mNZsOqTak4fFY=
+go.uber.org/zap v1.23.0/go.mod h1:D+nX8jyLsMHMYrln8A0rJjFt/T/9/bGgIhAqxv5URuY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/pkg/handler/collector/collector.go
+++ b/pkg/handler/collector/collector.go
@@ -17,9 +17,9 @@ package collector
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -42,11 +42,13 @@ var (
 	documentCollectors = map[string]Collector{}
 )
 
-func RegisterDocumentCollector(c Collector, collectorType string) {
+func RegisterDocumentCollector(c Collector, collectorType string) error {
 	if _, ok := documentCollectors[collectorType]; ok {
-		logrus.Warnf("the document collector is being overwritten: %s", collectorType)
+		return fmt.Errorf("the document collector is being overwritten: %s", collectorType)
 	}
 	documentCollectors[collectorType] = c
+
+	return nil
 }
 
 // Collect takes all the collectors and starts collecting artifacts

--- a/pkg/handler/processor/guesser/format_guesser.go
+++ b/pkg/handler/processor/guesser/format_guesser.go
@@ -16,12 +16,13 @@
 package guesser
 
 import (
+	"fmt"
+
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
-	RegisterDocumentFormatGuesser(&jsonFormatGuesser{}, "json")
+	_ = RegisterDocumentFormatGuesser(&jsonFormatGuesser{}, "json")
 }
 
 // DocumentFormatGuesser guesses the format of the document given a blob
@@ -35,9 +36,11 @@ var (
 	documentFormatGuessers = map[string]DocumentFormatGuesser{}
 )
 
-func RegisterDocumentFormatGuesser(g DocumentFormatGuesser, name string) {
+func RegisterDocumentFormatGuesser(g DocumentFormatGuesser, name string) error {
 	if _, ok := documentFormatGuessers[name]; ok {
-		logrus.Warnf("the document type guesser is being overwritten: %s", name)
+		return fmt.Errorf("the document type guesser is being overwritten: %s", name)
 	}
 	documentFormatGuessers[name] = g
+
+	return nil
 }

--- a/pkg/handler/processor/guesser/guesser.go
+++ b/pkg/handler/processor/guesser/guesser.go
@@ -16,18 +16,21 @@
 package guesser
 
 import (
+	"context"
+
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/sirupsen/logrus"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
-func GuessDocument(d *processor.Document) (processor.DocumentType, processor.FormatType, error) {
+func GuessDocument(ctx context.Context, d *processor.Document) (processor.DocumentType, processor.FormatType, error) {
+	logger := logging.FromContext(ctx)
 	format := d.Format
 
 	if format == processor.FormatUnknown {
 		for name, g := range documentFormatGuessers {
 			if f := g.GuessFormat(d.Blob); f != processor.FormatUnknown {
 				format = f
-				logrus.Debugf("Format guesser %v guessed document format %v", name, f)
+				logger.Debugf("Format guesser %v guessed document format %v", name, f)
 				break
 			}
 		}
@@ -38,7 +41,7 @@ func GuessDocument(d *processor.Document) (processor.DocumentType, processor.For
 		for name, g := range documentTypeGuessers {
 			if t := g.GuessDocumentType(d.Blob, format); t != processor.DocumentUnknown {
 				documentType = t
-				logrus.Debugf("DocumentType guesser %v guessed document format %v", name, t)
+				logger.Debugf("DocumentType guesser %v guessed document format %v", name, t)
 				break
 			}
 		}

--- a/pkg/handler/processor/guesser/type_guesser.go
+++ b/pkg/handler/processor/guesser/type_guesser.go
@@ -16,13 +16,14 @@
 package guesser
 
 import (
+	"fmt"
+
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
-	RegisterDocumentTypeGuesser(&ite6TypeGuesser{}, "ite6")
-	RegisterDocumentTypeGuesser(&dsseTypeGuesser{}, "dsse")
+	_ = RegisterDocumentTypeGuesser(&ite6TypeGuesser{}, "ite6")
+	_ = RegisterDocumentTypeGuesser(&dsseTypeGuesser{}, "dsse")
 }
 
 // DocumentTypeGuesser guesses the document type based on the blob and format given
@@ -36,9 +37,10 @@ var (
 	documentTypeGuessers = map[string]DocumentTypeGuesser{}
 )
 
-func RegisterDocumentTypeGuesser(g DocumentTypeGuesser, name string) {
+func RegisterDocumentTypeGuesser(g DocumentTypeGuesser, name string) error {
 	if _, ok := documentTypeGuessers[name]; ok {
-		logrus.Warnf("the document type guesser is being overwritten: %s", name)
+		return fmt.Errorf("the document type guesser is being overwritten: %s", name)
 	}
 	documentTypeGuessers[name] = g
+	return nil
 }

--- a/pkg/handler/processor/process/process_test.go
+++ b/pkg/handler/processor/process/process_test.go
@@ -16,6 +16,7 @@
 package process
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -24,7 +25,6 @@ import (
 	"github.com/guacsec/guac/internal/testing/ingestor/simpledoc"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/handler/processor/guesser"
-	"github.com/sirupsen/logrus"
 )
 
 func Test_SimpleDocProcessTest(t *testing.T) {
@@ -498,13 +498,19 @@ func Test_SimpleDocProcessTest(t *testing.T) {
 	},
 	}
 
-	logrus.SetLevel(logrus.DebugLevel)
 	// Register
-	RegisterDocumentProcessor(&simpledoc.SimpleDocProc{}, simpledoc.SimpleDocType)
-	guesser.RegisterDocumentTypeGuesser(&simpledoc.SimpleDocProc{}, "simple-doc-guesser")
+	err := RegisterDocumentProcessor(&simpledoc.SimpleDocProc{}, simpledoc.SimpleDocType)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = guesser.RegisterDocumentTypeGuesser(&simpledoc.SimpleDocProc{}, "simple-doc-guesser")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			docTree, err := Process(&tt.doc)
+			docTree, err := Process(context.TODO(), &tt.doc)
 			if err != nil {
 				if tt.expectErr {
 					return

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,50 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+var logger *zap.SugaredLogger
+
+type loggerKey struct{}
+
+func init() {
+	zapLogger, _ := zap.NewProduction()
+
+	// flushes buffer, if any
+	defer func() {
+		// intentionally ignoring error here, see https://github.com/uber-go/zap/issues/328
+		_ = zapLogger.Sync()
+	}()
+
+	logger = zapLogger.Sugar()
+}
+
+func WithLogger(ctx context.Context) context.Context {
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+func FromContext(ctx context.Context) *zap.SugaredLogger {
+	if logger, ok := ctx.Value(loggerKey{}).(*zap.SugaredLogger); ok {
+		return logger
+	}
+
+	return zap.NewNop().Sugar()
+}


### PR DESCRIPTION
Replaces the Sirupsen logging library with Zap.

Drive-by:
- Adds a .gitignore file

Fixes guacsec/guac#41
