### PR TITLE
Serialize subgraph to graph database

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -79,12 +79,12 @@ type GuacNode interface {
 	// should also be a key in the map returned by `Properties`.
 	PropertyNames() []string
 
-	// IdentifiablePropertyNames returns a list of tuples of property names
-	// that can uniquely specify a GuacNode.
+	// IdentifiablePropertyNames returns a list of property names that can
+	// uniquely specify a GuacNode.
 	//
-	// Any string found in a tuple returned by `IdentifiablePropertyNames`
+	// Any string found in the list returned by `IdentifiablePropertyNames`
 	// must also be returned by `PropertyNames`.
-	IdentifiablePropertyNames() [][]string
+	IdentifiablePropertyNames() []string
 }
 
 // GuacEdge represents an edge in the GUAC graph
@@ -109,26 +109,26 @@ type GuacEdge interface {
 	// should also be a key in the map returned by `Properties`.
 	PropertyNames() []string
 
-	// IdentifiablePropertyNames returns a list of tuples of property names
+	// IdentifiablePropertyNames returns a list of property names that can
 	// that can uniquely specify a GuacEdge, as an alternative to the two
 	// node endpoints.
 	//
-	// Any string found in a tuple returned by `IdentifiablePropertyNames`
+	// Any string found in the list returned by `IdentifiablePropertyNames`
 	// must also be returned by `PropertyNames`.
 	//
 	// TODO(mihaimaruseac): We might not need this?
-	IdentifiablePropertyNames() [][]string
+	IdentifiablePropertyNames() []string
 }
 
-// Subgraph represents a subgraph read from the database or written to it.
+// Graph represents a subgraph read from the database or written to it.
 // Note: this is experimental and might change. Please refer to source code for
 // more details about usage.
-type Subgraph struct {
-	V []GuacNode
-	E []GuacEdge
+type Graph struct {
+	Nodes []GuacNode
+	Edges []GuacEdge
 }
 
 // TODO(mihaimaruseac): Write queries to write/read subgraphs from DB?
 
 // AssemblerInput represents the inputs to add to the graph
-type AssemblerInput = Subgraph
+type AssemblerInput = Graph

--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 	"github.com/guacsec/guac/pkg/assembler/graphdb"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
 // Note: This module is experimental and might change often!
@@ -42,7 +42,7 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 		node_queries[i] = sb.String()
 		node_dicts[i] = map[string]interface{}{}
 		for k, v := range n.Properties() {
-			node_dicts[i]["n_" + k] = v
+			node_dicts[i]["n_"+k] = v
 		}
 	}
 
@@ -61,20 +61,20 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 		edge_queries[i] = sb.String()
 		edge_dicts[i] = map[string]interface{}{}
 		for k, v := range a.Properties() {
-			edge_dicts[i]["a_" + k] = v
+			edge_dicts[i]["a_"+k] = v
 		}
 		for k, v := range b.Properties() {
-			edge_dicts[i]["b_" + k] = v
+			edge_dicts[i]["b_"+k] = v
 		}
 		for k, v := range e.Properties() {
-			edge_dicts[i]["e_" + k] = v
+			edge_dicts[i]["e_"+k] = v
 		}
 	}
 
 	queries := append(node_queries, edge_queries...)
 	params := append(node_dicts, edge_dicts...)
 	_, err := session.WriteTransaction(
-		func (tx graphdb.Transaction) (interface{}, error) {
+		func(tx graphdb.Transaction) (interface{}, error) {
 			for i, query := range queries {
 				fmt.Printf("%v(where: %v)\n\n", query, params[i])
 				if _, err := tx.Run(query, params[i]); err != nil {
@@ -91,7 +91,7 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 func queryPartForMergeNode(sb *strings.Builder, n GuacNode, label string) error {
 	node_data := n.Properties()
 	sb.WriteString("MERGE (")
-	sb.WriteString(label)    // not user controlled
+	sb.WriteString(label) // not user controlled
 	sb.WriteString(":")
 	sb.WriteString(n.Type()) // not user controlled
 	sb.WriteString(" {")

--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -1,0 +1,153 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assembler
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+	"github.com/guacsec/guac/pkg/assembler/graphdb"
+)
+
+// Note: This module is experimental and might change often!
+
+// StoreSubgraph stores a Graph to the graph database given by Client
+func StoreGraph(g Graph, client graphdb.Client) error {
+	session := client.NewSession(neo4j.SessionConfig{})
+	defer session.Close()
+
+	node_queries := make([]string, len(g.Nodes))
+	for i, n := range g.Nodes {
+		var sb strings.Builder
+		if err := queryPartForMergeNode(&sb, n, "n"); err != nil {
+			return err
+		}
+		queryPartForNodeAttributes(&sb, "CREATE", n, "n")
+		queryPartForNodeAttributes(&sb, "MATCH", n, "n")
+
+		fmt.Println(sb.String())
+		node_queries[i] = sb.String()
+	}
+
+	edge_queries := make([]string, len(g.Edges))
+	for i, e := range g.Edges {
+		a, b := e.Nodes()
+		var sb strings.Builder
+		if err := queryPartForMergeNode(&sb, a, "a"); err != nil {
+			return err
+		}
+		if err := queryPartForMergeNode(&sb, b, "b"); err != nil {
+			return err
+		}
+		queryPartForEdgeConnection(&sb, e)
+
+		fmt.Println(sb.String())
+		edge_queries[i] = sb.String()
+	}
+
+	queries := append(node_queries, edge_queries...)
+	_, err := session.WriteTransaction(
+		func (tx graphdb.Transaction) (interface{}, error) {
+			for _, query := range queries {
+				if _, err := tx.Run(query, nil); err != nil {
+					return nil, nil
+				}
+			}
+			// TODO: for query, args: tf.Run(query, args)
+			return nil, nil
+		})
+
+	return err
+}
+
+// Creates the "MERGE (n:${NODE_TYPE} {${ATTR}:${VALUE}, ...})" part of the query
+func queryPartForMergeNode(sb *strings.Builder, n GuacNode, label string) error {
+	node_data := n.Properties()
+	sb.WriteString("MERGE (")
+	sb.WriteString(label)
+	sb.WriteString(":")
+	sb.WriteString(n.Type())
+	sb.WriteString(" {")
+	for ix, key := range n.IdentifiablePropertyNames() {
+		if val, ok := node_data[key]; ok {
+			writeKeyValToQuery(sb, key, val, label, false, ix == 0)
+		} else {
+			return errors.New(fmt.Sprintf("Node %v has no value for property %v", n, key))
+		}
+	}
+	sb.WriteString("})\n")
+
+	return nil
+}
+
+// Creates the "ON CREATE SET ${ATTR}=${VALUE}, ..." part of the query
+// Creates the "ON MATCH SET ${ATTR}=${VALUE}, ..." part of the query
+func queryPartForNodeAttributes(sb *strings.Builder, when string, n GuacNode, label string) {
+	node_data := n.Properties()
+	sb.WriteString("ON ")
+	sb.WriteString(when)
+	sb.WriteString(" SET ")
+	first := true
+	for key := range node_data {
+		writeKeyValToQuery(sb, key, node_data[key], label, true, first)
+		first = false
+	}
+	sb.WriteString("\n")
+}
+
+// Creates the "(a) -[e:${EDGE_TYPE}] -> (b)" part of the query and sets the edge attributes
+func queryPartForEdgeConnection(sb *strings.Builder, e GuacEdge) {
+	sb.WriteString("MERGE (a) -[e:")
+	sb.WriteString(e.Type())
+	sb.WriteString("]-> (b)")
+	if edge_data := e.Properties(); len(edge_data) > 0 {
+		sb.WriteString("\nSET ")
+		first := true
+		for key := range edge_data {
+			writeKeyValToQuery(sb, key, edge_data[key], "e", true, first)
+			first = false
+		}
+	}
+	sb.WriteString("\n")
+}
+
+// Creates either the "${ATTR}:${VALUE}" part (set=false) or the "n.${ATTR}=${VALUE}" one (set=true).
+// Uses first to determine if we need to add comma from what comes before
+func writeKeyValToQuery(sb *strings.Builder, key string, val interface{}, label string, set bool, first bool) {
+	if !first {
+		sb.WriteString(", ")
+	}
+	if set {
+		sb.WriteString(label)
+		sb.WriteString(".")
+	}
+	sb.WriteString(key)
+	if set {
+		sb.WriteString("=")
+	} else {
+		sb.WriteString(":")
+	}
+	switch val.(type) {
+	case string:
+		sb.WriteString("\"")
+		sb.WriteString(val.(string))
+		sb.WriteString("\"")
+	default:
+		sb.WriteString(fmt.Sprint(val))
+	}
+}

--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -16,7 +16,6 @@
 package assembler
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -39,8 +38,6 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 		}
 		queryPartForNodeAttributes(&sb, "CREATE", n, "n")
 		queryPartForNodeAttributes(&sb, "MATCH", n, "n")
-
-		fmt.Println(sb.String())
 		node_queries[i] = sb.String()
 	}
 
@@ -55,8 +52,6 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 			return err
 		}
 		queryPartForEdgeConnection(&sb, e)
-
-		fmt.Println(sb.String())
 		edge_queries[i] = sb.String()
 	}
 
@@ -87,7 +82,7 @@ func queryPartForMergeNode(sb *strings.Builder, n GuacNode, label string) error 
 		if val, ok := node_data[key]; ok {
 			writeKeyValToQuery(sb, key, val, label, false, ix == 0)
 		} else {
-			return errors.New(fmt.Sprintf("Node %v has no value for property %v", n, key))
+			return fmt.Errorf("Node %v has no value for property %v", n, key)
 		}
 	}
 	sb.WriteString("})\n")

--- a/pkg/assembler/graphdb/graphdb_test.go
+++ b/pkg/assembler/graphdb/graphdb_test.go
@@ -28,17 +28,11 @@ const (
 )
 
 func Test_Connect(t *testing.T) {
-	tk := CreateAuthTokenForTesting()
-	client, err := NewGraphClient(dbUri, tk)
+	client, err := EmptyClientForTesting(dbUri)
 	if err != nil {
-		t.Fatalf("Unexpected connection error %v", err)
+		t.Fatalf("Could not obtain testing database: %v", err)
 	}
 	defer client.Close()
-
-	err = ClearDBForTesting(client)
-	if err != nil {
-		t.Fatalf("Unexpected error clearing the test database: %v", err)
-	}
 	performBasicTest(client, t)
 }
 

--- a/pkg/assembler/graphdb/graphdb_test_utils.go
+++ b/pkg/assembler/graphdb/graphdb_test_utils.go
@@ -44,7 +44,7 @@ func WriteQueryForTesting(client Client, query string, args map[string]interface
 //
 // Returns the result as an interface to be handled by the caller (as records),
 // but this is not optimal to use in production!
-func ReadQueryForTesting(client Client, query string, args map[string]interface{}) ([][]interface{}, error) { ///*(interface{}, error) { //*/(neo4j.Result, error) {
+func ReadQueryForTesting(client Client, query string, args map[string]interface{}) ([][]interface{}, error) {
 	session := client.NewSession(neo4j.SessionConfig{})
 	defer session.Close()
 
@@ -87,4 +87,22 @@ func ClearDBForTesting(client Client) error {
 			return tx.Run("MATCH (n) DETACH DELETE n", nil)
 		})
 	return err
+}
+
+// EmptyClientForTesting returns a client to an empty database.
+//
+// Should only be used for testing.
+func EmptyClientForTesting(dbUri string) (Client, error) {
+	tk := CreateAuthTokenForTesting()
+	client, err := NewGraphClient(dbUri, tk)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ClearDBForTesting(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }

--- a/pkg/assembler/nodes.go
+++ b/pkg/assembler/nodes.go
@@ -64,9 +64,9 @@ func (in IdentityNode) PropertyNames() []string {
 	return []string{"id", "digest", "key"}
 }
 
-func (in IdentityNode) IdentifiablePropertyNames() [][]string {
-	// An artifact can be uniquely identified by digest
-	return [][]string{{"digest"}}
+func (in IdentityNode) IdentifiablePropertyNames() []string {
+	// An identity can be uniquely identified by digest
+	return []string{"digest"}
 }
 
 // AttestationNode is a node that represents an attestation
@@ -145,8 +145,8 @@ func (e IdentityForEdge) PropertyNames() []string {
 	return []string{}
 }
 
-func (e IdentityForEdge) IdentifiablePropertyNames() [][]string {
-	return [][]string{}
+func (e IdentityForEdge) IdentifiablePropertyNames() []string {
+	return []string{}
 }
 
 // AttestationForEdge is an edge that represents the fact that an

--- a/pkg/assembler/nodes.go
+++ b/pkg/assembler/nodes.go
@@ -36,9 +36,9 @@ func (an ArtifactNode) PropertyNames() []string {
 	return []string{"name", "digest"}
 }
 
-func (an ArtifactNode) IdentifiablePropertyNames() [][]string {
+func (an ArtifactNode) IdentifiablePropertyNames() []string {
 	// An artifact can be uniquely identified by digest
-	return [][]string{{"digest"}}
+	return []string{"digest"}
 }
 
 // IdentityNode is a node that represents an identity
@@ -91,9 +91,9 @@ func (an AttestationNode) PropertyNames() []string {
 	return []string{"filepath", "digest"}
 }
 
-func (an AttestationNode) IdentifiablePropertyNames() [][]string {
+func (an AttestationNode) IdentifiablePropertyNames() []string {
 	// An attestation can be uniquely identified by filename?
-	return [][]string{{"filepath"}}
+	return []string{"filepath"}
 }
 
 // BuilderNode is a node that represents a builder for an artifact
@@ -117,9 +117,9 @@ func (bn BuilderNode) PropertyNames() []string {
 	return []string{"type", "id"}
 }
 
-func (bn BuilderNode) IdentifiablePropertyNames() [][]string {
+func (bn BuilderNode) IdentifiablePropertyNames() []string {
 	// A builder needs both type and id to be identified
-	return [][]string{{"type", "id"}}
+	return []string{"type", "id"}
 }
 
 // IdentityForEdge is an edge that represents the fact that an
@@ -172,8 +172,8 @@ func (e AttestationForEdge) PropertyNames() []string {
 	return []string{}
 }
 
-func (e AttestationForEdge) IdentifiablePropertyNames() [][]string {
-	return [][]string{}
+func (e AttestationForEdge) IdentifiablePropertyNames() []string {
+	return []string{}
 }
 
 // BuiltByEdge is an edge that represents the fact that an
@@ -199,8 +199,8 @@ func (e BuiltByEdge) PropertyNames() []string {
 	return []string{}
 }
 
-func (e BuiltByEdge) IdentifiablePropertyNames() [][]string {
-	return [][]string{}
+func (e BuiltByEdge) IdentifiablePropertyNames() []string {
+	return []string{}
 }
 
 // DependsOnEdge is an edge that represents the fact that an
@@ -226,6 +226,6 @@ func (e DependsOnEdge) PropertyNames() []string {
 	return []string{}
 }
 
-func (e DependsOnEdge) IdentifiablePropertyNames() [][]string {
-	return [][]string{}
+func (e DependsOnEdge) IdentifiablePropertyNames() []string {
+	return []string{}
 }

--- a/pkg/assembler/nodes_test.go
+++ b/pkg/assembler/nodes_test.go
@@ -1,0 +1,146 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assembler
+
+import (
+	"testing"
+
+	"github.com/guacsec/guac/pkg/assembler/graphdb"
+)
+
+const (
+	dbUri string = "neo4j://localhost:7687"
+)
+
+type MockNode struct {
+	Id      string
+	Address string
+	Name    string
+	Age     *int
+	Score   *int
+}
+
+func (n MockNode) Type() string {
+	return "MockNode"
+}
+
+func (n MockNode) Properties() map[string]interface{} {
+	properties := make(map[string]interface{})
+	properties["id"] = n.Id
+	properties["address"] = n.Address
+	properties["name"] = n.Name
+	if n.Age != nil {
+		properties["age"] = *n.Age
+	}
+	if n.Score != nil {
+		properties["score"] = *n.Score
+	}
+	return properties
+}
+
+func (n MockNode) PropertyNames() []string {
+	keys := []string{"id", "address", "name"}
+	if n.Age != nil {
+		keys = append(keys, "age")
+	}
+	if n.Score != nil {
+		keys = append(keys, "score")
+	}
+	return keys
+}
+
+func (n MockNode) IdentifiablePropertyNames() []string {
+	// Can identify a MockNode uniquely either by id or by (name, age)
+	if n.Age != nil {
+		return []string{"name", "age"}
+	}
+	return []string{"id"}
+}
+
+type MockEdge struct {
+	A, B MockNode
+	Id   *int
+}
+
+func (e MockEdge) Type() string {
+	return "MockEdge"
+}
+
+func (e MockEdge) Nodes() (v, u GuacNode) {
+	return e.A, e.B
+}
+
+func (e MockEdge) Properties() map[string]interface{} {
+	properties := make(map[string]interface{})
+	if e.Id != nil {
+		properties["id"] = *e.Id
+	}
+	return properties
+}
+
+func (e MockEdge) PropertyNames() []string {
+	if e.Id != nil {
+		return []string{"id"}
+	}
+	return []string{}
+}
+
+func (e MockEdge) IdentifiablePropertyNames() []string {
+	if e.Id != nil {
+		return []string{"id"}
+	}
+	return []string{}
+}
+
+func Test_MockNodes(t *testing.T) {
+	client, err := graphdb.EmptyClientForTesting(dbUri)
+	if err != nil {
+		t.Fatalf("Could not obtain testing database: %v", err)
+	}
+	defer client.Close()
+
+	score1 := 0
+	score2 := 42
+	age := 42
+	n1 := MockNode{"id1", "addr1", "name1", &age, nil}
+	n2 := MockNode{"id2", "addr1", "name2", nil, &score1}
+	n3 := MockNode{"id3", "addr2", "name3", &age, &score2}
+	edge_id := 0
+	e1 := MockEdge{n1, n2, &edge_id}
+	e2 := MockEdge{n2, n3, nil}
+	graph := Graph{[]GuacNode{n1, n2, n3}, []GuacEdge{e1, e2}}
+
+	err = StoreGraph(graph, client)
+	if err != nil {
+		t.Errorf("Could not store graph: %v", err)
+	}
+
+	// TODO: retrieve nodes from DB using the last identifiable attribute
+
+}
+
+func Test_SLSASubgraph(t *testing.T) {
+	tests := []func() Graph{
+		func() Graph {
+			return Graph{}
+		},
+	}
+
+	for _, test := range tests {
+		_ = test() // build subgraph
+		// TODO: write and read to DB
+	}
+}


### PR DESCRIPTION
Fixes #11, opens a way to ingest SLSA attestations all the way to the graph database (#12, though the tests for ingesting SLSA nodes is WIP for a future PR).

Changes the interfaces for `GuacNode` and `GuacEdges`, makes them even simpler than before.

Left to do for future PRs:

- more testing
- read from the database (for now we only see that the nodes have been created by running an external query, see below)
- convert the serialization to use struct fields tags, further simplifying `GuacNode` and `GuacEdges`

Testing code generates the following structure (running `match (a)-[e]->(b) return a,e,b`):

```
╒═══════════════════════════════════════════════════════╤════════╤═════════════════════════════════════════════════════════════════╕
│"a"                                                    │"e"     │"b"                                                              │
╞═══════════════════════════════════════════════════════╪════════╪═════════════════════════════════════════════════════════════════╡
│{"address":"addr1","name":"name1","id":"id1","age":42} │{"id":0}│{"score":0,"address":"addr1","name":"name2","id":"id2"}          │
├───────────────────────────────────────────────────────┼────────┼─────────────────────────────────────────────────────────────────┤
│{"score":0,"address":"addr1","name":"name2","id":"id2"}│{}      │{"score":42,"address":"addr2","name":"name3","id":"id3","age":42}│
└───────────────────────────────────────────────────────┴────────┴─────────────────────────────────────────────────────────────────┘
```

Or, as an image:
![9xp33CstArXvJux](https://user-images.githubusercontent.com/323199/187563957-74522d9c-6639-4667-863a-818ae6e9c9bc.png)

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>