### PR TITLE
fix: fmt cmd & add copywrite check to fmt cmd

### DIFF
--- a/.github/scripts/copywrite.sh
+++ b/.github/scripts/copywrite.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#
+# Checks if a file has the correct copywrite
+#
+
+year=`date +%Y`
+header="//
+// Copyright ${year} The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the \"License\");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an \"AS IS\" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License."
+content=`cat $1`
+if  [[ $content != $header* ]]; then
+    echo $1
+fi

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ cover: test ## Run all the tests and opens the coverage report
 
 .PHONY: fmt
 fmt: ## Check the formatting
-	test -z "$(goimports -l -e .)"
+	test -z "$(shell goimports -l -e .)"
+	test -z "$(shell find . -name '*.go' -not -wholename './vendor/*' -exec .github/scripts/copywrite.sh {} \;)"
 
 .PHONY: lint
 lint: ## Run all the linters

--- a/pkg/handler/processor/dsse/dsse_test.go
+++ b/pkg/handler/processor/dsse/dsse_test.go
@@ -1,3 +1,4 @@
+//
 // Copyright 2022 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/handler/processor/guesser/format_json_test.go
+++ b/pkg/handler/processor/guesser/format_json_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package guesser
 
 import (

--- a/pkg/handler/processor/guesser/type_ite6_test.go
+++ b/pkg/handler/processor/guesser/type_ite6_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package guesser
 
 import (


### PR DESCRIPTION
Fix the `fmt` command as it doesn't have the shell directive and add copywrite checks as part of the formatting check