### PR TITLE
fix: dsse processor document type

### DIFF
--- a/pkg/handler/processor/dsse/dsse.go
+++ b/pkg/handler/processor/dsse/dsse.go
@@ -76,7 +76,7 @@ func (d *DSSEProcessor) Unpack(i *processor.Document) ([]*processor.Document, er
 		doc = &processor.Document{
 			Blob:              decodedPayload,
 			Type:              processor.DocumentUnknown,
-			Format:            processor.FormatUnknown,
+			Format:            processor.FormatJSON,
 			SourceInformation: i.SourceInformation,
 		}
 	}

--- a/pkg/handler/processor/dsse/dsse_test.go
+++ b/pkg/handler/processor/dsse/dsse_test.go
@@ -49,7 +49,7 @@ var (
 	unpackedUnknownDSSEDoc = processor.Document{
 		Blob:   decodedPayload,
 		Type:   processor.DocumentUnknown,
-		Format: processor.FormatUnknown,
+		Format: processor.FormatJSON,
 		SourceInformation: processor.SourceInformation{
 			Collector: "TestCollector",
 			Source:    "TestSource",


### PR DESCRIPTION
Fix the dsse processor to set the format type to be JSON. At this point, the input has been successfully parsed as json