### PR TITLE
Initalized docType and FormatType for GCS

### DIFF
--- a/pkg/handler/collector/gcs/gcs.go
+++ b/pkg/handler/collector/gcs/gcs.go
@@ -170,7 +170,9 @@ func (g *gcs) getArtifacts(ctx context.Context, docChannel chan<- *processor.Doc
 		}
 		if len(payload) > 0 {
 			doc := &processor.Document{
-				Blob: payload,
+				Blob:   payload,
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
 				SourceInformation: processor.SourceInformation{
 					Collector: string(CollectorGCS),
 					Source:    g.bucket,

--- a/pkg/handler/collector/gcs/gcs_test.go
+++ b/pkg/handler/collector/gcs/gcs_test.go
@@ -43,7 +43,9 @@ func TestGCS_RetrieveArtifacts(t *testing.T) {
 	client := server.Client()
 
 	var doc *processor.Document = &processor.Document{
-		Blob: []byte("inside the file"),
+		Blob:   []byte("inside the file"),
+		Type:   processor.DocumentUnknown,
+		Format: processor.FormatUnknown,
 		SourceInformation: processor.SourceInformation{
 			Collector: string(CollectorGCS),
 			Source:    getBucketPath(),


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Initalized the document Type and Format Type to be both unknown for GCS collector

Addressed issue from https://github.com/guacsec/guac/pull/79#discussion_r969984338