### PR TITLE
Add bot configurations

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[merge]
+blacklist_title_regex = "^WIP:.*"
+blacklist_labels = ["do-not-merge"]
+delete_branch_on_merge = true
+method = "squash"
+prioritize_ready_to_merge = true
+require_automerge_label = false
+
+[update]
+always = true
+require_automerge_label = false
+
+[approve]
+auto_approve_usernames = ["dependabot"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain Golang dependencies.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,32 @@
+# Number of days of inactivity before a PR becomes stale.
+daysUntilStale: 60
+# Number of days of inactivity before a stale PR is closed.
+daysUntilClose: 30
+
+# Limit to only `pulls`.
+only: pulls
+
+# Issues or Pull Requests with these labels will never be considered stale.
+# Set to `[]` to disable.
+exemptLabels:
+  - no-mergify
+  - do-not-merge
+
+# Comment to post when marking an issue as stale. Set to `false` to disable.
+markComment: >
+  This pull request has been automatically marked as stale because it has not
+  had recent activity (60 days of inactivity).
+
+  It will be closed in 30 days if no further activity occurs.
+
+  Thank you for your contribution!
+
+# Comment to post when closing a stale issue. Set to `false` to disable.
+closeComment: >
+  This pull request has been automatically closed because there has
+  been no activity for 90 days.
+
+  Please feel free to reopen it (or open a new one) if the proposed
+  change is still appropriate.
+
+  Thank you for your contribution!


### PR DESCRIPTION
Adds the configurations for the following bots:
- dependabot
- kodiak
- stale

The bots will have to be enabled by an admin in order to get activated.

Fixes guacsec/guac#55

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
