### PR TITLE
feat: implement xml guesser

### DIFF
--- a/pkg/handler/processor/guesser/format_guesser.go
+++ b/pkg/handler/processor/guesser/format_guesser.go
@@ -24,6 +24,7 @@ import (
 func init() {
 	_ = RegisterDocumentFormatGuesser(&jsonFormatGuesser{}, "json")
 	_ = RegisterDocumentFormatGuesser(&jsonLinesFormatGuesser{}, "json-lines")
+	_ = RegisterDocumentFormatGuesser(&xmlFormatGuesser{}, "xml")
 }
 
 // DocumentFormatGuesser guesses the format of the document given a blob

--- a/pkg/handler/processor/guesser/format_xml.go
+++ b/pkg/handler/processor/guesser/format_xml.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guesser
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+type xmlFormatGuesser struct{}
+
+// GuessFormat expects at least 1 XML element in a blob to identify it as an XML
+// formatted document
+func (_ *xmlFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
+	decoder := xml.NewDecoder(bytes.NewReader(blob))
+	for i := 0; ; i++ {
+		if err := decoder.Decode(new(interface{})); err != nil {
+			if err == io.EOF && i != 0 {
+				return processor.FormatXML
+			}
+			return processor.FormatUnknown
+		}
+	}
+}

--- a/pkg/handler/processor/guesser/format_xml.go
+++ b/pkg/handler/processor/guesser/format_xml.go
@@ -16,9 +16,7 @@
 package guesser
 
 import (
-	"bytes"
 	"encoding/xml"
-	"io"
 
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
@@ -28,13 +26,8 @@ type xmlFormatGuesser struct{}
 // GuessFormat expects at least 1 XML element in a blob to identify it as an XML
 // formatted document
 func (_ *xmlFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
-	decoder := xml.NewDecoder(bytes.NewReader(blob))
-	for i := 0; ; i++ {
-		if err := decoder.Decode(new(interface{})); err != nil {
-			if err == io.EOF && i != 0 {
-				return processor.FormatXML
-			}
-			return processor.FormatUnknown
-		}
+	if err := xml.Unmarshal(blob, new(interface{})); err == nil {
+		return processor.FormatXML
 	}
+	return processor.FormatUnknown
 }

--- a/pkg/handler/processor/guesser/format_xml_test.go
+++ b/pkg/handler/processor/guesser/format_xml_test.go
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guesser
+
+import (
+	"testing"
+
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+func Test_XMLGuesser(t *testing.T) {
+	testCases := []struct {
+		name     string
+		blob     []byte
+		expected processor.FormatType
+	}{{
+		name:     "simple XML",
+		blob:     []byte(`<a>value</a>`),
+		expected: processor.FormatXML,
+	}, {
+		name:     "invalid XML",
+		blob:     []byte(`{ "abc": "def"}`),
+		expected: processor.FormatUnknown,
+	}}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			guesser := &xmlFormatGuesser{}
+			f := guesser.GuessFormat(tt.blob)
+			if f != tt.expected {
+				t.Errorf("got the wrong format, got %v, expected %v", f, tt.expected)
+			}
+		})
+	}
+
+}

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -68,6 +68,7 @@ type FormatType string
 const (
 	FormatJSON      FormatType = "JSON"
 	FormatJSONLines FormatType = "JSON_LINES"
+	FormatXML       FormatType = "XML"
 	FormatUnknown   FormatType = "UNKNOWN"
 )
 


### PR DESCRIPTION
Adds an XML guesser required for CycloneDX support in https://github.com/guacsec/guac/issues/102 as CycloneDX has both a JSON and XML format