### PR TITLE
Add technical advisory members

### DIFF
--- a/TECHNICAL_ADVISORY_MEMBERS
+++ b/TECHNICAL_ADVISORY_MEMBERS
@@ -1,0 +1,21 @@
+# GUAC Technical Advisory Members
+#
+# See GOVERNANCE.md (https://github.com/guacsec/guac/blob/main/GOVERNANCE.md#technical-advisory-members)
+# For privacy, emails are not listed here. Part of private group https://groups.google.com/g/guac-advisory.
+#
+# Affiliation, Name
+#
+"Google", "Brandon Lum"
+"Kusari", "Michael Lieberman"
+"Purdue University", "Santiago Torres"
+"Citi", "Jonathan Meadows"
+"IBM", "Brandon Mitchell"
+"Intel", "Shripad Nadgowda"
+"Aquasec", "Teppei Fukuda"
+"Anchore", "Alex Goodman"
+"SPDX", "Gary O'Neall"
+"CycloneDX", "Patrick Dwyer"
+"TestifySec", "Mikhail Swift"
+"Shopify", "Jacques Chester"
+"BakerTilly", "Leo Alvarez"
+"Kyverno", "Jim Baguardia"


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>