### PR TITLE
Fix preallocated map size

### DIFF
--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -47,7 +47,7 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 	}
 
 	edge_queries := make([]string, len(g.Edges))
-	edge_dicts := make([]map[string]interface{}, len(g.Nodes))
+	edge_dicts := make([]map[string]interface{}, len(g.Edges))
 	for i, e := range g.Edges {
 		a, b := e.Nodes()
 		var sb strings.Builder


### PR DESCRIPTION
edge_dicts was incorrectly set to be sized to the number of the nodes. This means that if a document contains less nodes than edges it will crash.

Signed-off-by: Michael Lieberman <mlieberman85@gmail.com>