### PR TITLE
ingestor plugin registered as func instead of static struct

### DIFF
--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -24,6 +24,7 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 )
 
 type cyclonedxParser struct {
@@ -35,7 +36,7 @@ type parentPackages struct {
 	depPackages []parentPackages
 }
 
-func NewCycloneDXParser() *cyclonedxParser {
+func NewCycloneDXParser() common.DocumentParser {
 	return &cyclonedxParser{
 		rootPackage: parentPackages{},
 	}

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
@@ -31,7 +32,7 @@ type dsseParser struct {
 }
 
 // NewDSSEParser initializes the dsseParser
-func NewDSSEParser() *dsseParser {
+func NewDSSEParser() common.DocumentParser {
 	return &dsseParser{
 		identities: []assembler.IdentityNode{},
 	}

--- a/pkg/ingestor/parser/dsse/parser_dsse_test.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse_test.go
@@ -66,7 +66,7 @@ func Test_DsseParser(t *testing.T) {
 				t.Errorf("slsa.CreateEdges() = %v, want %v", edges, tt.wantEdges)
 			}
 			if identity := d.GetIdentities(ctx); !reflect.DeepEqual(identity, []assembler.IdentityNode{tt.wantIdentity}) {
-				t.Errorf("slsa.GetDocType() = %v, want %v", identity, []assembler.IdentityNode{tt.wantIdentity})
+				t.Errorf("slsa.GetIdentities() = %v, want %v", identity, []assembler.IdentityNode{tt.wantIdentity})
 			}
 		})
 	}

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/in-toto/in-toto-golang/in_toto"
 )
 
@@ -40,7 +41,7 @@ type slsaParser struct {
 }
 
 // NewSLSAParser initializes the slsaParser
-func NewSLSAParser() *slsaParser {
+func NewSLSAParser() common.DocumentParser {
 	return &slsaParser{
 		subjects:     []assembler.ArtifactNode{},
 		dependencies: []assembler.ArtifactNode{},

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/logging"
 	spdx_json "github.com/spdx/tools-golang/json"
 	spdx_common "github.com/spdx/tools-golang/spdx/common"
@@ -36,7 +37,7 @@ type spdxParser struct {
 	spdxDoc  *v2_2.Document
 }
 
-func NewSpdxParser() *spdxParser {
+func NewSpdxParser() common.DocumentParser {
 	return &spdxParser{
 		packages: map[string][]assembler.PackageNode{},
 		files:    map[string][]assembler.ArtifactNode{},
@@ -259,8 +260,4 @@ func getDependsOnEdge(foundNode assembler.GuacNode, relatedNode assembler.GuacNo
 
 func (s *spdxParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
 	return nil
-}
-
-func (s *spdxParser) GetDocType() processor.DocumentType {
-	return processor.DocumentSPDX
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -17,7 +17,6 @@ package spdx
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/guacsec/guac/internal/testing/ingestor/testdata"
@@ -63,9 +62,6 @@ func Test_spdxParser(t *testing.T) {
 			}
 			if edges := s.CreateEdges(ctx, nil); !testdata.GuacEdgeSliceEqual(edges, tt.wantEdges) {
 				t.Errorf("spdxParser.CreateEdges() = %v, want %v", edges, tt.wantEdges)
-			}
-			if docType := s.GetDocType(); !reflect.DeepEqual(docType, processor.DocumentSPDX) {
-				t.Errorf("spdxParser.GetDocType() = %v, want %v", docType, processor.DocumentSPDX)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes a bug where the ingestor plugin system reuses structs and thus isn't reset between each invocation of the plugin.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>