### PR TITLE
Consume results of write-only transactions

### DIFF
--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -76,7 +76,12 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 	_, err := session.WriteTransaction(
 		func(tx graphdb.Transaction) (interface{}, error) {
 			for i, query := range queries {
-				if _, err := tx.Run(query, params[i]); err != nil {
+				result, err := tx.Run(query, params[i])
+				if err != nil {
+					return nil, err
+				}
+				_, err = result.Consume()
+				if err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
While it's not strictly necessary, since the Neo4j server will execute the transaction queries just before commit at latest, consuming results makes sure the queries are run right when the client starts pulling results.

Another advantage is that some query errors will surface when you consume results and not when you commit.