### PR TITLE
Bug#206: Parse and include dependencies of CDX format

### DIFF
--- a/internal/testing/ingestor/testdata/testdata.go
+++ b/internal/testing/ingestor/testdata/testdata.go
@@ -430,6 +430,65 @@ var (
 			PackageNode:       cdxTopLevelPack,
 		},
 	}
+
+	// CycloneDX Testdata with package dependencies
+	cdxTopQuarkusPack = assembler.PackageNode{
+		Name:    "getting-started",
+		Version: "1.0.0-SNAPSHOT",
+		Purl:    "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+		Tags:    []string{"library"},
+		CPEs:    nil,
+		NodeData: *assembler.NewObjectMetadata(
+			processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		),
+	}
+
+	cdxResteasyPack = assembler.PackageNode{
+		Name:    "quarkus-resteasy-reactive",
+		Digest:  nil,
+		Version: "2.13.4.Final",
+		Purl:    "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+		CPEs:    nil,
+		NodeData: *assembler.NewObjectMetadata(
+			processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		),
+	}
+
+	cdxReactiveCommonPack = assembler.PackageNode{
+		Name:    "quarkus-resteasy-reactive-common",
+		Digest:  nil,
+		Version: "2.13.4.Final",
+		Purl:    "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+		CPEs:    nil,
+		NodeData: *assembler.NewObjectMetadata(
+			processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		),
+	}
+
+	CycloneDXQuarkusNodes = []assembler.GuacNode{cdxTopQuarkusPack, cdxResteasyPack, cdxReactiveCommonPack}
+	CyloneDXQuarkusEdges  = []assembler.GuacEdge{
+		assembler.DependsOnEdge{
+			PackageDependency: cdxResteasyPack,
+			PackageNode:       cdxTopQuarkusPack,
+		},
+		assembler.DependsOnEdge{
+			PackageDependency: cdxReactiveCommonPack,
+			PackageNode:       cdxTopQuarkusPack,
+		},
+		assembler.DependsOnEdge{
+			PackageDependency: cdxReactiveCommonPack,
+			PackageNode:       cdxResteasyPack,
+		},
+	}
 )
 
 type mockSigstoreVerifier struct{}

--- a/internal/testing/processor/testdata.go
+++ b/internal/testing/processor/testdata.go
@@ -46,6 +46,9 @@ var (
 	//go:embed testdata/quarkus-deps-cyclonedx.json
 	CycloneDXExampleQuarkusDeps []byte
 
+	//go:embed testdata/small-deps-cyclonedx.json
+	CycloneDXExampleSmallDeps []byte
+
 	//go:embed testdata/invalid-cyclonedx.json
 	CycloneDXInvalidExample []byte
 

--- a/internal/testing/processor/testdata.go
+++ b/internal/testing/processor/testdata.go
@@ -43,6 +43,9 @@ var (
 	//go:embed testdata/alpine-cyclonedx.json
 	CycloneDXExampleAlpine []byte
 
+	//go:embed testdata/quarkus-deps-cyclonedx.json
+	CycloneDXExampleQuarkusDeps []byte
+
 	//go:embed testdata/invalid-cyclonedx.json
 	CycloneDXInvalidExample []byte
 

--- a/internal/testing/processor/testdata/quarkus-deps-cyclonedx.json
+++ b/internal/testing/processor/testdata/quarkus-deps-cyclonedx.json
@@ -1,0 +1,7063 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-11-09T11:14:31Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.7.1",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "538c878ebf89b372876e247d056a3fc5"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "4561e50edb47e12a03712b1afce9b20cba32fd28"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "f0ea7b3bcf5c7ba649b8d9807e805385330501881677d47333aebce8305ef4d4"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "a35400ca6411692ae8964fe7030eaba2a83a2fa50e2883def3054191283c3b48e2dcdd68bf80f5a0ede3898cc6b7cb7b998aacd2c1e969320053c43b6ab8d873"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "75c0c03a03c69e82ad1f7b942d6d733da8261c4058174355d6b24ebd88cee34180f2e8484d2b0fedaf459078bdf6e927"
+          },
+          {
+            "alg" : "SHA3-384",
+            "content" : "98cd312d4dfc104a0a66d65023d0aade423f08951f2a9e0215e703f0c81c4f274d8e11a2db1abc30a558b820d65860c4"
+          },
+          {
+            "alg" : "SHA3-256",
+            "content" : "0c5fd65013128de457b049a824c4ad11212d668b503613ce19a54d545e5cf82d"
+          },
+          {
+            "alg" : "SHA3-512",
+            "content" : "72ea0ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.acme",
+      "name" : "getting-started",
+      "version" : "1.0.0-SNAPSHOT",
+      "licenses" : [ ],
+      "purl" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar"
+    }
+  },
+  "components" : [
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive",
+      "version" : "2.13.4.Final",
+      "description" : "A JAX-RS implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf39044af8c6ba66fc3beb034bc82ae8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "747022370dab15594b0a6b114f43ba68b8567a3c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "53edb9a7897bdd168335f3d011087205d6dfc416d8e325d1c4eeebcfc6875880"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a0386edca73048b1ceb01849edf6cea63a4bb7f1f88d799f7f8a8555b37cdcc0d02c20a2a000d0ed7d359e873f9b4cc3b1c79dfafaf943abe083bcd35b0a59e4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7940e0b73968df183a5f0b413fd90139d1be781c8ce55df9e958ade9e3a49c281eaecbb5d679631d65bc3986c7324139"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fb016cc3e2aec21dc371a034ab84d54194180f0a8c481c723e8bf90416badba1ce48370ff72a8b751cff4e0821395915"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "53bce7066660c6985f1cfd3f5e4fe6184ff0eee4283aaad345ef090b7c943d5e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6f90b36811373730365a282abb2b7bd7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f8b0dc76803d6626cdfcefaafd57eb25b784ba43"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "24d252682825a6f8147e20205ec76de97b244ced860c926ba4b4b425bebfc6da"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0da2b0bf51dd9281e5267a48dc2d249124b96b68a579cb9a789d3dd76e9b864e385eb0ac5e73b2650e8f8738195fbe91c55d9956d51b918d9681cee6e56db52b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d89e30a6c7e55db04cf09570edf1f9f81323ec7e01db847c8039c6efadeb37af8d18e3ed00d6bf2e4da842d8ef00c10c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5e9fe17b08ef755f6829e79fe6941ce040a4e6edf52687d5b773bc83d592d88e7415c494cec02afc7bbbffb010331c80"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "212c5a3c928c96ef21b20b5362b382512c5dfe7d0fc1d0461f4d6ecb4fe372e5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7ed7855f54e03730a236810abccc8358"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "682fe0def5fdcef4baf1a8c84a5316ecf979b86b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4778544c32b9ce3cebd1b40989ef5886c2b01f5a9676c94719f19ed104cedb21"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2efce1740e941a06c529b0f59135331bcb880e39e3efad20473645ca9f36c3a41dc161936096da188b776db6f858f975c8dc7aa70477de4d739adbc4ac08b64a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6c7b3a9d2199dc9b844a6646aa1ab94ee7db82bcc3fb4ab67d59be202bec86cf849a3516b14ecb65188fb9dc2f103731"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "517e20ce48fb213b7ffff14cc30a70df744a2bb8aabbcd2f11fca6b24498cac571454c8f310617d80d4d73cc86bd3ade"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e510f8180aa2ac71b47c0fecbcd418c3dbd913d9c2bd61789552c3c017a37046"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "03633e91e20d228bbdc4c70927e203fd600ae6c2feee599c06418b7bb78ff3257f7cbda8ab0cf17e97f2050f0dc882f010ce08c6ddfa139898d2de34c1bfd502"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-common-types",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f2f247f6b27914fd3adbab015953310f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "94ba9b655158193d1297c71251aa701ab3dc4ea8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "01f27293b8bca95c9ed14b36c02f098fd2a3eaae8d01236e4fea3149d2ae8d85"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0a1c3bd7499181dc500e7921a232057d432961656e53da8776b8b3faf46e049040c5fc7d4390d3c2bd9fdf59128258d09ae62948b88a00ba8ce43bf55304ad6e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ccf45a8e3b7fa44e05a6c150d1ce6f3262eb91f41cc43faa51211f409714c0294aae580fc1a3e3d5681618c1809c1e96"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b2a9f9bebe53489eb004a564415432feddd86d8d143d6b739926d5a9b110987b363462ac710c0e7a10a8219c2b90ef90"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f6f4bf0863f9e767a3a47c63a89937ba061c2c4c753cd3c6aa33334b963b1f39"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1fca5dd2602d08e3b6839a25ce9e2370ec349c6f7fd55aac8f9761550dfb3c8fd95eb1c756cfb3eda3f6cd574d401376be9b5f3267e9b766824fcb4e531cacb7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "mutiny",
+      "version" : "1.7.0",
+      "description" : "Intuitive Event-Driven Reactive Programming Library for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fdcbc9be9d2a19621a083dfad71b3956"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9cacd7f1dc0e9dd2943dfffd085da28592ce0315"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b0731ce29ee520cb62214ee5ed96cb143b221dcd0e57077c6f4f93d30b84398"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7393b3822c8d29f2c1d27076341da5a4de125755b050ee37c173c3ee7ffe2b6720d1cfd54cb6c73ecaeadbd362a484dba90008d9d2283ec94352fa88aa482ab0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "484b47041fea39be6e7ec508ed611c6c9054c2eb7544ce9798ca64d6a242ba3b6c90c8aefd9f4158475a7d386498eb90"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9f619efd46a522ec1104520462314b521a09d4140c3b6ac214200428e864a325f72c3de3fbb900d29a525b70ac16b5be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "be5d2112cc2c39495ce3962d9e0d6c706fdca248af5ce0922b30d61e56a0fc9f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "befb899a12f3174c5b8d1e8dd5a6daa12b977cd9ac684a0c180e866faafc8acc77cad05d9d1b77b3eaf455eb68449b6b937bd3adf639b7d06bcd8df45674f8cd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar"
+    },
+    {
+      "group" : "org.reactivestreams",
+      "name" : "reactive-streams",
+      "version" : "1.0.3",
+      "description" : "A Protocol for Asynchronous Non-Blocking Data Sequence",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "69122b098fff1c6b1bf2cd3b355e7e03"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d9fb7a7926ffa635b3dcaa5049fb2bfa25b3e7d0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1dee0481072d19c929b623e155e14d2f6085dc011529a0a0dbefc84cf571d865"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aafc86186d82b4f3bd44ef7f955978481172eab267d208aa80b24f8ca218bd902d69b587fcae2fe44a888b7a9f81fc5a209e837958307fdc0ee815248f7065f9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dde10163531896f3b60261795a977cea1d0114514e8fc95f1ac4b6f34789c4b78c4c83ead210901a2edb3cae9f113ed4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4f9e101774f39c8ebcb2ccd3f2fe996a1f99bd879fa34ac9ba319e824752f6bdc6159d242497d38587d7191bba796e3a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "45c5459f651963c5797e32c87e3b8456238229f9f9e64f543eb21d6a6b7a812e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9edc79ccfd2edabe1339ad79a10137cd0f1614671f976d6a8a603428b8e5179c9a6afbf4f9fcd44e6e3795be5c487cc5aa97a1d3e6d9a3e88a62d3f4de60a2ab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-annotation",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ba7e1165c3cc67b110d2783caa04c8c0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f77a7e1d14270b9d4faa2b772c76a321e0168b91"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "14ffd2e8b1346f0fb2bf568220828024f54c4480548108acf46dbdc00f5eb8ff"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6408eaa15062c85fcf2fec2635f48f51f2a3ad732d35928682f980bada9b12754753d2b2561a734ff7c999e972c3baee6b4acb702a1735f3be896768b18e8b2d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "33d910ead36375024703734371d0738d7f6d8a87b41ec8658fd09133be4385ca082b0d546560d5c983518a2a9daabfc0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c1c26b1f8920aad044d4823edb555b1ae2e5416e6f753df3e69b594e19f28856577da6bb6c86745ff55d2603fd935912"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4ec32269b3683ea16312cefdca537521a14d6e06c68e13de750efa22bd11ce16"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c3b6483b54e18340cc404833598fb4b10ab8fa433e0d6cdfedb9a2f7466a3a0e2d7c62c2960d21c9c6e306e66a3cbd07a4df8c8844e6b2cc345b179e66e2f18d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-mutiny",
+      "version" : "2.13.4.Final",
+      "description" : "Write reactive applications with the modern Reactive Programming library Mutiny",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "28ef0d6b366083968c67e7bd2abbec04"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25a7388b15b5e263f989b3f386310f1b8ad1e597"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9260a4c6047b7ba3b9a81782375a40017981459fd063c0dbf0de8406df54b518"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ef7ce4f91a1f7becbb37a439698c47d49188332c58f4547b88075646367dc3422456d85a910c3c5c54d178a5cfe80fb214d7ab8b0fcc8a4e28299b411c66f77a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b5ed7bedc2ac1a4a80301ee7992f7121f4eef841e1ad17ed504acbfec58503895cc6b184f08e4a259629e1476e68d961"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "91139e28a6d1954337ae36e1ceeed229f45da3790e66ca2061e53c5b74c90a47871674d62bb6b77705634bcaa66dfaf5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7f761afec580319409027f30031d46e6a4bceaef295a0ce4086cc8f072d7aadf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2814a3fa20350ac752a0b028aaf2895b16c11d26a166b12b939d3de2a3d608a638839d261ee66bc7e8eddaabc0d5a5341962a4dbe5f49d4dff77719f5ecaa68b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-smallrye-context-propagation",
+      "version" : "2.13.4.Final",
+      "description" : "Propagate contexts between managed threads in reactive applications",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1774e4ac30a4ad9b97991de431e13ab3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "697cf99d70a00012abe45762d3fd0ce20ed63444"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5fb2b7ffeb96cdcd1fbfb1aa7b238267285644917aa98e1f0da9cbd442d6035e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f46007a2b37c155bf66d780529da7de16a115d4d7555730e834e29e9358b81130d675d892f6681539a9487ef708023adffa01dfd564097f2a4e8aabc3a9c967d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3d505fc7f8d626dd1810aa310277d46e0c373bc2c7aa6f3bf4328bf61d660515dfdd19d9676f2585980af9d6acfa0fc7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e7d2fc3fd63de7d023737cc4bd4c9beb4b999d9d62687afb2c25aa0637b19734dfd066f3fb817394ec963dfbe91fc761"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "308f21bd94492d90876e74671d5e441804591d4c063dce4133c0c9ee6f23ae55"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "60843fcd69d74e57dcf42242e663444bdbdc37bc12c9be9213851a92d282c202102243599a435f2c2acaf47a41dab0efea4e0a78655fbcabab50ba1b331262ec"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.4.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation",
+      "version" : "1.2.2",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a827addf6a7db24542be45df6c818124"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e9dbd4df686dd1dd97f13cac346d8c0d6c9c35c3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7812f71926122929374742582c2bddccac29468ded9a15e327f8096865e1e0a2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a265f63a33027d9d28acb5ffe7dd22534251a3f0d4dfb6ed895e32338866d7addacba77cadba7c28fc31780ffddf793d365f1d0e4720a50981295dacda06f7ef"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0fb855b16a41de6f370ae5fd4787a1edfd10217479ee546d2cb6f41019cf8819c35d4e0c2f87cf0698ea3c92db44050d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "23517015aaa3a091f8550a434a62744923c22f6378191e26d00b338e949559e744673968a67b165d673397624f6431e5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5ccd73cd2c1ebb2ca2d3e1ab68e81a0001c00b5f6db97d19b155f26673d22042"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "24dbaa6e354517d0611a1a84000f275a73053e7545e407d88f34addde3b7708b50b28aa6d9ce9a7bf14aca9b8d7c8c1b0985a63eb958cf72617f339c3fcc2aab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-parent"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation-api",
+      "version" : "1.2.2",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fa67441455fe4e297e52dc361202a66e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9802755de30337cc5fe07d7c2c3b914f8fa3c13f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "36aca21d6d7ac6d30fb102bbff2169f7a542b8209e43e4eb1f6197e36360e475"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "26b39776682570c7be25dc76c42d5d719e86c52db85be4c2d16dba732f4f5b8d68f70962555e002e14362913b3e0d7d266cfc31e90f1fba60b5b8dd2e4fd9dd0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "17b4d36c25f212679b0234fb616d3da5984c347cb1234212ec0291c9353e4cc93fd0ea4b1d4bd0ae97e16c0ee0d50b4f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4b327c6c0265a1e196eb476f919bdadef6655ff898ee1fbd5a963866875aaa8a84d90b16a977979558f748fc6db63d67"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8492dcb560906726d24c8b762d028293f56e868f2cba879401ccfd0fc4396eea"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "29a6b3b586bca75685028f11adf65c70f14c9ff31ba5e96b9ece5fd1df46d8517c1cfd972bfa8d38e515ffe1e58ffe48b59eac9ba684e6652bbb464a777e3296"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-parent"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation-storage",
+      "version" : "1.2.2",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f7908e8262610c5317e3f800a85763b6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "daccce22e3578b8fb477ed0244447716aa7b417b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f119834cc7237fda5c4933816868cbdd77fdbb5c04815066278e7f4bf79ed350"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "60c95b6a41bfe245089ff126893f5798b8c4c1faf8e06c589c014792f5b90c0a3806908e1088ce011b2accf26d3335304eeb8b6ef63a8750606d76f2007a5c40"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "394d9661dbb4995fbb5db5432b560fbf795f5e1a4e4445d703c3884c611844dc49a942172c487d1e13142c59c190cded"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3d2a64b7492848ccb11ebde6242a3695368bd162b8674933ed9f70bbe5cd18179d300a0e632632e7a4c63986b0c3225d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a8966d367b0e4b0323405936f9b470a6cf0f970f9bf53d89404ce866a1d5c217"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d3161635d169e83e163c0b60e8f02a09d4284e2dade14f8efe34ea3f3bdcffac3afa3eee557c9eeb242a2cc28f1127267692b568233f665631e3c6b4cae06243"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-parent"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "mutiny-smallrye-context-propagation",
+      "version" : "1.7.0",
+      "description" : "Intuitive Event-Driven Reactive Programming Library for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "341d918932bb44a4d8f20c03ed8f6cda"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "63889b84415e37f2edaa0a5d45270a47a24c2125"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9ba0090c3e16b5d14bc73adac444622c7c75763175aa7ee1c64482f8c9a87564"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6f592bb5433b2b269706c5b1c3523f564f2d8ff4fea8fbcc828ccbb1511a253acd72f665bdfd6769a33b6bfb2cef02ee6606c65982d4c236280ed4561c15fdc7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b720c9d8004c21ad8e94242ae3f0e147fb8d207a39647ec463654aa9031f28e80464af3902e90ed081bf0d41f8c135c4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "de9e7931c162b80d00e8c57fc25d23c1da4e140972227579a65ae1153286750f9ed11f75b73279e642edd96106d955fb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "978357ca8fc8a567c3379624d29fca472cc505aed308debe119ecec7d1dd1598"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "86d8d40ad30a3821dc274840252c556b13dc6f3d7a3c10303ba0f7df4a610c09893baa118148496f1ce6b635f07cc673c5af31c263c74b69296374fb744136ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.context-propagation",
+      "name" : "microprofile-context-propagation-api",
+      "version" : "1.2",
+      "description" : "MicroProfile Context Propagation :: API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e830dad034ed760dea05d1f5bbd16d28"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e8efc0f2ab4ec6b31bd8474a4a4d834965e4e8e9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1576e21f3bf9cc3a3092e7cd40e9c9fef70532223af98a9218c1c9c885a71251"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b0fcebdefea35cf1d84bf977f77f86655c0254dcfc5b89443bf6f915534df6dce8de64c55d2e1eee2e9bf18796c5fa5e058dbc06dcda92841ccdaf20a9127058"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b8a16463da6243929a1e10450bd98c529a6f9e60e4ff7589131be8f39db8243205fdecf8f45d60bfea0de16a3141f532"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80d2e6c8d582c7ba028fbc2d87f4630d172b516869e3859d787f1fc0412b2b79c1ff87280b844adf1a00a299fc9a98cd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "68b2d5b74c15c75aa9e5eec37173b05e538032ace5deb6a5ffdc6a623439ad8a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a8a092b294ed147997cc15cc4288d0d54128b718d2468d323e375af584772cfc6218a94bbef29c3c5a891b0f47bcb8abad38c06daf15c93039f27e06f958a0d9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.eclipse.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx",
+      "version" : "2.13.4.Final",
+      "description" : "Write reactive applications with the Vert.x API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8808e7e5f5c93220f85802fc6579d998"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "58d6f38d000dfeeb82b90e66e1a7cf42600d0731"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2a3dff467b434823a7cfa3cb32d4a1ce5b3d52dbde0b67d91b35e9d36168b101"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cb51f3c50483ffadf423523ccc1bf1bbfc2e138e671ab5489e844dee675d67652d4626982b550817f95d98c6ffa3480b12c2f9ad81b405687a8de95345c214b3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "028c43c7d6973cf36b04ebbec045375bd4f9ab3b24953a544afae9dd9560007407e02b3d3de33d6be856a1d47ac9d561"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "65b9c87ce187d95e231b4100e9a5769937c68667cbc67aef65256d0381fab2484ab3e50d1f9695f170eb2df201ead1b8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "776e4766ee3640262184997c3014a16d9f31e9996d6a2d5b111307e2d4cf03c9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "93f8f7cd1ef95675f6f59e8987c42a2884774d304d66f8512ba6f18c099ee9a43f3ef99580f103043a571cecf0c7617f3e1d7b63defe6c3e66d29179e12d50bf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-arc",
+      "version" : "2.13.4.Final",
+      "description" : "Build time CDI dependency injection",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1dcce585c196beebe89b15ab7eb6ddb8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f963848a42736d16e8675f6a64462c00001c872d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "247f70b826913f1bf11da868fb6132f2fbd6f20d6160241d304ed5a8757d1e4a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0e6f5294250e469e7067617e3791b1e21c66604f537935f78cd474addfb2aa28f7ffe480c8a0444d2720ac23efa71890bbe00a589a8d7c39a79f578452f6e3fa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2c2b92603b2e56ba7fd60dc51ff77d4293efc38e685495be4888d5abc2209374c4bab54bbbb7e40cc3ae4c2c33917214"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a4b91f1e57cdaa9aca39a650f3d3173f2ce9456e931d0e0c49bce8e1a8b3e9ad05bf76c9d9c94f2fd93383aef8ac2dca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8d12122223092367946269cfa8324d1a055bbcd0c19b67aeec55ca886089ca1a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5f002adf6c54584d4fe7ce7dc81b52b75df7a76617dcb1f70ebfff62a7ed2e18a54808625d4705232cbb088968be165144e90cfbaf99a9e6e19be1907dcc83e0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-netty",
+      "version" : "2.13.4.Final",
+      "description" : "Netty is a non-blocking I/O client-server framework. Used by Quarkus as foundation layer.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "302776beccd39d452eb04e8f038ac0e8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "00880c18870cba48b7afa589c0a8cf84f85a3108"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e39a4e8268d219ae4841d717fa7647c4180970cdd4a080ee6280daede0ec804a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9132816e5dfbb654fe6d83182ca7d02300f1172ca0b3ea14cfcf6012c66dd48c35953dcf7d3394347649894ab61280470a0dad792db750b88b1674426f81d436"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3fed023c9d9fe5ac854852ab99dcfffc3e2c69c50febb8109a4e871294ab444589295cd7362aaa5dca6b571ad6140eb2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d0fabd48e823b42a447a703ca5e08574fc75ded3a66592e8e29b4e3ec3058ce8cef45356ba880ad334ca8447f647e11a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8462c26414ab1c032f621e349e32d27287315f31012c66e818a2967ebaa7ad87"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c636dac2c5d2495cf641d77dc39ea69383b009760d3dc0d7834d6d729a087860f950b2a238d59bb16260199ca1ecea33fdf0141c779a378d2e9ea18eda84b15e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-netty@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-netty@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1159d0cdba19ca29a21c90f1409accb8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b77200379acb345a9ffdece1c605e591ac3e4e0a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "170c0ce091c2e1cc1d952d87a6a30deb773922507bbc609b962b539f03f53407"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4314ede39e2b94bbd88a88bc63785ed4883d05662b318f163e7da5292b8e69f41e00bd315fa812bc4707e7ff44d40a3e1415a54f115dd8eb3748ef9bccd7c012"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "890cb2895c38960425805f161511154fdf359ca7a789205e8a119df5aa533f7761bead412edcc0b17e5862b88ea1e072"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8a56c2c73295cffb263b82ac6a455fa5650c1c24b63759c021c47f9a9d0f99a045d633233368b55bd7ca07e2c593b466"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5d6c383971a8b39642fbe083f3b04f1b01a86f4139eaa80138773db10c400fb3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0a01cd17dd0115fe86ff380ace9635211bac52e9db3f4915e4e046eba77a70ef54c5e553fd8a4b802bf0d3b330406fb69422479437df231af0a0ca6361fe4dbb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-http",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bb20eff02c811cec9fb14febb1091069"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f74b563d5206b71c430eeae4cdf703b0ed9cf07c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1e94af48085ec503d69520b58913888f9546b4b4ed2efc8bcb33eb718333edb3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b02fbf9c1211d72d54f14520e63e8d65865518519b87e989eb3530666bb00342e2c0339e7c9732f42230396b612ff390678299a787e45e6c37c5f64ba86ab100"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3b953b140577abf46d4fdde544a8a9bed56cadd302b58364846c6e8b9fb0f72642ee6a6f369dd7cd80ebb58bc0744c1a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1b4ac6c16be04c209a06aa00c045d01047cb664923ad68abe9ad3ccb5874bc447948ae8cba36169347b8362b74b966d1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "26a0ffb125f3dc67f32d1cfc4f551ba296ff29fe38348ab07262ebc256098db7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4183caf4806e731d34d4358c0e05610cfa0955c681cd2b67b6272176f8d253f6af579e84b0133473ddee7b7baa9752ff7f7b731a6eb9b82ded14a6b522b6016f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-http2",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bfd52d45e6a04b71a0ddb5fbed505b2c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "238798287388d7b2f5ab309b941b513956649c92"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "00a29471304c56738c4016f8e811ba63390b79b74459bffecf0571998a8cc52f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9087e3096faf8d7a50354993edf1d5ae103a9ee85dcf95baaf3ffdce83a8841284e7c03b893c7b040c02348ec99f214c02bde3f61cea3171909d908032f26af9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d5d0464abd0aa864641d5fb7f06602aaa73253e80d2e41b89f6a2d2a10d7ed7fe1f0402666673b40da79e340d33c4c50"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6615959e9a1f12eeaf412a1abae51535d8d4e368159f1c8d27552e484afebf8a05eeaa1aece81f3f2f2f56f00b6a03ba"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "041e0ea9d2024d9bf3fa9b94b0c48e6c09e79ae2d08184ab838ec0829d9452ed"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7d47aba9bffea7182fc8c9e31027393c8b2374f6b0134ade15ed01cbe73440007b5ce86debaf1ab34b2200644023486f0f01158be5b3265b50f396f71d95ac13"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-handler",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a6c1b7878a9e90a365c572a9fd2f15cc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "644041d1fa96a5d3130a29e8978630d716d76e38"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "31015505983dc57eec491ad4873411ba51f0f3beb24d22d509336c72511019cb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e27c984dcff5bfd048daaf47b01d3fb69b31cbbec4dc3b76c398b0d9c7c57580c0c2b867e00660b390f64ceaec08cfdbf600d4f1be3e6845445afda5e11aeb12"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "031df846f3731e5d66f9d6d3efe4e1ea7206b536776857afbdf6901c4273edeb384b3dd9f0433cc5547bf343406ead40"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a4eb83a29861b117b35181f8009af3b913923dbdd195a47a8fed40091768b355bedb0d11c82dcc6ff4fcbe82b56832a5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d514a449ef4c471c870b72a376f517cb0fc67c552de229ad056e06880fbfce93"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "40d3b96f0663dc8d225ca76e26cecc46055f81d2c8ca781ec6e823e84647b4c99ffda1e1f41fa7551016b62b07a0fd1e0fb292e25a40e50600a8f94e09ecf90a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-transport-native-unix-common",
+      "version" : "4.1.82.Final",
+      "description" : "Static library which contains common unix utilities.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8184757d93ca61b6a47c739798b6e249"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3e895b35ca1b8a0eca56cacff4c2dde5d2c6abce"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1096f16527a51dd5f44ced90636110a429cc7359a9a8a91db25000b747793429"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "321d42e684bb73513b18ce7a0b44beb71b4914be44b1646d6e394f5487af5eb8e9b186e78e4e23d3526f47acb9a26c2faa2909b4ffdfd2a0dc755fbe19dfac85"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "51b1522a4866284099f28c66de4a973ef22567f6aa67423f93ddb322c68941a7024a1bb8d1b0bda511cf9ed04272d45b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "018a39f3e0c52cdc2f763e0e04b73e66443e7dbad43c4c2c0c79e676da956ebac2ba15cd98733c5adf50924a0844284e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "44a818c6f7dae46afe4d57bca12fbfd80f66b4e2db1719e13573a088e1ab5607"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3fcb40044cc7a4e44387ae7dc3511a8ca17fb14d737aa359aff8f425acc20d61295077b83e71e0f2c650dc61ce89e01b72a67f2a00f5f6b1f16b27776c15c3cb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final?type=jar"
+    },
+    {
+      "group" : "com.aayushatharva.brotli4j",
+      "name" : "brotli4j",
+      "version" : "1.8.0",
+      "description" : "Brotli4j provides Brotli compression and decompression for Java.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9d899a5b07f28ed79d6586e9c46b672b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2bc52df23c9aed6aaaf63156fa9a4f7beca80f56"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cbe0688bc3f0dba1b30b89327deb9480b8f5d10a9faadb58ce212bcdf11d0a3b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7ff8346789fb35b172b697454b5114ba8b2ac8e85f8a1a75ae7afd9c4bb8bef750f0f934a3455e9202a19bfbc366353d02d12befd33f2a215297fac31e448c7c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0c48696edc23567dcffc4884441c1ef33aac75a3bebd90e79d34c81bbc9390747fd215f68f1654dface2e092389e2a85"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e294bb855c83671dc03a52e7b28caa0a61a411e0e581a53f86921bdd8fb1f3a5b03a341a25ae59828385b6da9bdc96f0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "19af78edfbde16f5ea12151314da8fa48e860f16f26342d0d9f6aa88d9c339b8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cf475dd6698f45b86eba73c2e840ee7ff6d37e982f274d23a196711d16dafc098267821e5a22d3981008316e0119fbaba25ec1a5097ba3f7fdd2f8da9019f2aa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.8.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hyperxpro/Brotli4j.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.8.0?type=jar"
+    },
+    {
+      "group" : "com.aayushatharva.brotli4j",
+      "name" : "native-linux-x86_64",
+      "version" : "1.8.0",
+      "description" : "Brotli4j provides Brotli compression and decompression for Java.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2b586cfe244b7459f2bda5632411da13"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "add74b11206e3a6ff14c7405718a0b61abae9a75"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d6d1a825bd805a19338dfdf6c533cd589b2a89e6155cee8e55f7bffb40b4a1d5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "447070e0ab13372fea0d4669fb05b700aa9a55f6158b869580cf1ffca75e14c870d51fa2e7ed3d41638b2014490f6ccd4bb0ec4cbe75ba7aaa5754f1551d9737"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "857c37b5cac0be4f563d5e588cf133758cbe92bf8a97747acec30969e322d4094b10e2a1b864a18ed41531239db69f7c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ec8ad43b46c202355057bc21cdb4e6b55225f9014da070effa0de73188bb374c6892dc916ed3e21a41e1a04858683731"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "21e73b20a234f1d64827fcf8f7f697de1ed266300c866018916f70721edbd1f7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "eb6591ba57bf7944c6521610aca7599783e5056d2b28236928fa5c4cf054f3db012bac7a7f915b45d35ead23fbc4a56803387a52c6236ce4b48bf8e30e1fd514"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.8.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hyperxpro/Brotli4j.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.8.0?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-haproxy",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "15b6192e47f4871c40ef17179f46ce7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2aba0ad65b38eacf7e55d0d7880b0ed4ddc72320"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f80c1dc981916085d4e128144d10b06508baf3586a9cc610ad74b194d425fae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fcb593f86d445498d6937c64f66c434a50d533bead51f18c62df425565fd5fc571c3b2e2f01ca8c3687a334048e3745dea19c4f6d28775c72607c3a993c409ac"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a8d3979f00016ce14dd5bf10249d388d0c4c153f77bdf426f2b1109e189297efa90a90d3f8892b501222c3298c32412f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6a78f681adea2b3a004fe8cd2a11015d3952459cfd97e6941249e0dfdd019f4c18445d09b72710ec50b52e30aa607de1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "db0177adddeaf69935f6d978d5812cad4df04e5c670962b2fa5639b6956c227a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c62a85ea30e608f6ac6b2b4ac571e93b450626cdfb67b97a8a6109b93fbfbc8264aa994965a6d7b389b73f2c040b16c0e6e7f8ff6478fce3a9f5312a4b9b9b3c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-buffer",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "47b1a2d86a0b211d971fc4156560f793"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a544270cf1ae8b8077082f5036436a9a9971ea71"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a7ce7f6d8c1e82b044cd56765dab4338251596416de03b1f9a05d7402429c29d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5e04ffbe47398028fff4c92974973a950283fb243a81d117b8b93705a31d18c62fd29937a7c95a9f77d5caa7ba73b3f8be0226a89e83c09dd0a2b11e3c8f3782"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0fdba4b8b39ecf9b306eb6eb8be0b917d608deb8312ce8f685d4b7303ffe552b1911a878083d83ff78542a0b461d6616"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c50452ce720eb86e59f51a9cd332771bff125e85ccc24bf83a5acdf71c0d34ae798f4fcc872ebba3af38d1c12f93b5b0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "925fbb9666cd2f55188672137ceb0ea776831bf2b27952495d9fec81ed5e8a46"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0d40d726169257b616e5839cb526f74c018143376a43a6b319c7bbf609f3af0b8ac50ac2a8623e082cda04f91df9e66cfcdd5bd4973ecc97eff2dcfc154789ba"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-transport",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "763e0f1a9170807d91dcd25e26f09667"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e431a218d91acb6476ccad5f5aafde50aa3945ca"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c210069be4ab4120f5ac7cb5e4a126d3a007e78a64fd44c9971220e013dbaef1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d8ea740600013adbc419252a3c30f288da8015a47b345cb929d20cdeb5eb33e846dca9b738e59c31e97bd8dbde2e7c0eb7690f16d16d7c160736bb46e9de87d3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2c14c187e6d6bf52d5f6f138053b55b645e25598a52ba0f8c259cb2e87c913222f66a3cd34389f03aae240824296e824"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0d8c6944a8a674cd41c5f1c1f512975380f755eb9b44a863a170c7098503791c34e9972437b8d57fc58d32efd41223cf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2b8dae722981c05e32195c290f44c27a5212d1eb474c9787afb3ca7ab9caad1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "71c14f13bfa6fa70232682cd865f78d18f9f452c5618d5cb6f4bb433625453658830a037fb5e421a1077f95b5dbe5d3d400fc5ed45b81de50daacbe554c2df32"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-latebound-mdc-provider",
+      "version" : "2.13.4.Final",
+      "description" : "Quarkus Vert.x Late Bound MDC Provider",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eb7ffb45cacafb496e3b3404317d143b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0b8765428d0f36bd3923893d066cbfa9ac59bf5b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d043da60ed2f82c4068efe56ed2805c283192840b11b3a23ed8b09416898d78d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "66d785beee11990d22f405bd21cf75069ebe8f395a9edeec7f3c9f51429c9713c22611afb3c45e1bc23aaf6ca03fb84e3a50e256f8eaa649e9c6b24b026e85c6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0b5dda4e008c3bb7b66189d7ab954ea8e61cb9118d0de02016f8c80aa84597e71bb6cad675e22eeea5224fb736feeed5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "efed1a915be4002818b78ceeaf24c360c801cb07b0cd57b9a22d4eed01350d40aeccb78f172c1488a7c147fffa1ddab1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e0022be85290f1c6748c354ee963d4b9e5dbde57585383e1224cfbbade3689a7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d743dcf6dcf6a3bb79dec7a64260c8d70f79bd032432a46a37ae03e2c9d5593dde0c92569481a720f83e97749d07a366e1e26bf0056161f65060cd676d58ba25"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.4.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-fault-tolerance-vertx",
+      "version" : "5.5.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52fad6806222f1a433e9b7e19c85b563"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "039e60ca32d5fde3b02c36ca29c8171ee569bf80"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aa37ed981e758189d73cfdadff6faaefa42740f9b3e62d221dc50d8b6a19153a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "48716d1b5360627183c53b1c6ea6f0e2c110952f774f59d8612f6f2cf0848a965029c5f3f91a77c6c23d993ec5392894c406e8316158a85ea041544d94bdd4cf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de5ec04be2117e7e7c92f8204c443c148343710362dc895caded77191386e962fd15f1dfbbbb3d0aafb8a4f9ccc3d12a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "972994e5b6b6675a4533146ecdd4e4c1b9117bb2a968ebb5e4c1af02b374246950f61793b9836d4fbf2f18b73c774a49"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8eb9982e838bce33b3ba3fdc0bed0447170358cd4fc1aa4b08e1cdbdef0049b4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d4d9c3c029fd2ff48f7b94273bfa34a2c5090a402a6ccdf64df0af04965125a861be708b5b8bdd8c457203f1af45fdd6d0b4c9d247677062c6cfa1a59948f38e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-fault-tolerance/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-fault-tolerance/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-vertx",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8fd53cdf4d70ebe9b22799c03329be3c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1a516820f9080d9debcf230615215d183bc9f79b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "caf6201fe71bc968ce1e16262ceceb72c1d447ca192ba46ba6bdba2504764a6b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b7f6e10dd7ae04df77f519296176bc7fdba983f9f2f9beb0e6e61f4750cb78478fd18472f5fbdffab6a8f08343f0fcbe9a19a31d1641efd1cfd5ec4867faa338"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "caca47037ec4afaacc67a5001a06254b9aafbce55fb818e20b8ed9b5816db41ef118645bdcd6933d8b9d3bc8bb2c440f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "853bec1cc1ae8fed9cec4c09c3b33c434bbddac83a260adc80ec6f458177b9c5b8463b9ca1650a053681ed09059ad96c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c6333335252036a0f040fa0d62f94c7710c51085eafaa3e9173e2d113f6fbe98"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a78c43cd3b10af88f20df245ff198851420518692a1dc34e7174593d871fd622c40e79514796670e5175f90af0552db158ab71035551cb171ee4be0ed4d18ecb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-web",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6da99bf7770413e168c8295aae891dbb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ca5bd74f15376ee4d617bddbf5b266859f9ec285"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8eb68a3fcf76505f26c5d7fb916d15998d54926449715e5ab75095650c90668d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1752d5afda3f35e7af716ae72d15701b112f251a5f27dc4633b41aa2de1b2efb9cfe22e3d085514a4fccdc4147e3dfefe3fb12df00bf08bdcc9848bd423a751f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "10da99ebf21643669bcb9020c240421982d430c219b2bff4999aa69dd8ce3281bf000d96f921bb6d7d815fcde14794ec"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d8b038f34d50950af88c7ae06aff90c7553c8b7de44406ffa18cd3ed6050365da3ca1d88734403bfbf59ced27a01e6e2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "414474a3c020b9a122d9806b4e15f15550f9710d373fbb55eca8c5f35a5a6f0a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e2818672faaa72e3d0d205b9d983d32a14b4b53714f3859a7b36e0c5e0d10f8a0fdc4a33069aa03efe29b2ab248407caf16871e686504abcfd5c3ece02621f2a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-web-common",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "34806fdf8abff2d2678cedce0da00ff4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "44e567022e91c7bfacb577ece6b944181e395cac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "97c9f392e8948d7d1e02e8b4546b20e45d78ddd7e59169197d122021c9d1019a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f369363e0363043be52ab21c3fd09b0b8c0bb07b4fb755d1d0609f2983a4c0fea2cfbdb6a08bd174ab5120d61ab9a0c9b97311eaf19c9c587e7a0e2efde4bb34"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "76292ea22c4cdec0a77c8e9e0b442c18fe251f466ef4fe062771921c282e30fb217f87a2006db8719272e77abfbf192f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8dd4581b0ed59b39d1beee03e3d578229f3ccce3756fe9c9866ee8d2f2207fa4facb71c80daa396099c95a113025256b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a67842497d886619d02e43de31bfe502d7ecacc0d94b2bcb51e288e50dd947b8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7ee48307ee178db6da5ac3f3a441bee53767fefcdc9269251d299c5675dae10b694d6b55ecbbc9762dca1834d3099e8b4a1bd175f10e02d8244bc957e7ac5482"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-web-common@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-web-common@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-auth-common",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "95c9d029377411c36d3a1101e8f137ad"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d35911ba09b92713c901111a40f94886db162303"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "732bda03465ef1aa081ebcf8a18a7934c8c994d757178213cbca5056e4b64807"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1f4db343db19ccbcf536a3f18e5cbc8ee7a14d1bf9bfa55bb4280f6b038dea31d071c5b8e12bcc763992fee87d6f10d81d405de07a74cf9a20b7bceaffaae8eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "45b8a7d6b1d6d15ed8cffda1c2258573f877dbe5b321f45a24d623628c9a5b27f22595e4966d427eba5f05f5ca7461c2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c45c0929bdeda10b2c6d6ae44a1e548c87d17397644933f4b104eba25a39f2789b0c23d189ea3b75da6585f825384341"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b3e12901255fae676aa73668a3338142d95c013ad9da7b611663de6be435e3ed"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b6a6ee4ecd73a7a2bf4e8571c3d56ab3a630ee302d28893312209cbdafc838c59fbf4ee30521d824e79f718055c5ea9d97b74d68f86ea0ac8d186083710eed8e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-auth-common@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-auth-common@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-bridge-common",
+      "version" : "4.3.4",
+      "description" : "Vert.x 3 eventbus bridge common configuration",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e138c34befe8824fb429de7f05c79746"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f23ed6d61ca6abe57243141a26693b32d6341095"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "38ae5be409e3cbefe374b10f6f72dad1bab10fc28b69a7b74d83da32fa34e00b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a445144952ab1a5f198ea9b2836904fffe52688fe3bf944a6df0d3b804d4e9bdc04832a629d681e8e91aeaa007559072292c42afaf66b97b6e06ae27d955fd4b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5c919d5db66a77d59282a1a0a871ed3615074368339b8ff73b96812397d22a22117a9083d69863556331ac1ebde516e6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "814a46d5205ed627803a929512196331977a40370053424738d209c368f3f86e1e23df8e7d8c05397912bc4d198e15fe"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b5d819a779efb28afdb3694af7db999aba4f3c42f07a1ce00dfa1e0edd8d6541"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "33fb99a6986e1779f9480074501f34b2459fa5f445da551e1e265f7d20114c60ed798858ca29ed0b5b452dd73f45ccce3f4707824f2c09b24886c3ccbffc8399"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-core",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "62d19ff5e03b7d9d615696c069847d08"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25ea5f78eb430b392ea1d905cde5b5f8a7ef933d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "46f334c99b5c7646c41ecc82c0104365237ca02d1d7273414a2087a978a7a178"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4377182269f38fc8007a969ddfd61e491229bdd1bc93237f5daf041f54b90ac8a1603195b97320c61607537b7904871d0838c0556f158c27386235a99ec80020"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b7d45f5cb0ffd2b43c8e05e17616bf4a2fa3a46c709e1f2acbd0294bffd4a4eb522ca34155dd83a85a4b651a9f231579"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9571c6cfac3fb6190d862f023ab6e19041060cb26c56986e657f9769327106cdf9477870e6b5aaa4492e085756f1d3cc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3e87d3fb60c10c78b003b17a74dbd4d8fb89c29707f85192b807235318e72d88"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "77daee422568c96e20db969a5c2e918f4739ea7206cf2d66befa238200933dfe90c7c651e74cc6ea3a3da69d7defe9ecb6da13b8f39c9a5957b29f235e880c42"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-common",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7ae14b5005c3cac74a82977245e957c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "022d148e85c3f5ebdacc0ce1f5aabb1d420f73f3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d5923db1cc68b26baf5368f1f76ec2c6100d12db8406c6de00eb6dbc08052550"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dd3bf3d7481b9047cef0b11eb38be925623d2322ebfdd5bb74e5d69818301280d65848fd78d114f9f9f49bd9ea765f5ff840eab11ec9d6885699838f1017429d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0c6b173a398edbd29a777e4a2dbaac46c67fae2af86a4261cee737adbf8dac9edcd8408b5568ccb9216ce742b1e1ad80"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "58aa78a2e923943b70349f7261b30c29371eaeb7f849a89809f089c436059f1a1b95b2310e12621a89131d5e2abe8d08"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1ae3151d336e30933160ad3256cd68e0e8084a5ea31e9e81d2909ed1e2c2eb23"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4deeaea5f97b87e75fb322bce624637335fc8bc2575a5cc79edf7ed90bf81402c651445137ad972eac71cc18e1695bf77eed6b0a4690c3e2ed0735e2e0f7f780"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-handler-proxy",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e412f4a51c119180a739ee09873806cc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "14e417ea8bf374309040e39a9726d446724438f9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1776ada44536c021c31f18dc2915d48be84585bad9ca4dd7c7bff8205b318df7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cb8f3cb608c23befd03945da78b8a4bf56e6c5a26a447465cccddd7da1ebea7d9690d5205d29da686b24e155946c0f8ce88a251eb3833171d681ac36ab88df72"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f06d9ab2c899c2dff1de3217f92bbdf8f59fbf9cbaef001a8b2c0eb353f005c56be0dd6405683f10dc2c2261fcecc5ce"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "137f1fb9a45806c9ae4636ff345451b9732d2f715ff38af97df4c372b11af984323cfb565b808df813a7544fc5fc314c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cfc0bfec7148ee3d12cc74f92a541114dba6aa1c6d5c599291791b4f350df051"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "af51764e6d8c6880e42aaeae19d228b946337547527cd431ce8f971dbc2b2722481b1d42f9c95e8639bf16ab1d8f1860713ec0ce7d6a61f23e8b7e425533dff2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-socks",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7db348e9ff817b59866e0e83072beb3f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a25236fd9c8ecda6eb811d914bf4a875f523ce0a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "defd4672c4dbf3d0fef4307cedee39fe7766c3e7baf77adae5fa069b18f0c7b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "57cad8915e9cb4a7427a37dd2ce9104fd38b534714f77de8976fa1e87f47ddcdf26760057b4265b6623bd772bd327e8b0371d2f5347dd891c89d93a7e2a637f4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d18582db3edbaf0cf1c264b15476f94cc642e54fd98151ac3a0f20eb885496a7aadc0fc73d4c1f5b877e1e234928d831"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c02952967cc7637b1b22ee896bf327775e28f132f6643910818d5f327c06c89eaf9ea9693bb240cbf261ccf9d5fe3fca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8bfac48443d0940538daf41d5dbfb9f08b5a51bb63ac511edaef514f3aae494a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "592af4879d8484a30de6f05119bcd1862a2fd5cb773e2efbd4062b1e4d8baf5c0760ab64266034571fdbdbe8c734d5f942005d4f8644b7d19af7226c5fd25339"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-resolver",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "acd354b623c1fc096dd601759d4da7a7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "38f665ae8dcd29032eea31245ba7806bed2e0fa8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4cfeba7ec535964a35722178aeecc87ec186dba0203d04389a850e8e62575383"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ccd9aa1b9fd5a3683140f80b9c2c354d6a21b2a0e62eb0414ca2fe51fe550d3502d6d506375a1af19b3c82acb810e5492938d81ad4ba67f760c63c07ae395a5a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "786b5f9caf523a192d59f6543010c5d340fc60ca825ba247b8015e3f59357e476099e790f0afab783cdba022041e08b5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "271a3304b2cb88ccc088a631a3f4c331dcbb4c93b794681a7e5a0277b853db9726be8f75b1efdfaffda80121da6933a4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c8a1d9498ad8d791ecee4503012fb831a2b00f53454b7f5117d73e598c0eee56"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "441fa779a6e7f4b032a23fced530cbf89616f74a1a5f4df3dc136dc8cf121b961d066efac299eb3788a85073e4cc217fdede44fea575c686588eb058ac2e03c3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-resolver-dns",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a5af10d8bf367e5167eff8655d59b78d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "18317f6bd0bc4a8b293b09a789875b59a2f46575"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a40c38730dbba50b93ca7741ca1e5a024a995795c2de7dd267747be91f096989"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "127ad24c689cd51855a1229553daf3e1079cca3569134cd91523cf068e90299d44e6d07a325f9bfce5c272f71e94922e506fe5007becaa091f418c982dba476d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1881d950fcf145c9dd9d5ff9df9df11df82331590ed975b16693f8a3e8afb0227f8b3187582763e1e80f941ffb8097af"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "976faa7088f29996c69ab4c72dded63d5c1264996d40a39f67fe774c38e2320a242bb4844faf6e95c8a8d609131090c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f16c07c2d47e4415aa0907e9f99ac5b728fe3351c1b3aa814a837099b5bb5b88"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "19768ec4bed647332ec2c11e362c7e1679717608f7bd92e09ecb25c752a26c0173968c518a4206d5fc8f3fb446693abe7af03d653273bf7fd9fb452fc7509626"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-dns",
+      "version" : "4.1.82.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f5f766117d09a4d12635e0355a37a1a6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8697f6b958e4d814ddad21e439e6efc1ff5a1714"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "463f80707bd2275f46349b6f542c31adaf1fcbd8a0661e79f7ff9cc2be46c7a6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3d3657227b6a1b14dc5c6c8dd7affce2a911495d8ade7925a84984f7d604bb159093ae40f6b534cef9e7092b40d14a5863241b2a1a16aeecabcd93bd46e964be"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8013b150d749c6bd40eedbfec45b4937ab8322b66132accfa9c88e2e7deda29e4eaff07d65834fb4925909332843fa04"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d9556560ec3b47187c78141023c2943f82e5f3311562d941f28dbe2d9e17f4a35878ba2171928efec9e18a7077b6a0bf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aa48ebeb745c884ad29184e22b859822a995e5a564e19ec5764b1300539c86fe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "72271f7bd27d523666e5717b1c85fe896f51d7a01f0bb5ec2b4bace4bf617d79602365a7b5b5376128b81067809307dc9c9ef6a3f1959000ab6b9bd11bdef2eb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.13.4",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e8f064827ddb8deb06e45d20988bcaa5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0cf934c681294b97ef6d80082faeefbe1edadf56"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4c2e043200edd9ee7ba6fc378bd5c17784a5bf2388e152d208068b51fd0839cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cf54bf5be3a5015a4b2c3ac986bf01f64517df224c8ba67197118d06f7fbe8ad64e39d002df326a72feb5aec8f0bc7f15338e90c4ba0668a167a0f03a81ce47f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5fd2723a9f5bae811e71b596180c56355497f87cdd6c9bdc74716224ea1d133b6ed4e5df20b6ec169b3745066019ad94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "47217ac4e35397ed519916b26ec780ecbff69de0069afcbf9329a84f52b0e8fc4700e0c7b6bce7b9ddf585df7d944f22"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2be4b3203664ef4249d40af8d3ea9516805a573515a8ece27c5e625c0969ed0f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "75b4fa4464de9e5efbed460b940ef79b34fc7c477cb61540960f6e56039915a520176d6bf42077453cb049ec184d3b6d88006a4016a02b5de87da907d8c0791a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "website",
+          "url" : "http://fasterxml.com/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-core",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "39c713336cb7345faca175b2420b8868"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3a37d7daa9b8f8dbc381fedc8146feb5744af3af"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "387c446c783f9b5882602f0022ca5613bcf4807344f699dc757f2775c11cb38b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2fb70df14c871291b6222fc4020d5f2e53dc66e1f3eeb72bc1c357aa5dd8a4a5dd683d2cd19297e9636eb06b471db2b046fe6a5aa3b7b5769028a3e94bf1aed3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f35dc9140026898ea13cbdd13466e1b65c5e0d0d65973db99480789c313bc9767d8bb833eb6a5534dc60ae2fb04efc4f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "04691ba66fe69bbce74bdfcd1025d7207a379cb8abc150c643dd47c8caa190552b4f15343a82df871d81138b5314e511"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2b7af4a9aa561ef685a4cef4b9d681f07628555c8fa2295f51d1522494ea046"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57c08b21b88243f1580db7f1437d7049c14bc8530b7f1ce7b42a6571b3968994f0de2e400edee1c5f4f092c49e1d8eb8cdd5695eb75a8bf0cae275c712687e7e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-runtime",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a2a0d0dd45f6a8ead18929d1be0571ce"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a345633c7a8ade41d671739b781fb6692845d00d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "26597a70aa86d70df83ec3bd74aa231e2f020f3a39b4f4cc001d773bd15dca3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d576764e874dc58618b5c371e1ba6203fa10f6bea3110a157ce2387b8c747b23b833744604ba90030938f259393e3ca1d5ce57a84911c34557c9140783305571"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5328d115d690157dcb25a4f347f62c6b08f5c9fc0a05433fe611c4796b61c21b42a86cc02a29a905e6b03eae020ac708"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "17f608af9a8298b4fa0002b70f2ba695ee737788c6d18d7ac553c7d56d657666bc3c479f89002123ad1999523b91e3d4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "14818ce3b6a52fa555888edf78318d9c7d5986c15cd5f26bcbf4dce9ffb75a80"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "de0a64b6bbe5660c08c7c56fd922afc1c67f6316b034b79e5488d336bd0f9b1edf55e9224ef59aef98eaabeda79a9cfaeb7bfb7ba5616c4b2bf86fd7eb707e6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "vertx-mutiny-generator",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ab05cf822a93c6e5f4eae44c90a2be9d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "81166a4143701967d82e2240a0443bd632051999"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b3010f9d9b691827dcfdfb43aa142c729d02198c1f7df574a68ed3521398f2e5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d2e6ddec8429c4d3a9b769b1b366c76b0ad06114ca594078c4917baf8417540774e3c53c505e782be929a951c05fc35fda41b53a44d848c7b361247f10ac69ef"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "733b0dc21c290f0b9aae86c436cdc04a9fe93f0a19b5d6a89bbfe582873c0a26887031e58f41cac9e494595b6b46a5a0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9598c22da5b0a4c48aa5c11e681514326f367ce3ce356dadc4c5f5e5d7a070b22fbd3f80495b83ddb50de18a71307624"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df33660099cd03f20335425aa3d277f14d53168a82e167dc00a2e9ea1cc84f77"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b0ffb1a39cb0909b4b1251c0c81a0569ab10b3784171c9109f35a38223e69dce145f948504568b94eee1e67cae48cddb1598303af7efe618dad7cb982132c56c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-codegen",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "64b9cd20ef35bc523552f84fafee1b44"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ea3f8d37ba91bd13e1fca517fbdb15e3d9295735"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fbded2c268ccf2fafe92cfb69c1f539eb252de282802586d29e5c8d5f727234"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "44c0499b424a738586a6f57689b446fb025b3e012abf850a748201efdcf2ce65b4c21008986dd1e0dff62eef4f5695c785ff3b763706c41bafebe91c855b8749"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "042830a0e2d29af669793a620e1ce9cb29c88eedbb85ac16e687c2eea70092cfd62af6732e3d81ec07189bf22d74fc64"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "63149b4915f283e45d4eb14135c4bf2f6626c98adc8f1b28947cff8c5bbd3424fd7490d926fbcedcfe1b70be4c1b7df6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8c8994eebf301b62381be6ab883220818c2ab86a12bce154a576fccac279a046"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6c36ab5c4749db92141d07330dc624e71ef9feb49858c80a328c7c96a9aeeec0229bbb1af593c770f8da31c8fca1e9e605a10d641d512782d5a557b7fb0a4d3a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f61488348753ef6220fde50710c86826"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9a7a45bb9f3b53896302d5190605d642a2cbcdc4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "070c79c02409c779107ade4426be224992f123ff5dec169f46951d20f1cc948b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "580f30856b7e3cd5e274456ef01f695850317a59d50ae1e97632bd4c2075e8048cf9cf1d4315a358910b49e4e7fe8b8fac0c4141933f8e2202ca09ee61f5517f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "15ccf45d1eaa9327331b17f1fd7571a21fcc01f5a37d8a287ca27cb6d689d8ef1fe7b88e459be88bfefe3e04d4beedb4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "db669e862bd51f300c910ab50b5f230501fb3bc6608d8a5de74d72571c47d35bf76eb899f575321936a3d0db87c9e371"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ab87e356443339cc0a72247ed9ee9a61661a3c43e8fcc71c0216dc4e13e48fdb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "075585fde07496f0677f3c4123d2cc1e6e2cbc49ee07a1172fefae139bde28ffcd8ddbb9e65f47eefc5ad4ecee876691838860b6782129351e5d15ab2eb372e2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.enterprise",
+      "name" : "jakarta.enterprise.cdi-api",
+      "version" : "2.0.2",
+      "description" : "APIs for Jakarta CDI (Contexts and Dependency Injection)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff8956b6aa6e32e6f9064597d9c9f1bd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "58f497f362cd19c2f8842d75c491d270f0600e7f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e71bbe0e4cacfce5b7d609021344d883531aa3e19321db17390f849fdb04a509"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1d51ee835f7abfd87c4df3431ddd99d9c0603cf4efc129215516379a56a23c907a0503727bb5b604a0a88f887a5c6782536724e823a6f1e8331df4fa391d217"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d2f9399e0dd05773168b18993e7c00887ea02f689276d34cf5368f5100a447209f1f5fb5188b82b835b22d448183f078"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "472ad1589c164f82d7d2764eee2c4cd6299a1c3a849078b60ea05529d6d18d63a602b81cf47dfa9195a611d07ee3e752"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a58e19128f278cc5c66198e2ba48c84ddd6bbcb24cd874096e43347c54305c2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5b386c90b6b94edf2ba682b2aff63364f8cacc2c2ce33cb5ac0bf1898420a7ce33827550b6569f54a54c45ebe8d72405dd5ed6a7eacd5a30a763d68b847418bf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jakarta.ee"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/cdi/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.el",
+      "name" : "jakarta.el-api",
+      "version" : "3.0.3",
+      "description" : "Jakarta Expression Language defines an expression language for Java applications",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "528ed6138395d22fb54912b2b889e88e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f311ab94bb1d4380690a53d737226a6b879dd4f1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "47ae0a91fb6dd32fdaa5d9bda63df043ac8148e00c297ccce8ab9c56b95cf261"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f76c94036f0f49d3cf9d1f90697fa96a97d94aba93a0dccad7b907d6c63ff3bceacc6fd40405ff68d6c248b13d056b3543ccb3d2b405917b2ccddaae78ad8900"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5796acb1f22b55e2713763584eaf2b62abbcfcee85530138006fbb55abb19b2c534b2887c28a2f5301168783416fb6c8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bdb09cc896874c0a4a3c470e355f2b23f954800510986753cfc2d4da41cb6c4de567b9014d618da3f89f04e36cfe620b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fc4437d2638002741f4217003f3a9de47c037458dbeabee1a1a5bec96547466"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5857452b1eb5e9ad141717dd9e989763e99a98bf49150ebeb66c423daee8e890ae9b89737abdebedd7ef7e47e6c2fd8cfeaa9276014fb6dc88134ccd2234ab5f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/el-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/el-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/el-ri"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.interceptor",
+      "name" : "jakarta.interceptor-api",
+      "version" : "1.2.5",
+      "description" : "Jakarta Interceptors defines a means of interposing on business method invocations and specific events—such as lifecycle events and timeout events—that occur on instances of Jakarta EE components and other managed classes.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "69ab3deaef95f1a6522e7e828694ab14"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "20cbde692c555692ca835fb6ecb4a8c95acbe6e0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "210c4f0a5a8f387457d58afa3982b9abdd28f0a891e6289b329a6d8cf2210299"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "70f3c36d4e48d52b7c23a5a019e5947b375f8c5c49cf6f305989460217428f62e43b1cb9cadcdeeb61979c6406abd50bbffda08572a048dd45b871566308c1e0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de8479983fbe9cb409aefb286a778f58c00e3cc1a04681e73d394e7fff03cb9c2c405961b1c06f328e38be27e22bd2ca"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8d65c279a249fa0a2d035ce6348bffcc3ba4a6e3cc3543fed8c4d29ea1a2785357b9f19bf55d9c9ce667a06dec081fd7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "368289095b8324d747b009f448d8b508354eced1abf776d634e75019b4c4c269"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "080b664d0924a44a2afae7c2fee6f314fc991c240c5f727b2e2a6a0d4a0695bbdeb569501c459cf3f15f61ad4b70c087262d8ec155c8cfe3a35b115166843d2c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/interceptor-api/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/interceptor-api"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.spec.javax.ws.rs",
+      "name" : "jboss-jaxrs-api_2.1_spec",
+      "version" : "2.0.1.Final",
+      "description" : "Jakarta API for RESTful Web Services",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "35b4d1b6b5f70f01c108c6b2349e4635"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "75cdeb26ccf87bc6f9d0f31b5ec4d80aa15b662c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3518db0a3980aacfdae916f0eb081d0fcefaa2076d2ba603edc779a601d2d1a4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "32e2c300b8e03beef0245d1e52a779c4be1929e010ddd37ab6f05299f99887760b015b8e59efefebacb099947137a38c9cbceda94ff7e8b49e84fd4ac1df8e8a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fc45e2494021ea64942c5e48180df8ac1945cf98509fc9301c40924f0a8633f63bfb1968281f6967aa4d23d84a25aa84"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ad9136a00c74fcc705a5950f70caa961b0df458150357036ec3a06aee25fa977368d20149976a9507efc41f89f27fc2a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a53676703f732a68b5d0f1ceae9b4f569ffb3b1e829d47c9ce73fffc8dedfafa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e4a112cfbfa9e150f77bb47a38dc1449d2905bfb1ada7a237ec43a6fe053c57561cae8c9fdbe4911975d5b1a61b743c68afd7babb66bfc8a4fd94c95ebefbe5c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss/jboss-jakarta-jaxrs-api_spec"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "1.3.5",
+      "description" : "Jakarta Annotations API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "commons-logging-jboss-logging",
+      "version" : "1.0.0.Final",
+      "description" : "Apache Commons Logging to JBoss Logging implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "46328c16f47be35563b73425d456445a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "27a4e823d661bde67ec103bba2baf33cddde6e75"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f12176263ea25f4e78bb4fa4b36d335a29738dde6a8123e1b6da89a655d150ff"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b56221f841fc73f8547bbc1bf06c6b8a635b6009d342f6d0f321a0c5895f5c0876d099c03f98ecda9728ff523c06613ab2cbb242f3e45c7ed4d497d9fc24aa5b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dcadc6881b698e04d426b30831d05df8c25712fb1d0782b8307d8a2f54afddf75c7854c7cbfadcd8533a19e63214c79b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1bcc924caf9b23e1c3dd46b0c52281765bbf7fb34609288c9c1f425a74f4c15aeb37a050eb79326491a74136e2c85d58"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e622f1f358e48847675b0d8901c9474f7a3a1da71d110380f3543fb9b677c5ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a31abb471f63a32e49f0f8b2aa94acfdb6f2a527d8ba2a58229e959067638175a9f2a0ed24e1ba052515e6572300af46adad01091eb1f36cdac5a6378c956190"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/commons-logging-jboss-logging"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.spec.javax.xml.bind",
+      "name" : "jboss-jaxb-api_2.3_spec",
+      "version" : "2.0.0.Final",
+      "description" : "Jakarta XML Binding API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3f3c17761bb0bc98b82b3cfb9311660b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1d2b5404a556a4aeddde8a9676cec8ee01b4e0a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f73f5832acef810d4d72da3b04378b6a70b72e955fdb0315591f0115c3ee701b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c342e4fac2d42ae246e078e1b0be047f58be4ff96b4aed48e9106d49a7bffe94faeb8700db09845eab5f97cde6762ac680a012814f031f087a2f88a735eaef51"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d726be0a754571de0681e5ab036049bf35eeb6dd0c08c1b9346c5f0b69b71fd2e240529d338f87ccac61a93efb353d71"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3989d9601159184c50c3e76daac8004091b64d6dd43671475bb5c6c8e571fa4ed67a39c2a2beba67f5d80e1184d6e672"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e6f7dd63be4d0a5328425d51571f939c23b4b91158ead4a0a21d0f1860fd9f0a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6f4c1904385aada6a39b3700eff0e69c451db87b64dca0f3a966f403af845b96468173ec81e5e82e16e9ff6205c375bed1befc26a1a2adfcae2a69c870dd7567"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss/jboss-jakarta-jaxb-api_spec.git"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging",
+      "version" : "3.5.0.Final",
+      "description" : "The JBoss Logging Framework",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bdb57db05e9905e02dbbf1cbedf26469"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c19307cc11f28f5e2679347e633a3294d865334d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7bb135b081952f6d32d83374619ae5201b05ca3bf862a28dd111016ce19b2c07"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c47792f5f0f219f000ce5d4cb48b3b26c97aadc056a9a9ad8062b6ef38dc9ec34db2c557f247b230c69378ecbccac8c6699a9c73a6377880e3bc8c36f39351a0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3d3ad1aa598053681febf84756de486b607c979b6692e4e916a80944a283b20b1101ccf44f42b9118b6660a79f54e3de"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9e24c40bfb4efbd71666eb23b71d965c847dd99eceb57be478b41925d47e30aedb15e3d49c7d24213811505ec257cab6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1abe69d0d1227f38501bf9391d998ba2daba0af3c0cd7e3d4d0136025fe6ecef"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4c56b974af9d17cbe5965240e493c8c5de211280d6711f94688b75b8b61b822f026dbda1870684891354a7a6b0167392501ad798d6910ed80b81fc1add54748f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/jboss-logging"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-http",
+      "version" : "2.13.4.Final",
+      "description" : "Vert.x HTTP",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "976f811a7d3d21845ca73fab176ee49d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cea9a402b5c2d8f76019a211f35a24b89fa68cc4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "49a96315aacf8a082e236be5faaa4bfff72e478535aea3d9d707291a667c7a30"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "19c170ce80b3cf78fb5de484059356b46a693f5b05414a1db18bae7e74a70c64efe0aaed7e85f78c1eddb8cab05f25ed7dd409409c4face668d0a2ff6bb7f3a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a24cf10781f60f7f64d52fe51201150ea0582f4625754c7b5bbb3c5e1610f1da9b31d0d8b9252a28faa43d90c33b55ee"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "74140baff06ed9fd40fd59d609d09eddd47dcf4b88a46d5ce3e3c36ccc7e39eadc1cc2f85bab9094ac37c2f1a159b1c3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "29dc30b888812ec1a32718f4fac0e2844a349e88af1762c7918c29ed7683489a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1353e392ba22cb90ab4f6712b56ef36e69b08449463d636080b91e023045970a41c5380afe0d16eb61c7b4d428d8f5463c82ea7806cdb589c7936ac4fd88c0c6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-security-runtime-spi",
+      "version" : "2.13.4.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7b4c784d9b7d02dd189c7c12597296b0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4223c20f75455ff2630c3815a3b717cf0b08e72e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e259aa4f969cd88ff8021db21ef27d510fe7e578dabf0e7f5fa74c732ddb4b5e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "01b6452c6699a265d435533526a6397e0274281d226a5f65e7307562199ef10a4aa99ac19b409489d919e06b2cf2cd2b7ff874e4de8510868470dcd8a6fb6b84"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b1e3c76f142f31fd0bfe5a49e6adba48ed2c24b44d1a68b5ea2c9c8a9f49be0375d00e384d33f544b53a6f24c9b4bc08"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8c9cec970279fa3ef596fd820ef16af90e5cf5fb6766d0b4a0c3275bfc61a380d14a7ad2c41afea2f77573c445c78809"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a41ec88b4d8571d1871ce24949e3c6472921039316e63f714684d38e01e80c93"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3052642658ccb7efb2be98871c1831034f26abb7dfbb8fffebb26efd6c5f37b48fe4ed1767a7284416db7f66bcf4bf692789ba0acbdc4e7247c4c454eded6e65"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-credentials",
+      "version" : "2.13.4.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6c388bf59f882687031a9a3e6416f78b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5edfa17378cc0c26825838110ace5741b608403b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f8f47986939ba89ef1296652bc1fb1f4156141fd4190de8a33838cf82b2b82f2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ff2a8244722522498ca7a550f856aa881ff641e8a033c01067ec9aa4a6e883a3a226329ea15f5095a82881d0155b5933fff2b54effe1a06f0975a192d9b31dd5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "be01edef3d61d738cf9677fa3fea847443299cb59066313b32f36c50d85a8fd9aaa84c144a298fb722fea5e7970db59e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c06c4c984f87d8d0d091f23358b08b7bab487be9faba2edbc9bfacf3259d64c0e52035f16a20e0ab818602f327c97013"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d984be78ef0e688bfbeab6dd1c160b48d18d62d25e260fd34a95c0f7267cf032"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2fb4111c2b7e46519a484e1b6cdab332a8decc6781a56a69c9e0c1f7f18f56bb3cae8a6e9f92766f5b5bc0dbb8be3c939f38fa3462d29d40519f5bd9aaf848f1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.arc",
+      "name" : "arc",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e3fcaf2146d26a3425fc63d83a5c3ee9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "607de5a060e45cd5f6ec4f1312dd509db2675450"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5d56421f68e81d9996f2e419c634586172b5ed89f3be526289d4b42a46bb6f47"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ee016fcd102a7164f52bda3f34795f7d05389851c69d628a61ab65b4e216ad73a845711daeb6a9b1d3b35c897fc39085d0d890bc11efccc7fd00e88df07412d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "90c0fdbfb4daaa89d76c330afadda901af8d4640d7db5e3f3050a475a4844cf2990621bb9042fb85e82798a12eebfa4a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "addcda6f4fb580c1c984a8e93a046a91bb323d8a6411357b8e391e6a5f89aa3bc80ad84e53218a449073dbfb0f75be4e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5a38aa5613cd745c2c21d7db46773be6f72b4df1c24ee44209f4ba2c11864807"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "da977e015bb10a6c64a47917f10c12e0dc2e88b6e261dc221a40fb2dd6d54a94f3b7dd79cacf346a17c4254ea48a70d26530ce181e95dd7e18940baa3a66f7b5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "EE4J Community",
+      "group" : "jakarta.transaction",
+      "name" : "jakarta.transaction-api",
+      "version" : "1.3.3",
+      "description" : "Jakarta Transactions",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cc45726045cc9a0728f803f9db4c90c4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4179d48720a1e87202115fbed6089bdc4195405"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b02a194dd04ee2e192dc9da9579e10955dd6e8ac707adfc91d92f119b0e67ab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "764ade8ba807682dcd1ec7382c35275f3d8ab09a03d5b45c48e732501190e2738269080aaf28aa8dd656c11ee84bfb7dae6953dd2768f2acecd3a8cf0ca4961e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "63adeb3c5eb24ad0147377436b6e3208d5e97c0e800e0e1e4cb3ba92699f1b06034c2ba00e3689aa8f909ee96c432db0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dd0a253f45dac003d40ebeed7f38b0850ff4b08941d55db5b3bbf4c936f94062d23799729ff718c54a565de2482bfd3d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d47afbaf1daba46c7aa107bf1b476857523738370309394958f96a2105686684"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b744b2d939a8d0a2bbd0be29c717af4a5e2374ca26fbb95a16df03aa55d2aa092e9314f20d5b080f02030ae1b70e4904ef0f8e1509680b9001153cdb7bc1934"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jta-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jta-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jta-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-vertx-context",
+      "version" : "1.13.1",
+      "description" : "A set of utility classes to ease the usage of Vert.x context locals and duplicated contexts.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "83e40acfdfa852debb9744cad7f4d571"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bc6f67585c992309300a322f8d0a3aa92b75e2b1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "842d3ca945b192d69ea4b659b7346a69efbff98f33f2735568db37b361bbe630"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c81d5a9d31c27d598b2530ed16d012749d67d6f9cef359fe6c78f87b8a2f38c63e8fc9c4f6e33ed336efc090328beed3becd4bf32026410c37d9d373d0373ac4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "332f0611b3fb0b0d4794b4ebf1cce047193f8f4c7376e24b78a9cb47f4dd4b8b504477f279350ec5da73328f29d41266"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "38a7fced4f8c2fb9817b07e44ebb5490a040a4f21b6d76945fe4041f6fd00e9bd87ae6065fc2b27b6c97fa233f0484c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "357146417f1855c1ea50f55fe64b7eea27a6f538afebea368fed0665afcd5345"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f68501de091b463e1a9c461d9923f05a8873c8737083ebe4dadd4f11e273e4619dd812b49253c7aff627917f7dfbd795566632b0ce0d99e822841fc40c28eade"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-constraint",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dddcfedb835d059ad848698eb48c2155"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0a0292ee318dfdd1c94d1c22d2954a7c4c004265"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fb38ccb5811aacd3d92727ccdb46fc481981b026a0c60311673e0e2d3f833a70"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d106863cb1d5cb36bacf779cfef99e4db710c1e87a262a0fa99d64545f9e3458706cfa331980fdc2004c0991d7d40b7f5df92505fc00464d5adb160c56c8e923"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d907e1d3dd27ab88d6cdab735ce6ebcbea8558fd3371927271bedea0e6e119eae78cdec92eb2e5314403f1b351ba4b11"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a10a3b01dba0e0d8f59a1864c4b6933f408ed3e941b382f66ae79111b3b9f48638c70167d1c9430ab54430eef80c2ae8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4c6967483e2005c41be4b2f3d0524c240b2d4f426cd4127388d1d8ba1f455d32"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "af08e30e429bce7a368a91b3ebf4aeeeb02d290784b549a333e1f85335dbc69c759472d67a2e0660a3b6b0f032a6cb776d4af01b5ee0ad6081aa258d488c2ffc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-http-dev-console-runtime-spi",
+      "version" : "2.13.4.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "10925242fef958f975206d6ee61f742f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "832f634f722fb4bfc53dab68eb360fde30ee2572"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ee6f987e48010125e7727a31981815467a7265b26a6e90684f727ae3f7105ec4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "525c0ad5071222b301bc801d046127539506c95f6e6df5aadd6510a7028a1d5609dc772fba0e3b73ed2cf40df8c8f2b0bcb54b3f52d8ec68d4bd153fe2d6d69c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab0172bdfd22dad50ad836b422281bbb99a70de7631d8d8222f76ce76a334328adfca19d49795d41aa5501868517fbde"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cd0c5278c41006945ad871537d7b9695fb62dd816ed08568b7d47373fef4b4296e95a2d9f3b3181c79d0d1bfb6b72d6d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "44f01fd701e9909e5b71849371b11042e03f1acff20a041ea9bb828e7b786912"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4a869b4976c093d19a6e745a7bfb861dafda9f03ba67706ae428cbc4294b9c77564f4c0f151a40816bb4494b521940984bae49a6e908980f8acd7f241c2b885e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.security",
+      "name" : "quarkus-security",
+      "version" : "1.1.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "245629cc1b47cda796842e38066f1209"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "80471f8fa23a4a1c9237426807013c2ea853cb1a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f3be7905a2d7b27713cab0cc1d4440f4050dd41b3d0a8244b152a3adffb5d28a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aada33c497d6c344c226070829f66ef3a593c4876fec24df84ac7e113c84439ed08ee87ed76656ee57e58cf82b348182c09b606db7e53df7e02aa31833fbb2f7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "04a029e1f59b5b1650eaf809d84e5ea7afdd68a561d062616afa1a5fb5be1ae9b1b91e61a78a8a6279102657fd6de46d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "be7bde2f6db71ae992b91e0072f925912132dbb774c1a59bf967f53b2a8134e85133d358830baacda63a3169b3900b52"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a6ff8a6220b21f0e708e15c3c21bf1966c1ae3b9a65dd2a3a657bc0146e0db4c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "842f728401390bae568ae24368bac1be7dd5658c1798e199be9f309d235b2fc59f1177a7fbf894be00348d908136a416264b9d3182399b8e0b0611e72bc28849"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-web",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2506218f5d8237ff218c8597de996366"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e7dcc58d0a2f2ffd54b54cde51f94369ed0ad82b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ff1749d932746610bafad44d5658daaa0e33b9aa513fed6fb446e88cade1f40c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fb6afa99aef91549977429e22a0ee6375df79407f19230959d89b0de57e786abc13ed5fe597954c73dc8141e85e495820f06d8e90cdf687da97e011a1bbf0d3e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3682ab48a9028637ef745d6b01cb9be1c455258d30080bdac87e262988afc9005e110f3323d85c79875070c9b879f65d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ecdb044bd0744a0648d5e73af63e8fceea8e7f77ac852f7061f23c356e71f401b828838cf16b718c25a0f3bbcfd37be4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1428a6846696f8154a0ee5a0572f3d9ac99ca6001f8caf33d829ce95fd6e72f6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "569c6928084c973e569b72ac925a19e767f9abeb07d2ec7045f427429a2437727fd3dc65f9d750e174c05aac9350e0d23599761c6eca57b83412d5be7fa1327a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-web-common",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c7c3fed0305245c7386e0a7ef7d788d7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "76b2a96f6b4c4b1d7fe3ac4dbc302930ace97723"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4bd4c6065faf1a58d87fcb65a0b626078f05df5c061e67015e4ca6c563cb3ff8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1e8003b70d16a75a3692c324ca235c1b3418fc4c6961a2e755394dce789841204bdef9a4aa520c772323021d60f6f6ae6ad8b1284be791a25a273115c72f9991"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "40205b6543a2f7d2ba2af217c54a6b5884d7230bdab32372bbfb8f22fdd5a8d195cec93921e73ab41c9422c80ecc98f3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c6d24cf3f8cfd4bb48e43c22c1d849569b52524bea0b95b771ef3cfc95c197ac95368f0f16be661c2ac1bc961c781690"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f94375023cbf38e3ed082164315ad885b38ce6529ca26d124a1c22e1a9a13128"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e8a754949dbd39695474c6f4a0cc7e286f48b0c66288217e169fbf53ee1392de5ea272a17dc70e009cc18d3757a2e4f53e754831944ebc6eb435c252351c3e1d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-auth-common",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "af83e2855091477ade47442405d411ae"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5998c50f94a2354aa3dde0d75d9da4d605e322a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b4a3e53cbfded683c224b124c545fc18083add164fe48eff86df52a42a2063f7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5a85125e5391072c28c9843b91a5722b73e75104614f461bca55868d0562d02cded4f8ff0e11f21601820f668f9ff25ef29142388b90a43deaaa8fef03055cc6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "860975df0c680be8faef788e59105982e9776a17681ae6b484f32d84efad46d2dab7f877afafbff467d6bd3316876eeb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e407346a1cec819b55500934ab59635e704b3a25e35b70007f6466a3c6fd5ada79548d6f3dddec355d6e0361b229d0bd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "584496b904eb1a2dc1ac30f7c48d3989ba86e36917db2eaa51bce00f0dbd95cf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dac796885de59b30b5c9fd66fafbc0ecf4af46b23dccc339370c86cbabe252d057014ca4b70a525e60c82b0e95a0f3f3076aabf22da6f477d3b9b7b24e273e12"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-bridge-common",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "86b7af31bde89b0f75fb937cb31ef461"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d54a813a2029b3523f95da142676d1e75809a7f8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ca80e7d9e0b40dfb2852c6ce7ded2bc4072933adf1b1f19455a973818740f59c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ab9d162204f9fd213d5562adb0bf4ab91b2b0295833794cf4604dc1b315c2fc6af7fba091c019cd0a3dc53daec9561605296ad0e0f735e17fb79f651f428577a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e10ac1deb3f3172b56057731a9dda74c1ae7559ce0c65581201ee8d5125bc51b720027a0fd1fd44136df2bd94dd3c3f5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "18a192a233a6f29f9190aa1400f9015b8c09ee155b3cc1a547f593e0ae1bb174b88fe0f70c81f9b3d0eafd8cb9c9f66c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8bdaf1c15f1127a38a2b49f058df595ce82d0e9116fe0e6730f3f6dbec3de457"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dd65dcbdd652b0c7818a82def89e0ee8e61f1c412c4e4d751b1bd6fd96ae5caf6288efec8df9ab911855de90189a57b094a30dfbcbdb4e0af82aef03b3619b28"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-uri-template",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8756663af131035a2090d83f5f1b4054"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b7dc8f7443afe8ad1f2ad4266dd6b32fa231b3b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "62475a7cef7914532ec618802cc98e150bda0b3e78c444f4c4b334e09712f9ef"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b6b287ed6223718aa4b8180a8b7b59dd45f8adaa8a2c2bc291ea4f21e47519626735ccf88a88dfab26ce012401fd65d97d65059f2a0ebae38bd6af1a7a099471"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0fbd79252edb9dc36122b6a2e9035bd34c7b8b37535f3ea823d691d9f448dc8aadcc1ca9aebe2d0024c9eeb681e21256"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "49f247ef0d3cb2818ceaf65d054d314c133ba4962d1c7be7a03f30c42ee5d6ebb2bb47f610caeb8f67b2813d3f19580d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "442c335996cc60715e47dec23e818b3ec0ef7ef33f8e1144da0cdd9d0632b95c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1d99227821eb6b939227447ead1ac54f094a48b66cc75fd4cb3f38863014788cbca110f739e274b760b14e29e80fad998c4baac2440238982e1de3834168b5e0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-uri-template",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7e89f43f0e9f243ab9ebce23df41690d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f618891eee0f42142e2b90518c07ee047571e928"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b6ccbc754542b363f310f3777553b5b9be65020637ec05f20810c07728b7abc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bc0f120f4bad89fddd51a512da652127cd7c985f2d90346ff4a9b3f22b0aa5110ecbef9653998038354f526a8b39103d270431da500c3817d030526d081772bd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8b0c9b633ed7029c11ca80dba48da5691f52022d09d6c62a7aba6daf512d558deb5cdb08e6d5a29d60fb79d9926de88b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c7c7bda0bcbf4b4bb7cca0283757037a194d7406f1953380aae0c7227e412c3572e05831954298a0a3bea02940353884"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "13f657ede29a26c960dba4e05ca99cd019be12a22ea046113494b4e5043955cc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e967e8f6c818cb2618f6fe7acf48a530e54965bd8637e51bf1bfedbac62e9481f1878219befae276f609085654ce1a6ee0ca4c4249c1bbd827df496995005936"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4?type=jar"
+    },
+    {
+      "group" : "io.github.crac",
+      "name" : "org-crac",
+      "version" : "0.1.1",
+      "description" : "A wrapper for OpenJDK CRaC API to build and run on any JDK",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "460570b5ea051c6e17c4ac5d0ecb316e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8386af55f19787b4bc78f02f651d568e9eb504ee"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5c2b82c8c6c8e6a1b39b20e51f5cf4ad1699c0b3780d535b8a89c2ba5221ee56"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "02671cfb9ce57b4507444060d4b9c0c907c0dd45c06ea7cf41c825368fada9aa663ddcd40ec134abaf26ed97ebdbeaf37f6e4bb77a702b537fd4e70fa3e02e7f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "996b3ff164f0d6bca7af718f41ff29245bd37433a03e253aeabac1f539eb4734be7782f9ac942a17f459ac267395ee4b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8b6907250bcadf82ec17fea8b6f5c6313a7ab68f9f1817a319d7dc41a9432e67e39b563ad0278a1adc81f6259d606a39"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1c0077645e9395961c2776276069b384f166990a30d3ddce2078da613426d7ca"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "299cead119233f9dc66397ec37b18d32c51f8f08bb5d01b54ebf7093218806e713cbb2e27e23cf5702632431666bd4a50cce9871e7ecba053721940c9ea77f44"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.github.crac/org-crac@0.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/CRaC/org.crac/tree/master"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.github.crac/org-crac@0.1.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-jsonp",
+      "version" : "2.13.4.Final",
+      "description" : "JSON Processing support",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "834cae5e54efc26062b38e2886791a20"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3d2ca0791a4fa487107852d2b1a0ebea7b125000"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1e5d43b2f6cef734a1090cfe4b6b84ad93f7134c13e617d96f8447cd434e7476"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5738698b91f805b95b10468adea084c59f5c07509261de4b5eca4babfadff216c4440421158c8879138edd09748a293b103ae9c44583db22084752af50c68341"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b1a9331160ef556cca30e02dd4cbe6ee8db7afc1aa4b4c332d5aa4e7bbf92b3502b2dd1ba26e0557386d3eece798b1a6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "77e3a6ab8eb87e90466ce44fab2b0e34a740c796bca20e254ae0c3c4909c998b76929cf8685b808e3516196c16de1dd0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b40e8c0726cfeead389f7100d92f0738171e028a725c488a8027f76ffaaf381"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c16d4175e8439da4d11c275adca8082068dcd417572a89f42ba1f654d52d0a53f7f0bdda57f01d3bfe6b44904c7bac1d9eddc509c0844cd0116a1412f0ebecd7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish",
+      "name" : "jakarta.json",
+      "version" : "1.1.6",
+      "description" : "Default provider for Jakarta JSON Processing",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "929731627c96deeef4e963b247089c3c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a39aba0ef0a70c3f54a44a2c539a4f11c9bb07e8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4e1414edc1d6c7dc0747d187c94b451515ed340a9b735156daa91fcefc6aa1b0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2c5cdc4410006e0de4180970de815832ab997ed6e7ede6c153327d589913c221df4d9ffa1d63549f0b428cdc87d9b808db340566111ab0c26981c2fe644876fe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "931055c59d6cbf2f994bb09a511d17e5f8f7ce0ef78994f367b15bbca84cd968d15219953495783468d95d711d2af555"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ae8ae8c8e445bf809ed11f975548fde8110d808866cc2c39384224542821db2bdb6e72349789a5e5643c3b68730814a9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "edbf6f209ffe3b369496fb6766f2dac3ef62e30900eb7ce8619e578f8d0cf7d8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0b9ffc46c100a5e2a32666b93ba6d2205045c1dbfd9d57dfa506b3d6ac6507d6acec5a802fdf1dd1aaf378f61fa42381470cd35e4652d27a62b38983e020faea"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0",
+            "url" : "https://www.eclipse.org/legal/epl-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU General Public License, version 2 with the GNU Classpath Exception",
+            "url" : "https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jsonp"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/ee4j/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-io",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "38d561d173ca5ac005c27ecffcd2555c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "beb9260dace36b10b5cd4bbd329bd4413259bbea"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "190d544ac906c23b73006c3437b10d7ad54ab56d795b80c494dc323a2a364d30"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "52d1346a0d8fb86cd266e82f76415feadf02b0a4b5b2634c040f919c32b9f227c95989789a6bc78e78be32653efe7f53f52cb44b6dbe37314f2e4918272563ae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0c3084bf4e0050d70bc4bb293c066056e7b79593b20f8c46c74ac257d31bcf3f0ee9f50f40bf3354853ac00b56ba32ca"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3381ede01e6176fe45b56b5af243cca90789c77be636e3ff190d376cffd7f7da53933c4da30e7b140ef9742b80422f5f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a100dd56ccc9b2afbcf44da255e572ff06e356e72b5c1b81f0fe3d5b79de7249"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "abc77b695f3ca62ab4083851ae39673bcf9731db1929abc233dec1a0619339d8291d8d77bb7db3ed3aaa4a7c5caa4a12fcc585d32b730a639c8b93329fe8679c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-core",
+      "version" : "2.13.4.Final",
+      "description" : "Quarkus core components",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "92112c17ae23c2c70616cdeb4617d488"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8d8bb552903bfffd6ecb3feb6b95880777e65c70"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "22b7f4e39e2f469094d9af1e96ff0143905cf70dfac9a5c35be44c829e716f83"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "669e4a68e5efa89ce92fcb34eb8506f915339c4b553a7375503be6c6eea410914e39d330ece091eb5742c22e7d059cb591e97f61055406bbf42ad80fffe65d03"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f655f5cac47425ea32fa45a6ba15e91731652242e4dff3adfa0d3b365e1e4f700b5c93f7046063f359202e38e43ee9b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f279205c30afc1980b9d92b4b3bb241ec25b03951f62f6bcded5a2ffffe62aee3ed55d322398228b3b663a6a58d504c3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cd476f3f71c9e88039b3badc6b8396f1d8a5905fb46c43d844f1390148440082"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8e4ce6be509a07952637fd481c7106a5ee00858dad15337bbb521e9330af4624d3b36aafdf1db439f341e08991ff06840ff149cebb86b8ca240dc54673d60144"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.inject",
+      "name" : "jakarta.inject-api",
+      "version" : "1.0",
+      "description" : "Jakarta Dependency Injection",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2e07624f1dc24ee8f6cdd69b0aa99ba9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "93164437046e06b4876e069b8e7a321a02f10a2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3655ffdcdc058816632666a8bcbcf4bfd09751c6a77dedf70619f37294abb01f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4a7fb12ee1e765404e6ddd1ed02e92f26173e6c6ff418cf6250b356939b734ed43a41b3d9896136f8cadc1e46d9b2d83c38a4279a50d2fa8471aa22a3bc3d9e2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b5582ce82dd7fb4e0282af2f7f5cd69f9ff713a1837f0cdbd6970781007eb3ee73a2209045a2552d6d5d98fa74617679"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "90d8839cefd3458fc3aeee84457fff58208bc85fb920918e083205b808d11d4f89fc700b57ceadb0d090014db3a8f706"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3c194e73253fed256ca975b3cf3c617e3685042b39cbeed44d37ea17f89537d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e3c4f2a3e920e2c3ea60af37aafce51d798f0403bd48c4de840b96ecf112d587133a2062301d3007fdd9d4381f4c8ccc79cd2b274d68571e5829bef2f94eb78"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/injection-api"
+        },
+        {
+          "type" : "website",
+          "url" : "https://www.eclipse.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/ee4j/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-ide-launcher",
+      "version" : "2.13.4.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2fc28972e507540e2063d661a7e0e88b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a9fe0b05a612668907e139032fbbe4991910d1cd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "66926fe7f76855b28bf3b0cc81d799e3b9f3d01f6b6f2b49d5c3dbbb7268345a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "817749b26859d531b86816b619bcc47d9f322580737112a032b426af0f3fbe5d3077b891c3143e92fb1ca35aaa7e3ee8f1960c3533398e4a587a5eadd1cc31ec"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ff0072645314f9ef6e695fcf7be7fdd7eda482fa1a8e396b5d436f17bbc5b5251208d7920739535ec7acf3337e0c1d5e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ff534821cdca5cfdfedfeba4d9adc7e1362bd669090727025285383deb45208839161fdf2a52a9e7e57f8dbdb2fe32e3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3fa16f4aeca8b8a49c51ef1e1797a7cc4e9afceb7d31d360acd42d04697322e7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "63554168925ab9a345d7ce67799f905228cd8d5c1ee6f27bac7094f9768ef456ebc44424fb1a7911fb5a6c4b9691a1a9a48182857b89317c9fc5550ca66ddb56"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-development-mode-spi",
+      "version" : "2.13.4.Final",
+      "description" : "SPI classes for Quarkus Development mode.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "df684f884e333cc1abc8e6dbed5e7b71"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5c8694675709528e968a7bd00c6f9295336c89ae"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "072e52c05238738fa110a067556fa015223f01948b8d6bdef5384ed854555364"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ee99129353f5b8e492adf4d78f27a4dae6e95c4b359618cfb20923e9b6d8ff8757ce9e735c9dd1a24c8b49dceea609bc7eec97627f9601a1e8f7e70024394616"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c1d86a89a1416e5c7fcb64f2e25a6144c5a953ae1fdb5870442b3571471bd5a39116b1c4bccdfa6b544cf19393cf3d23"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7f594b63b6e3360cda0b161687e4ec1bf45c72a879540426aa7d015978957506159c054782363b5a796710eaf0231a5b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "95142eafc57cac494bcd329a548fcf85e54e5f20459e1d0d3c9a97e91ddde0cc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e2758dc6b95d22e4aac6418f0a5b5d3bc1dde1931d578dc13da832a7f9ac5d4dc38c9cdda08355e3d2b1e573566197cfd0deb1d3aa75f5caa9a2c992ecc04c90"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.4.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config",
+      "version" : "2.12.0",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "36cf6bf274d17218f02a1f474dcdb1e6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48454dd9f327335a04f69779eae3aaea8cc282e5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b3fede1acb24fbc55bfd79926f4baa5e1e764f1ddf7c1ba1b95ed761ba0eac44"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ee5e96c90d991aed2aa48a7f62c9dcc04da4d1015e9b7d04cad87f24baf8fb15df38500688d9b801859d6d13cf506afd22fcb1339d5c57df2643b8036678d356"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ae6562ba37b08cf43ffa31639c643a1f8a01f80bfdd2300046f8564fd418709946463a7c50a6b3f03ae09847a1a26178"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "48ab22326f56731e9511fa14abfc5953091934972324b9ed90c486c8492e4a0677907b73ec14d5b78baf18bdc676aad9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4c22e660096f20c9df226964324f259d548f1841db386498d64374709d1a71a6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "00bb9efc88e19f0f260b62096618c78c606d4bd862e456f8adfba789de802439928e5e888e1d6dde44079900bf6b564c6e055cf815818fec40b320711713cb73"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config@2.12.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config@2.12.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config-core",
+      "version" : "2.12.0",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "24bd21a5a4fabb3623c2d840b3f97ae1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c1488e7baf36578ac0cc2a49f4f55d1d0cbe58aa"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7ea6d5ea6b1f3b70701156f551d8702aabb04c47425c237527ed9f0ea7928cb7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "677ec4ec49e59e048ce3e5eab0380e269fec9aeac0a623226016116b937ae3248c25c24c3cbfcddf59112547045e04d7df7a4f57defe034487e0959c676ef739"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "65876d4736ad72951f669fd7883627ca4c8be30fc42f827b7100d1541afe356e4a9d04d88a5c9f17241962139a9e21b6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fb180789c2ce917c40f035d4d7c44082946b936b71c0acb5d64a07af637b10a48211b257521d6ed0f92ba7a0d08fdde1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3e5fd9a6af8a47d2b8078f8594385ac7bf6e057ce1eebfb082e0499d20943cbb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8d0780f8921b4538c2867d25d1e44be9f892f1a0770e76b5232f5348defaf8910797bca9f899a36d983c8fd566f73f9e5f19325a4916b30e0692183f1b4f1976"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.config",
+      "name" : "microprofile-config-api",
+      "version" : "2.0.1",
+      "description" : "MicroProfile Config :: API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ca38f9ed87c3387b81de49562d1c9b04"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "26fc0aba41ac450ddf86c8d72d58635e89b84feb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4040dabeefd10de26473acbdbc2a52419a9228d31b1f9f0561e9e83e1122874"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9da68d7d99414a2e3a0a06b2e1f34fa821bc861cc36184fbc5315859addb1facfc3675976e1ac225a11a645cf143e53c8ffa2d31d4f87e2e78281b556a99ebdd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "18372b64dfbcd34288d50269fc87a759b063c04d216a4be4407d4aad3838d902f02a75b70d6027b9f27d079f19b75c03"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7d68a29f0c5d2d7a81f0211f1c3ce545105e2b987b5d330a829e48298c27241bbb609ca39e3ca536a304ac4790836d94"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba63d078616f58abf57648f4bbc70c10cf492375b7918fa8333bf57f7345366e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e6b2fadb4b7d2faea55505f83e5cd09bb94ebbf983bbe13dd17394e4190de3353d7e9e43ae4aa38679636d51bd2eb2b1928a1b2bdc9249cd43c34197d8dddc3e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.eclipse.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-config"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-expression",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "64ae3ecbdd0e745dc157bd245e20ed09"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4058b1d1f186d30f62686c9520a1d131c86a143e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d602e9f7e40075688518622d9300d985c633b57d3b63afe339845e563a294f2e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dceeb192397ea0212d1d4c0772296ab2ca1912d7b315c5b4ec539e6e3266919feaedfa3096efe06d9e5cd829c5734e9024b7945bba2c6b5b8c395f0a17d4df88"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f33af565ca104d72fc2aec9285cffcad13261867903f5d0ae70028569cafa81934a0ecce8faff57d7a744f82eb4d25a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ed310fa7d70c945fc75c0107d423a349fc372d373e91f6d165cb3f2f763a5d13f4bff9c9436787deb3c2fe0db3c8736f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1bcdff58709e3e0c40d2ccb55597534a4214b503fa290f01f532ff92f1583453"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cb3e5b7423f86527abaa2ddfa1125e79208c5ce46c1bf8f19a14d26497ae3970dd4d9cc89cfae93b9223066b2ecce3c0cc26655cab1b10c0c051da5ad2446f10"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-function",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "54fe4e8d68fb2b7849de1c5f39a63650"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9fba3dc08283cd93a5cf83c3c69b5469a6a232d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0534ab6fc52e2d3bd44c5809f336df269fe8ea5df0726edaf92b89254bfeb7a8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9338a38c889abc43e44b8731995412b5c123b4b1d90f6ccb2ce94fd236993522fcc6ed8563cc87897940d738f28ad699eeea729f38709e501a4046b563695a7e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ea25dfbb66628299e105fc7386790557b4de9c76dd9aae9bde1ccb756cab2877fc99c9e538615d322c0e9ad9ec52040c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fa3b04879bf400f532a6a571880eceb087dec33ffa0e8fddfc9544c8760bac07e33c95e42a1f3d271586d0ff361da16a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0ef9a8811d62d6a2891534640d5b7f639debe1c874f800d4dfca53f5579463ab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ef94245f8baff697832485312719984dad2c2d0fe69b8026f2083816aaf8021033e4d6677108b1ec20ac46f91c40a89c7bdae88c74c568396430321c57463e6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-classloader",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0535fb224afaa7f0eff93740ddb2b984"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f476e48a9dfd8f97bbc5b739cd4c5a3ab2e5cd26"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5eeeb050679b6b6d6b6fdfdc946f8d6f873a3dcea9817abcef2b9fe2a025058e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "345ce1776f77ec720c2d5d3d9036856130b969f12b74e183ec008102bd2ed12e5e82b38bf5b6d6fa8392ce23ce455aa8ca17e035400b1932bb2ab7c0329cb716"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ce666e3c3da89d72aa2acac2b07922b15f996d19d1df5bcb5f3b89238021a27367f5042bd2cab2cee1fb2517eed9c883"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "851544b3c2160bf8707f305a21d33635aea01422d06aacfc5aac971272d2a81063affcabd5c90f9318d8dc37ecdd0ff1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d0cc68fb13a77f46cf83a6d8f97c47fd996ee200d0341222284d8ca5ace18753"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d49fd652b01b0d53943251aaa60baea907fadfc84e1d8e346f8ae32259d0299955dd58ea5793c30c4209e4f27b12555289a7100ef6183dd24bcc0aab9f1e5cc9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config-common",
+      "version" : "2.12.0",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d7b5b65180663ead88624d1b92be9a8f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a63c348165cae08f1a7fb837e76958f3791f9f04"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1dcd65e14304df6c7816ea8c55144181ac4f4b18b8ef4a8aa3c336d633b9b684"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6e9d1a70725768fbcde99e63448978847733f6c02a718301ef210d7bc03823cc305fbdcfc3fa5c9e350d154537ca1229afa90c1d7d4c21b3b74b4cad79cd1d0b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1df1dae3229ab79ca916051195195cf08bb056a9f9e31e0051ae44b93f5a4b46a4aeb2f0ca1351c5cb4ef28c9c516f6e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "71a7e01be94ad80b2da491ee7f1d8243429a9345683590d6a5485bc7a3c284a4ba132c18c3150d8c383f72eee0973247"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "429ce6c6b7316760bc2aff2e64abaa91b3b86f5ab1eff7b1331c36d2160e1bc2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "27115da1bc29af08834405db03f49337b243ea4db51f07cf515ce77ca3fe4de70aa48246acb603876c5037eae0a3ced8393f00a507787a915569e734f4655949"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logmanager",
+      "name" : "jboss-logmanager-embedded",
+      "version" : "1.0.10",
+      "description" : "An implementation of java.util.logging.LogManager",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d10d28a0eb1ff9e9ef9379410b8154c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "458edc8e3147cfbd5f5ec2ee694deba6abe1d6be"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "adf131d8fa6004a2db6558544e1d22bf8bca08215e87a952a42ae9e2523a16e7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8b5695bf4e35245b394de11a979fd6f0636175e322eacb14f44dc9d3010ff35791f06f23968ee464be4cd8a3d0e48a178ba77f9f19f4eb6317211132a5c4d5e5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7f4e55c9c70bca00c4ab60c87076bc7448c81338a10103c75cad4bb888f02c15a20482406da9c1c620f0d4c7ec6d2d82"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "62e97f4e4e38580d2dde0369f9d9620a6bc5676f2f8c22188ba5592e072f0dded2ad8a73a8df3f25e75b883563b1b6b9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6e9a92995c1ab3584122f32cb1fc0bd40fbfb9a6200f0a15c1186d87f2e20d92"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "df9ae26ca03fde6821635ba5755c4538fd5e29a41cfdac99dda074d6c978b670368ed98c22419ee392373395ab13d82e26fdfeafb8ff8157e227408d08b0224f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging-annotations",
+      "version" : "2.2.1.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "65ea45ee652a89f43a9a06bd8f0e5139"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ee3db82d956ee22c4f1f2df9c611e048e79a4a43"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f1524fc9d7ed3afc87d365ab0d280ef260c8dd1836435689e8300fd5a51ed178"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "81a9c364bfdbffa50920b91730378a704bc8c73748e028e032d4a5938b20875de47d601b1a55f451530fdeef8cf2a6199285e755682f6f04df50b61fdcc79572"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c63d0bc5a2abb7639087a5559bd55cc344c52589ad98f956d2199dd19e73c2154059e1c4b078ecd88527a465f4e90412"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c7ccbe80e22ef72215d2ec0e17708d28c0282472841c01442e9fb17a85089a91427904e6e3a5949ee14b1a91856135c3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0bc405f4bc71ba6159e5680bf9788c8075f24af81cbb03aab1a7b8a6824a3cac"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d86adeaf631775d155e2768d7f65fe1deccb3e3c68bffb271808fba1632a4d89ebe81797c1f1724876e46519a790cc7599d2437097276e5e6a6ef57bbf9728e9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss-logging/jboss-logging-tools"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.threads",
+      "name" : "jboss-threads",
+      "version" : "3.4.3.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff95ed49f2ceea0512dc6a4284d9d976"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2433a04e5a0f8982454a2bbe2700ee272a3a71c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bcb44133a0d3b94282aa5ce32a686db5cb9b7f069de4dd2f75c07d93d29b7c0b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "db57b33c01ec49d21f44b0b059d6b9cc0ff7d793b65cab6adbed2e43ea0eb4919fc0c4d183c976b562705ca29f4b64a0342365d1709addb5a7a7cef388b3589d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fbb587e6fc4d1e25d27bb016de9a6967779e328f50e955c589c5284f8ec1e580182f09f44c2bdf63e1b6dfd886b02439"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d80fc6b699d18a8751cf2400384c3afc44dd1b2d9b002273486ef096b4a16f477f651d4c7b89c6675a2bd7c7e2a664c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cfe10a80063744f4231ffb096ab08b5e1cf7a60f58045dc0677d8b657cd5af51"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b29ad5074d12bd7708ac0a5fe47f8717d00973deedda314fc9b24b2eb3998302be3b9103bcbe57787fcf6f3681c7e29327ccf55ea1cc5d587bedfb191eb6b9ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/browse/JBTHR"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jbossas/jboss-threads"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "1.7.36",
+      "description" : "The slf4j API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "872da51f5de7f3923da4de871d57fd85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6c62681a2f655b49963a5983b8b0950a6120ae14"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9b033fc019a44f98b16048da7e2b59edd4a6a527ba60e358f65ab88e0afae03a9340f1b3e8a543d49fa542290f499c5594259affa1ff3e6e7bf3b428d4c610b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2b14ad035877087157e379d3277dcdcd79e58d6bdb147c47d29e377d75ce53ad42cafbf22f5fb7827c7e946ff4876b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3bc3110dafb8d5be16a39f3b2671a466463cd99eb39610c0e4719a7bf2d928f2ea213c734887c6926a07c4cca7769e4b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba2608179fcf46e2291a90b9cbb4aa30d718e481f59c350cc21c73b88d826881"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14c4edcd19702ef607d78826839d8a6d3a39157df54b89a801d3d3cbbe1307131a77671b041c761122730fb1387888c5ec2e46bdd80e1cb07f8f144676441824"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.qos.ch"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.slf4j",
+      "name" : "slf4j-jboss-logmanager",
+      "version" : "1.2.0.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c05dc8cc28c4de74caeecaff502d84ea"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "baff8ae78011e6859e127a5cb6f16332a056fd93"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a6e925ae7df61c682939d22e90d868910d1d123f2dba6260f197ad585de60eeb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e313efe40724224e854f215f5867a94df19fc5b40b432381f897d6d56279d040147fad79ffb490c8d2b2f8ec4d310831611c2e809a692629d7816ad026267904"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3031ff774726fe71d100b387ca8194639cdc9c1ac30fd641cda212a4afd24ca2dd435e273f01baf94513b4f43d1d7ea7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8735fbd597e4c997ffb4c404647f00ad72d4b2c25076c6bc3be5696b4e592c6ac1baec0c7b2a06d887d481c0d0120ff6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9dafd71a40c88a02b31f12bee833aabe45d08ba18c13a076fa9f9d6d540144db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ea3c2ce3e4d3a2b838650d598d0f4d595cdc0b7ff70a907f4c5e56a0429d2718fafa3f947c438d7513ecbb39f5ada7c1302f716cab56e936aff625f98242b056"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar"
+    },
+    {
+      "group" : "org.graalvm.sdk",
+      "name" : "graal-sdk",
+      "version" : "22.3.0",
+      "description" : "GraalVM is an ecosystem for compiling and running applications written in multiple languages. GraalVM removes the isolation between programming languages and enables interoperability in a shared runtime.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "32a6e8ee74a54448614f0a9124378e15"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83179e3310a2ece87266923fede5ef7355c68c9a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "30de7b098642c64767d48a880abdd1f1ef149fc52c1a69f155acff6a8d406cd9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1da4dfd548a7594251a198153849e1fe469d68698aa171218471fee615844e3d7b4d1a4f0819b4174903bac563e5e47f19af8fea7be12a48dc7e840c9fd2c735"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ba6185c7900bdb54024719dea935b760bbf98f37fc3cd347a9710dd1572497e7a7525fdaf27735fc8b35460c1bb72a40"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f7c634229f5fc0cb3a1bb80e9d3cda6013ba325038e0ff7645ea34ee2002b77d06f36f161e72e3451b026e10371e6d5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "82f3703bf09c9ac8aefb3f9d701ecbacb18bda4634d88c3c76ee369d23d6e769"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "39d349db44246937b068f5e38b2568a34c9c2d403d2f72371409b16953419874de5a5f4673e262cdace80f5ef3291b0d2df3a98b45ef56b2146a4f15a850d018"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "UPL-1.0",
+            "url" : "https://opensource.org/licenses/UPL"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/graal"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.wildfly.common",
+      "name" : "wildfly-common",
+      "version" : "1.5.4.Final-format-001",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8cf2730c4d707939cbe16a1b7e846aa3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d600b29d51306b30b29e7de64f6fedf61beb1808"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9884f791f815d0fed8c51771af71164afd48f96e621f26009f9ebe791c053f1b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0b25be38b95b346fcbbe0d6508ee4ed2f50931491ffe3cbde32bddae0bd8893d14c2e59ad86915802cb67f6762965c0d6f5dbd5a84ae4941283964f5ad2cb5d9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b5077edeaa28c52af348ac2c4da05b39f3e8537c576f8a8981f13bea4ca5aaaeff696d5468db0a0636ac5c6a39d55a6b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "453c01d7083395d91d5526a33f9db17ea1e49089867683bea048dd69a198234813b5d84b52b8f6a2aa84a64b0137af92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "071eabd604f4fa0ca944682d3e4cf6f80d321db4da1631db480d76eb2113bd7a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0332241277ee28a491a9fa04882e5277cc6f0d938e172876153b891ab1540c6e2d4514a3dcd9264b56e4a7f38e9f7b8bb49bbc8f6f6e9182be097ee67305aeef"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-bootstrap-runner",
+      "version" : "2.13.4.Final",
+      "description" : "The entry point for production applications using the custom ClassLoader. This contains the production ClassLoader code and must not have any non parent first dependencies.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eb7ce5dda7e02315f7366be7ec06e796"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ffc4f84746593dcbab6d2e55c6d525389a49a5f6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9c72cda021c6ca1138584d1e3c0720e5a6c68eb7aab3f4dbbdb552f0ebc8c5b1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "54e41c30223cad7e612ac055c35e3c1373d7e517f59f93b249abdaa558b99593a7ffc99c620c9ec003d8046706a2342b4c15cbd9b0efbe98e282774cd11bd6ed"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "99f6fee7c650417e53922b702a3a0bfa91c87c0102dd91b233dfd501f24b8f7874a1098af2e64c700c6a7d12fb0d448f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "eb44a8df03c830ed3f50495be14dfb41dfddc6acb6600d709fd0ab13a2c139ccaffa637c11547e076cfeb07a7f73c336"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5bf0ffc53d6f76786a000e201867a7bda974bd678218e34c9b96ad223a382a14"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d1d879fa1410f9a0455c5941853d527a4e9bfe2ff8c9d075a92beb88f47be0dcdd354fbd859ab153933c233cb557ea5a2aacb598a0729a55786fa6c0d6a2dd59"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-fs-util",
+      "version" : "0.0.9",
+      "description" : "Quarkus Filesystem Utils",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c69d9010050e0c96967794a5a58280bb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "af43a8b4da2a2c9119e5280929887445847597a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ea0a3a3b46ba0d60eee318691f6d9dda4d0cd47d208512b90d83a62d4ecdca36"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49b837b883291252137a9924b29959603fd0bc3d13f67055582e846e7a6a15d14800680ddb623fe9dc8be1b69d0ec076bf5bf8088b6308d203d25965831889f2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "34b134e5e721201f568c6d842d18e3caf19ada6327aaa12ca941122d0063e564abddc8e6eb0864238b1d690dc574e24b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "09162230f0c5bff32064a7653ec884f2eccc10147f76fa9a7ccba632fcdc4f40de902ae26381cafbb2e095a8c1bf42c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1a220fca11fe4b311acb2af2fa4b19158d7663820cff46201ee6a95983c77865"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "abbf3315c28e4cf9be4be67dcdbe1cfc8759fbd2fb57bae17e0ff5f94af9c60d5ad27929d868b586f3c0d224cdc030b8a143992955f8a2e988b854b9daac5936"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkusfs-util/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus-fs-util"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+        "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+        "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2?type=jar",
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-netty@2.13.4.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-netty@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@2.13.4.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.8.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.8.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.8.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.8.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.4.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web-common@4.3.4?type=jar",
+        "pkg:maven/io.vertx/vertx-auth-common@4.3.4?type=jar",
+        "pkg:maven/io.vertx/vertx-bridge-common@4.3.4?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-web-common@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-auth-common@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-handler-proxy@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-socks@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-resolver-dns@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-dns@4.1.82.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.82.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.82.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+        "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-credentials@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0?type=jar",
+        "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar",
+        "pkg:maven/io.github.crac/org-crac@0.1.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@1.7.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus.arc/arc@2.13.4.Final?type=jar",
+        "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web-common@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-auth-common@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-bridge-common@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-uri-template@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.github.crac/org-crac@0.1.1?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/internal/testing/processor/testdata/small-deps-cyclonedx.json
+++ b/internal/testing/processor/testdata/small-deps-cyclonedx.json
@@ -87,10 +87,6 @@
       "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
       "hashes" : [
         {
-          "alg" : "MD5",
-          "content" : "6f90b36811373730365a282abb2b7bd7"
-        },
-        {
           "alg" : "SHA3-512",
           "content" : "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
         }
@@ -105,200 +101,12 @@
       "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
       "externalReferences" : [
         {
-          "type" : "distribution",
-          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-        },
-        {
           "type" : "mailing-list",
           "url" : "http://lists.jboss.org/pipermail/jboss-user/"
         }
       ],
       "type" : "library",
       "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
-    },
-    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus.resteasy.reactive",
-      "name" : "resteasy-reactive-common",
-      "version" : "2.13.4.Final",
-      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "7ed7855f54e03730a236810abccc8358"
-        },
-        {
-          "alg" : "SHA3-512",
-          "content" : "03633e91e20d228bbdc4c70927e203fd600ae6c2feee599c06418b7bb78ff3257f7cbda8ab0cf17e97f2050f0dc882f010ce08c6ddfa139898d2de34c1bfd502"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "distribution",
-          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar"
-    },
-    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus.resteasy.reactive",
-      "name" : "resteasy-reactive-vertx",
-      "version" : "2.13.4.Final",
-      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "8fd53cdf4d70ebe9b22799c03329be3c"
-        },
-        {
-          "alg" : "SHA3-512",
-          "content" : "a78c43cd3b10af88f20df245ff198851420518692a1dc34e7174593d871fd622c40e79514796670e5175f90af0552db158ab71035551cb171ee4be0ed4d18ecb"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "distribution",
-          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar"
-    },    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus",
-      "name" : "quarkus-vertx-http",
-      "version" : "2.13.4.Final",
-      "description" : "Vert.x HTTP",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "976f811a7d3d21845ca73fab176ee49d"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "distribution",
-          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar"
-    },    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus",
-      "name" : "quarkus-jsonp",
-      "version" : "2.13.4.Final",
-      "description" : "JSON Processing support",
-      "hashes" : [
-        {
-          "alg" : "SHA3-256",
-          "content" : "4b40e8c0726cfeead389f7100d92f0738171e028a725c488a8027f76ffaaf381"
-        },
-        {
-          "alg" : "SHA3-512",
-          "content" : "c16d4175e8439da4d11c275adca8082068dcd417572a89f42ba1f654d52d0a53f7f0bdda57f01d3bfe6b44904c7bac1d9eddc509c0844cd0116a1412f0ebecd7"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "mailing-list",
-          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
-    },
-    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus",
-      "name" : "quarkus-mutiny",
-      "version" : "2.13.4.Final",
-      "description" : "Write reactive applications with the modern Reactive Programming library Mutiny",
-      "hashes" : [
-        {
-          "alg" : "SHA3-512",
-          "content" : "2814a3fa20350ac752a0b028aaf2895b16c11d26a166b12b939d3de2a3d608a638839d261ee66bc7e8eddaabc0d5a5341962a4dbe5f49d4dff77719f5ecaa68b"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "mailing-list",
-          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar"
-    },
-    {
-      "publisher" : "JBoss by Red Hat",
-      "group" : "io.quarkus",
-      "name" : "quarkus-vertx",
-      "version" : "2.13.4.Final",
-      "description" : "Write reactive applications with the Vert.x API",
-      "hashes" : [
-        {
-          "alg" : "SHA3-512",
-          "content" : "93f8f7cd1ef95675f6f59e8987c42a2884774d304d66f8512ba6f18c099ee9a43f3ef99580f103043a571cecf0c7617f3e1d7b63defe6c3e66d29179e12d50bf"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "mailing-list",
-          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar"
     }
   ],
   "dependencies" : [
@@ -311,19 +119,7 @@
     {
       "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
       "dependsOn" : [
-        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
-      ]
-    },
-    {
-      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
-      "dependsOn" : [
-        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
-        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
       ]
     }
   ]

--- a/internal/testing/processor/testdata/small-deps-cyclonedx.json
+++ b/internal/testing/processor/testdata/small-deps-cyclonedx.json
@@ -1,0 +1,330 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-11-09T11:14:31Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.7.1",
+        "hashes" : [
+          {
+            "alg" : "SHA3-512",
+            "content" : "72ea0ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.acme",
+      "name" : "getting-started",
+      "version" : "1.0.0-SNAPSHOT",
+      "licenses" : [ ],
+      "purl" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar"
+    }
+  },
+  "components" : [
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive",
+      "version" : "2.13.4.Final",
+      "description" : "A JAX-RS implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf39044af8c6ba66fc3beb034bc82ae8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6f90b36811373730365a282abb2b7bd7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7ed7855f54e03730a236810abccc8358"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "03633e91e20d228bbdc4c70927e203fd600ae6c2feee599c06418b7bb78ff3257f7cbda8ab0cf17e97f2050f0dc882f010ce08c6ddfa139898d2de34c1bfd502"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-vertx",
+      "version" : "2.13.4.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8fd53cdf4d70ebe9b22799c03329be3c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a78c43cd3b10af88f20df245ff198851420518692a1dc34e7174593d871fd622c40e79514796670e5175f90af0552db158ab71035551cb171ee4be0ed4d18ecb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar"
+    },    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-http",
+      "version" : "2.13.4.Final",
+      "description" : "Vert.x HTTP",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "976f811a7d3d21845ca73fab176ee49d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar"
+    },    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-jsonp",
+      "version" : "2.13.4.Final",
+      "description" : "JSON Processing support",
+      "hashes" : [
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b40e8c0726cfeead389f7100d92f0738171e028a725c488a8027f76ffaaf381"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c16d4175e8439da4d11c275adca8082068dcd417572a89f42ba1f654d52d0a53f7f0bdda57f01d3bfe6b44904c7bac1d9eddc509c0844cd0116a1412f0ebecd7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-mutiny",
+      "version" : "2.13.4.Final",
+      "description" : "Write reactive applications with the modern Reactive Programming library Mutiny",
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "2814a3fa20350ac752a0b028aaf2895b16c11d26a166b12b939d3de2a3d608a638839d261ee66bc7e8eddaabc0d5a5341962a4dbe5f49d4dff77719f5ecaa68b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx",
+      "version" : "2.13.4.Final",
+      "description" : "Write reactive applications with the Vert.x API",
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "93f8f7cd1ef95675f6f59e8987c42a2884774d304d66f8512ba6f18c099ee9a43f3ef99580f103043a571cecf0c7617f3e1d7b63defe6c3e66d29179e12d50bf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.4.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.4.Final?type=jar"
+      ]
+    }
+  ]
+}

--- a/pkg/handler/processor/cyclonedx/cyclonedx_test.go
+++ b/pkg/handler/processor/cyclonedx/cyclonedx_test.go
@@ -90,6 +90,15 @@ func TestCycloneDXProcessor_ValidateSchema(t *testing.T) {
 		},
 		expectErr: false,
 	}, {
+		name: "valid CycloneDX quarkus document with package dependencies",
+		doc: processor.Document{
+			Blob:              testdata.CycloneDXExampleQuarkusDeps,
+			Format:            processor.FormatJSON,
+			Type:              processor.DocumentCycloneDX,
+			SourceInformation: processor.SourceInformation{},
+		},
+		expectErr: false,
+	}, {
 		name: "invalid CycloneDX document",
 		doc: processor.Document{
 			Blob:              testdata.CycloneDXInvalidExample,

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -137,11 +137,13 @@ func (c *cyclonedxParser) addPackages(cdxBom *cdx.BOM) {
 		pkgMap[comp.BOMRef] = &parentPkg
 	}
 
-	for _, deps := range *cdxBom.Dependencies {
-		if topPkg, found := pkgMap[deps.Ref]; found {
-			for _, depPkg := range *deps.Dependencies {
-				if depPkg, exist := pkgMap[depPkg]; exist {
-					topPkg.depPackages = append(topPkg.depPackages, depPkg)
+	if cdxBom.Dependencies != nil {
+		for _, deps := range *cdxBom.Dependencies {
+			if topPkg, found := pkgMap[deps.Ref]; found {
+				for _, depPkg := range *deps.Dependencies {
+					if depPkg, exist := pkgMap[depPkg]; exist {
+						topPkg.depPackages = append(topPkg.depPackages, depPkg)
+					}
 				}
 			}
 		}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -48,7 +48,22 @@ func Test_cyclonedxParser(t *testing.T) {
 		wantNodes: testdata.CycloneDXNodes,
 		wantEdges: testdata.CyloneDXEdges,
 		wantErr:   false,
-	}}
+	}, {
+		name: "valid small CycloneDX document with package dependencies",
+		doc: &processor.Document{
+			Blob:   processor_data.CycloneDXExampleSmallDeps,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+			SourceInformation: processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		},
+		wantNodes: testdata.CycloneDXQuarkusNodes,
+		wantEdges: testdata.CyloneDXQuarkusEdges,
+		wantErr:   false,
+	},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewCycloneDXParser()


### PR DESCRIPTION
Fixes Bug #206 

If CDX Document has dependencies section, it now parses those and adds to the graph accordingly.

Sample graph for bom from : https://github.com/guacsec/guac/issues/206#issuecomment-1309327095
![Screenshot (4)](https://user-images.githubusercontent.com/8685412/201677982-8cbefebc-be2d-4f1f-9f9b-921e331a78e9.png)

While running guac for this bom, it took about 35 seconds, which I found little slow. But, most of this time was spent in DB transactions https://github.com/guacsec/guac/blob/main/pkg/assembler/graphdb.go#L77-L89
