### PR TITLE
remove all logrus calls. Add ctx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf
 	github.com/neo4j/neo4j-go-driver/v4 v4.4.4
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
-	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	go.uber.org/zap v1.23.0
 	google.golang.org/api v0.103.0
@@ -88,6 +87,7 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa // indirect
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/theupdateframework/go-tuf v0.5.2-0.20220930112810-3890c1e7ace4 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect

--- a/internal/testing/ingestor/testdata/testdata.go
+++ b/internal/testing/ingestor/testdata/testdata.go
@@ -16,6 +16,7 @@
 package testdata
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"reflect"
@@ -438,7 +439,7 @@ func NewMockSigstoreVerifier() *mockSigstoreVerifier {
 	return &mockSigstoreVerifier{}
 }
 
-func (m *mockSigstoreVerifier) Verify(payloadBytes []byte) ([]verifier.Identity, error) {
+func (m *mockSigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]verifier.Identity, error) {
 
 	keyHash, _ := dsse.SHA256KeyID(ecdsaPubKey)
 	return []verifier.Identity{

--- a/pkg/handler/collector/gcs/gcs.go
+++ b/pkg/handler/collector/gcs/gcs.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/sirupsen/logrus"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 type gcs struct {
@@ -142,6 +142,7 @@ func (g *gcs) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processo
 }
 
 func (g *gcs) getArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
 	it, err := g.reader.getIterator(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get reader for object for bucket: %s, error: %w", g.bucket, err)
@@ -158,13 +159,13 @@ func (g *gcs) getArtifacts(ctx context.Context, docChannel chan<- *processor.Doc
 		if g.lastDownload.IsZero() {
 			payload, err = g.getObject(ctx, attrs.Name)
 			if err != nil {
-				logrus.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
+				logger.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
 				continue
 			}
 		} else if attrs.Updated.After(g.lastDownload) {
 			payload, err = g.getObject(ctx, attrs.Name)
 			if err != nil {
-				logrus.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
+				logger.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
 				continue
 			}
 		}

--- a/pkg/ingestor/key/inmemory/inmemory.go
+++ b/pkg/ingestor/key/inmemory/inmemory.go
@@ -16,36 +16,40 @@
 package inmemory
 
 import (
+	"context"
+
 	"github.com/guacsec/guac/pkg/ingestor/key"
-	"github.com/sirupsen/logrus"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 type inmemory struct {
-	collector map[string]key.Key
+	collector map[string]*key.Key
 }
 
 func newInmemoryProvider() *inmemory {
 	return &inmemory{
-		collector: map[string]key.Key{},
+		collector: map[string]*key.Key{},
 	}
 }
 
-func (m *inmemory) RetrieveKey(id string) (*key.Key, error) {
+func (m *inmemory) RetrieveKey(ctx context.Context, id string) (*key.Key, error) {
 	if key, ok := m.collector[id]; ok {
-		return &key, nil
+		return key, nil
 	}
 	return nil, nil
 }
 
-func (m *inmemory) StoreKey(id string, pk *key.Key) error {
-	m.collector[id] = *pk
-	logrus.Warnf("key is being overwritten: %s", id)
+func (m *inmemory) StoreKey(ctx context.Context, id string, pk *key.Key) error {
+	logger := logging.FromContext(ctx)
+	m.collector[id] = pk
+	logger.Warnf("key is being overwritten: %s", id)
 	return nil
 }
 
-func (m *inmemory) DeleteKey(id string) error {
+func (m *inmemory) DeleteKey(ctx context.Context, id string) error {
+	logger := logging.FromContext(ctx)
 	delete(m.collector, id)
-	logrus.Warnf("key is being deleted: %s", id)
+	logger.Warnf("key is being deleted: %s", id)
 	return nil
 }
 

--- a/pkg/ingestor/key/inmemory/inmemory_test.go
+++ b/pkg/ingestor/key/inmemory/inmemory_test.go
@@ -16,20 +16,23 @@
 package inmemory
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/guacsec/guac/internal/testing/ingestor/keyutil"
 	"github.com/guacsec/guac/pkg/ingestor/key"
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 func Test_inmemory_RetrieveKey(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
 	provider, pubKey := setupProvider(t)
-	provider.collector["ecdsa"] = *pubKey[0]
-	provider.collector["rsa"] = *pubKey[1]
-	provider.collector["ed25519"] = *pubKey[2]
+	provider.collector["ecdsa"] = pubKey[0]
+	provider.collector["rsa"] = pubKey[1]
+	provider.collector["ed25519"] = pubKey[2]
 	tests := []struct {
 		name    string
 		id      string
@@ -58,7 +61,7 @@ func Test_inmemory_RetrieveKey(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := provider.RetrieveKey(tt.id)
+			got, err := provider.RetrieveKey(ctx, tt.id)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("inmemory.RetrieveKey() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -74,6 +77,7 @@ func Test_inmemory_RetrieveKey(t *testing.T) {
 }
 
 func Test_inmemory_StoreKey(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
 	provider, pubKey := setupProvider(t)
 	type args struct {
 		id string
@@ -111,12 +115,12 @@ func Test_inmemory_StoreKey(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := provider.StoreKey(tt.args.id, tt.args.pk)
+			err := provider.StoreKey(ctx, tt.args.id, tt.args.pk)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("inmemory.StoreKey() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err == nil {
-				got, _ := provider.RetrieveKey(tt.args.id)
+				got, _ := provider.RetrieveKey(ctx, tt.args.id)
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("inmemory.RetrieveKey() = %v, expected %v", got, tt.want)
 				}
@@ -126,10 +130,11 @@ func Test_inmemory_StoreKey(t *testing.T) {
 }
 
 func Test_inmemory_DeleteKey(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
 	provider, pubKey := setupProvider(t)
-	provider.collector["ecdsa"] = *pubKey[0]
-	provider.collector["rsa"] = *pubKey[1]
-	provider.collector["ed25519"] = *pubKey[2]
+	provider.collector["ecdsa"] = pubKey[0]
+	provider.collector["rsa"] = pubKey[1]
+	provider.collector["ed25519"] = pubKey[2]
 	tests := []struct {
 		name    string
 		id      string
@@ -149,7 +154,7 @@ func Test_inmemory_DeleteKey(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := provider.DeleteKey(tt.id)
+			err := provider.DeleteKey(ctx, tt.id)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("inmemory.DeleteKey() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -42,15 +42,15 @@ func NewDSSEParser() common.DocumentParser {
 // Parse breaks out the document into the graph components
 func (d *dsseParser) Parse(ctx context.Context, doc *processor.Document) error {
 	d.doc = doc
-	err := d.getIdentity()
+	err := d.getIdentity(ctx)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *dsseParser) getIdentity() error {
-	identities, err := verifier.VerifyIdentity(d.doc)
+func (d *dsseParser) getIdentity(ctx context.Context) error {
+	identities, err := verifier.VerifyIdentity(ctx, d.doc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
@@ -17,6 +17,7 @@ package sigstore_verifier
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"encoding/json"
 	"fmt"
@@ -38,14 +39,14 @@ func NewSigstoreVerifier() *sigstoreVerifier {
 
 // Verify validates that the signature is valid for the payload
 // TODO: this currently only supports SHA256 hash function when validating signatures
-func (d *sigstoreVerifier) Verify(payloadBytes []byte) ([]verifier.Identity, error) {
+func (d *sigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]verifier.Identity, error) {
 	identities := []verifier.Identity{}
 	envelope, err := parseDSSE(payloadBytes)
 	if err != nil {
 		return nil, err
 	}
 	for _, signature := range envelope.Signatures {
-		key, err := key.Find(signature.KeyID)
+		key, err := key.Find(ctx, signature.KeyID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ingestor/verifier/verifier.go
+++ b/pkg/ingestor/verifier/verifier.go
@@ -16,6 +16,7 @@
 package verifier
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/guacsec/guac/pkg/handler/processor"
@@ -36,7 +37,7 @@ type Verifier interface {
 	// about the unverified identity. Upstream caller is expected to know
 	// which verifier it needs to based on what type of enveloper or
 	// signature is being verified.
-	Verify(payloadBytes []byte) ([]Identity, error)
+	Verify(ctx context.Context, payloadBytes []byte) ([]Identity, error)
 	// Type returns the verifier type
 	Type() VerifierType
 }
@@ -66,11 +67,11 @@ func RegisterVerifier(k Verifier, providerType VerifierType) error {
 }
 
 // VerifyIdentity goes through the registered providers and verifies the signatures in the payload
-func VerifyIdentity(doc *processor.Document) ([]Identity, error) {
+func VerifyIdentity(ctx context.Context, doc *processor.Document) ([]Identity, error) {
 	switch doc.Type {
 	case processor.DocumentDSSE:
 		if verifier, ok := verifierProviders["sigstore"]; ok {
-			return verifier.Verify(doc.Blob)
+			return verifier.Verify(ctx, doc.Blob)
 		}
 	}
 	return nil, fmt.Errorf("failed verification for document type: %s", doc.Type)

--- a/pkg/ingestor/verifier/verifier_test.go
+++ b/pkg/ingestor/verifier/verifier_test.go
@@ -16,6 +16,7 @@
 package verifier
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"reflect"
@@ -25,6 +26,7 @@ import (
 	"github.com/guacsec/guac/internal/testing/ingestor/keyutil"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/key"
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
@@ -98,7 +100,7 @@ func newMockSigstoreVerifier() *mockSigstoreVerifier {
 	return &mockSigstoreVerifier{}
 }
 
-func (m *mockSigstoreVerifier) Verify(payloadBytes []byte) ([]Identity, error) {
+func (m *mockSigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]Identity, error) {
 	keyHash, err := dsse.SHA256KeyID(ecdsaPubKey)
 	if err != nil {
 		return nil, err
@@ -122,6 +124,7 @@ func (m *mockSigstoreVerifier) Type() VerifierType {
 }
 
 func TestVerifyIdentity(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
 	err := RegisterVerifier(newMockSigstoreVerifier(), "sigstore")
 	if err != nil {
 		t.Errorf("RegisterVerifier() failed with error: %v", err)
@@ -166,7 +169,7 @@ func TestVerifyIdentity(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := VerifyIdentity(tt.doc)
+			got, err := VerifyIdentity(ctx, tt.doc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("VerifyIdentity() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Remove all traces of Logrus that is not being used. Also, pass context to get logger from context. 

Fixed unit test bug in key_test.go

Edit:

Fixes #232

Signed-off-by: pxp928 <parth.psu@gmail.com>