### PR TITLE
Fix package overwite cipher bug

### DIFF
--- a/pkg/assembler/helper.go
+++ b/pkg/assembler/helper.go
@@ -43,7 +43,7 @@ func (o *objectMetadata) addProperties(prop map[string]interface{}) {
 		prop["source"] = o.sourceInfo
 	}
 	if len(o.collectorInfo) > 0 {
-		prop["collector"] = o.sourceInfo
+		prop["collector"] = o.collectorInfo
 	}
 }
 

--- a/pkg/assembler/helper.go
+++ b/pkg/assembler/helper.go
@@ -39,8 +39,12 @@ func NewObjectMetadata(s processor.SourceInformation) *objectMetadata {
 }
 
 func (o *objectMetadata) addProperties(prop map[string]interface{}) {
-	prop["source"] = o.sourceInfo
-	prop["collector"] = o.sourceInfo
+	if len(o.sourceInfo) > 0 {
+		prop["source"] = o.sourceInfo
+	}
+	if len(o.collectorInfo) > 0 {
+		prop["collector"] = o.sourceInfo
+	}
 }
 
 func (o *objectMetadata) getProperties() []string {

--- a/pkg/assembler/nodes.go
+++ b/pkg/assembler/nodes.go
@@ -66,12 +66,24 @@ func (pn PackageNode) Type() string {
 
 func (pn PackageNode) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
-	properties["name"] = pn.Name
-	properties["purl"] = pn.Purl
-	properties["version"] = pn.Version
-	properties["cpes"] = pn.CPEs
-	properties["digest"] = toLower(pn.Digest...)
-	properties["tags"] = pn.Tags
+	if len(pn.Name) > 0 {
+		properties["name"] = pn.Name
+	}
+	if len(pn.Purl) > 0 {
+		properties["purl"] = pn.Purl
+	}
+	if len(pn.Version) > 0 {
+		properties["version"] = pn.Version
+	}
+	if len(pn.CPEs) > 0 {
+		properties["cpes"] = pn.CPEs
+	}
+	if len(pn.Digest) > 0 {
+		properties["digest"] = toLower(pn.Digest...)
+	}
+	if len(pn.Tags) > 0 {
+		properties["tags"] = pn.Tags
+	}
 	pn.NodeData.addProperties(properties)
 	return properties
 }


### PR DESCRIPTION
When running a separate ingestion step that only gives a purl for a package, the previous node in the DB would get overriden with empy fields for all other properties.

This PR attempts a workaround while I'm working on a better solution that automates all this boilerplate.