### PR TITLE
Fix: Bug #236 

### DIFF
--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -119,22 +119,27 @@ func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 
 func (c *cyclonedxParser) addPackages(cdxBom *cdx.BOM) {
 	for _, comp := range *cdxBom.Components {
-		curPkg := assembler.PackageNode{
-			Name: comp.Name,
-			// Digest: []string{comp.Version},
-			Purl:     comp.PackageURL,
-			Version:  comp.Version,
-			NodeData: *assembler.NewObjectMetadata(c.doc.SourceInformation),
+		// skipping over the "operating-system" type as it does not contain
+		// the required purl for package node. Currently there is no use-case
+		// to capture OS for GUAC.
+		if comp.Type != cdx.ComponentTypeOS {
+			curPkg := assembler.PackageNode{
+				Name: comp.Name,
+				// Digest: []string{comp.Version},
+				Purl:     comp.PackageURL,
+				Version:  comp.Version,
+				NodeData: *assembler.NewObjectMetadata(c.doc.SourceInformation),
+			}
+			if comp.CPE != "" {
+				curPkg.CPEs = []string{comp.CPE}
+			}
+			parentPkg := component{
+				curPackage:  curPkg,
+				depPackages: []*component{},
+			}
+			c.rootComponent.depPackages = append(c.rootComponent.depPackages, &parentPkg)
+			c.pkgMap[comp.BOMRef] = &parentPkg
 		}
-		if comp.CPE != "" {
-			curPkg.CPEs = []string{comp.CPE}
-		}
-		parentPkg := component{
-			curPackage:  curPkg,
-			depPackages: []*component{},
-		}
-		c.rootComponent.depPackages = append(c.rootComponent.depPackages, &parentPkg)
-		c.pkgMap[comp.BOMRef] = &parentPkg
 	}
 
 	if cdxBom.Dependencies == nil {


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

With the introduction to check if the package node does not input empty parameters, a bug was discovered where the last component in CDX sbom was of type `operating-system` that did not have a purl. Being the `purl` is an `IdentifiablePropertyName`, this caused the assembler to fail. Currently, we do not have a use-case to capture the operating system thus, it will be ignored for now.

Fixes #236 