### PR TITLE
added marshal and unmarshal for guac nodes and edge interfaces (NATS PR: 2 of 4)

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -202,11 +202,11 @@ var (
 	keyHash, _               = dsse.SHA256KeyID(EcdsaPubKey)
 
 	Ident = assembler.IdentityNode{
-		ID:        "test",
-		Digest:    keyHash,
-		Key:       base64.StdEncoding.EncodeToString(pemBytes),
-		KeyType:   "ecdsa",
-		KeyScheme: "ecdsa",
+		IdentityID: "test",
+		Digest:     keyHash,
+		Key:        base64.StdEncoding.EncodeToString(pemBytes),
+		KeyType:    "ecdsa",
+		KeyScheme:  "ecdsa",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -581,14 +581,14 @@ func GuacNodeSliceEqual(slice1, slice2 []assembler.GuacNode) bool {
 					}
 				}
 			} else if node1.Type() == "Identity" && node2.Type() == "Identity" {
-				if node1.(assembler.IdentityNode).ID == node2.(assembler.IdentityNode).ID {
+				if node1.(assembler.IdentityNode).IdentityID == node2.(assembler.IdentityNode).IdentityID {
 					if reflect.DeepEqual(node1, node2) {
 						e = true
 						break
 					}
 				}
 			} else if node1.Type() == "Vulnerability" && node2.Type() == "Vulnerability" {
-				if node1.(assembler.VulnerabilityNode).ID == node2.(assembler.VulnerabilityNode).ID {
+				if node1.(assembler.VulnerabilityNode).VulnerabilityID == node2.(assembler.VulnerabilityNode).VulnerabilityID {
 					if reflect.DeepEqual(node1, node2) {
 						e = true
 						break

--- a/pkg/assembler/helper.go
+++ b/pkg/assembler/helper.go
@@ -24,26 +24,26 @@ import (
 
 // objectMetadata appends metadata associated with the node
 type objectMetadata struct {
-	// sourceInfo is the file location from which the node was created
-	sourceInfo string
-	// collectorInfo is the collector from which the file that created the node came from
-	collectorInfo string
+	// Source is the file location from which the node was created
+	Source string
+	// Collector is the collector from which the file that created the node came from
+	Collector string
 }
 
 // NewObjectMetadata creates a new instance to add metadata to nodes
 func NewObjectMetadata(s processor.SourceInformation) *objectMetadata {
 	return &objectMetadata{
-		sourceInfo:    s.Source,
-		collectorInfo: s.Collector,
+		Source:    s.Source,
+		Collector: s.Collector,
 	}
 }
 
 func (o *objectMetadata) addProperties(prop map[string]interface{}) {
-	if len(o.sourceInfo) > 0 {
-		prop["source"] = o.sourceInfo
+	if len(o.Source) > 0 {
+		prop["source"] = o.Source
 	}
-	if len(o.collectorInfo) > 0 {
-		prop["collector"] = o.collectorInfo
+	if len(o.Collector) > 0 {
+		prop["collector"] = o.Collector
 	}
 }
 

--- a/pkg/assembler/nodes.go
+++ b/pkg/assembler/nodes.go
@@ -15,18 +15,52 @@
 
 package assembler
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	ArtifactNodeType       string = "Artifact"
+	PackageNodeType        string = "Package"
+	IdentityNodeType       string = "Identity"
+	AttestationNodeType    string = "Attestation"
+	BuilderNodeType        string = "Builder"
+	MetadataNodeType       string = "Metadata"
+	VulnerabilityNodeType  string = "Vulnerability"
+	IdentityForEdgeType    string = "Identity"
+	AttestationForEdgeType string = "Attestation"
+	BuiltByEdgeType        string = "BuiltBy"
+	DependsOnEdgeType      string = "DependsOn"
+	ContainsEdgeType       string = "Contains"
+	MetadataForEdgeType    string = "MetadataFor"
+	VulnerableEdgeType     string = "Vulnerable"
+)
 
 // ArtifactNode is a node that represents an artifact
 type ArtifactNode struct {
-	Name     string
-	Digest   string
-	Tags     []string
-	NodeData objectMetadata
+	Name     string         `json:"name"`
+	Digest   string         `json:"digest"`
+	Tags     []string       `json:"tags"`
+	NodeData objectMetadata `json:"nodedata"`
+}
+
+func (an ArtifactNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range an.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = an.Type()
+	marshalProperties["nodedata"] = an.NodeData
+
+	return json.Marshal(marshalProperties)
 }
 
 func (an ArtifactNode) Type() string {
-	return "Artifact"
+	return ArtifactNodeType
 }
 
 func (an ArtifactNode) Properties() map[string]interface{} {
@@ -51,17 +85,30 @@ func (an ArtifactNode) IdentifiablePropertyNames() []string {
 
 // PackageNode is a node that represents an artifact
 type PackageNode struct {
-	Name     string
-	Digest   []string
-	Version  string
-	Purl     string
-	CPEs     []string
-	Tags     []string
-	NodeData objectMetadata
+	Name     string         `json:"name"`
+	Digest   []string       `json:"digest"`
+	Version  string         `json:"version"`
+	Purl     string         `json:"purl"`
+	CPEs     []string       `json:"cpes"`
+	Tags     []string       `json:"tags"`
+	NodeData objectMetadata `json:"nodedata"`
+}
+
+func (pn PackageNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range pn.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = pn.Type()
+	marshalProperties["nodedata"] = pn.NodeData
+
+	return json.Marshal(marshalProperties)
 }
 
 func (pn PackageNode) Type() string {
-	return "Package"
+	return PackageNodeType
 }
 
 func (pn PackageNode) Properties() map[string]interface{} {
@@ -100,32 +147,44 @@ func (pn PackageNode) IdentifiablePropertyNames() []string {
 
 // IdentityNode is a node that represents an identity
 type IdentityNode struct {
-	ID     string
-	Digest string
+	IdentityID string `json:"identity_id"`
+	Digest     string `json:"digest"`
 	// base64 encoded
-	Key       string
-	KeyType   string
-	KeyScheme string
-	NodeData  objectMetadata
+	Key       string         `json:"key"`
+	KeyType   string         `json:"key_type"`
+	KeyScheme string         `json:"key_scheme"`
+	NodeData  objectMetadata `json:"nodedata"`
+}
+
+func (in IdentityNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range in.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = in.Type()
+	marshalProperties["nodedata"] = in.NodeData
+	return json.Marshal(marshalProperties)
 }
 
 func (in IdentityNode) Type() string {
-	return "Identity"
+	return IdentityNodeType
 }
 
 func (in IdentityNode) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
-	properties["id"] = in.ID
+	properties["identity_id"] = in.IdentityID
 	properties["digest"] = strings.ToLower(in.Digest)
 	properties["key"] = in.Key
-	properties["keyType"] = in.KeyType
-	properties["keyScheme"] = in.KeyScheme
+	properties["key_type"] = in.KeyType
+	properties["key_scheme"] = in.KeyScheme
 	in.NodeData.addProperties(properties)
 	return properties
 }
 
 func (in IdentityNode) PropertyNames() []string {
-	fields := []string{"id", "digest", "key", "keyType", "keyScheme"}
+	fields := []string{"identity_id", "digest", "key", "key_type", "key_scheme"}
 	fields = append(fields, in.NodeData.getProperties()...)
 	return fields
 }
@@ -138,15 +197,28 @@ func (in IdentityNode) IdentifiablePropertyNames() []string {
 // AttestationNode is a node that represents an attestation
 type AttestationNode struct {
 	// TODO(mihaimaruseac): Unsure what fields to store here
-	FilePath        string
-	Digest          string
-	AttestationType string
-	Payload         map[string]interface{}
-	NodeData        objectMetadata
+	FilePath        string                 `json:"filepath"`
+	Digest          string                 `json:"digest"`
+	AttestationType string                 `json:"attestation_type"`
+	Payload         map[string]interface{} `json:"payload"`
+	NodeData        objectMetadata         `json:"nodedata"`
+}
+
+func (an AttestationNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range an.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = an.Type()
+	marshalProperties["nodedata"] = an.NodeData
+	marshalProperties["payload"] = an.Payload
+	return json.Marshal(marshalProperties)
 }
 
 func (an AttestationNode) Type() string {
-	return "Attestation"
+	return AttestationNodeType
 }
 
 func (an AttestationNode) Properties() map[string]interface{} {
@@ -177,107 +249,161 @@ func (an AttestationNode) IdentifiablePropertyNames() []string {
 
 // BuilderNode is a node that represents a builder for an artifact
 type BuilderNode struct {
-	BuilderType string
-	BuilderId   string
-	NodeData    objectMetadata
+	BuilderType string         `json:"builder_type"`
+	BuilderId   string         `json:"builder_id"`
+	NodeData    objectMetadata `json:"nodedata"`
+}
+
+func (bn BuilderNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range bn.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = bn.Type()
+	marshalProperties["nodedata"] = bn.NodeData
+	return json.Marshal(marshalProperties)
 }
 
 func (bn BuilderNode) Type() string {
-	return "Builder"
+	return BuilderNodeType
 }
 
 func (bn BuilderNode) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
-	properties["type"] = bn.BuilderType
-	properties["id"] = bn.BuilderId
+	properties["builder_type"] = bn.BuilderType
+	properties["builder_id"] = bn.BuilderId
 	bn.NodeData.addProperties(properties)
 	return properties
 }
 
 func (bn BuilderNode) PropertyNames() []string {
-	fields := []string{"type", "id"}
+	fields := []string{"builder_type", "builder_id"}
 	fields = append(fields, bn.NodeData.getProperties()...)
 	return fields
 }
 
 func (bn BuilderNode) IdentifiablePropertyNames() []string {
 	// A builder needs both type and id to be identified
-	return []string{"type", "id"}
+	return []string{"builder_type", "builder_id"}
 }
 
 // MetadataNode is a node that represents metadata about an artifact/package
 type MetadataNode struct {
-	MetadataType string
-	ID           string
-	Details      map[string]interface{}
+	MetadataType string                 `json:"metadata_type"`
+	MetadataID   string                 `json:"metadata_id"`
+	Details      map[string]interface{} `json:"details"`
+	NodeData     objectMetadata         `json:"nodedata"`
+}
+
+func (mn MetadataNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range mn.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = mn.Type()
+	marshalProperties["nodedata"] = mn.NodeData
+	marshalProperties["details"] = mn.Details
+	return json.Marshal(marshalProperties)
 }
 
 func (mn MetadataNode) Type() string {
-	return "Metadata"
+	return MetadataNodeType
 }
 
 func (mn MetadataNode) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
 	properties["metadata_type"] = mn.MetadataType
-	properties["id"] = mn.ID
+	properties["metadata_id"] = mn.MetadataID
 
 	for k, v := range mn.Details {
 		properties[k] = v
 	}
 
+	mn.NodeData.addProperties(properties)
 	return properties
 }
 
 func (mn MetadataNode) PropertyNames() []string {
-	fields := []string{"metadata_type", "id"}
+	fields := []string{"metadata_type", "metadata_id"}
 	for k := range mn.Details {
 		fields = append(fields, k)
 	}
-
+	fields = append(fields, mn.NodeData.getProperties()...)
 	return fields
 }
 
 func (mn MetadataNode) IdentifiablePropertyNames() []string {
-	return []string{"metadata_type", "id"}
+	return []string{"metadata_type", "metadata_id"}
 }
 
 // VulnerabilityNode is a node that represents a vulnerability associated with the certifier attestation
 type VulnerabilityNode struct {
-	ID       string
-	NodeData objectMetadata
+	VulnerabilityID string         `json:"vulnerability_id"`
+	NodeData        objectMetadata `json:"nodedata"`
+}
+
+func (vn VulnerabilityNode) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range vn.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["type"] = vn.Type()
+	marshalProperties["nodedata"] = vn.NodeData
+	return json.Marshal(marshalProperties)
 }
 
 func (vn VulnerabilityNode) Type() string {
-	return "Vulnerability"
+	return VulnerabilityNodeType
 }
 
 func (vn VulnerabilityNode) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
-	properties["id"] = vn.ID
+	properties["vulnerability_id"] = vn.VulnerabilityID
 	vn.NodeData.addProperties(properties)
 	return properties
 }
 
 func (vn VulnerabilityNode) PropertyNames() []string {
-	fields := []string{"id"}
+	fields := []string{"vulnerability_id"}
 	fields = append(fields, vn.NodeData.getProperties()...)
 	return fields
 }
 
 func (vn VulnerabilityNode) IdentifiablePropertyNames() []string {
 	// Based on the ID of the vulnerability, more information can be obtained but not stored in the graph DB
-	return []string{"id"}
+	return []string{"vulnerability_id"}
 }
 
 // IdentityForEdge is an edge that represents the fact that an
 // `IdentityNode` is an identity for an `AttestationNode`.
 type IdentityForEdge struct {
-	IdentityNode    IdentityNode
-	AttestationNode AttestationNode
+	IdentityNode    IdentityNode    `json:"identitynode"`
+	AttestationNode AttestationNode `json:"attestationnode"`
+}
+
+func (e IdentityForEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["identitynode"] = e.IdentityNode
+	marshalProperties["attestationnode"] = e.AttestationNode
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e IdentityForEdge) Type() string {
-	return "Identity"
+	return IdentityForEdgeType
 }
 
 func (e IdentityForEdge) Nodes() (v, u GuacNode) {
@@ -300,13 +426,29 @@ func (e IdentityForEdge) IdentifiablePropertyNames() []string {
 // `AttestationNode` is an attestation for an `ArtifactNode/PackageNode`.
 // Only one of each side of the edge should be defined.
 type AttestationForEdge struct {
-	AttestationNode AttestationNode
-	ForArtifact     ArtifactNode
-	ForPackage      PackageNode
+	AttestationNode AttestationNode `json:"attestationnode"`
+	ForArtifact     ArtifactNode    `json:"forartifact"`
+	ForPackage      PackageNode     `json:"forpackage"`
+}
+
+func (e AttestationForEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["attestationnode"] = e.AttestationNode
+	marshalProperties["forartifact"] = e.ForArtifact
+	marshalProperties["forpackage"] = e.ForPackage
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e AttestationForEdge) Type() string {
-	return "Attestation"
+	return AttestationForEdgeType
 }
 
 func (e AttestationForEdge) Nodes() (v, u GuacNode) {
@@ -340,12 +482,27 @@ func (e AttestationForEdge) IdentifiablePropertyNames() []string {
 // BuiltByEdge is an edge that represents the fact that an
 // `ArtifactNode` has been built by a `BuilderNode`
 type BuiltByEdge struct {
-	ArtifactNode ArtifactNode
-	BuilderNode  BuilderNode
+	ArtifactNode ArtifactNode `json:"artifactnode"`
+	BuilderNode  BuilderNode  `json:"buildernode"`
+}
+
+func (e BuiltByEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["artifactnode"] = e.ArtifactNode
+	marshalProperties["buildernode"] = e.BuilderNode
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e BuiltByEdge) Type() string {
-	return "BuiltBy"
+	return BuiltByEdgeType
 }
 
 func (e BuiltByEdge) Nodes() (v, u GuacNode) {
@@ -368,14 +525,31 @@ func (e BuiltByEdge) IdentifiablePropertyNames() []string {
 // `ArtifactNode/PackageNode` depends on another `ArtifactNode/PackageNode`
 // Only one of each side of the edge should be defined.
 type DependsOnEdge struct {
-	ArtifactNode       ArtifactNode
-	PackageNode        PackageNode
-	ArtifactDependency ArtifactNode
-	PackageDependency  PackageNode
+	ArtifactNode       ArtifactNode `json:"artifactnode"`
+	PackageNode        PackageNode  `json:"packagenode"`
+	ArtifactDependency ArtifactNode `json:"artifactdependency"`
+	PackageDependency  PackageNode  `json:"packagedependency"`
+}
+
+func (e DependsOnEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["artifactnode"] = e.ArtifactNode
+	marshalProperties["packagenode"] = e.PackageNode
+	marshalProperties["artifactdependency"] = e.ArtifactDependency
+	marshalProperties["packagedependency"] = e.PackageDependency
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e DependsOnEdge) Type() string {
-	return "DependsOn"
+	return DependsOnEdgeType
 }
 
 func (e DependsOnEdge) Nodes() (v, u GuacNode) {
@@ -419,12 +593,27 @@ func (e DependsOnEdge) IdentifiablePropertyNames() []string {
 // Contains is an edge that represents the fact that an
 // `PackageNode` contains a `ArtifactNode`
 type ContainsEdge struct {
-	PackageNode       PackageNode
-	ContainedArtifact ArtifactNode
+	PackageNode       PackageNode  `json:"packagenode"`
+	ContainedArtifact ArtifactNode `json:"containedartifact"`
+}
+
+func (e ContainsEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["packagenode"] = e.PackageNode
+	marshalProperties["containedartifact"] = e.ContainedArtifact
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e ContainsEdge) Type() string {
-	return "Contains"
+	return ContainsEdgeType
 }
 
 func (e ContainsEdge) Nodes() (v, u GuacNode) {
@@ -448,19 +637,36 @@ func (e ContainsEdge) IdentifiablePropertyNames() []string {
 // Only one of each side of the edge should be defined.
 type MetadataForEdge struct {
 	// From node
-	MetadataNode MetadataNode
+	MetadataNode MetadataNode `json:"metadatanode"`
 	// To node
-	ForArtifact ArtifactNode
-	ForPackage  PackageNode
+	ForArtifact ArtifactNode `json:"forartifact"`
+	ForPackage  PackageNode  `json:"forpackage"`
+}
+
+func (e MetadataForEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["metadatanode"] = e.MetadataNode
+	marshalProperties["forartifact"] = e.ForArtifact
+	marshalProperties["forpackage"] = e.ForPackage
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e MetadataForEdge) Type() string {
-	return "MetadataFor"
+	return MetadataForEdgeType
 }
 
 func (e MetadataForEdge) Nodes() (v, u GuacNode) {
 	uA, uP := isDefined(e.ForArtifact), isDefined(e.ForPackage)
 	if uA == uP {
+		fmt.Print("bad place reached")
 		panic("only one of package and artifact dependency node defined for DependsOn relationship")
 	}
 
@@ -490,12 +696,27 @@ func (e MetadataForEdge) IdentifiablePropertyNames() []string {
 // artifact is vulnerable or not based on certification attestation
 // This edge gets created when the attestation contains vulnerabilities
 type VulnerableEdge struct {
-	AttestationNode   AttestationNode
-	VulnerabilityNode VulnerabilityNode
+	AttestationNode   AttestationNode   `json:"attestationnode"`
+	VulnerabilityNode VulnerabilityNode `json:"vulnerabilitynode"`
+}
+
+func (e VulnerableEdge) MarshalJSON() ([]byte, error) {
+	marshalProperties := make(map[string]interface{})
+
+	for k, v := range e.Properties() {
+		marshalProperties[k] = v
+	}
+
+	marshalProperties["attestationnode"] = e.AttestationNode
+	marshalProperties["vulnerabilitynode"] = e.VulnerabilityNode
+
+	marshalProperties["type"] = e.Type()
+
+	return json.Marshal(marshalProperties)
 }
 
 func (e VulnerableEdge) Type() string {
-	return "Vulnerable"
+	return VulnerableEdgeType
 }
 
 func (e VulnerableEdge) Nodes() (v, u GuacNode) {

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -60,7 +60,7 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 			return fmt.Errorf("MarshalPublicKeyToPEM returned error: %v", err)
 		}
 		d.identities = append(d.identities, assembler.IdentityNode{
-			ID: i.ID, Digest: i.Key.Hash, Key: base64.StdEncoding.EncodeToString(pemBytes),
+			IdentityID: i.ID, Digest: i.Key.Hash, Key: base64.StdEncoding.EncodeToString(pemBytes),
 			KeyType: string(i.Key.Type), KeyScheme: string(i.Key.Scheme), NodeData: *assembler.NewObjectMetadata(d.doc.SourceInformation)})
 	}
 	return nil

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -100,7 +100,7 @@ func metadataId(s *sc.JSONScorecardResultV2) string {
 func getMetadataNode(s *sc.JSONScorecardResultV2) assembler.MetadataNode {
 	mnNode := assembler.MetadataNode{
 		MetadataType: "scorecard",
-		ID:           metadataId(s),
+		MetadataID:   metadataId(s),
 		Details:      map[string]interface{}{},
 	}
 

--- a/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
@@ -45,7 +45,7 @@ func Test_scorecardParser(t *testing.T) {
 		wantNodes: []assembler.GuacNode{
 			assembler.MetadataNode{
 				MetadataType: "scorecard",
-				ID:           "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
+				MetadataID:   "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
 				Details: map[string]interface{}{
 					"repo":                "git+https://github.com/kubernetes/kubernetes",
 					"commit":              "sha1:5835544ca568b757a8ecae5c153f317e5736700e",
@@ -72,7 +72,7 @@ func Test_scorecardParser(t *testing.T) {
 			assembler.MetadataForEdge{
 				MetadataNode: assembler.MetadataNode{
 					MetadataType: "scorecard",
-					ID:           "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
+					MetadataID:   "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
 					Details: map[string]interface{}{
 						"repo":                "git+https://github.com/kubernetes/kubernetes",
 						"commit":              "sha1:5835544ca568b757a8ecae5c153f317e5736700e",

--- a/pkg/ingestor/parser/vuln/cerify_vuln.go
+++ b/pkg/ingestor/parser/vuln/cerify_vuln.go
@@ -114,8 +114,8 @@ func (c *vulnCertificationParser) getAttestation(blob []byte, source string, sta
 func (c *vulnCertificationParser) getVulns(blob []byte, source string, statement *attestation_vuln.VulnerabilityStatement) {
 	for _, id := range statement.Predicate.Scanner.Result {
 		vulNode := assembler.VulnerabilityNode{
-			ID:       id.VulnerabilityId,
-			NodeData: *assembler.NewObjectMetadata(c.doc.SourceInformation),
+			VulnerabilityID: id.VulnerabilityId,
+			NodeData:        *assembler.NewObjectMetadata(c.doc.SourceInformation),
 		}
 		c.vulns = append(c.vulns, vulNode)
 	}

--- a/pkg/ingestor/parser/vuln/certify_vuln_test.go
+++ b/pkg/ingestor/parser/vuln/certify_vuln_test.go
@@ -77,7 +77,7 @@ var (
 	}
 
 	vulNode1 = assembler.VulnerabilityNode{
-		ID: "GHSA-7rjr-3q55-vv33",
+		VulnerabilityID: "GHSA-7rjr-3q55-vv33",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -86,7 +86,7 @@ var (
 		),
 	}
 	vulNode2 = assembler.VulnerabilityNode{
-		ID: "GHSA-8489-44mv-ggj8",
+		VulnerabilityID: "GHSA-8489-44mv-ggj8",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -95,7 +95,7 @@ var (
 		),
 	}
 	vulNode3 = assembler.VulnerabilityNode{
-		ID: "GHSA-fxph-q3j8-mv87",
+		VulnerabilityID: "GHSA-fxph-q3j8-mv87",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -104,7 +104,7 @@ var (
 		),
 	}
 	vulNode4 = assembler.VulnerabilityNode{
-		ID: "GHSA-jfh8-c2jp-5v3q",
+		VulnerabilityID: "GHSA-jfh8-c2jp-5v3q",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -113,7 +113,7 @@ var (
 		),
 	}
 	vulNode5 = assembler.VulnerabilityNode{
-		ID: "GHSA-p6xc-xr62-6r2g",
+		VulnerabilityID: "GHSA-p6xc-xr62-6r2g",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",
@@ -122,7 +122,7 @@ var (
 		),
 	}
 	vulNode6 = assembler.VulnerabilityNode{
-		ID: "GHSA-vwqq-5vrc-xw9h",
+		VulnerabilityID: "GHSA-vwqq-5vrc-xw9h",
 		NodeData: *assembler.NewObjectMetadata(
 			processor.SourceInformation{
 				Collector: "TestCollector",


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Added `UnmarshalJSON` and `MarshalJSON` for GuacNode and GuacEdge interface. This will allow for byte arrays to be generated that can be used by NATS to publish. These will be unmarshalled back to a GuacNode and GuacEdge to store into the graphDB. 

Note: ID was changed to be more descriptive to ensure proper marshal and unmarshal if a node or edge uses a free-form property like `Details   map[string]interface{}` that can take in any string parameter for the key.

Part 2 of 4 for issue https://github.com/guacsec/guac/issues/31

