### PR TITLE
fix: handled error state when cyclonedx dependencies are missing a depends on property

### DIFF
--- a/internal/testing/testdata/exampledata/npm-cyclonedx-dependencies-missing-depends-on.json
+++ b/internal/testing/testdata/exampledata/npm-cyclonedx-dependencies-missing-depends-on.json
@@ -1,0 +1,35 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2022-11-22T17:14:57Z",
+    "tools": [
+      {
+        "vendor": "Vendor",
+        "name": "SBOM Exporter"
+      }
+    ],
+    "component": {
+      "bom-ref": "web-app@1.0.0",
+      "type": "application",
+      "name": "web-app",
+      "version": "1.0.0",
+      "purl": "pkg:npm/web-app@1.0.0"
+    }
+  },
+  "components": [
+    {
+      "name": "bootstrap",
+      "version": "4.0.0-beta.2",
+      "purl": "pkg:npm/bootstrap@4.0.0-beta.2",
+      "type": "library",
+      "bom-ref": "bootstrap@4.0.0-beta.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "bootstrap@4.0.0-beta.2"
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -72,6 +72,9 @@ var (
 	//go:embed exampledata/big-mongo-cyclonedx.json
 	CycloneDXBigExample []byte
 
+	//go:embed exampledata/npm-cyclonedx-dependencies-missing-depends-on.json
+	CycloneDXDependenciesMissingDependsOn []byte
+
 	//go:embed exampledata/crev-review.json
 	ITE6CREVExample []byte
 
@@ -540,6 +543,45 @@ var (
 		assembler.DependsOnEdge{
 			PackageDependency: cdxReactiveCommonPack,
 			PackageNode:       cdxResteasyPack,
+		},
+	}
+
+	cdxWebAppPackage = assembler.PackageNode{
+		Name:    "web-app",
+		Digest:  nil,
+		Version: "1.0.0",
+		Purl:    "pkg:npm/web-app@1.0.0",
+		Tags:    []string{"application"},
+		CPEs:    nil,
+		NodeData: *assembler.NewObjectMetadata(
+			processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		),
+	}
+	cdxBootstrapPackage = assembler.PackageNode{
+		Name:    "bootstrap",
+		Digest:  nil,
+		Version: "4.0.0-beta.2",
+		Purl:    "pkg:npm/bootstrap@4.0.0-beta.2",
+		CPEs:    nil,
+		NodeData: *assembler.NewObjectMetadata(
+			processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		),
+	}
+
+	NpmMissingDependsOnCycloneDXNodes = []assembler.GuacNode{
+		cdxWebAppPackage,
+		cdxBootstrapPackage,
+	}
+	NpmMissingDependsOnCycloneDXEdges = []assembler.GuacEdge{
+		assembler.DependsOnEdge{
+			PackageDependency: cdxBootstrapPackage,
+			PackageNode:       cdxWebAppPackage,
 		},
 	}
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -150,9 +150,11 @@ func (c *cyclonedxParser) addPackages(cdxBom *cdx.BOM) {
 		if !found {
 			continue
 		}
-		for _, depPkg := range *deps.Dependencies {
-			if depPkg, exist := c.pkgMap[depPkg]; exist {
-				currPkg.depPackages = append(currPkg.depPackages, depPkg)
+		if deps.Dependencies != nil {
+			for _, depPkg := range *deps.Dependencies {
+				if depPkg, exist := c.pkgMap[depPkg]; exist {
+					currPkg.depPackages = append(currPkg.depPackages, depPkg)
+				}
 			}
 		}
 	}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -61,6 +61,20 @@ func Test_cyclonedxParser(t *testing.T) {
 		wantNodes: testdata.CycloneDXQuarkusNodes,
 		wantEdges: testdata.CyloneDXQuarkusEdges,
 		wantErr:   false,
+	}, {
+		name: "valid CycloneDX document where dependencies are missing dependsOn properties",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXDependenciesMissingDependsOn,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+			SourceInformation: processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		},
+		wantNodes: testdata.NpmMissingDependsOnCycloneDXNodes,
+		wantEdges: testdata.NpmMissingDependsOnCycloneDXEdges,
+		wantErr:   false,
 	},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`guacone` is failing to parse CycloneDX documents where dependencies are missing a dependsOn property.

From the [CycloneDX specification component definition](https://github.com/CycloneDX/specification/blob/ccbf7b5781ef534cd62616e3c4221004c7c82a66/schema/bom-1.4.schema.json#L895-L920), this is not a required property, and should not raise an exception.
