### PR TITLE
fix: viper flag name missmatch

### DIFF
--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -36,7 +36,7 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
-	flagNames := []string{"dbAddr", "gdbuser", "gdbuser", "realm"}
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/cmd/ingest/cmd/root.go
+++ b/cmd/ingest/cmd/root.go
@@ -37,7 +37,7 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
-	flagNames := []string{"dbAddr", "gdbuser", "gdbuser", "realm"}
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Fix the flag name miss-match that was causing the flags to never get set to the based on the input from the cli.