### PR TITLE
fix: add key and verifier registration to guacone cli

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -17,8 +17,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/guacsec/guac/pkg/assembler"
@@ -30,6 +32,8 @@ import (
 	"github.com/guacsec/guac/pkg/ingestor/key"
 	"github.com/guacsec/guac/pkg/ingestor/key/inmemory"
 	"github.com/guacsec/guac/pkg/ingestor/parser"
+	"github.com/guacsec/guac/pkg/ingestor/verifier"
+	"github.com/guacsec/guac/pkg/ingestor/verifier/sigstore_verifier"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -40,7 +44,8 @@ var flags = struct {
 	gdbuser string
 	gdbpass string
 	realm   string
-	key     string
+	keyPath string
+	keyID   string
 }{}
 
 type options struct {
@@ -48,7 +53,10 @@ type options struct {
 	user   string
 	pass   string
 	realm  string
-	key    string
+	// path to the pem file
+	keyPath string
+	// ID related to the key being stored
+	keyID string
 	// path to folder with documents to collect
 	path string
 	// map of image repo and tags
@@ -67,7 +75,8 @@ var exampleCmd = &cobra.Command{
 			viper.GetString("gdbpass"),
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
-			viper.GetString("key"),
+			viper.GetString("keyPath"),
+			viper.GetString("keyID"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -76,15 +85,30 @@ var exampleCmd = &cobra.Command{
 		}
 
 		// Register Keystore
-
 		inmemory := inmemory.NewInmemoryProvider()
 		err = key.RegisterKeyProvider(inmemory, inmemory.Type())
 		if err != nil {
 			logger.Errorf("unable to register key provider: %v", err)
 		}
 
-		if opts.key != "" {
-			key.Store(ctx)
+		if opts.keyPath != "" && opts.keyID != "" {
+			keyRaw, err := os.ReadFile(opts.keyPath)
+			if err != nil {
+				logger.Errorf("error: %v", err)
+				os.Exit(1)
+			}
+			err = key.Store(ctx, opts.keyID, keyRaw, inmemory.Type())
+			if err != nil {
+				logger.Errorf("error: %v", err)
+				os.Exit(1)
+			}
+		}
+
+		// Register Verifier
+		sigstore := sigstore_verifier.NewSigstoreVerifier()
+		err = verifier.RegisterVerifier(sigstore, sigstore.Type())
+		if err != nil {
+			logger.Errorf("unable to register key provider: %v", err)
 		}
 
 		// Register collector
@@ -162,13 +186,23 @@ var exampleCmd = &cobra.Command{
 	},
 }
 
-func validateFlags(user string, pass string, dbAddr string, realm string, key string, args []string) (options, error) {
+func validateFlags(user string, pass string, dbAddr string, realm string, keyPath string, keyID string, args []string) (options, error) {
 	var opts options
 	opts.user = user
 	opts.pass = pass
 	opts.dbAddr = dbAddr
 	opts.realm = realm
-	opts.key = key
+
+	if keyPath != "" {
+		if strings.HasSuffix(keyPath, "pem") {
+			opts.keyPath = keyPath
+		} else {
+			return opts, errors.New("key must be passed in as a pem file")
+		}
+	}
+	if keyPath != "" {
+		opts.keyID = keyID
+	}
 
 	if len(args) != 1 {
 		return opts, fmt.Errorf("expected positional argument for file_path")

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -75,8 +75,8 @@ var exampleCmd = &cobra.Command{
 			viper.GetString("gdbpass"),
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
-			viper.GetString("keyPath"),
-			viper.GetString("keyID"),
+			viper.GetString("verifier-keyPath"),
+			viper.GetString("verifier-keyID"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -105,8 +105,8 @@ var exampleCmd = &cobra.Command{
 		}
 
 		// Register Verifier
-		sigstore := sigstore_verifier.NewSigstoreVerifier()
-		err = verifier.RegisterVerifier(sigstore, sigstore.Type())
+		sigstoreAndKeyVerifier := sigstore_verifier.NewSigstoreAndKeyVerifier()
+		err = verifier.RegisterVerifier(sigstoreAndKeyVerifier, sigstoreAndKeyVerifier.Type())
 		if err != nil {
 			logger.Errorf("unable to register key provider: %v", err)
 		}

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
+	persistentFlags.StringVar(&flags.key, "key", "", "pem file to verify dsse")
 	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -36,8 +36,9 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
-	persistentFlags.StringVar(&flags.key, "key", "", "pem file to verify dsse")
-	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm"}
+	persistentFlags.StringVar(&flags.keyPath, "keypath", "", "path to pem file to verify dsse")
+	persistentFlags.StringVar(&flags.keyID, "keyid", "", "ID of the key to be stored")
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "keypath", "keyid"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -36,9 +36,9 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
-	persistentFlags.StringVar(&flags.keyPath, "keypath", "", "path to pem file to verify dsse")
-	persistentFlags.StringVar(&flags.keyID, "keyid", "", "ID of the key to be stored")
-	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "keypath", "keyid"}
+	persistentFlags.StringVar(&flags.keyPath, "verifier-keyPath", "", "path to pem file to verify dsse")
+	persistentFlags.StringVar(&flags.keyID, "verifier-keyID", "", "ID of the key to be stored")
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "verifier-keyPath", "verifier-keyID"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/pkg/ingestor/key/inmemory/inmemory.go
+++ b/pkg/ingestor/key/inmemory/inmemory.go
@@ -26,7 +26,7 @@ type inmemory struct {
 	collector map[string]*key.Key
 }
 
-func newInmemoryProvider() *inmemory {
+func NewInmemoryProvider() *inmemory {
 	return &inmemory{
 		collector: map[string]*key.Key{},
 	}

--- a/pkg/ingestor/key/inmemory/inmemory_test.go
+++ b/pkg/ingestor/key/inmemory/inmemory_test.go
@@ -214,7 +214,7 @@ func setupProvider(t *testing.T) (*inmemory, []*key.Key) {
 		Scheme: "ed25519",
 	}
 
-	provider := newInmemoryProvider()
+	provider := NewInmemoryProvider()
 
 	return provider, []*key.Key{ecdsaKey, rsaKey, ed25519Key}
 }

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
@@ -51,6 +51,11 @@ func (d *sigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]v
 			return nil, err
 		}
 
+		// currently keyID needs to be the hash of the public key
+		// see:
+		// https://github.com/sigstore/sigstore/blob/main/pkg/signature/dsse/dsse.go#L107
+		// and
+		// https://github.com/secure-systems-lab/go-securesystemslib/blob/main/dsse/verify.go#L69
 		foundIdentity := verifier.Identity{
 			ID:  signature.KeyID,
 			Key: *key,

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
@@ -33,7 +33,7 @@ type sigstoreVerifier struct {
 }
 
 // NewSigstoreVerifier initializes the sigstore verifier
-func NewSigstoreVerifier() *sigstoreVerifier {
+func NewSigstoreAndKeyVerifier() *sigstoreVerifier {
 	return &sigstoreVerifier{}
 }
 

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
@@ -214,7 +214,7 @@ func TestSigstoreVerifier_Verify(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sigVerifier := NewSigstoreVerifier()
+			sigVerifier := NewSigstoreAndKeyVerifier()
 			got, err := sigVerifier.Verify(ctx, tt.doc.Blob)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SigstoreVerifier.Verify() error = %v, wantErr %v", err, tt.wantErr)
@@ -332,7 +332,7 @@ func TestMultiSignatureSigstoreVerifier_Verify(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sigVerifier := NewSigstoreVerifier()
+			sigVerifier := NewSigstoreAndKeyVerifier()
 			got, err := sigVerifier.Verify(ctx, tt.doc.Blob)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SigstoreVerifier.Verify() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Adding the missing key and sigstore verifier registration to the guacone CLI to have the ability to verify DSSE and create identity nodes.

Address Issue #304 