### PR TITLE
update make fmt to skip pb codegen files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ cover: test ## Run all the tests and opens the coverage report
 
 .PHONY: fmt
 fmt: ## Check the formatting
-	test -z "$(shell goimports -l -e .)"
-	test -z "$(shell find . -name '*.go' -not -wholename './vendor/*' -exec .github/scripts/copywrite.sh {} \;)"
+	test -z "$(shell find . -name '*.go' -not -wholename './vendor/*' -not -name '*.pb.go' -exec goimports -l -e {} \;)"
+	test -z "$(shell find . -name '*.go' -not -wholename './vendor/*' -not -name '*.pb.go' -exec .github/scripts/copywrite.sh {} \;)"
 
 .PHONY: lint
 lint: ## Run all the linters


### PR DESCRIPTION
Codegen files may fail lint and copyright check (see #306), this skips checks for those files.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>