### PR TITLE
Test Pubsub cmd (NATS PR: 4 of 4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ build: ## Build a version
 	go build -ldflags ${LDFLAGS} -o bin/collector cmd/collector/main.go
 	go build -ldflags ${LDFLAGS} -o bin/ingest cmd/ingest/main.go
 	go build -ldflags ${LDFLAGS} -o bin/guacone cmd/guacone/main.go
+	go build -ldflags ${LDFLAGS} -o bin/pubsub_test cmd/pubsub_test/main.go
 
 .PHONY: clean
 clean: ## Remove temporary files

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -1,0 +1,204 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/guacsec/guac/pkg/assembler"
+	"github.com/guacsec/guac/pkg/assembler/graphdb"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
+	root_package "github.com/guacsec/guac/pkg/certifier/components"
+	"github.com/guacsec/guac/pkg/emitter"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/nats-io/nats.go"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var certifierCmd = &cobra.Command{
+	Use:   "certifier",
+	Short: "certifies packages in GUAC graph",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateCertifierFlags(
+			viper.GetString("gdbuser"),
+			viper.GetString("gdbpass"),
+			viper.GetString("gdbaddr"),
+			viper.GetString("realm"),
+		)
+
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(opts.user, opts.pass, opts.realm)
+		client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		// initialize jetstream
+		// TODO: pass in credentials file for NATS secure login
+		jetStream := emitter.NewJetStream(nats.DefaultURL, "", "")
+		ctx, err = jetStream.JetStreamInit(ctx)
+		if err != nil {
+			logger.Errorf("jetStream initialization failed with error: %v", err)
+			os.Exit(1)
+		}
+		// recreate stream to remove any old lingering documents
+		// NOT TO BE USED IN PRODUCTION
+		err = jetStream.RecreateStream(ctx)
+		if err != nil {
+			logger.Errorf("unexpected error recreating jetstream: %v", err)
+		}
+		defer jetStream.Close()
+
+		certifierPubFunc, err := getCertifierPublish(ctx)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		assemblerFunc, err := getAssembler(opts)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		processorTransportFunc := func(d processor.DocumentTree) error {
+			docTreeBytes, err := json.Marshal(d)
+			if err != nil {
+				return fmt.Errorf("failed marshal of document: %w", err)
+			}
+			err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeBytes)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		ingestorTransportFunc := func(d []assembler.Graph) error {
+			err := assemblerFunc(d)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		processorFunc, err := getProcessor(ctx, processorTransportFunc)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+		ingestorFunc, err := getIngestor(ctx, ingestorTransportFunc)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		packageQueryFunc, err := getPackageQuery(client)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		// Set emit function to go through the entire pipeline
+		emit := func(d *processor.Document) error {
+			err = certifierPubFunc(d)
+			if err != nil {
+				logger.Errorf("collector ended with error: %v", err)
+				os.Exit(1)
+			}
+			return nil
+		}
+
+		// Collect
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("collector ended gracefully")
+				return true
+			}
+			logger.Errorf("collector ended with error: %v", err)
+			return false
+		}
+
+		// Assuming that publisher and consumer are different processes.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := processorFunc()
+			if err != nil {
+				logger.Errorf("processor ended with error: %v", err)
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := ingestorFunc()
+			if err != nil {
+				logger.Errorf("parser ended with error: %v", err)
+			}
+		}()
+
+		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		wg.Wait()
+	},
+}
+
+func validateCertifierFlags(user string, pass string, dbAddr string, realm string) (options, error) {
+	var opts options
+	opts.user = user
+	opts.pass = pass
+	opts.dbAddr = dbAddr
+	opts.realm = realm
+
+	return opts, nil
+}
+
+func getCertifierPublish(ctx context.Context) (func(*processor.Document) error, error) {
+	return func(d *processor.Document) error {
+		return certify.Publish(ctx, d)
+	}, nil
+}
+
+func getPackageQuery(client neo4j.Driver) (func() certifier.QueryComponents, error) {
+	return func() certifier.QueryComponents {
+		packageQuery := root_package.NewPackageQuery(client)
+		return packageQuery
+	}, nil
+}
+
+func init() {
+	rootCmd.AddCommand(certifierCmd)
+}

--- a/cmd/pubsub_test/cmd/files.go
+++ b/cmd/pubsub_test/cmd/files.go
@@ -1,0 +1,306 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/guacsec/guac/pkg/assembler"
+	"github.com/guacsec/guac/pkg/assembler/graphdb"
+	"github.com/guacsec/guac/pkg/emitter"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/collector/file"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/handler/processor/process"
+	"github.com/guacsec/guac/pkg/ingestor/parser"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/nats-io/nats.go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var flags = struct {
+	dbAddr  string
+	gdbuser string
+	gdbpass string
+	realm   string
+	keyPath string
+	keyID   string
+}{}
+
+type options struct {
+	dbAddr string
+	user   string
+	pass   string
+	realm  string
+	// path to the pem file
+	keyPath string
+	// ID related to the key being stored
+	keyID string
+	// path to folder with documents to collect
+	path string
+}
+
+var filesCmd = &cobra.Command{
+	Use:   "files [flags] file_path",
+	Short: "take a folder of files and create a GUAC graph utilizing Nats pubsub",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		opts, err := validateFlags(
+			viper.GetString("gdbuser"),
+			viper.GetString("gdbpass"),
+			viper.GetString("gdbaddr"),
+			viper.GetString("realm"),
+			viper.GetString("verifier-keyPath"),
+			viper.GetString("verifier-keyID"),
+			args)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		// Register collector
+		fileCollector := file.NewFileCollector(ctx, opts.path, false, time.Second)
+		err = collector.RegisterDocumentCollector(fileCollector, file.FileCollector)
+		if err != nil {
+			logger.Errorf("unable to register file collector: %v", err)
+		}
+
+		// initialize jetstream
+		// TODO: pass in credentials file for NATS secure login
+		jetStream := emitter.NewJetStream(nats.DefaultURL, "", "")
+		ctx, err = jetStream.JetStreamInit(ctx)
+		if err != nil {
+			logger.Errorf("jetStream initialization failed with error: %v", err)
+			os.Exit(1)
+		}
+		// recreate stream to remove any old lingering documents
+		// NOT TO BE USED IN PRODUCTION
+		err = jetStream.RecreateStream(ctx)
+		if err != nil {
+			logger.Errorf("unexpected error recreating jetstream: %v", err)
+		}
+		defer jetStream.Close()
+
+		// Get pipeline of components
+		collectorPubFunc, err := getCollectorPublish(ctx)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		assemblerFunc, err := getAssembler(opts)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		processorTransportFunc := func(d processor.DocumentTree) error {
+			docTreeBytes, err := json.Marshal(d)
+			if err != nil {
+				return fmt.Errorf("failed marshal of document: %w", err)
+			}
+			err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeBytes)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		ingestorTransportFunc := func(d []assembler.Graph) error {
+			err := assemblerFunc(d)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		processorFunc, err := getProcessor(ctx, processorTransportFunc)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+		ingestorFunc, err := getIngestor(ctx, ingestorTransportFunc)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		// Set emit function to go through the entire pipeline
+		emit := func(d *processor.Document) error {
+			err = collectorPubFunc(d)
+			if err != nil {
+				logger.Errorf("collector ended with error: %v", err)
+				os.Exit(1)
+			}
+			return nil
+		}
+
+		// Collect
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("collector ended gracefully")
+				return true
+			}
+			logger.Errorf("collector ended with error: %v", err)
+			return false
+		}
+
+		// Assuming that publisher and consumer are different processes.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := processorFunc()
+			if err != nil {
+				logger.Errorf("processor ended with error: %v", err)
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := ingestorFunc()
+			if err != nil {
+				logger.Errorf("parser ended with error: %v", err)
+			}
+		}()
+
+		if err := collector.Collect(ctx, emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		wg.Wait()
+	},
+}
+
+func validateFlags(user string, pass string, dbAddr string, realm string, keyPath string, keyID string, args []string) (options, error) {
+	var opts options
+	opts.user = user
+	opts.pass = pass
+	opts.dbAddr = dbAddr
+	opts.realm = realm
+
+	if keyPath != "" {
+		if strings.HasSuffix(keyPath, "pem") {
+			opts.keyPath = keyPath
+		} else {
+			return opts, errors.New("key must be passed in as a pem file")
+		}
+	}
+	if keyPath != "" {
+		opts.keyID = keyID
+	}
+
+	if len(args) != 1 {
+		return opts, fmt.Errorf("expected positional argument for file_path")
+	}
+
+	opts.path = args[0]
+
+	return opts, nil
+}
+
+func getCollectorPublish(ctx context.Context) (func(*processor.Document) error, error) {
+	return func(d *processor.Document) error {
+		return collector.Publish(ctx, d)
+	}, nil
+}
+
+func getProcessor(ctx context.Context, transportFunc func(processor.DocumentTree) error) (func() error, error) {
+	return func() error {
+		return process.Subscribe(ctx, transportFunc)
+	}, nil
+}
+
+func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph) error) (func() error, error) {
+	return func() error {
+		err := parser.Subscribe(ctx, transportFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, nil
+}
+
+func getAssembler(opts options) (func([]assembler.Graph) error, error) {
+	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
+		opts.user,
+		opts.pass,
+		opts.realm,
+	)
+
+	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
+	if err != nil {
+		return nil, err
+	}
+
+	err = createIndices(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(gs []assembler.Graph) error {
+		combined := assembler.Graph{
+			Nodes: []assembler.GuacNode{},
+			Edges: []assembler.GuacEdge{},
+		}
+		for _, g := range gs {
+			combined.AppendGraph(g)
+		}
+		if err := assembler.StoreGraph(combined, client); err != nil {
+			return err
+		}
+
+		return nil
+	}, nil
+}
+
+func createIndices(client graphdb.Client) error {
+	indices := map[string][]string{
+		"Artifact":      {"digest", "name"},
+		"Package":       {"purl", "name"},
+		"Metadata":      {"id"},
+		"Attestation":   {"digest"},
+		"Vulnerability": {"id"},
+	}
+
+	for label, attributes := range indices {
+		for _, attribute := range attributes {
+			err := assembler.CreateIndexOn(client, label, attribute)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(filesCmd)
+}

--- a/cmd/pubsub_test/cmd/root.go
+++ b/cmd/pubsub_test/cmd/root.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/guacsec/guac/pkg/logging"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	persistentFlags := rootCmd.PersistentFlags()
+	persistentFlags.StringVar(&flags.dbAddr, "gdbaddr", "neo4j://localhost:7687", "address to neo4j db")
+	persistentFlags.StringVar(&flags.gdbuser, "gdbuser", "", "neo4j user credential to connect to graph db")
+	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
+	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
+	persistentFlags.StringVar(&flags.keyPath, "verifier-keyPath", "", "path to pem file to verify dsse")
+	persistentFlags.StringVar(&flags.keyID, "verifier-keyID", "", "ID of the key to be stored")
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "verifier-keyPath", "verifier-keyID"}
+	for _, name := range flagNames {
+		if flag := persistentFlags.Lookup(name); flag != nil {
+			if err := viper.BindPFlag(name, flag); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to bind flag: %v", err)
+				os.Exit(1)
+			}
+		}
+	}
+}
+
+func initConfig() {
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+	} else {
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get user home directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		viper.AddConfigPath(home)
+		viper.AddConfigPath(".")
+		viper.SetConfigName("guac")
+		viper.SetConfigType("yaml")
+	}
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("guac")
+
+	if err := viper.ReadInConfig(); err == nil {
+		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "guacone",
+	Short: "guacone is an all in one flow cmdline for GUAC",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/pubsub_test/main.go
+++ b/cmd/pubsub_test/main.go
@@ -1,0 +1,24 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/guacsec/guac/cmd/pubsub_test/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -161,41 +161,22 @@ func Test_Publish(t *testing.T) {
 	ctx, cancel = context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	docChan := make(chan processor.DocumentTree, 1)
-	errChan := make(chan error, 1)
-	defer close(errChan)
-	defer close(docChan)
-
-	go func() {
-		errChan <- testSubscribe(ctx, docChan)
-	}()
-
-	numSubscribers := 1
-	subscribersDone := 0
-
-	for subscribersDone < numSubscribers {
-		select {
-		case d := <-docChan:
-			if !dochelper.DocTreeEqual(d, expectedDocTree) {
-				t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
-			}
-		case err := <-errChan:
-			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-				t.Errorf("nats emitter Subscribe test errored = %v", err)
-			}
-			subscribersDone += 1
-		}
-	}
-	for len(docChan) > 0 {
-		d := <-docChan
+	transportFunc := func(d processor.DocumentTree) error {
 		if !dochelper.DocTreeEqual(d, expectedDocTree) {
 			t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
 		}
+		return nil
 	}
 
+	err = testSubscribe(ctx, transportFunc)
+	if err != nil {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("nats emitter Subscribe test errored = %v", err)
+		}
+	}
 }
 
-func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree) error {
+func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error) error {
 	logger := logging.FromContext(ctx)
 	id := uuid.NewV4().String()
 
@@ -210,7 +191,7 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		if err != nil {
 			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
 			logger.Error(fmtErr)
-			return err
+			return fmtErr
 		}
 
 		docNode := &processor.DocumentNode{
@@ -219,7 +200,12 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		}
 
 		docTree := processor.DocumentTree(docNode)
-		docChannel <- docTree
+		err = transportFunc(docTree)
+		if err != nil {
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			logger.Error(fmtErr)
+			return fmtErr
+		}
 		logger.Infof("[processor: %s] docTree Processed: %+v", id, docTree.Document.SourceInformation)
 		return nil
 	}

--- a/pkg/emitter/nats_data.go
+++ b/pkg/emitter/nats_data.go
@@ -60,8 +60,3 @@ func (psub *pubSub) GetDataFromNats(ctx context.Context, dataFunc DataFunc) erro
 		}
 	}
 }
-
-// SendDataToNats publishes the data in bytes to the stream based on the subject
-func (psub *pubSub) SendDataToNats(ctx context.Context, subj string, data []byte) error {
-	return Publish(ctx, subj, data)
-}

--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -36,7 +36,7 @@ const (
 	DurableProcessor        string        = "processor"
 	DurableIngestor         string        = "ingestor"
 	BufferChannelSize       int           = 1000
-	BackOffTimer            time.Duration = 5 * time.Second
+	BackOffTimer            time.Duration = 1 * time.Second
 )
 
 type jetStream struct {
@@ -185,7 +185,7 @@ func createSubscriber(ctx context.Context, id string, subj string, durable strin
 			msgs, err := sub.Fetch(1)
 			if err != nil {
 				if errors.Is(err, nats.ErrTimeout) {
-					logger.Infof("[%s: %s] error consuming, backing off for a second: %v", durable, id, err)
+					logger.Infof("[%s: %s] nothing to consume, backing off for %s: %v", durable, id, backOffTimer.String(), err)
 					time.Sleep(backOffTimer)
 					continue
 				} else {

--- a/pkg/emitter/nats_emitter_test.go
+++ b/pkg/emitter/nats_emitter_test.go
@@ -108,35 +108,17 @@ func TestNatsEmitter_PublishOnEmit(t *testing.T) {
 	ctx, cancel = context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	docChan := make(chan processor.DocumentTree, 1)
-	errChan := make(chan error, 1)
-	defer close(errChan)
-	defer close(docChan)
-
-	go func() {
-		errChan <- testSubscribe(ctx, docChan)
-	}()
-
-	numSubscribers := 1
-	subscribersDone := 0
-
-	for subscribersDone < numSubscribers {
-		select {
-		case d := <-docChan:
-			if !dochelper.DocTreeEqual(d, expectedDocTree) {
-				t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
-			}
-		case err := <-errChan:
-			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-				t.Errorf("nats emitter Subscribe test errored = %v", err)
-			}
-			subscribersDone += 1
-		}
-	}
-	for len(docChan) > 0 {
-		d := <-docChan
+	transportFunc := func(d processor.DocumentTree) error {
 		if !dochelper.DocTreeEqual(d, expectedDocTree) {
 			t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
+		}
+		return nil
+	}
+
+	err = testSubscribe(ctx, transportFunc)
+	if err != nil {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("nats emitter Subscribe test errored = %v", err)
 		}
 	}
 }
@@ -209,7 +191,7 @@ func testPublish(ctx context.Context, d *processor.Document) error {
 	return nil
 }
 
-func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree) error {
+func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error) error {
 	logger := logging.FromContext(ctx)
 	id := uuid.NewV4().String()
 
@@ -224,7 +206,7 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		if err != nil {
 			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
 			logger.Error(fmtErr)
-			return err
+			return fmtErr
 		}
 
 		docNode := &processor.DocumentNode{
@@ -233,7 +215,12 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		}
 
 		docTree := processor.DocumentTree(docNode)
-		docChannel <- docTree
+		err = transportFunc(docTree)
+		if err != nil {
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			logger.Error(fmtErr)
+			return fmtErr
+		}
 		logger.Infof("[processor: %s] docTree Processed: %+v", id, docTree.Document.SourceInformation)
 		return nil
 	}

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -120,40 +120,22 @@ func Test_Publish(t *testing.T) {
 	ctx, cancel = context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	docChan := make(chan processor.DocumentTree, 1)
-	errChan := make(chan error, 1)
-	defer close(errChan)
-	defer close(docChan)
-
-	go func() {
-		errChan <- testSubscribe(ctx, docChan)
-	}()
-
-	numSubscribers := 1
-	subscribersDone := 0
-
-	for subscribersDone < numSubscribers {
-		select {
-		case d := <-docChan:
-			if !dochelper.DocTreeEqual(d, expectedDocTree) {
-				t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
-			}
-		case err := <-errChan:
-			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-				t.Errorf("nats emitter Subscribe test errored = %v", err)
-			}
-			subscribersDone += 1
-		}
-	}
-	for len(docChan) > 0 {
-		d := <-docChan
+	transportFunc := func(d processor.DocumentTree) error {
 		if !dochelper.DocTreeEqual(d, expectedDocTree) {
 			t.Errorf("doc tree did not match up, got\n%s, \nexpected\n%s", dochelper.StringTree(d), dochelper.StringTree(expectedDocTree))
+		}
+		return nil
+	}
+
+	err = testSubscribe(ctx, transportFunc)
+	if err != nil {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("nats emitter Subscribe test errored = %v", err)
 		}
 	}
 }
 
-func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree) error {
+func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error) error {
 	logger := logging.FromContext(ctx)
 	id := uuid.NewV4().String()
 
@@ -168,7 +150,7 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		if err != nil {
 			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
 			logger.Error(fmtErr)
-			return err
+			return fmtErr
 		}
 
 		docNode := &processor.DocumentNode{
@@ -177,7 +159,12 @@ func testSubscribe(ctx context.Context, docChannel chan<- processor.DocumentTree
 		}
 
 		docTree := processor.DocumentTree(docNode)
-		docChannel <- docTree
+		err = transportFunc(docTree)
+		if err != nil {
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			logger.Error(fmtErr)
+			return fmtErr
+		}
 		logger.Infof("[processor: %s] docTree Processed: %+v", id, docTree.Document.SourceInformation)
 		return nil
 	}

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -56,7 +56,7 @@ func RegisterDocumentProcessor(p processor.DocumentProcessor, d processor.Docume
 
 // Subscribe is used by NATS JetStream to stream the documents received from the collector
 // and process them them via Process
-func Subscribe(ctx context.Context) error {
+func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error) error {
 	logger := logging.FromContext(ctx)
 
 	id := uuid.NewV4().String()
@@ -79,14 +79,14 @@ func Subscribe(ctx context.Context) error {
 			logger.Error(fmtErr)
 			return fmtErr
 		}
-		docTreeBytes, err := json.Marshal(docTree)
+
+		err = transportFunc(docTree)
 		if err != nil {
-			return fmt.Errorf("failed marshal of document: %w", err)
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			logger.Error(fmtErr)
+			return fmtErr
 		}
-		err = psub.SendDataToNats(ctx, emitter.SubjectNameDocProcessed, docTreeBytes)
-		if err != nil {
-			return err
-		}
+
 		logger.Infof("[processor: %s] docTree Processed: %+v", id, docTree.Document.SourceInformation)
 		return nil
 	}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -69,7 +69,7 @@ func RegisterDocumentParser(p func() common.DocumentParser, d processor.Document
 
 // Subscribe is used by NATS JetStream to stream the documents received from the processor
 // and parse them them via ParseDocumentTree
-func Subscribe(ctx context.Context) error {
+func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error) error {
 	logger := logging.FromContext(ctx)
 
 	id := uuid.NewV4().String()
@@ -86,25 +86,19 @@ func Subscribe(ctx context.Context) error {
 			logger.Error(fmtErr)
 			return err
 		}
-		_, err = ParseDocumentTree(ctx, processor.DocumentTree(&docNode))
+		assemblerInputs, err := ParseDocumentTree(ctx, processor.DocumentTree(&docNode))
 		if err != nil {
 			fmtErr := fmt.Errorf("[ingestor: %s] failed parse document: %v", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}
 
-		// TODO: Once the graphDB is abstracted via GraphQL, add NATS back to ingestor. See issue https://github.com/guacsec/guac/issues/299
-		//
-		// 	assemblerInputsJSON, err := json.Marshal(assemblerInputs)
-		// 	if err != nil {
-		// 		return nil, err
-		// 	}
-		// err = psub.SendDataToNats(ctx, emitter.SubjectNameDocParsed, assemblerInputsJSON)
-		// if err != nil {
-		// 	return err
-		// }
-		// 	logger.Infof("doc parsed: %+v", docTree.Document.SourceInformation)
-		//
+		err = transportFunc(assemblerInputs)
+		if err != nil {
+			fmtErr := fmt.Errorf("[ingestor: %s] failed transportFunc: %v", id, err)
+			logger.Error(fmtErr)
+			return fmtErr
+		}
 
 		logger.Infof("[ingestor: %s] ingested docTree: %+v", id, processor.DocumentTree(&docNode).Document.SourceInformation)
 		return nil

--- a/pkg/ingestor/parser/parser_test.go
+++ b/pkg/ingestor/parser/parser_test.go
@@ -182,7 +182,17 @@ func Test_ParserSubscribe(t *testing.T) {
 			ctx, cancel = context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
-			err = Subscribe(ctx)
+			transportFunc := func(d []assembler.Graph) error {
+				if len(d) != len(tt.want) {
+					t.Errorf("ParseDocumentTree() = %v, want %v", d, tt.want)
+				}
+				for i := range d {
+					compare(t, d[i].Edges, tt.want[i].Edges, d[i].Nodes, tt.want[i].Nodes)
+				}
+				return nil
+			}
+
+			err = Subscribe(ctx, transportFunc)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("nats emitter Subscribe test errored = %v, want %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Added test pubsub cmd that will eventually be turned into an integration test. Tests the functionality of NATS pub/sub for the collector, processor, and ingestor. 

Modified the `Subscribe` function to take in a `transportFunc` that defines how the data is transported to the next service once processed or parsed.

To test locally:

1. install nats-server: `brew install nats-server`
2. create js.conf file with the following:
```
// change max payload from default 1MB to 64MB (though it's recommended to stay below 8Mb)
max_payload: 64MB
// enables jetstream, an empty block will enable and use defaults
jetstream {}
```
3. Run `nats-server --config js.conf`
4. `make build` in the GUAC repo
5. Run ` ./bin/pubsub_test files --gdbuser neo4j --gdbpass s3cr3t <FILE PATH>`
6. Run `/bin/pubsub_test certifier --gdbuser neo4j --gdbpass s3cr3t`

Part 4 of 4 for issue https://github.com/guacsec/guac/issues/31
closes #31 
