### PR TITLE
Included Tests for pkg/certifier/osv/osv

### DIFF
--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -157,7 +157,7 @@ func generateDocument(purl string, digest []string, vulns []osv_scanner.Entry) (
 	return doc, nil
 }
 
-func createAttestation(projectURL string, digests []string, vulns []osv_scanner.Entry) *attestation_vuln.VulnerabilityStatement {
+func createAttestation(packageURL string, digests []string, vulns []osv_scanner.Entry) *attestation_vuln.VulnerabilityStatement {
 	currentTime := time.Now()
 	var subjects []intoto.Subject
 
@@ -184,7 +184,7 @@ func createAttestation(projectURL string, digests []string, vulns []osv_scanner.
 	for _, digest := range digests {
 		digestSplit := strings.Split(digest, ":")
 		subjects = append(subjects, intoto.Subject{
-			Name: projectURL,
+			Name: packageURL,
 			Digest: slsa.DigestSet{
 				digestSplit[0]: digestSplit[1],
 			},
@@ -192,7 +192,7 @@ func createAttestation(projectURL string, digests []string, vulns []osv_scanner.
 	}
 	if len(digests) == 0 {
 		subjects = append(subjects, intoto.Subject{
-			Name: projectURL,
+			Name: packageURL,
 		})
 	}
 

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -141,7 +141,7 @@ func getVulnerabilities(query osv_query.BatchedQuery, docChannel chan<- *process
 }
 
 func generateDocument(purl string, digest []string, vulns []osv_scanner.Entry) (*processor.Document, error) {
-	payload, err := generateOSVCertifyPredicateBlob(createAttestation(purl, digest, vulns))
+	payload, err := json.Marshal(createAttestation(purl, digest, vulns))
 	if err != nil {
 		return nil, err
 	}
@@ -157,35 +157,46 @@ func generateDocument(purl string, digest []string, vulns []osv_scanner.Entry) (
 	return doc, nil
 }
 
-func createAttestation(purl string, digest []string, vulns []osv_scanner.Entry) *attestation_vuln.VulnerabilityStatement {
+func createAttestation(projectURL string, digests []string, vulns []osv_scanner.Entry) *attestation_vuln.VulnerabilityStatement {
 	currentTime := time.Now()
 	var subjects []intoto.Subject
 
-	attestation := &attestation_vuln.VulnerabilityStatement{}
-	attestation.StatementHeader.Type = intoto.StatementInTotoV01
-	attestation.StatementHeader.PredicateType = attestation_vuln.PredicateVuln
-	if len(digest) > 0 {
-		for _, digest := range digest {
-			digestSplit := strings.Split(digest, ":")
-			subjects = append(subjects, intoto.Subject{
-				Name: purl,
-				Digest: slsa.DigestSet{
-					digestSplit[0]: digestSplit[1],
-				},
-			})
-		}
-	} else {
+	attestation := &attestation_vuln.VulnerabilityStatement{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: attestation_vuln.PredicateVuln,
+		},
+		Predicate: attestation_vuln.VulnerabilityPredicate{
+			Invocation: attestation_vuln.Invocation{
+				Uri:        INVOC_URI,
+				ProducerID: PRODUCER_ID,
+			},
+			Scanner: attestation_vuln.Scanner{
+				Uri:     URI,
+				Version: VERSION,
+			},
+			Metadata: attestation_vuln.Metadata{
+				ScannedOn: &currentTime,
+			},
+		},
+	}
+
+	for _, digest := range digests {
+		digestSplit := strings.Split(digest, ":")
 		subjects = append(subjects, intoto.Subject{
-			Name: purl,
+			Name: projectURL,
+			Digest: slsa.DigestSet{
+				digestSplit[0]: digestSplit[1],
+			},
+		})
+	}
+	if len(digests) == 0 {
+		subjects = append(subjects, intoto.Subject{
+			Name: projectURL,
 		})
 	}
 
 	attestation.StatementHeader.Subject = subjects
-	attestation.Predicate.Invocation.Uri = INVOC_URI
-	attestation.Predicate.Invocation.ProducerID = PRODUCER_ID
-	attestation.Predicate.Scanner.Uri = URI
-	attestation.Predicate.Scanner.Version = VERSION
-	attestation.Predicate.Metadata.ScannedOn = &currentTime
 
 	for _, vuln := range vulns {
 		attestation.Predicate.Scanner.Result = append(attestation.Predicate.Scanner.Result, attestation_vuln.Result{
@@ -193,12 +204,4 @@ func createAttestation(purl string, digest []string, vulns []osv_scanner.Entry) 
 		})
 	}
 	return attestation
-}
-
-func generateOSVCertifyPredicateBlob(p *attestation_vuln.VulnerabilityStatement) ([]byte, error) {
-	blob, err := json.Marshal(p)
-	if err != nil {
-		return nil, err
-	}
-	return blob, nil
 }

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -135,7 +135,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 func Test_createAttestation(t *testing.T) {
 	currentTime := time.Now()
 	type args struct {
-		projectURL string
+		packageURL string
 		digests    []string
 		vulns      []osv_scanner.Entry
 	}
@@ -211,7 +211,7 @@ func Test_createAttestation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := createAttestation(test.args.projectURL, test.args.digests, test.args.vulns)
+			got := createAttestation(test.args.packageURL, test.args.digests, test.args.vulns)
 			if !deepEqualIgnoreTimestamp(got, test.want) {
 				t.Errorf("createAttestation() = %v, want %v", got, test.want)
 			}


### PR DESCRIPTION
- Included tests for the function `createAttestation()` in the file `pkg/certifier/osv/osv.go`
- Refactored some code in `pkg/certifier/osv/osv.go`
	- Removed `generateOSVCertifyPredicateBlob()` because it was kind of redundent
	- Refactored `createAttestation()` for cleanliness.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>