### PR TITLE
feat: add de-duplication via NATs jetstream 

### DIFF
--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -171,6 +171,7 @@ var certifierCmd = &cobra.Command{
 		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler); err != nil {
 			logger.Fatal(err)
 		}
+
 		wg.Wait()
 	},
 }

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -171,7 +171,6 @@ var certifierCmd = &cobra.Command{
 		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler); err != nil {
 			logger.Fatal(err)
 		}
-
 		wg.Wait()
 	},
 }

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -189,7 +189,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		doc := processor.Document{}
 		err := json.Unmarshal(d, &doc)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}
@@ -202,7 +202,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		docTree := processor.DocumentTree(docNode)
 		err = transportFunc(docTree)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}

--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -17,6 +17,8 @@ package emitter
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -121,6 +123,9 @@ func createStreamOrExists(ctx context.Context, js nats.JetStreamContext) error {
 			Name:      StreamName,
 			Subjects:  []string{StreamSubjects},
 			Retention: nats.WorkQueuePolicy,
+			// window to track duplicates in the stream.
+			// see https://github.com/nats-io/nats.docs/blob/master/using-nats/jetstream/model_deep_dive.md#message-deduplication
+			Duplicates: 5 * time.Minute,
 		})
 		if err != nil {
 			return err
@@ -173,7 +178,7 @@ func createSubscriber(ctx context.Context, id string, subj string, durable strin
 	js := FromContext(ctx)
 	sub, err := js.PullSubscribe(subj, durable)
 	if err != nil {
-		logger.Errorf("%s subscribe failed: %s", durable, err)
+		logger.Errorf("%s subscribe failed: %w", durable, err)
 		return nil, nil, err
 	}
 	go func() {
@@ -185,17 +190,17 @@ func createSubscriber(ctx context.Context, id string, subj string, durable strin
 			msgs, err := sub.Fetch(1)
 			if err != nil {
 				if errors.Is(err, nats.ErrTimeout) {
-					logger.Infof("[%s: %s] nothing to consume, backing off for %s: %v", durable, id, backOffTimer.String(), err)
+					logger.Infof("[%s: %s] nothing to consume, backing off for %s: %w", durable, id, backOffTimer.String(), err)
 					time.Sleep(backOffTimer)
 					continue
 				} else {
-					errChan <- fmt.Errorf("[%s: %s] unexpected NATS fetch error: %v", durable, id, err)
+					errChan <- fmt.Errorf("[%s: %s] unexpected NATS fetch error: %w", durable, id, err)
 				}
 			}
 			if len(msgs) > 0 {
 				err := msgs[0].Ack()
 				if err != nil {
-					fmtErr := fmt.Errorf("[%s: %v] unable to Ack: %v", durable, id, err)
+					fmtErr := fmt.Errorf("[%s: %v] unable to Ack: %w", durable, id, err)
 					logger.Error(fmtErr)
 					errChan <- fmtErr
 				}
@@ -212,9 +217,17 @@ func Publish(ctx context.Context, subj string, data []byte) error {
 	if js == nil {
 		return errors.New("jetstream not found from context")
 	}
-	_, err := js.Publish(subj, data)
+	// messageID set using the hash to check for duplicate data on the stream
+	// see: https://github.com/nats-io/nats.docs/blob/master/using-nats/jetstream/model_deep_dive.md#message-deduplication
+	_, err := js.Publish(subj, data, nats.MsgId(getHash(data)))
 	if err != nil {
 		return fmt.Errorf("failed to publish document on stream: %w", err)
 	}
 	return nil
+}
+
+func getHash(data []byte) string {
+	sha256sum := sha256.Sum256(data)
+	hash := base64.RawStdEncoding.EncodeToString(sha256sum[:])
+	return hash
 }

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -148,7 +148,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		doc := processor.Document{}
 		err := json.Unmarshal(d, &doc)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}
@@ -161,7 +161,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		docTree := processor.DocumentTree(docNode)
 		err = transportFunc(docTree)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -69,20 +69,20 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 		doc := processor.Document{}
 		err := json.Unmarshal(d, &doc)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed unmarshal the document bytes: %w", id, err)
 			logger.Error(fmtErr)
 			return err
 		}
 		docTree, err := Process(ctx, &doc)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed process document: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed process document: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}
 
 		err = transportFunc(docTree)
 		if err != nil {
-			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %v", id, err)
+			fmtErr := fmt.Errorf("[processor: %s] failed transportFunc: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -82,20 +82,20 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 		docNode := processor.DocumentNode{}
 		err := json.Unmarshal(d, &docNode)
 		if err != nil {
-			fmtErr := fmt.Errorf("[ingestor: %s] failed unmarshal the document tree bytes: %v", id, err)
+			fmtErr := fmt.Errorf("[ingestor: %s] failed unmarshal the document tree bytes: %w", id, err)
 			logger.Error(fmtErr)
 			return err
 		}
 		assemblerInputs, err := ParseDocumentTree(ctx, processor.DocumentTree(&docNode))
 		if err != nil {
-			fmtErr := fmt.Errorf("[ingestor: %s] failed parse document: %v", id, err)
+			fmtErr := fmt.Errorf("[ingestor: %s] failed parse document: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}
 
 		err = transportFunc(assemblerInputs)
 		if err != nil {
-			fmtErr := fmt.Errorf("[ingestor: %s] failed transportFunc: %v", id, err)
+			fmtErr := fmt.Errorf("[ingestor: %s] failed transportFunc: %w", id, err)
 			logger.Error(fmtErr)
 			return fmtErr
 		}


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Adds the ability for Jetstream to automatically remove duplicate entries in the stream via `nats.MsgId` header. This header is set to the hash of the `processor.document`. 

Fixed error wrapping from #313