### PR TITLE
Upgrade to go 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.2.1
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -63,7 +63,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.2.1
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -82,7 +82,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.2.1
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - name: Install formatter
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check format

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -46,7 +46,6 @@ func setupCsubClient(cmd *cobra.Command, args []string) (context.Context, *clien
 	opts, err := validateCsubClientFlags(
 		viper.GetString("csub-addr"),
 	)
-
 	if err != nil {
 		fmt.Printf("unable to validate flags: %v\n", err)
 		_ = cmd.Help()
@@ -68,10 +67,10 @@ func validateCsubClientFlags(addr string) (csubClientOptions, error) {
 }
 
 /*
-	Examples:
+Examples:
 
-	# add two entries
-	echo '[{"type":"DATATYPE_GIT", "value":"git+somerepo"},{"type":"DATATYPE_OCI", "value":"oci://abc"}]' | bin/guacone csub-client  add-collect-entries
+# add two entries
+echo '[{"type":"DATATYPE_GIT", "value":"git+somerepo"},{"type":"DATATYPE_OCI", "value":"oci://abc"}]' | bin/guacone csub-client  add-collect-entries
 */
 var csubAddCollectEntriesCmd = &cobra.Command{
 	Use:   "add-collect-entries",
@@ -115,13 +114,13 @@ var getAllFilters = []*collectsub.CollectEntryFilter{
 }
 
 /*
-	Examples:
+Examples:
 
-	# get all entries (default)
-	guacone csub-client get-collect-entries
+# get all entries (default)
+guacone csub-client get-collect-entries
 
-	# use custom filters
-	echo '[{"type":"DATAYPE_GIT", "value":"*"}]' | guacone csub-client get-collect-entries stdin
+# use custom filters
+echo '[{"type":"DATAYPE_GIT", "value":"*"}]' | guacone csub-client get-collect-entries stdin
 */
 var csubGetCollectEntriesCmd = &cobra.Command{
 	Use:   "get-collect-entries [all | stdin] (defaults to all)",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/guacsec/guac
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.29.0
@@ -42,8 +42,14 @@ require (
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
+	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/grpc v1.51.0 // indirect
+	google.golang.org/grpc v1.51.0
 	google.golang.org/grpc v1.52.0
+	google.golang.org/protobuf v1.28.1
+	google.golang.org/protobuf v1.28.1 // indirect
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -42,14 +42,8 @@ require (
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
-	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.51.0 // indirect
-	google.golang.org/grpc v1.51.0
 	google.golang.org/grpc v1.52.0
-	google.golang.org/protobuf v1.28.1
-	google.golang.org/protobuf v1.28.1 // indirect
 	google.golang.org/protobuf v1.28.1
 )
 


### PR DESCRIPTION
- The go 1.20 will be released in 02/23 which will make 1.18 unsupported for security fixes.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>