### PR TITLE
Modified certifier to be generic to allow for other component types

### DIFF
--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -24,7 +24,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphdb"
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
-	root_package "github.com/guacsec/guac/pkg/certifier/components"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"

--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -53,10 +53,8 @@ var certifierCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-		if err != nil {
-			logger.Errorf("unable to register key provider: %w", err)
-			os.Exit(1)
+		if err := certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV); err != nil {
+			logger.Fatalf("unable to register certifier: %w", err)
 		}
 
 		authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(opts.user, opts.pass, opts.realm)

--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -25,6 +25,7 @@ import (
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
 	root_package "github.com/guacsec/guac/pkg/certifier/components"
+	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -49,6 +50,12 @@ var certifierCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		err = certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
+		if err != nil {
+			logger.Errorf("unable to register key provider: %w", err)
 			os.Exit(1)
 		}
 

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -57,10 +57,8 @@ var certifierCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-		if err != nil {
-			logger.Errorf("unable to register key provider: %w", err)
-			os.Exit(1)
+		if err := certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV); err != nil {
+			logger.Fatalf("unable to register certifier: %w", err)
 		}
 
 		authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(opts.user, opts.pass, opts.realm)

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -27,6 +27,7 @@ import (
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
 	root_package "github.com/guacsec/guac/pkg/certifier/components"
+	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
@@ -53,6 +54,12 @@ var certifierCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		err = certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
+		if err != nil {
+			logger.Errorf("unable to register key provider: %w", err)
 			os.Exit(1)
 		}
 

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -26,7 +26,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphdb"
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
-	root_package "github.com/guacsec/guac/pkg/certifier/components"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/guacsec/guac/internal/testing/keyutil"
 	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
@@ -777,24 +777,24 @@ var (
 		Purl: "pkg:maven/org.apache.commons/commons-text@1.9",
 	}
 
-	text4shell = &certifier.Component{
+	text4shell = &root_package.PackageComponent{
 		Package:     text4ShelPackage,
-		DepPackages: []*certifier.Component{},
+		DepPackages: []*root_package.PackageComponent{},
 	}
 
-	log4j = &certifier.Component{
+	log4j = &root_package.PackageComponent{
 		Package:     log4JPackage,
-		DepPackages: []*certifier.Component{},
+		DepPackages: []*root_package.PackageComponent{},
 	}
 
-	secondLevel = &certifier.Component{
+	secondLevel = &root_package.PackageComponent{
 		Package:     secondLevelPackage,
-		DepPackages: []*certifier.Component{text4shell},
+		DepPackages: []*root_package.PackageComponent{text4shell},
 	}
 
-	RootComponent = &certifier.Component{
+	RootComponent = &root_package.PackageComponent{
 		Package:     rootPackage,
-		DepPackages: []*certifier.Component{secondLevel, log4j},
+		DepPackages: []*root_package.PackageComponent{secondLevel, log4j},
 	}
 )
 

--- a/pkg/certifier/certifier.go
+++ b/pkg/certifier/certifier.go
@@ -18,18 +18,21 @@ package certifier
 import (
 	"context"
 
-	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
 type Certifier interface {
 	// CertifyComponent takes a GUAC component and generates processor.documents that are
-	// push to the docChannel to be ingested
-	CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error
+	// push to the docChannel to be ingested.
+	// Note: there is an implicit contract with "QueryComponents" where the compChan type must be the same as
+	// the one used by "components"
+	CertifyComponent(ctx context.Context, components interface{}, docChannel chan<- *processor.Document) error
 }
 
 type QueryComponents interface {
 	// GetComponents runs as a goroutine to get the GUAC components that will be certified by the Certifier interface
+	// Note: there is an implicit contract with "CertifyComponent" where the components type must be the same as
+	// the one used by "compChan"
 	GetComponents(ctx context.Context, compChan chan<- interface{}) error
 }
 
@@ -46,9 +49,3 @@ type CertifierType string
 const (
 	CertifierOSV CertifierType = "OSV"
 )
-
-// Component represents the top level package node and its dependencies
-type Component struct {
-	Package     assembler.PackageNode
-	DepPackages []*Component
-}

--- a/pkg/certifier/certifier.go
+++ b/pkg/certifier/certifier.go
@@ -23,13 +23,13 @@ import (
 )
 
 type Certifier interface {
-	// CertifyComponent takes a guac component and generates processor.documents that are
+	// CertifyComponent takes a GUAC component and generates processor.documents that are
 	// push to the docChannel to be ingested
 	CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error
 }
 
 type QueryComponents interface {
-	// GetComponents runs as a goroutine to get the guac components that will be certified by the Certifier interface
+	// GetComponents runs as a goroutine to get the GUAC components that will be certified by the Certifier interface
 	GetComponents(ctx context.Context, compChan chan<- interface{}) error
 }
 

--- a/pkg/certifier/certifier.go
+++ b/pkg/certifier/certifier.go
@@ -23,15 +23,14 @@ import (
 )
 
 type Certifier interface {
-	// CertifyComponent takes the type Component and recursively scans each dependency
-	// aggregating the results for the top/root level artifact. As attestation documents are generated
-	// they are push to the docChannel to be ingested
-	CertifyComponent(ctx context.Context, rootComponent *Component, docChannel chan<- *processor.Document) error
+	// CertifyComponent takes a guac component and generates processor.documents that are
+	// push to the docChannel to be ingested
+	CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error
 }
 
 type QueryComponents interface {
-	// GetComponents runs as a goroutine to get the components that will be certified by the Certifier interface
-	GetComponents(ctx context.Context, compChan chan<- *Component) error
+	// GetComponents runs as a goroutine to get the guac components that will be certified by the Certifier interface
+	GetComponents(ctx context.Context, compChan chan<- interface{}) error
 }
 
 // Emitter processes a document

--- a/pkg/certifier/certify/certify.go
+++ b/pkg/certifier/certify/certify.go
@@ -55,7 +55,7 @@ func RegisterCertifier(c func() certifier.Certifier, certifierType certifier.Cer
 func Certify(ctx context.Context, query certifier.QueryComponents, emitter certifier.Emitter, handleErr certifier.ErrHandler) error {
 
 	// docChan to collect artifacts
-	compChan := make(chan *certifier.Component, BufferChannelSize)
+	compChan := make(chan interface{}, BufferChannelSize)
 	// errChan to receive error from collectors
 	errChan := make(chan error, 1)
 	// logger
@@ -91,7 +91,7 @@ func Certify(ctx context.Context, query certifier.QueryComponents, emitter certi
 
 // generateDocuments runs CertifyVulns as a goroutine to scan and generate a vulnerability certification that
 // are emitted as processor documents to be ingested
-func generateDocuments(ctx context.Context, collectedComponent *certifier.Component, emitter certifier.Emitter, handleErr certifier.ErrHandler) error {
+func generateDocuments(ctx context.Context, collectedComponent interface{}, emitter certifier.Emitter, handleErr certifier.ErrHandler) error {
 
 	// docChan to collect artifacts
 	docChan := make(chan *processor.Document, BufferChannelSize)

--- a/pkg/certifier/certify/certify.go
+++ b/pkg/certifier/certify/certify.go
@@ -31,13 +31,18 @@ const (
 )
 
 var (
-	documentCertifier = map[certifier.CertifierType]func() certifier.Certifier{}
+	documentCertifier     = map[certifier.CertifierType]func() certifier.Certifier{}
+	errCertifierOverwrite = fmt.Errorf("the certifier is being overwritten")
 )
+
+func certifierTypeOverwriteError(certifierType certifier.CertifierType) error {
+	return fmt.Errorf("%w: %s", errCertifierOverwrite, certifierType)
+}
 
 // RegisterCertifier registers the active certifier for to generate attestations
 func RegisterCertifier(c func() certifier.Certifier, certifierType certifier.CertifierType) error {
 	if _, ok := documentCertifier[certifierType]; ok {
-		return fmt.Errorf("the certifier is being overwritten: %s", certifierType)
+		return certifierTypeOverwriteError(certifierType)
 	}
 	documentCertifier[certifierType] = c
 

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -68,7 +68,7 @@ func TestCertify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 
 	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-	if err != nil && !strings.Contains(err.Error(), "the certifier is being overwritten") {
+	if err != nil && !errors.Is(err, fmt.Errorf("the certifier is being overwritten: %s", certifier.CertifierOSV)) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -164,7 +164,7 @@ func TestCertify(t *testing.T) {
 
 func Test_Publish(t *testing.T) {
 	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-	if err != nil && !strings.Contains(err.Error(), "the certifier is being overwritten") {
+	if err != nil && !errors.Is(err, fmt.Errorf("the certifier is being overwritten: %s", certifier.CertifierOSV)) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	expectedDocTree := dochelper.DocNode(&testdata.Ite6SLSADoc)

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -42,7 +42,7 @@ func newMockQuery() certifier.QueryComponents {
 }
 
 // GetComponents returns components for test
-func (q *mockQuery) GetComponents(ctx context.Context, compChan chan<- *certifier.Component) error {
+func (q *mockQuery) GetComponents(ctx context.Context, compChan chan<- interface{}) error {
 	compChan <- testdata.RootComponent
 	return nil
 }

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
@@ -51,6 +52,11 @@ func (q *mockQuery) GetComponents(ctx context.Context, compChan chan<- interface
 
 func TestCertify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
+
+	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
+	if err != nil && !strings.Contains(err.Error(), "the certifier is being overwritten") {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	errHandler := func(err error) bool {
 		return err == nil
@@ -149,6 +155,11 @@ func (q *mockUnknownQuery) GetComponents(ctx context.Context, compChan chan<- in
 func TestUnknownTypeCertify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 
+	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
+	if err != nil && !strings.Contains(err.Error(), "the certifier is being overwritten") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	errHandler := func(err error) bool {
 		return err == nil
 	}
@@ -162,7 +173,7 @@ func TestUnknownTypeCertify(t *testing.T) {
 		name:       "unknown type for collected component",
 		query:      newMockUnknownQuery(),
 		wantErr:    true,
-		errMessage: "certifier failed to determine type of collectedComponent",
+		errMessage: "rootComponent type is not *certifier.Component",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,6 +196,10 @@ func TestUnknownTypeCertify(t *testing.T) {
 }
 
 func Test_Publish(t *testing.T) {
+	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
+	if err != nil && !strings.Contains(err.Error(), "the certifier is being overwritten") {
+		t.Errorf("unexpected error: %v", err)
+	}
 	expectedDocTree := dochelper.DocNode(&testdata.Ite6SLSADoc)
 
 	natsTest := nats_test.NewNatsTestServer()

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -68,7 +67,7 @@ func TestCertify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 
 	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-	if err != nil && !errors.Is(err, fmt.Errorf("the certifier is being overwritten: %s", certifier.CertifierOSV)) {
+	if err != nil && !errors.Is(err, errCertifierOverwrite) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -81,7 +80,7 @@ func TestCertify(t *testing.T) {
 		query      certifier.QueryComponents
 		want       []*processor.Document
 		wantErr    bool
-		errMessage string
+		errMessage error
 	}{{
 		name:  "query and generate attestation",
 		query: newMockQuery(),
@@ -128,7 +127,7 @@ func TestCertify(t *testing.T) {
 		name:       "unknown type for collected component",
 		query:      newMockUnknownQuery(),
 		wantErr:    true,
-		errMessage: "rootComponent type is not *certifier.Component",
+		errMessage: osv.ErrOSVComponenetTypeMismatch,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -154,7 +153,7 @@ func TestCertify(t *testing.T) {
 					}
 				}
 			} else {
-				if !strings.Contains(err.Error(), tt.errMessage) {
+				if !errors.Is(err, tt.errMessage) {
 					t.Errorf("Certify() errored with message = %v, wanted error message %v", err, tt.errMessage)
 				}
 			}
@@ -164,7 +163,7 @@ func TestCertify(t *testing.T) {
 
 func Test_Publish(t *testing.T) {
 	err := RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV)
-	if err != nil && !errors.Is(err, fmt.Errorf("the certifier is being overwritten: %s", certifier.CertifierOSV)) {
+	if err != nil && !errors.Is(err, errCertifierOverwrite) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	expectedDocTree := dochelper.DocNode(&testdata.Ite6SLSADoc)

--- a/pkg/certifier/components/root_package.go
+++ b/pkg/certifier/components/root_package.go
@@ -38,7 +38,7 @@ func NewPackageQuery(client graphdb.Client) certifier.QueryComponents {
 
 // GetComponents runs as a goroutine to query for root level and dependent packages to scan and passes them
 // to the compChan as they are found
-func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- *certifier.Component) error {
+func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- interface{}) error {
 	// Get top level package MATCH (p:Package) WHERE NOT (p)<-[:DependsOn]-() return p
 	// Get all packages that the top level package depends on MATCH (p:Package) WHERE NOT (p)<-[:DependsOn]-() WITH p MATCH (p)-[:DependsOn]->(p2:Package) return p2
 	// MATCH (p:Package) WHERE p.purl = "pkg:oci/vul-image-latest?repository_url=ppatel1989" WITH p MATCH (p)-[:DependsOn]->(p2:Package) return p2

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -25,6 +25,12 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/dbtype"
 )
 
+// PackageComponent represents the top level package node and its dependencies
+type PackageComponent struct {
+	Package     assembler.PackageNode
+	DepPackages []*PackageComponent
+}
+
 type packageQuery struct {
 	client graphdb.Client
 }
@@ -37,7 +43,7 @@ func NewPackageQuery(client graphdb.Client) certifier.QueryComponents {
 }
 
 // GetComponents runs as a goroutine to query for root level and dependent packages to scan and passes them
-// to the compChan as they are found
+// to the compChan as they are found. The interface will be type "*Component"
 func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- interface{}) error {
 	// Get top level package MATCH (p:Package) WHERE NOT (p)<-[:DependsOn]-() return p
 	// Get all packages that the top level package depends on MATCH (p:Package) WHERE NOT (p)<-[:DependsOn]-() WITH p MATCH (p)-[:DependsOn]->(p2:Package) return p2
@@ -61,7 +67,7 @@ func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- interf
 		if err != nil {
 			return err
 		}
-		rootComponent := &certifier.Component{
+		rootComponent := &PackageComponent{
 			Package:     rootPackage,
 			DepPackages: deps,
 		}
@@ -70,13 +76,13 @@ func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- interf
 	return nil
 }
 
-func getCompHelper(ctx context.Context, client graphdb.Client, parentPurl string) ([]*certifier.Component, error) {
+func getCompHelper(ctx context.Context, client graphdb.Client, parentPurl string) ([]*PackageComponent, error) {
 	dependencies, err := graphdb.ReadQuery(client, "MATCH (p:Package) WHERE p.purl = $rootPurl WITH p MATCH (p)-[:DependsOn]->(p2:Package) return p2",
 		map[string]any{"rootPurl": parentPurl})
 	if err != nil {
 		return nil, err
 	}
-	depPackages := []*certifier.Component{}
+	depPackages := []*PackageComponent{}
 	for _, dep := range dependencies {
 		foundDep, ok := dep.(dbtype.Node)
 		if !ok {
@@ -91,7 +97,7 @@ func getCompHelper(ctx context.Context, client graphdb.Client, parentPurl string
 		if err != nil {
 			return nil, err
 		}
-		depPackages = append(depPackages, &certifier.Component{
+		depPackages = append(depPackages, &PackageComponent{
 			Package:     foundDepPack,
 			DepPackages: deps,
 		})

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -18,6 +18,7 @@ package osv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -51,7 +52,11 @@ func NewOSVCertificationParser() certifier.Certifier {
 // CertifyComponent takes in the root component from the gauc database and does a recursive scan
 // to generate vulnerability attestations
 func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
-	o.rootComponents = rootComponent.(*certifier.Component)
+	if component, ok := rootComponent.(*certifier.Component); ok {
+		o.rootComponents = component
+	} else {
+		return errors.New("rootComponent type is not *certifier.Component")
+	}
 	m := make(map[string]bool)
 	_, err := o.certifyHelper(ctx, o.rootComponents, docChannel, m)
 	if err != nil {

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -18,7 +18,6 @@ package osv
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -55,7 +54,7 @@ func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent inter
 	if component, ok := rootComponent.(*certifier.Component); ok {
 		o.rootComponents = component
 	} else {
-		return errors.New("rootComponent type is not *certifier.Component")
+		return fmt.Errorf("rootComponent type is not *certifier.Component")
 	}
 	m := make(map[string]bool)
 	_, err := o.certifyHelper(ctx, o.rootComponents, docChannel, m)

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/certifier"
 	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/certifier/osv/internal/osv_query"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -42,7 +43,7 @@ const (
 var ErrOSVComponenetTypeMismatch error = fmt.Errorf("rootComponent type is not *certifier.Component")
 
 type osvCertifier struct {
-	rootComponents *certifier.Component
+	rootComponents *root_package.PackageComponent
 }
 
 // NewOSVCertificationParser initializes the OSVCertifier
@@ -53,7 +54,7 @@ func NewOSVCertificationParser() certifier.Certifier {
 // CertifyComponent takes in the root component from the gauc database and does a recursive scan
 // to generate vulnerability attestations
 func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
-	if component, ok := rootComponent.(*certifier.Component); ok {
+	if component, ok := rootComponent.(*root_package.PackageComponent); ok {
 		o.rootComponents = component
 	} else {
 		return ErrOSVComponenetTypeMismatch
@@ -74,7 +75,7 @@ func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent inter
 // attestation is generated containing all the vulnerabilities of its dependencies
 // these vulnerabilities are passed up until it reaches the root level node which contains an attestation
 // with all the aggregate vulnerabilities. The visited map is used to prevent infinite recursion.
-func (o *osvCertifier) certifyHelper(ctx context.Context, topLevel *certifier.Component, docChannel chan<- *processor.Document,
+func (o *osvCertifier) certifyHelper(ctx context.Context, topLevel *root_package.PackageComponent, docChannel chan<- *processor.Document,
 	visited map[string]bool) ([]osv_scanner.Entry, error) {
 	if visited == nil {
 		return nil, fmt.Errorf("visited map is nil")

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -50,10 +50,10 @@ func NewOSVCertificationParser() certifier.Certifier {
 
 // CertifyComponent takes in the root component from the gauc database and does a recursive scan
 // to generate vulnerability attestations
-func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent *certifier.Component, docChannel chan<- *processor.Document) error {
-	o.rootComponents = rootComponent
+func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
+	o.rootComponents = rootComponent.(*certifier.Component)
 	m := make(map[string]bool)
-	_, err := o.certifyHelper(ctx, rootComponent, docChannel, m)
+	_, err := o.certifyHelper(ctx, o.rootComponents, docChannel, m)
 	if err != nil {
 		return err
 	}

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -39,6 +39,8 @@ const (
 	PRODUCER_ID string = "guacsec/guac"
 )
 
+var ErrOSVComponenetTypeMismatch error = fmt.Errorf("rootComponent type is not *certifier.Component")
+
 type osvCertifier struct {
 	rootComponents *certifier.Component
 }
@@ -54,7 +56,7 @@ func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent inter
 	if component, ok := rootComponent.(*certifier.Component); ok {
 		o.rootComponents = component
 	} else {
-		return fmt.Errorf("rootComponent type is not *certifier.Component")
+		return ErrOSVComponenetTypeMismatch
 	}
 	m := make(map[string]bool)
 	_, err := o.certifyHelper(ctx, o.rootComponents, docChannel, m)

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 
 	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	osv_scanner "golang.org/x/vuln/osv"
 
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	"github.com/guacsec/guac/internal/testing/testdata"
-	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
 )
@@ -245,27 +245,27 @@ func deepEqualIgnoreTimestamp(a, b *attestation_vuln.VulnerabilityStatement) boo
 }
 
 func TestCertifyHelperStackOverflow(t *testing.T) {
-	var A, B, C *certifier.Component
+	var A, B, C *root_package.PackageComponent
 	// Create a cyclical dependency between two components
-	A = &certifier.Component{
+	A = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
 			Name: "example.com/A",
 		},
 	}
 
-	B = &certifier.Component{
+	B = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
 			Purl: "example.com/B",
 		},
 	}
-	C = &certifier.Component{
+	C = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
 			Purl: "example.com/C",
 		},
 	}
-	A.DepPackages = []*certifier.Component{B, C}
-	B.DepPackages = []*certifier.Component{C, A}
-	C.DepPackages = []*certifier.Component{A, B}
+	A.DepPackages = []*root_package.PackageComponent{B, C}
+	B.DepPackages = []*root_package.PackageComponent{C, A}
+	C.DepPackages = []*root_package.PackageComponent{A, B}
 	// Create a channel to receive the generated documents
 	docChannel := make(chan *processor.Document, 10)
 	o := NewOSVCertificationParser()


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Currently, the certifier only takes in components that are package nodes. Changing it to an `interface{}` allows for other types to be specified and certified.

Part of issue #249 to allow for `assembler.ArtifactNode` to be used.