### PR TITLE
Replaced returning err with fmt.Errorf

### DIFF
--- a/pkg/handler/collector/git/git.go
+++ b/pkg/handler/collector/git/git.go
@@ -17,6 +17,7 @@ package git_collector
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -73,7 +74,7 @@ func (g *gitDocumentCollector) RetrieveArtifacts(ctx context.Context, docChannel
 			}
 			err := g.createOrPull(ctx, logger, docChannel)
 			if err != nil {
-				return err
+				return fmt.Errorf("error creating git repo: %v", err)
 			}
 			g.lastChecked = time.Now()
 			time.Sleep(g.interval)
@@ -81,7 +82,7 @@ func (g *gitDocumentCollector) RetrieveArtifacts(ctx context.Context, docChannel
 	} else {
 		err := g.createOrPull(ctx, logger, docChannel)
 		if err != nil {
-			return err
+			return fmt.Errorf("error pulling git repo: %v", err)
 		}
 		g.lastChecked = time.Now()
 	}
@@ -92,29 +93,29 @@ func (g *gitDocumentCollector) RetrieveArtifacts(ctx context.Context, docChannel
 func (g *gitDocumentCollector) createOrPull(ctx context.Context, logger *zap.SugaredLogger, docChannel chan<- *processor.Document) error {
 	exists, err := checkIfDirExists(g.dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("error checking if directory exists: %v", err)
 	}
 
 	if !exists {
 		if err := os.Mkdir(g.dir, os.ModePerm); err != nil {
-			return err
+			return fmt.Errorf("error creating directory: %v", err)
 		}
 		err := cloneRepoToDir(logger, g.url, g.dir)
 		if err != nil {
-			return err
+			return fmt.Errorf("error cloning repo: %v", err)
 		}
 		err = g.fileCollector.RetrieveArtifacts(ctx, docChannel)
 		if err != nil {
-			return err
+			return fmt.Errorf("error retrieving artifacts: %v", err)
 		}
 	} else {
 		err := pullRepo(logger, g.dir)
 		if err != nil && err != git.NoErrAlreadyUpToDate {
-			return err
+			return fmt.Errorf("error pulling repo: %v", err)
 		} else if err == nil {
 			err = g.fileCollector.RetrieveArtifacts(ctx, docChannel)
 			if err != nil {
-				return err
+				return fmt.Errorf("error retrieving artifacts: %v", err)
 			}
 		}
 	}
@@ -132,7 +133,7 @@ func checkIfDirExists(name string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, err
+		return false, fmt.Errorf("error checking if directory exists: %v", err)
 	}
 	return true, nil
 }
@@ -147,18 +148,18 @@ func cloneRepoToDir(logger *zap.SugaredLogger, url string, directory string) err
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error cloning repo: %v", err)
 	}
 
 	// Retrieve the branch being pointed by HEAD
 	ref, err := r.Head()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving HEAD: %v", err)
 	}
 	// Retrieve the commit object
 	commit, err := r.CommitObject(ref.Hash())
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving commit object: %v", err)
 	}
 
 	logger.Debugf("Commit: %s", commit)
@@ -169,18 +170,18 @@ func pullRepo(logger *zap.SugaredLogger, directory string) error {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(directory)
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening repo: %v", err)
 	}
 	// Get the working directory for the repository
 	w, err := r.Worktree()
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting worktree: %v", err)
 	}
 
 	// Pull the latest changes from the origin remote and merge into the current branch
 	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
 	if err != nil {
-		return err
+		return fmt.Errorf("error pulling repo: %v", err)
 	}
 
 	return nil

--- a/pkg/handler/collector/git/git_test.go
+++ b/pkg/handler/collector/git/git_test.go
@@ -76,7 +76,7 @@ func Test_gitCol_RetrieveArtifacts(t *testing.T) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
 		t.Run(tt.name, func(t *testing.T) {
-			// incase the file exists from a failed run, delete it
+			// in case the file exists from a failed run, delete it
 			os.RemoveAll(tt.fields.dir)
 			g := NewGitDocumentCollector(ctx, tt.fields.url, tt.fields.dir, tt.fields.poll, tt.fields.interval)
 


### PR DESCRIPTION
- Replaced the `return err` with `return fmt.Errorf()`

Returning `fmt.Errorf()` instead of `return err` in Go is generally considered to be best practice because it allows for more detailed and informative error messages. `fmt.Errorf()` is a function that formats a string and returns an error, which means that developers can include additional context and information in the error message that can be helpful for debugging and troubleshooting. In contrast, simply returning `err` without any additional context can make it more difficult to understand the cause of the error and how to fix it. Additionally, by returning a formatted error message, it makes error handling and debugging more consistent.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>