### PR TITLE
Add skip files for golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,6 @@
 run:
   timeout: 2m
+  skip-files:
+    - ".*\\.pb\\.go$"
+    - "pkg/assembler/generated/.*"
+    - "resolvers/schema\\.resolvers\\.go"


### PR DESCRIPTION
Due to autogenerated files in #326 not including the appropriate comments to flag for auto-generated code, adding exceptions to the linter to skip files in CI check.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>