### PR TITLE
Cleaned Up Code in git_test

### DIFF
--- a/pkg/handler/collector/git/git_test.go
+++ b/pkg/handler/collector/git/git_test.go
@@ -105,12 +105,10 @@ func Test_gitCol_RetrieveArtifacts(t *testing.T) {
 				errChan <- g.RetrieveArtifacts(ctx, docChan)
 			}()
 
-			numCollectors := 1
-			collectorsDone := 0
-
+			hasErrored := false
 			collectedDocs := []*processor.Document{}
 
-			for collectorsDone < numCollectors {
+			for !hasErrored {
 				select {
 				case d := <-docChan:
 					collectedDocs = append(collectedDocs, d)
@@ -118,7 +116,8 @@ func Test_gitCol_RetrieveArtifacts(t *testing.T) {
 					if (err != nil) != tt.wantErr {
 						t.Errorf("fileCollector.RetrieveArtifacts() = %v, want %v", err, tt.wantErr)
 					}
-					collectorsDone += 1
+
+					hasErrored = true
 				}
 			}
 


### PR DESCRIPTION
- Cleaned up some code in `git_test.go`
- There is no need for `numCollectors` and `collectorsDone`, because `numCollectors` is always 1 and `collectorsDone` is only incremented when `case err := <-errChan`

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>