### PR TITLE
fix: updated cdx purl parsing to match spec

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -169,7 +169,7 @@ We then run the following commands that finds other containers that share depend
 with the debian image, and counts the number of shared dependencies in descending order.
 
 ```
-MATCH (n:Package{purl:"pkg:oci/debian:latest?repository_url=docker.io/library"}) -[:Contains|DependsOn*1..5]->(d)<-[*1..3]-(o:Package)
+MATCH (n:Package{purl:"pkg:oci/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d?repository_url=docker.io/library/debian&tag=latest"}) -[:Contains|DependsOn*1..5]->(d)<-[*1..3]-(o:Package)
 where "CONTAINER" in o.tags
 WITH o.purl AS target, collect(d.name) as shared_dep
 RETURN target, SIZE(shared_dep) as num_deps, shared_dep
@@ -179,12 +179,12 @@ ORDER BY num_deps desc;
 The result of that is a list of containers that share dependencies with debian.
 We can see the top matches which have a lot of shared packages/files.
 
-![image](https://user-images.githubusercontent.com/3060102/197051119-31ebf12d-2b6a-4f0d-b188-f5194956e626.png)
+![image](https://user-images.githubusercontent.com/88045217/214941835-f1ce3627-97c1-43f3-8a7b-a5c5deed8180.png)
 
 Going down the list, we see other containers which do not have many shared
 packages/files, and thus probably don't use the debian image.
 
-![image](https://user-images.githubusercontent.com/3060102/197051163-47db6eb1-af3b-41df-a0dc-8fd7c5d582b8.png)
+![image](https://user-images.githubusercontent.com/88045217/214942287-040d842d-5afa-4a2b-9d7d-925d85d3887a.png)
 
 ## Clean-up
 

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -430,7 +430,7 @@ var (
 		Name:    "gcr.io/distroless/static:nonroot",
 		Digest:  []string{"sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388"},
 		Version: "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
-		Purl:    "pkg:oci/static:nonroot?repository_url=gcr.io/distroless",
+		Purl:    "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
 		Tags:    []string{"CONTAINER"},
 		CPEs:    nil,
 		NodeData: *assembler.NewObjectMetadata(

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -118,9 +118,10 @@ func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 				if len(splitTag) == 2 {
 					rootPackage.Purl = "pkg:oci/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
 						"?repository_url=" + splitImage[0] + "/" + splitImage[1] + "/" + splitTag[0] + "&tag=" + splitTag[1]
-					rootPackage.Version = cdxBom.Metadata.Component.Version
-					rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
-					rootPackage.Tags = []string{"CONTAINER"}
+				} else {
+					// no tag specified
+					rootPackage.Purl = "pkg:oci/" + splitImage[2] + "@" + cdxBom.Metadata.Component.Version +
+						"?repository_url=" + splitImage[0] + "/" + splitImage[1] + "/" + splitImage[2] + "&tag="
 				}
 			} else if len(splitImage) == 2 {
 				// example: library/debian:latest
@@ -128,11 +129,15 @@ func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 				if len(splitTag) == 2 {
 					rootPackage.Purl = "pkg:oci/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
 						"?repository_url=" + splitImage[0] + "/" + splitTag[0] + "&tag=" + splitTag[1]
-					rootPackage.Version = cdxBom.Metadata.Component.Version
-					rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
-					rootPackage.Tags = []string{"CONTAINER"}
+				} else {
+					// no tag specified
+					rootPackage.Purl = "pkg:oci/" + splitImage[1] + "@" + cdxBom.Metadata.Component.Version +
+						"?repository_url=" + splitImage[0] + "/" + splitImage[1] + "&tag="
 				}
 			}
+			rootPackage.Version = cdxBom.Metadata.Component.Version
+			rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
+			rootPackage.Tags = []string{"CONTAINER"}
 		}
 		c.rootComponent = component{
 			curPackage:  rootPackage,

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -113,10 +113,25 @@ func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 		} else {
 			splitImage := strings.Split(cdxBom.Metadata.Component.Name, "/")
 			if len(splitImage) == 3 {
-				rootPackage.Purl = "pkg:oci/" + splitImage[2] + "?repository_url=" + splitImage[0] + "/" + splitImage[1]
-				rootPackage.Version = cdxBom.Metadata.Component.Version
-				rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
-				rootPackage.Tags = []string{"CONTAINER"}
+				// example: gcr.io/distroless/static:nonroot
+				splitTag := strings.Split(splitImage[2], ":")
+				if len(splitTag) == 2 {
+					rootPackage.Purl = "pkg:oci/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
+						"?repository_url=" + splitImage[0] + "/" + splitImage[1] + "/" + splitTag[0] + "&tag=" + splitTag[1]
+					rootPackage.Version = cdxBom.Metadata.Component.Version
+					rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
+					rootPackage.Tags = []string{"CONTAINER"}
+				}
+			} else if len(splitImage) == 2 {
+				// example: library/debian:latest
+				splitTag := strings.Split(splitImage[1], ":")
+				if len(splitTag) == 2 {
+					rootPackage.Purl = "pkg:oci/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
+						"?repository_url=" + splitImage[0] + "/" + splitTag[0] + "&tag=" + splitTag[1]
+					rootPackage.Version = cdxBom.Metadata.Component.Version
+					rootPackage.Digest = append(rootPackage.Digest, cdxBom.Metadata.Component.Version)
+					rootPackage.Tags = []string{"CONTAINER"}
+				}
 			}
 		}
 		c.rootComponent = component{

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -168,6 +168,17 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 		},
 		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
 	}, {
+		name: "gcr.io/distroless/static - purl not provided, tag not specified",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "gcr.io/distroless/static",
+					Version: "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
+				},
+			},
+		},
+		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=",
+	}, {
 		name: "library/debian:latest - purl not provided, assume docker.io",
 		cdxBom: &cdx.BOM{
 			Metadata: &cdx.Metadata{
@@ -178,6 +189,17 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=latest",
+	}, {
+		name: "library/debian - purl not provided, assume docker.io, tag not specified",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "library/debian",
+					Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+				},
+			},
+		},
+		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -17,8 +17,10 @@ package cyclonedx
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
+	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
@@ -135,4 +137,64 @@ func Test_addEdgesRecursive(t *testing.T) {
 	var e []assembler.GuacEdge
 	visited = make(map[string]bool)
 	addEdges(packageA, &e, visited)
+}
+
+func Test_cyclonedxParser_addRootPackage(t *testing.T) {
+	tests := []struct {
+		name     string
+		cdxBom   *cdx.BOM
+		wantPurl string
+	}{{
+		name: "purl provided",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:       "gcr.io/distroless/static:nonroot",
+					Version:    "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
+					PackageURL: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+				},
+			},
+		},
+		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+	}, {
+		name: "gcr.io/distroless/static:nonroot - purl not provided",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "gcr.io/distroless/static:nonroot",
+					Version: "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
+				},
+			},
+		},
+		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+	}, {
+		name: "library/debian:latest - purl not provided, assume docker.io",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "library/debian:latest",
+					Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+				},
+			},
+		},
+		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=latest",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cyclonedxParser{
+				doc: &processor.Document{
+					SourceInformation: processor.SourceInformation{
+						Collector: "test",
+						Source:    "test",
+					},
+				},
+				rootComponent: component{},
+				pkgMap:        map[string]*component{},
+			}
+			c.addRootPackage(tt.cdxBom)
+			if !reflect.DeepEqual(c.rootComponent.curPackage.Purl, tt.wantPurl) {
+				t.Errorf("addRootPackage failed to produce expected purl = %v, want %v", c.rootComponent.curPackage.Purl, tt.wantPurl)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Updated CDX heuristic to handle `docker.io` use case and match the [oci purl type](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci). 

Updated `setup.md` with the changes to the CDX parser.

fixes #354 
fixes https://github.com/guacsec/guac/issues/360