### PR TITLE
add usecase where the name is just the image name in cdx/spdx sbom created via syft

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -134,7 +134,7 @@ In this next query we want to ask what are all the binaries in this container, a
 for each of them, is there any metadata tied to them?
 
 ```
-MATCH p=((n:Package{purl: "pkg:oci/kube-controller-manager-v1.24.6?repository_url=k8s.gcr.io"})-[:DependsOn|Contains*1..5]->(a))
+MATCH p=((n:Package{purl: "pkg:oci/kube-controller-manager-v1.24.6?repository_url=k8s.gcr.io/kube-controller-manager-v1.24.6"})-[:DependsOn|Contains*1..5]->(a))
 WHERE "BINARY" in a.tags
 WITH a,p
 OPTIONAL MATCH pp=((a)-[:DependsOn|Contains*0..5]->()<-[:MetadataFor|Attestation]-(k))

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -267,7 +267,7 @@ var (
 	topLevelPack = assembler.PackageNode{
 		Name:   "gcr.io/google-containers/alpine-latest",
 		Digest: nil,
-		Purl:   "pkg:oci/alpine-latest?repository_url=gcr.io/google-containers",
+		Purl:   "pkg:oci/alpine-latest?repository_url=gcr.io/google-containers/alpine-latest",
 		CPEs:   nil,
 		Tags:   []string{"container"},
 		NodeData: *assembler.NewObjectMetadata(

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -135,6 +135,17 @@ func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 						rootPackage.Purl = "pkg:oci/" + splitImage[1] + "@" + cdxBom.Metadata.Component.Version +
 							"?repository_url=" + splitImage[0] + "/" + splitImage[1] + "&tag="
 					}
+				} else {
+					// example: debian:latest
+					splitTag := strings.Split(splitImage[0], ":")
+					if len(splitTag) == 2 {
+						rootPackage.Purl = "pkg:oci/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
+							"?repository_url=" + splitTag[0] + "&tag=" + splitTag[1]
+					} else {
+						// no tag specified
+						rootPackage.Purl = "pkg:oci/" + splitImage[0] + "@" + cdxBom.Metadata.Component.Version +
+							"?repository_url=" + splitImage[0] + "&tag="
+					}
 				}
 			} else if cdxBom.Metadata.Component.Type == cdx.ComponentTypeFile {
 				// example: file type ("/home/work/test/build/webserver/")

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -224,6 +224,32 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 		wantTag:  "container",
 		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=",
 	}, {
+		name: "library/debian:latest - purl not provided, registry not provided and repo not provided",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "debian:latest",
+					Type:    cdx.ComponentTypeContainer,
+					Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+				},
+			},
+		},
+		wantTag:  "container",
+		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=debian&tag=latest",
+	}, {
+		name: "library/debian - purl not provided, registry not provided and repo not provided, tag not specified",
+		cdxBom: &cdx.BOM{
+			Metadata: &cdx.Metadata{
+				Component: &cdx.Component{
+					Name:    "debian",
+					Type:    cdx.ComponentTypeContainer,
+					Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+				},
+			},
+		},
+		wantTag:  "container",
+		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=debian&tag=",
+	}, {
 		name: "file type - purl nor provided, version provided",
 		cdxBom: &cdx.BOM{
 			Metadata: &cdx.Metadata{

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -61,21 +61,18 @@ func (s *spdxParser) Parse(ctx context.Context, doc *processor.Document) error {
 func (s *spdxParser) getTopLevelPackage() {
 	// oci purl: pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
 	splitImage := strings.Split(s.spdxDoc.DocumentName, "/")
+	topPackage := assembler.PackageNode{}
 	if len(splitImage) == 3 {
-		topPackage := assembler.PackageNode{}
-		topPackage.Purl = "pkg:oci/" + splitImage[2] + "?repository_url=" + splitImage[0] + "/" + splitImage[1]
-		topPackage.Name = s.spdxDoc.DocumentName
-		topPackage.Tags = []string{"container"}
-		topPackage.NodeData = *assembler.NewObjectMetadata(s.doc.SourceInformation)
-		s.packages[string(s.spdxDoc.SPDXIdentifier)] = append(s.packages[string(s.spdxDoc.SPDXIdentifier)], topPackage)
+		topPackage.Purl = "pkg:oci/" + splitImage[2] + "?repository_url=" + splitImage[0] + "/" + splitImage[1] + "/" + splitImage[2]
 	} else if len(splitImage) == 2 {
-		topPackage := assembler.PackageNode{}
-		topPackage.Purl = "pkg:oci/" + splitImage[1] + "?repository_url=" + splitImage[0]
-		topPackage.Name = s.spdxDoc.DocumentName
-		topPackage.Tags = []string{"container"}
-		topPackage.NodeData = *assembler.NewObjectMetadata(s.doc.SourceInformation)
-		s.packages[string(s.spdxDoc.SPDXIdentifier)] = append(s.packages[string(s.spdxDoc.SPDXIdentifier)], topPackage)
+		topPackage.Purl = "pkg:oci/" + splitImage[1] + "?repository_url=" + splitImage[0] + "/" + splitImage[1]
+	} else {
+		topPackage.Purl = "pkg:oci/" + splitImage[0] + "?repository_url=" + splitImage[0]
 	}
+	topPackage.Name = s.spdxDoc.DocumentName
+	topPackage.Tags = []string{"container"}
+	topPackage.NodeData = *assembler.NewObjectMetadata(s.doc.SourceInformation)
+	s.packages[string(s.spdxDoc.SPDXIdentifier)] = append(s.packages[string(s.spdxDoc.SPDXIdentifier)], topPackage)
 }
 
 func (s *spdxParser) getPackages() {


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

1. Handle usecase where the "name" in CDX SBOM is just the image name (no registry or repo).
2. Update SPDX for single document name usecase
3. Update SPDX to partially match OCI spec until tool is  https://github.com/anchore/syft/issues/1241 is resolved.
4. Updated setup.md with changes to query for SPDX

fixes #387
