### PR TITLE
Improve certifier reliability

### DIFF
--- a/pkg/certifier/certify/certify.go
+++ b/pkg/certifier/certify/certify.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	BufferChannelSize int = 1000
+	BufferChannelSize int = 1
 )
 
 var (
@@ -53,7 +53,6 @@ func RegisterCertifier(c func() certifier.Certifier, certifierType certifier.Cer
 // Certify queries the graph DB to get the components to scan. Utilizing the registered certifiers,
 // it generates new nodes and attestations.
 func Certify(ctx context.Context, query certifier.QueryComponents, emitter certifier.Emitter, handleErr certifier.ErrHandler) error {
-
 	// docChan to collect artifacts
 	compChan := make(chan interface{}, BufferChannelSize)
 	// errChan to receive error from collectors


### PR DESCRIPTION
- Reduce buffer channel size in `certify.go` from `1000` to `1` [pkg/certifier/certify/certify.go]
- Fixes https://github.com/guacsec/guac/issues/381

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>