### PR TITLE
Refactor OCI

### DIFF
--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -117,7 +117,7 @@ func (o *ociCollector) getTagsAndFetch(ctx context.Context, repo string, tags []
 		// Filter out tags that are not images
 		for _, tag := range allTags.Tags {
 			// filter out tags that looking for sha256- followed by a 64 character hex string
-			if !(strings.HasPrefix(tag, "sha256-") && len(tag) == 71) {
+			if !(strings.HasPrefix(tag, "sha256-") && len(tag) >= 71) {
 				fetchTags = append(fetchTags, tag)
 			}
 		}

--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -90,7 +90,6 @@ func (o *ociCollector) getTagsAndFetch(ctx context.Context, repo string, tags []
 	if docChannel == nil {
 		return errors.New("invalid document channel")
 	}
-	excludedSuffixes := []string{"sbom", "att", "sig"}
 
 	rcOpts := []regclient.Opt{
 		regclient.WithDockerCreds(),
@@ -117,14 +116,8 @@ func (o *ociCollector) getTagsAndFetch(ctx context.Context, repo string, tags []
 
 		// Filter out tags that are not images
 		for _, tag := range allTags.Tags {
-			shouldInclude := true
-			for _, suffix := range excludedSuffixes {
-				if strings.HasSuffix(tag, suffix) {
-					shouldInclude = false
-					break
-				}
-			}
-			if shouldInclude {
+			// filter out tags that looking for sha256- followed by a 64 character hex string
+			if !(strings.HasPrefix(tag, "sha256-") && len(tag) == 71) {
 				fetchTags = append(fetchTags, tag)
 			}
 		}


### PR DESCRIPTION
- Add checks for nil channel, missing repository name, missing tag, invalid document channel, and excluded suffixes
- Add error messages for failing to parse repository reference, and other errors

[pkg/handler/collector/oci/oci.go]
- Raise the amount of returned recordings from `10` to `100`
- Fix the condition for polling
- Add a check for a nil channel
- Add an error message for missing repository name
- Add an error message for missing tag
- Add an error message for invalid document channel
- Add a filter for excluded suffixes
- Add a check for the context being done
- Add an error message for failing to parse the repository reference

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>