### PR TITLE
Handle subpath in package trie.

### DIFF
--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -87,7 +87,7 @@ func filterVersion(n *model.PackageName, pkgSpec *model.PkgSpec) *model.PackageN
 	var versions []*model.PackageVersion
 	for _, v := range n.Versions {
 		if pkgSpec.Version == nil || v.Version == *pkgSpec.Version {
-			newV := filterQualifiers(v, pkgSpec)
+			newV := filterQualifiersAndSubpath(v, pkgSpec)
 			if newV != nil {
 				versions = append(versions, newV)
 			}
@@ -102,7 +102,12 @@ func filterVersion(n *model.PackageName, pkgSpec *model.PkgSpec) *model.PackageN
 	}
 }
 
-func filterQualifiers(v *model.PackageVersion, pkgSpec *model.PkgSpec) *model.PackageVersion {
+func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec) *model.PackageVersion {
+	// First check for subpath matching
+	if pkgSpec.Subpath != nil && *pkgSpec.Subpath != v.Subpath {
+		return nil
+	}
+
 	// Because we operate on GraphQL-generated structs directly we cannot
 	// use a key-value map, so this is O(n^2). Production resolvers will
 	// run queries that match the qualifiers faster.

--- a/pkg/assembler/backends/testing/ingest.go
+++ b/pkg/assembler/backends/testing/ingest.go
@@ -25,94 +25,96 @@ func registerAllPackages() *demoClient {
 	// TODO: add util to convert from pURL to package fields
 	client := demoClient{}
 	// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
-	client.registerPackage("apk", "alpine", "apk", "2.12.9-r3", "arch=x86")
+	client.registerPackage("apk", "alpine", "apk", "2.12.9-r3", "", "arch=x86")
 	// pkg:apk/alpine/curl@7.83.0-r0?arch=x86
-	client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "arch=x86")
+	client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "", "arch=x86")
 	// pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&shared=True&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c
-	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "arch=x86_64", "build_type=Debug", "compiler=Visual%20Studio", "compiler.runtime=MDd", "compiler.version=16", "os=Windows", "shared=True", "rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e", "prev=b429db8a0e324114c25ec387bfd8281f330d7c5c")
+	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "arch=x86_64", "build_type=Debug", "compiler=Visual%20Studio", "compiler.runtime=MDd", "compiler.version=16", "os=Windows", "shared=True", "rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e", "prev=b429db8a0e324114c25ec387bfd8281f330d7c5c")
 	// pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
-	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "user=bincrafters", "channel=stable")
+	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "user=bincrafters", "channel=stable")
 	// pkg:conan/openssl@3.0.3
-	client.registerPackage("conan", "", "openssl", "3.0.3")
+	client.registerPackage("conan", "", "openssl", "3.0.3", "")
 	// pkg:deb/debian/attr@1:2.4.47-2?arch=amd64
-	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "arch=amd64")
+	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch=amd64")
 	// pkg:deb/debian/attr@1:2.4.47-2?arch=source
-	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "arch=source")
+	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch=source")
 	// pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
-	client.registerPackage("deb", "debian", "curl", "7.50.3-1", "arch=i386", "distro=jessie")
+	client.registerPackage("deb", "debian", "curl", "7.50.3-1", "", "arch=i386", "distro=jessie")
 	// pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch
-	client.registerPackage("deb", "debian", "dpkg", "1.19.0.4", "arch=amd64", "distro=stretch")
+	client.registerPackage("deb", "debian", "dpkg", "1.19.0.4", "", "arch=amd64", "distro=stretch")
 	// pkg:deb/ubuntu/dpkg@1.19.0.4?arch=amd64
-	client.registerPackage("deb", "ubuntu", "dpkg", "1.19.0.4", "arch=amd64")
+	client.registerPackage("deb", "ubuntu", "dpkg", "1.19.0.4", "", "arch=amd64")
 	// pkg:docker/cassandra@latest
-	client.registerPackage("docker", "", "cassandra", "latest")
+	client.registerPackage("docker", "", "cassandra", "latest", "")
 	// pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c
-	client.registerPackage("docker", "", "cassandra", "sha256:244fd47e07d1004f0aed9c")
+	client.registerPackage("docker", "", "cassandra", "sha256:244fd47e07d1004f0aed9c", "")
 	// pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io
-	client.registerPackage("docker", "customer", "dockerimage", "sha256:244fd47e07d1004f0aed9c", "repository_url=gcr.io")
+	client.registerPackage("docker", "customer", "dockerimage", "sha256:244fd47e07d1004f0aed9c", "", "repository_url=gcr.io")
 	// pkg:docker/smartentry/debian@dc437cc87d10
-	client.registerPackage("docker", "smartentry", "debian", "dc437cc87d10")
+	client.registerPackage("docker", "smartentry", "debian", "dc437cc87d10", "")
 	// pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32
-	client.registerPackage("generic", "", "bitwarderl", "", "vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32")
+	client.registerPackage("generic", "", "bitwarderl", "", "", "vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32")
 	// pkg:generic/openssl@1.1.10g
-	client.registerPackage("generic", "", "openssl", "1.1.10g")
+	client.registerPackage("generic", "", "openssl", "1.1.10g", "")
 	// pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da
-	client.registerPackage("generic", "", "openssl", "1.1.10g", "download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz", "checksum=sha256:de4d501267da")
+	client.registerPackage("generic", "", "openssl", "1.1.10g", "", "download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz", "checksum=sha256:de4d501267da")
 	// pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
-	client.registerPackage("oci", "", "debian", "sha256:244fd47e07d10", "repository_url=ghcr.io/debian", "tag=bullseye")
+	client.registerPackage("oci", "", "debian", "sha256:244fd47e07d10", "", "repository_url=ghcr.io/debian", "tag=bullseye")
 	// pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1
-	client.registerPackage("oci", "", "hello-wasm", "sha256:244fd47e07d10", "tag=v1")
+	client.registerPackage("oci", "", "hello-wasm", "sha256:244fd47e07d10", "", "tag=v1")
 	// pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest
-	client.registerPackage("oci", "", "static", "sha256:244fd47e07d10", "repository_url=gcr.io/distroless/static", "tag=latest")
+	client.registerPackage("oci", "", "static", "sha256:244fd47e07d10", "", "repository_url=gcr.io/distroless/static", "tag=latest")
 	// pkg:pypi/django-allauth@12.23
-	client.registerPackage("pypi", "", "django-allauth", "12.23")
+	client.registerPackage("pypi", "", "django-allauth", "12.23", "")
 	// pkg:pypi/django@1.11.1
-	client.registerPackage("pypi", "", "django", "1.11.1")
+	client.registerPackage("pypi", "", "django", "1.11.1", "")
+	// pkg:pypi/django@1.11.1#subpath
+	client.registerPackage("pypi", "", "django", "1.11.1", "subpath")
 	return &client
 }
 
-func (c *demoClient) registerPackage(pkgType, namespace, name, version string, qualifiers ...string) {
+func (c *demoClient) registerPackage(pkgType, namespace, name, version, subpath string, qualifiers ...string) {
 	for i, p := range c.packages {
 		if p.Type == pkgType {
-			c.packages[i] = registerNamespace(p, namespace, name, version, qualifiers...)
+			c.packages[i] = registerNamespace(p, namespace, name, version, subpath, qualifiers...)
 			return
 		}
 	}
 
 	newPkg := &model.Package{Type: pkgType}
-	newPkg = registerNamespace(newPkg, namespace, name, version, qualifiers...)
+	newPkg = registerNamespace(newPkg, namespace, name, version, subpath, qualifiers...)
 	c.packages = append(c.packages, newPkg)
 }
 
-func registerNamespace(p *model.Package, namespace, name, version string, qualifiers ...string) *model.Package {
+func registerNamespace(p *model.Package, namespace, name, version, subpath string, qualifiers ...string) *model.Package {
 	for i, ns := range p.Namespaces {
 		if ns.Namespace == namespace {
-			p.Namespaces[i] = registerName(ns, name, version, qualifiers...)
+			p.Namespaces[i] = registerName(ns, name, version, subpath, qualifiers...)
 			return p
 		}
 	}
 
 	newNs := &model.PackageNamespace{Namespace: namespace}
-	newNs = registerName(newNs, name, version, qualifiers...)
+	newNs = registerName(newNs, name, version, subpath, qualifiers...)
 	p.Namespaces = append(p.Namespaces, newNs)
 	return p
 }
 
-func registerName(ns *model.PackageNamespace, name, version string, qualifiers ...string) *model.PackageNamespace {
+func registerName(ns *model.PackageNamespace, name, version, subpath string, qualifiers ...string) *model.PackageNamespace {
 	for i, n := range ns.Names {
 		if n.Name == name {
-			ns.Names[i] = registerVersion(n, version, qualifiers...)
+			ns.Names[i] = registerVersion(n, version, subpath, qualifiers...)
 			return ns
 		}
 	}
 
 	newN := &model.PackageName{Name: name}
-	newN = registerVersion(newN, version, qualifiers...)
+	newN = registerVersion(newN, version, subpath, qualifiers...)
 	ns.Names = append(ns.Names, newN)
 	return ns
 }
 
-func registerVersion(n *model.PackageName, version string, qualifiers ...string) *model.PackageName {
+func registerVersion(n *model.PackageName, version, subpath string, qualifiers ...string) *model.PackageName {
 	// TODO(mihaimaruseac): Here we could use a utility to compare if there
 	// is already a version matching all of the arguments to not create
 	// duplicates, but in the end this is test data and we don't generate
@@ -120,6 +122,7 @@ func registerVersion(n *model.PackageName, version string, qualifiers ...string)
 	// create a new node.
 	newV := &model.PackageVersion{
 		Version:    version,
+		Subpath:    subpath,
 		Qualifiers: buildQualifierSet(qualifiers...),
 	}
 	n.Versions = append(n.Versions, newV)

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -244,6 +244,8 @@ func (ec *executionContext) fieldContext_PackageName_versions(ctx context.Contex
 				return ec.fieldContext_PackageVersion_version(ctx, field)
 			case "qualifiers":
 				return ec.fieldContext_PackageVersion_qualifiers(ctx, field)
+			case "subpath":
+				return ec.fieldContext_PackageVersion_subpath(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PackageVersion", field.Name)
 		},
@@ -527,6 +529,50 @@ func (ec *executionContext) fieldContext_PackageVersion_qualifiers(ctx context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _PackageVersion_subpath(ctx context.Context, field graphql.CollectedField, obj *model.PackageVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackageVersion_subpath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Subpath, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackageVersion_subpath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackageVersion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_packages(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_packages(ctx, field)
 	if err != nil {
@@ -761,7 +807,7 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers"}
+	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers", "subpath"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -805,6 +851,14 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qualifiers"))
 			it.Qualifiers, err = ec.unmarshalOPackageQualifierInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "subpath":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subpath"))
+			it.Subpath, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -982,6 +1036,13 @@ func (ec *executionContext) _PackageVersion(ctx context.Context, sel ast.Selecti
 		case "qualifiers":
 
 			out.Values[i] = ec._PackageVersion_qualifiers(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "subpath":
+
+			out.Values[i] = ec._PackageVersion_subpath(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -59,6 +59,7 @@ type ComplexityRoot struct {
 
 	PackageVersion struct {
 		Qualifiers func(childComplexity int) int
+		Subpath    func(childComplexity int) int
 		Version    func(childComplexity int) int
 	}
 
@@ -144,6 +145,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PackageVersion.Qualifiers(childComplexity), true
+
+	case "PackageVersion.subpath":
+		if e.complexity.PackageVersion.Subpath == nil {
+			break
+		}
+
+		return e.complexity.PackageVersion.Subpath(childComplexity), true
 
 	case "PackageVersion.version":
 		if e.complexity.PackageVersion.Version == nil {
@@ -301,10 +309,19 @@ Versions are optional and each Package type defines own rules for handling them.
 For this level of GUAC, these are just opaque strings.
 
 This node can be referred to by other parts of GUAC.
+
+Subpath and qualifiers are optional. Lack of qualifiers is represented by an
+empty list and lack of subpath by empty string (to be consistent with
+optionality of namespace and version). Two nodes that have different qualifiers
+and/or subpath but the same version mean two different packages in the trie
+(they are different). Two nodes that have same version but qualifiers of one are
+a subset of the qualifier of the other also mean two different packages in the
+trie.
 """
 type PackageVersion {
   version: String!
   qualifiers: [PackageQualifier!]!
+  subpath: String!
 }
 
 """
@@ -339,6 +356,7 @@ input PkgSpec {
   name: String
   version: String
   qualifiers: [PackageQualifierInput!]
+  subpath: String
 }
 
 """

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -84,9 +84,18 @@ type PackageQualifierInput struct {
 // For this level of GUAC, these are just opaque strings.
 //
 // This node can be referred to by other parts of GUAC.
+//
+// Subpath and qualifiers are optional. Lack of qualifiers is represented by an
+// empty list and lack of subpath by empty string (to be consistent with
+// optionality of namespace and version). Two nodes that have different qualifiers
+// and/or subpath but the same version mean two different packages in the trie
+// (they are different). Two nodes that have same version but qualifiers of one are
+// a subset of the qualifier of the other also mean two different packages in the
+// trie.
 type PackageVersion struct {
 	Version    string              `json:"version"`
 	Qualifiers []*PackageQualifier `json:"qualifiers"`
+	Subpath    string              `json:"subpath"`
 }
 
 // PkgSpec allows filtering the list of packages to return.
@@ -103,4 +112,5 @@ type PkgSpec struct {
 	Name       *string                  `json:"name"`
 	Version    *string                  `json:"version"`
 	Qualifiers []*PackageQualifierInput `json:"qualifiers"`
+	Subpath    *string                  `json:"subpath"`
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -80,10 +80,19 @@ Versions are optional and each Package type defines own rules for handling them.
 For this level of GUAC, these are just opaque strings.
 
 This node can be referred to by other parts of GUAC.
+
+Subpath and qualifiers are optional. Lack of qualifiers is represented by an
+empty list and lack of subpath by empty string (to be consistent with
+optionality of namespace and version). Two nodes that have different qualifiers
+and/or subpath but the same version mean two different packages in the trie
+(they are different). Two nodes that have same version but qualifiers of one are
+a subset of the qualifier of the other also mean two different packages in the
+trie.
 """
 type PackageVersion {
   version: String!
   qualifiers: [PackageQualifier!]!
+  subpath: String!
 }
 
 """
@@ -118,6 +127,7 @@ input PkgSpec {
   name: String
   version: String
   qualifiers: [PackageQualifierInput!]
+  subpath: String
 }
 
 """


### PR DESCRIPTION
Query to test

```gql
fragment allPkgTree on Package {
  type
  namespaces {
    namespace
    names {
      name
      versions {
        version
        qualifiers {
          key
          value
        }
        subpath
      }
    }
  }
}

query QB {
  packages(pkgSpec: {subpath: "subpath"}) {
    ...allPkgTree
  }
}
```

This concludes the package trie, we can now move to the rest of the ontology.

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>