### PR TITLE
Handle matching for no qualifiers.

### DIFF
--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -108,6 +108,13 @@ func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec)
 		return nil
 	}
 
+	// Allow matching on nodes with no qualifiers
+	if pkgSpec.MatchOnlyEmptyQualifiers != nil {
+		if *pkgSpec.MatchOnlyEmptyQualifiers && len(v.Qualifiers) != 0 {
+			return nil
+		}
+	}
+
 	// Because we operate on GraphQL-generated structs directly we cannot
 	// use a key-value map, so this is O(n^2). Production resolvers will
 	// run queries that match the qualifiers faster.

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -807,7 +807,14 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers", "subpath"}
+	if _, present := asMap["qualifiers"]; !present {
+		asMap["qualifiers"] = []interface{}{}
+	}
+	if _, present := asMap["matchOnlyEmptyQualifiers"]; !present {
+		asMap["matchOnlyEmptyQualifiers"] = false
+	}
+
+	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers", "matchOnlyEmptyQualifiers", "subpath"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -851,6 +858,14 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qualifiers"))
 			it.Qualifiers, err = ec.unmarshalOPackageQualifierInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "matchOnlyEmptyQualifiers":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("matchOnlyEmptyQualifiers"))
+			it.MatchOnlyEmptyQualifiers, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -348,14 +348,19 @@ that level. For example, to get all packages in GUAC backend, use a PkgSpec
 where every field is ` + "`" + `null` + "`" + `.
 
 Empty string at a field means matching with the empty string. If passing in
-qualifiers, all of the values in the list must match.
+qualifiers, all of the values in the list must match. Since we want to return
+nodes with any number of qualifiers if no qualifiers are passed in the input, we
+must also return the same set of nodes it the qualifiers list is empty. To match
+on nodes that don't contain any qualifier, set ` + "`" + `matchOnlyEmptyQualifiers` + "`" + ` to
+true. If this field is true, then the qualifiers argument is ignored.
 """
 input PkgSpec {
   type: String
   namespace: String
   name: String
   version: String
-  qualifiers: [PackageQualifierInput!]
+  qualifiers: [PackageQualifierInput!] = []
+  matchOnlyEmptyQualifiers: Boolean = false
   subpath: String
 }
 

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -105,12 +105,17 @@ type PackageVersion struct {
 // where every field is `null`.
 //
 // Empty string at a field means matching with the empty string. If passing in
-// qualifiers, all of the values in the list must match.
+// qualifiers, all of the values in the list must match. Since we want to return
+// nodes with any number of qualifiers if no qualifiers are passed in the input, we
+// must also return the same set of nodes it the qualifiers list is empty. To match
+// on nodes that don't contain any qualifier, set `matchOnlyEmptyQualifiers` to
+// true. If this field is true, then the qualifiers argument is ignored.
 type PkgSpec struct {
-	Type       *string                  `json:"type"`
-	Namespace  *string                  `json:"namespace"`
-	Name       *string                  `json:"name"`
-	Version    *string                  `json:"version"`
-	Qualifiers []*PackageQualifierInput `json:"qualifiers"`
-	Subpath    *string                  `json:"subpath"`
+	Type                     *string                  `json:"type"`
+	Namespace                *string                  `json:"namespace"`
+	Name                     *string                  `json:"name"`
+	Version                  *string                  `json:"version"`
+	Qualifiers               []*PackageQualifierInput `json:"qualifiers"`
+	MatchOnlyEmptyQualifiers *bool                    `json:"matchOnlyEmptyQualifiers"`
+	Subpath                  *string                  `json:"subpath"`
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -119,14 +119,19 @@ that level. For example, to get all packages in GUAC backend, use a PkgSpec
 where every field is `null`.
 
 Empty string at a field means matching with the empty string. If passing in
-qualifiers, all of the values in the list must match.
+qualifiers, all of the values in the list must match. Since we want to return
+nodes with any number of qualifiers if no qualifiers are passed in the input, we
+must also return the same set of nodes it the qualifiers list is empty. To match
+on nodes that don't contain any qualifier, set `matchOnlyEmptyQualifiers` to
+true. If this field is true, then the qualifiers argument is ignored.
 """
 input PkgSpec {
   type: String
   namespace: String
   name: String
   version: String
-  qualifiers: [PackageQualifierInput!]
+  qualifiers: [PackageQualifierInput!] = []
+  matchOnlyEmptyQualifiers: Boolean = false
   subpath: String
 }
 


### PR DESCRIPTION
Compare these 2 queries

```gql
fragment allPkgTree on Package {
  type
  namespaces {
    namespace
    names {
      name
      versions {
        version
        qualifiers {
          key
          value
        }
        subpath
      }
    }
  }
}

query Q1 {
  packages(pkgSpec: {}) {
    ...allPkgTree
  }
}

query QC {
  packages(pkgSpec: {matchOnlyEmptyQualifiers:true}) {
    ...allPkgTree
  }
}
```

First one matches everything (regardless of how many qualifiers we have), second one only the package nodes that have no qualifier.

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>