### PR TITLE
Add a collectsub client type Datasource for collectors

### DIFF
--- a/pkg/collectsub/datasource/csubsource/csubsource.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource.go
@@ -27,7 +27,7 @@ import (
 )
 
 type csubDataSources struct {
-	c            *client.Client
+	c            client.Client
 	lastEntries  *datasource.DataSources
 	pollDuration time.Duration
 }
@@ -36,7 +36,7 @@ type csubDataSources struct {
 // from a configuration file. This configuration file is in YAML and
 // follows the structure outlined in the FileFormat struct. An example
 // is as follows:
-func NewCsubDatasource(c *client.Client, pollDuration time.Duration) (datasource.CollectSource, error) {
+func NewCsubDatasource(c client.Client, pollDuration time.Duration) (datasource.CollectSource, error) {
 	return &csubDataSources{
 		c:            c,
 		pollDuration: pollDuration,
@@ -46,7 +46,10 @@ func NewCsubDatasource(c *client.Client, pollDuration time.Duration) (datasource
 // GetDataSources returns a data source containing targets for the
 // collector to collect
 func (d *csubDataSources) GetDataSources(ctx context.Context) (*datasource.DataSources, error) {
-	entries, err := d.c.GetCollectEntries(ctx, []*pb.CollectEntryFilter{})
+	entries, err := d.c.GetCollectEntries(ctx, []*pb.CollectEntryFilter{
+		{Type: pb.CollectDataType_DATATYPE_OCI, Glob: "*"},
+		{Type: pb.CollectDataType_DATATYPE_GIT, Glob: "*"},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collectsub/datasource/csubsource/csubsource.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource.go
@@ -1,0 +1,110 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csubsource
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/guacsec/guac/pkg/collectsub/client"
+	pb "github.com/guacsec/guac/pkg/collectsub/collectsub"
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+)
+
+type csubDataSources struct {
+	c            *client.Client
+	lastEntries  *datasource.DataSources
+	pollDuration time.Duration
+}
+
+// NewFileDataSources creates a datasource which gets its data sources
+// from a configuration file. This configuration file is in YAML and
+// follows the structure outlined in the FileFormat struct. An example
+// is as follows:
+func NewCsubDatasource(c *client.Client, pollDuration time.Duration) (datasource.CollectSource, error) {
+	return &csubDataSources{
+		c:            c,
+		pollDuration: pollDuration,
+	}, nil
+}
+
+// GetDataSources returns a data source containing targets for the
+// collector to collect
+func (d *csubDataSources) GetDataSources(ctx context.Context) (*datasource.DataSources, error) {
+	entries, err := d.c.GetCollectEntries(ctx, []*pb.CollectEntryFilter{})
+	if err != nil {
+		return nil, err
+	}
+	ds := entriesToSources(entries)
+	d.lastEntries = ds
+
+	return ds, nil
+}
+
+// DataSourcesUpdate will return a channel which will get an element
+// if the CollectSource has new data. Upon update, nil is inserted
+// into the channel and non-nil if the channel no longer is able to
+// serve updates.
+func (d *csubDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, error) {
+	updateChan := make(chan error)
+	go func() {
+		for {
+			select {
+			case <-time.After(d.pollDuration):
+				entries, err := d.c.GetCollectEntries(ctx, []*pb.CollectEntryFilter{})
+				if err != nil {
+					updateChan <- err
+					return
+				}
+				ds := entriesToSources(entries)
+				if reflect.DeepEqual(ds, d.lastEntries) {
+					continue
+				}
+
+				d.lastEntries = ds
+				updateChan <- nil
+			case <-ctx.Done():
+				err := fmt.Errorf("file watcher ending from context closure")
+				updateChan <- err
+				fmt.Printf("ctx is closed: %+v\n", err)
+				return
+			}
+		}
+	}()
+	return updateChan, nil
+}
+
+func entriesToSources(entries []*pb.CollectEntry) *datasource.DataSources {
+	d := &datasource.DataSources{}
+	for _, e := range entries {
+		switch e.Type {
+		case pb.CollectDataType_DATATYPE_GIT:
+			d.GitDataSources = append(d.GitDataSources, datasource.Source{
+				Value: e.Value,
+			})
+		case pb.CollectDataType_DATATYPE_OCI:
+			d.OciDataSources = append(d.OciDataSources, datasource.Source{
+				Value: e.Value,
+			})
+
+		default:
+			// unhandled datatype, skip
+		}
+	}
+	return d
+}

--- a/pkg/collectsub/datasource/datasource.go
+++ b/pkg/collectsub/datasource/datasource.go
@@ -15,6 +15,8 @@
 
 package datasource
 
+import "context"
+
 // CollectSource provides a way for collector to get collect targets from
 // a data source (e.g. a file, a database, a pubsub queue, etc.)
 //
@@ -24,11 +26,12 @@ package datasource
 type CollectSource interface {
 	// GetDataSources returns a data source containing targets for the
 	// collector to collect
-	GetDataSources() (*DataSources, error)
+	GetDataSources(ctx context.Context) (*DataSources, error)
 
 	// DataSourcesUpdate will return a channel which will get an element
-	// if the CollectSource has new data
-	DataSourcesUpdate() (<-chan error, error)
+	// if the CollectSource has new data. This is heuristical and the
+	// channel may get an eleemnt even if there is no new data.
+	DataSourcesUpdate(ctx context.Context) (<-chan error, error)
 }
 
 type DataSources struct {

--- a/pkg/collectsub/datasource/filesource/filesource.go
+++ b/pkg/collectsub/datasource/filesource/filesource.go
@@ -104,7 +104,6 @@ func (d *fileDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, 
 					return
 
 				}
-				fmt.Printf("GOT EVENT: %+v\n", ev)
 				if ev.Has(fsnotify.Write) {
 					updateChan <- nil
 				}
@@ -114,13 +113,11 @@ func (d *fileDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, 
 					return
 				}
 				updateChan <- err
-				fmt.Printf("got err while watching: %+v\n", err)
 				return
 
 			case <-ctx.Done():
 				err := fmt.Errorf("file watcher ending from context closure")
 				updateChan <- err
-				fmt.Printf("ctx is closed: %+v\n", err)
 				return
 			}
 		}

--- a/pkg/collectsub/datasource/filesource/filesource.go
+++ b/pkg/collectsub/datasource/filesource/filesource.go
@@ -16,6 +16,7 @@
 package filesource
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -58,7 +59,7 @@ func NewFileDataSources(path string) (datasource.CollectSource, error) {
 
 // GetDataSources returns a data source containing targets for the
 // collector to collect
-func (d *fileDataSources) GetDataSources() (*datasource.DataSources, error) {
+func (d *fileDataSources) GetDataSources(_ context.Context) (*datasource.DataSources, error) {
 	f, err := os.Open(d.filePath)
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func (d *fileDataSources) GetDataSources() (*datasource.DataSources, error) {
 // if the CollectSource has new data. Upon update, nil is inserted
 // into the channel and non-nil if the channel no longer is able to
 // serve updates.
-func (d *fileDataSources) DataSourcesUpdate() (<-chan error, error) {
+func (d *fileDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, error) {
 	updateChan := make(chan error)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -114,6 +115,12 @@ func (d *fileDataSources) DataSourcesUpdate() (<-chan error, error) {
 				}
 				updateChan <- err
 				fmt.Printf("got err while watching: %+v\n", err)
+				return
+
+			case <-ctx.Done():
+				err := fmt.Errorf("file watcher ending from context closure")
+				updateChan <- err
+				fmt.Printf("ctx is closed: %+v\n", err)
 				return
 			}
 		}


### PR DESCRIPTION
Add a collectsub client type Datasource for collectors to use as part of #244 

Depends on https://github.com/guacsec/guac/pull/402

