### PR TITLE
Fix - Unused parameter in OCI Collector 

### DIFF
--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -43,7 +43,7 @@ type ociCollector struct {
 // NewOCICollector initializes the oci collector by passing in the repo and tag being collected.
 // Note: OCI collector can be called upon by a upstream registry collector in the future to collect from all
 // repos in a given registry. For further details see issue #298
-func NewOCICollector(ctx context.Context, repoTags map[string][]string, poll bool, interval time.Duration) *ociCollector {
+func NewOCICollector(_ context.Context, repoTags map[string][]string, poll bool, interval time.Duration) *ociCollector {
 	return &ociCollector{
 		repoTags:      repoTags,
 		checkedDigest: map[string][]string{},


### PR DESCRIPTION
- Update the argument type of `NewOCICollector` from `context.Context` to `_`

[pkg/handler/collector/oci/oci.go]
- Change the argument type of `NewOCICollector` from `context.Context` to `_`

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>