### PR TITLE
Update error context and timeout for NATS calls

### DIFF
--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -245,7 +245,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(ctx, processFunc)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -245,7 +245,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc, time.Minute*5)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -245,7 +245,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc)
+	err = psub.GetDataFromNats(processFunc, time.Minute*5)
 	if err != nil {
 		return err
 	}

--- a/pkg/emitter/nats_data.go
+++ b/pkg/emitter/nats_data.go
@@ -18,7 +18,6 @@ package emitter
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 )
 
@@ -45,7 +44,7 @@ func NewPubSub(ctx context.Context, id string, subj string, durable string, back
 
 // GetDataFromNats is a blocking function that will wait for data or error on the channels.
 // If data is received, it will be	transformed by the dataFunc and returned.
-func (psub *pubSub) GetDataFromNats(dataFunc DataFunc, timeout time.Duration) error {
+func (psub *pubSub) GetDataFromNats(dataFunc DataFunc) error {
 	for {
 		select {
 		case d := <-psub.dataChan:
@@ -59,10 +58,7 @@ func (psub *pubSub) GetDataFromNats(dataFunc DataFunc, timeout time.Duration) er
 					return fmt.Errorf("error while transforming data: %w", err)
 				}
 			}
-			return fmt.Errorf("error while receiving data: %w", err)
-		case <-time.After(timeout):
-			log.Println("timed out while waiting for data or error on channels")
-			return nil
+			return err
 		}
 	}
 }

--- a/pkg/emitter/nats_data.go
+++ b/pkg/emitter/nats_data.go
@@ -46,7 +46,7 @@ func NewPubSub(ctx context.Context, id string, subj string, durable string, back
 // GetDataFromNats is a blocking function that will wait for data or error on the channels.
 // If data is received, it will be	transformed by the dataFunc and returned.
 func (psub *pubSub) GetDataFromNats(dataFunc DataFunc) error {
-	const timeout = time.Second * 30
+	const timeout = time.Second * 300
 	for {
 		select {
 		case d := <-psub.dataChan:

--- a/pkg/emitter/nats_emitter_test.go
+++ b/pkg/emitter/nats_emitter_test.go
@@ -293,7 +293,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(ctx, processFunc)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/emitter/nats_emitter_test.go
+++ b/pkg/emitter/nats_emitter_test.go
@@ -293,7 +293,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc, time.Minute*5)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/emitter/nats_emitter_test.go
+++ b/pkg/emitter/nats_emitter_test.go
@@ -293,7 +293,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc)
+	err = psub.GetDataFromNats(processFunc, time.Minute*5)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -169,7 +169,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(ctx, processFunc)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -169,7 +169,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc)
+	err = psub.GetDataFromNats(processFunc, time.Minute*5)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -169,7 +169,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc, time.Minute*5)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
@@ -92,7 +93,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc)
+	err = psub.GetDataFromNats(processFunc, time.Minute*5)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -92,7 +92,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 		return nil
 	}
 
-	err = psub.GetDataFromNats(ctx, processFunc)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
@@ -33,9 +32,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-var (
-	documentProcessors = map[processor.DocumentType]processor.DocumentProcessor{}
-)
+var documentProcessors = map[processor.DocumentType]processor.DocumentProcessor{}
 
 func init() {
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Generic)
@@ -93,7 +90,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 		return nil
 	}
 
-	err = psub.GetDataFromNats(processFunc, time.Minute*5)
+	err = psub.GetDataFromNats(processFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/emitter"
@@ -44,9 +43,7 @@ func init() {
 	_ = RegisterDocumentParser(scorecard.NewScorecardParser, processor.DocumentScorecard)
 }
 
-var (
-	documentParser = map[processor.DocumentType]func() common.DocumentParser{}
-)
+var documentParser = map[processor.DocumentType]func() common.DocumentParser{}
 
 type docTreeBuilder struct {
 	identities    []assembler.IdentityNode
@@ -106,7 +103,7 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 		return nil
 	}
 
-	err = psub.GetDataFromNats(parserFunc, time.Minute*5)
+	err = psub.GetDataFromNats(parserFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -105,7 +105,7 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 		return nil
 	}
 
-	err = psub.GetDataFromNats(ctx, parserFunc)
+	err = psub.GetDataFromNats(parserFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/emitter"
@@ -105,7 +106,7 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 		return nil
 	}
 
-	err = psub.GetDataFromNats(parserFunc)
+	err = psub.GetDataFromNats(parserFunc, time.Minute*5)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Remove `ctx` parameter from `GetDataFromNats` calls
- Add `fmt` and `log` imports
- Update `NewPubSub` and `GetDataFromNats` functions to return an error with more context and add a timeout for data or error on the channels

[pkg/ingestor/parser/parser.go]
- Remove the `ctx` parameter from `psub.GetDataFromNats` call [pkg/emitter/nats_data.go]
- Add `fmt` and `log` imports
- Update `NewPubSub` function to return an error with more context
- Update `GetDataFromNats` function to return an error with more context and add a timeout for data or error on the channels [pkg/certifier/certify/certify_test.go]
- Remove the `ctx` parameter from `GetDataFromNats` [pkg/handler/collector/collector_test.go]
- Remove `ctx` parameter from `psub.GetDataFromNats` function call [pkg/handler/processor/process/process.go]
- Remove the `ctx` parameter from the `GetDataFromNats` call [pkg/emitter/nats_emitter_test.go]
- Remove `ctx` from the `GetDataFromNats` call

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>