### PR TITLE
Update PURL handling 

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,6 @@ github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7X
 github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/ossf/scorecard/v4 v4.8.0 h1:No/CjCi+A2iONxJPsv12sxfim0LxsLACK+BOx9Ua2lE=
 github.com/ossf/scorecard/v4 v4.8.0/go.mod h1:QWW/oKnemvLqNiTeYbWUjLHyGZljkrEOwKXZq1cZpDw=
-github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
-github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 h1:DiLBVp4DAcZlBVBEtJpNWZpZVq0AEeCY7Hqk8URVs4o=
 github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=

--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	PurlTypeGuac  = "guac"
-	repoSeparator = "/"
-	repositoryurl = "repository_url"
+	PurlTypeGuac              = "guac"
+	repositoryUrlQualifierKey = "repository_url"
 )
 
 // PurlToPkg converts a purl URI string into a graphql package node
@@ -100,13 +99,13 @@ func ociHandler(p purl.PackageURL) (*model.Package, error) {
 	qs := p.Qualifiers.Map()
 	var ns string
 	for k, v := range qs {
-		if k == repositoryurl {
+		if k == repositoryUrlQualifierKey {
 			ns = v
 		}
 	}
 
-	delete(qs, repositoryurl)
-	ns = strings.TrimRight(ns, repoSeparator+p.Name)
+	delete(qs, repositoryUrlQualifierKey)
+	ns = strings.TrimRight(ns, "/"+p.Name)
 	r := pkg(p.Type, ns, p.Name, p.Version, p.Subpath, qs)
 	return r, nil
 }
@@ -127,14 +126,14 @@ func dockerHandler(p purl.PackageURL) (*model.Package, error) {
 	qs := p.Qualifiers.Map()
 	var repUrl string
 	for k, v := range qs {
-		if k == repositoryurl {
+		if k == repositoryUrlQualifierKey {
 			repUrl = v
 		}
 	}
-	delete(qs, repositoryurl)
+	delete(qs, repositoryUrlQualifierKey)
 
 	ns := filepath.Join(repUrl, p.Namespace)
-	ns = strings.Trim(ns, repoSeparator)
+	ns = strings.Trim(ns, "/")
 
 	r := pkg(p.Type, ns, p.Name, p.Version, p.Subpath, qs)
 	return r, nil

--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	PurlTypeGuac              = "guac"
+	PurlTypeGUAC              = "guac"
 	repositoryUrlQualifierKey = "repository_url"
 )
 
@@ -42,6 +42,12 @@ func PurlToPkg(purlUri string) (*model.Package, error) {
 
 // purlConvert converts a purl URI into a graphql package node.
 func purlConvert(p purl.PackageURL) (*model.Package, error) {
+	// Enumeration of https://github.com/package-url/purl-spec#known-purl-types
+	// TODO(lumjjb): each PURL definition usually comes with a default repository
+	// we should consider addition of default repository to the prefix of the namespace
+	// so that they can be referenced with higher specificity in GUAC
+	//
+	// PURL types not defined in purl library handled generically
 	purlTypeMap := map[string]func(purl.PackageURL) (*model.Package, error){
 		"alpm":             genericHandler,
 		"apk":              genericHandler,
@@ -50,7 +56,7 @@ func purlConvert(p purl.PackageURL) (*model.Package, error) {
 		"qpkg":             genericHandler,
 		"pub":              genericHandler,
 		"swid":             genericHandler,
-		PurlTypeGuac:       genericHandler,
+		PurlTypeGUAC:       genericHandler,
 		purl.TypeBitbucket: genericHandler,
 		purl.TypeCocoapods: genericHandler,
 		purl.TypeCargo:     genericHandler,
@@ -90,10 +96,10 @@ func genericHandler(p purl.PackageURL) (*model.Package, error) {
 
 // ociHandler is a handler for OCI purl types
 func ociHandler(p purl.PackageURL) (*model.Package, error) {
-	// For OCI, the namespace is not used and respository_url may contain a namespace
+	// For OCI, the namespace is not used and repository_url may contain a namespace
 	// as part of the physical location of the package. Therefore, in order to use it
 	// in the graphQL model consistently with other types, we special case OCI to take
-	// the respository_url and encode it as the Package namespace.
+	// the repository_url and encode it as the Package namespace.
 	//
 	// Ref: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci
 	qs := p.Qualifiers.Map()
@@ -120,7 +126,7 @@ func dockerHandler(p purl.PackageURL) (*model.Package, error) {
 	// - The namespace is the registry/user/organization if present.
 	// - The version should be the image id sha256 or a tag. Since tags can
 	// be moved, a sha256 image id is preferred.  as part of the physical
-	// location of the package.. However, this is not enforced, and examples use tags
+	// location of the package. However, this is not enforced, and examples use tags
 	//
 	// Ref: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#docker
 	qs := p.Qualifiers.Map()


### PR DESCRIPTION
- Add a constant `repoSeparator` for trimming the repository URL
- Move the enumeration of known PURL types to a map
- Add handlers for all known PURL types
- Special case OCI and Docker PURL types to include the repository URL in the namespace
- Remove the repository URL from the qualifiers map

[pkg/assembler/helpers/purl.go]
- Add a constant `repoSeparator` to be used when trimming the repository URL
- Add a constant `repositoryurl` to be used when getting the repository URL from the qualifiers map
- Move the enumeration of known PURL types to a map
- Add handlers for all known PURL types
- Special case OCI and Docker PURL types to include the repository URL in the namespace
- Remove the repository URL from the qualifiers map

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>