### PR TITLE
Create inmemDataSource and change oci convention

### DIFF
--- a/pkg/collectsub/datasource/csubsource/csubsource_test.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource_test.go
@@ -33,8 +33,8 @@ func createSimpleCsubClient(ctx context.Context) (client.Client, error) {
 	}
 
 	err = c.AddCollectEntries(ctx, []*collectsub.CollectEntry{
-		{Type: collectsub.CollectDataType_DATATYPE_OCI, Value: "oci://abc"},
-		{Type: collectsub.CollectDataType_DATATYPE_OCI, Value: "oci://def"},
+		{Type: collectsub.CollectDataType_DATATYPE_OCI, Value: "abc"},
+		{Type: collectsub.CollectDataType_DATATYPE_OCI, Value: "def"},
 		{Type: collectsub.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
 	})
 	if err != nil {
@@ -69,8 +69,8 @@ func Test_FileSourceGetDataSources(t *testing.T) {
 
 	expected := &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},
@@ -111,8 +111,8 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 
 	expected := &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},
@@ -156,8 +156,8 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 
 	expected = &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},

--- a/pkg/collectsub/datasource/filesource/filesource.go
+++ b/pkg/collectsub/datasource/filesource/filesource.go
@@ -43,8 +43,8 @@ type FileFormat struct {
 // sources.yaml
 // ----
 // oci:
-// - oci://abc
-// - oci://def
+// - abc
+// - def
 // git:
 // - git+https://github.com/...
 func NewFileDataSources(path string) (datasource.CollectSource, error) {

--- a/pkg/collectsub/datasource/filesource/filesource_test.go
+++ b/pkg/collectsub/datasource/filesource/filesource_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 var simpleConfig = []byte(`oci:
-- oci://abc
-- oci://def
+- abc
+- def
 git:
 - git+https://github.com/guacsec/guac`)
 
@@ -59,8 +59,8 @@ func Test_FileSourceGetDataSources(t *testing.T) {
 
 	expected := &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},
@@ -103,8 +103,8 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 
 	expected := &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},
@@ -152,8 +152,8 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 
 	expected = &datasource.DataSources{
 		OciDataSources: []datasource.Source{
-			{Value: "oci://abc"},
-			{Value: "oci://def"},
+			{Value: "abc"},
+			{Value: "def"},
 		},
 		GitDataSources: []datasource.Source{
 			{Value: "git+https://github.com/guacsec/guac"},

--- a/pkg/collectsub/datasource/inmemsource/inmemsource.go
+++ b/pkg/collectsub/datasource/inmemsource/inmemsource.go
@@ -1,0 +1,60 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmemsource
+
+import (
+	"context"
+
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+)
+
+var _ datasource.CollectSource = (*inmemDataSources)(nil)
+
+type inmemDataSources struct {
+	dataSources *datasource.DataSources
+	updateChan  chan error
+}
+
+// NewInmemDataSources creates an in-memory datasource which initializes based on a
+// datasource.
+func NewInmemDataSources(dataSources *datasource.DataSources) (*inmemDataSources, error) {
+	return &inmemDataSources{
+		dataSources: dataSources,
+		updateChan:  make(chan error),
+	}, nil
+}
+
+// GetDataSources returns a data source containing targets for the
+// collector to collect
+func (d *inmemDataSources) GetDataSources(_ context.Context) (*datasource.DataSources, error) {
+	return d.dataSources, nil
+}
+
+// DataSourcesUpdate will return a channel which will get an element
+// if the CollectSource has new data. Upon update, nil is inserted
+// into the channel and non-nil if the channel no longer is able to
+// serve updates.
+func (d *inmemDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, error) {
+	return d.updateChan, nil
+}
+
+// UpdateDataSources updates the in-memory datasource with a new set of dataSources
+func (d *inmemDataSources) UpdateDataSources(dataSources *datasource.DataSources) {
+	d.dataSources = dataSources
+	go func() {
+		d.updateChan <- nil
+	}()
+}

--- a/pkg/collectsub/datasource/inmemsource/inmemsource_test.go
+++ b/pkg/collectsub/datasource/inmemsource/inmemsource_test.go
@@ -1,0 +1,130 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmemsource
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+)
+
+func Test_InmemSourceGetDataSources(t *testing.T) {
+	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	expected := &datasource.DataSources{
+		OciDataSources: []datasource.Source{
+			{Value: "oci://abc"},
+			{Value: "oci://def"},
+		},
+		GitDataSources: []datasource.Source{
+			{Value: "git+https://github.com/guacsec/guac"},
+		},
+	}
+
+	cds, err := NewInmemDataSources(expected)
+	if err != nil {
+		t.Errorf("unable to initiliaze InmemDataSources: %v", err)
+	}
+	ds, err := cds.GetDataSources(ctx)
+	if err != nil {
+		t.Errorf("unable to get DataSources: %v", err)
+		return
+	}
+
+	if !reflect.DeepEqual(ds, expected) {
+		t.Errorf("unexpected datasource output: expect %v, got %v", expected, ds)
+	}
+}
+
+func Test_InmemSourceDataSourcesUpdate(t *testing.T) {
+	ctx := context.TODO()
+
+	expected := &datasource.DataSources{
+		OciDataSources: []datasource.Source{
+			{Value: "oci://abc"},
+			{Value: "oci://def"},
+		},
+		GitDataSources: []datasource.Source{
+			{Value: "git+https://github.com/guacsec/guac"},
+		},
+	}
+
+	cds, err := NewInmemDataSources(expected)
+	if err != nil {
+		t.Errorf("unable to initiliaze InmemDataSources: %v", err)
+	}
+
+	upChan, err := cds.DataSourcesUpdate(ctx)
+	if err != nil {
+		t.Errorf("unable to get DataSourcesUpdate: %v", err)
+	}
+
+	ds, err := cds.GetDataSources(ctx)
+	if err != nil {
+		t.Errorf("unable to get DataSources: %v", err)
+		return
+	}
+
+	if !reflect.DeepEqual(ds, expected) {
+		t.Errorf("unexpected datasource output: expect %v, got %v", expected, ds)
+
+	}
+
+	// Check for update
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	expectedNew := &datasource.DataSources{
+		OciDataSources: []datasource.Source{
+			{Value: "oci://abc"},
+			{Value: "oci://def"},
+		},
+		GitDataSources: []datasource.Source{
+			{Value: "git+https://github.com/guacsec/guac"},
+			{Value: "git+newentry"},
+		},
+	}
+
+	go func() {
+		cds.UpdateDataSources(expectedNew)
+	}()
+	select {
+	case err = <-upChan:
+		if err != nil {
+			t.Errorf("got error from update channel: %v", err)
+			return
+		}
+	case <-ctx.Done():
+		t.Errorf("test timed out")
+		return
+	}
+
+	// Get new data source and compare
+	ds, err = cds.GetDataSources(ctx)
+	if err != nil {
+		t.Errorf("unable to get DataSources: %v", err)
+		return
+	}
+
+	if !reflect.DeepEqual(ds, expectedNew) {
+		t.Errorf("unexpected datasource output: expect %v, got %v", expected, ds)
+	}
+}


### PR DESCRIPTION
- Create an inmemory data source which can be used for testing and other simple purposes
- remove `oci://` from OCI convention

Signed-off-by: Brandon Lum <lumjjb@gmail.com>