### PR TITLE
Fixed error statments

### DIFF
--- a/cmd/collector/cmd/files.go
+++ b/cmd/collector/cmd/files.go
@@ -83,7 +83,7 @@ func validateFlags(natsAddr string, args []string) (options, error) {
 
 func getCollectorPublish(ctx context.Context) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return collector.Publish(ctx, d)
+		return collector.Publish(ctx, d) // nolint:wrapcheck
 	}, nil
 }
 

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -214,7 +214,7 @@ func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler
 	return func(doc processor.DocumentTree) ([]assembler.Graph, error) {
 		inputs, err := parser.ParseDocumentTree(ctx, doc)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse document tree: %v", err)
+			return nil, fmt.Errorf("unable to parse document tree: %w", err)
 		}
 		return inputs, nil
 	}, nil
@@ -229,7 +229,7 @@ func getAssembler(opts options) (func([]assembler.Graph) error, error) {
 
 	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create graph client: %v", err)
+		return nil, fmt.Errorf("unable to create graph client: %w", err)
 	}
 
 	err = createIndices(client)
@@ -246,7 +246,7 @@ func getAssembler(opts options) (func([]assembler.Graph) error, error) {
 			combined.AppendGraph(g)
 		}
 		if err := assembler.StoreGraph(combined, client); err != nil {
-			return fmt.Errorf("unable to store graph: %v", err)
+			return fmt.Errorf("unable to store graph: %w", err)
 		}
 
 		return nil
@@ -266,7 +266,7 @@ func createIndices(client graphdb.Client) error {
 		for _, attribute := range attributes {
 			err := assembler.CreateIndexOn(client, label, attribute)
 			if err != nil {
-				return fmt.Errorf("unable to create index on %v: %v", attribute, err)
+				return fmt.Errorf("unable to create index on %v: %w", attribute, err)
 			}
 		}
 	}

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -103,7 +103,7 @@ var certifierCmd = &cobra.Command{
 			}
 			err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeBytes)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to publish document: %w", err)
 			}
 			return nil
 		}
@@ -194,7 +194,7 @@ func validateCertifierFlags(user string, pass string, dbAddr string, realm strin
 
 func getCertifierPublish(ctx context.Context) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return certify.Publish(ctx, d)
+		return certify.Publish(ctx, d) // nolint:wrapcheck
 	}, nil
 }
 

--- a/internal/testing/dochelper/dochelper.go
+++ b/internal/testing/dochelper/dochelper.go
@@ -131,7 +131,7 @@ func DocEqualWithTimestamp(gotDoc, wantDoc *processor.Document) (bool, error) {
 func parseVulnCertifyPredicate(p []byte) (*attestation_vuln.VulnerabilityStatement, error) {
 	predicate := attestation_vuln.VulnerabilityStatement{}
 	if err := json.Unmarshal(p, &predicate); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal json: %s", err)
 	}
 	return &predicate, nil
 }

--- a/internal/testing/nats/nats.go
+++ b/internal/testing/nats/nats.go
@@ -79,5 +79,5 @@ func getFreePort() (int, error) {
 			return l.Addr().(*net.TCPAddr).Port, nil
 		}
 	}
-	return 0, err
+	return 0, fmt.Errorf("unable to get free port: %w", err)
 }

--- a/internal/testing/simpledoc/simpledoc.go
+++ b/internal/testing/simpledoc/simpledoc.go
@@ -78,7 +78,7 @@ func (dp *SimpleDocProc) ValidateSchema(d *processor.Document) error {
 
 	var p SimpleDoc
 	if err := json.Unmarshal(d.Blob, &p); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal simple doc: %w", err)
 	}
 
 	return validateSimpleDoc(p)
@@ -99,14 +99,14 @@ func validateSimpleDoc(pd SimpleDoc) error {
 func (dp *SimpleDocProc) Unpack(d *processor.Document) ([]*processor.Document, error) {
 	var p SimpleDoc
 	if err := json.Unmarshal(d.Blob, &p); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal simple doc: %w", err)
 	}
 
 	retDocs := make([]*processor.Document, len(p.Nested))
 	for i, nd := range p.Nested {
 		b, err := json.Marshal(nd)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to marshal nested doc: %w", err)
 		}
 		retDocs[i] = &processor.Document{
 			Blob:   b,

--- a/pkg/assembler/backends/neo4j/artifact.go
+++ b/pkg/assembler/backends/neo4j/artifact.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -99,7 +100,7 @@ func (c *neo4jClient) Artifacts(ctx context.Context, artifactSpec *model.Artifac
 			return artifacts, nil
 		})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read transaction: %w", err)
 	}
 
 	return result.([]*model.Artifact), nil

--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -53,7 +54,7 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 
 	if err = driver.VerifyConnectivity(); err != nil {
 		driver.Close()
-		return nil, err
+		return nil, fmt.Errorf("unable verify connectivity: %w", err)
 	}
 	client := &neo4jClient{driver}
 	if config.TestData {

--- a/pkg/assembler/backends/neo4j/builder.go
+++ b/pkg/assembler/backends/neo4j/builder.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -67,7 +68,7 @@ func (c *neo4jClient) Builders(ctx context.Context, builderSpec *model.BuilderSp
 			sb.WriteString(" RETURN n.uri")
 			result, err := tx.Run(sb.String(), queryValues)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read transactions: %w", err)
 			}
 
 			builders := []*model.Builder{}
@@ -78,13 +79,13 @@ func (c *neo4jClient) Builders(ctx context.Context, builderSpec *model.BuilderSp
 				builders = append(builders, builder)
 			}
 			if err = result.Err(); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read transactions: %w", err)
 			}
 
 			return builders, nil
 		})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read transactions: %w", err)
 	}
 
 	return result.([]*model.Builder), nil

--- a/pkg/assembler/backends/neo4j/cve.go
+++ b/pkg/assembler/backends/neo4j/cve.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler"
@@ -214,7 +215,7 @@ func (c *neo4jClient) Cve(ctx context.Context, cveSpec *model.CVESpec) ([]*model
 			return cves, nil
 		})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get transaction: %w", err)
 	}
 
 	return result.([]*model.Cve), nil
@@ -259,7 +260,7 @@ func (c *neo4jClient) cveYear(ctx context.Context, cveSpec *model.CVESpec) ([]*m
 			return cves, nil
 		})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading transaction: %w", err)
 	}
 
 	return result.([]*model.Cve), nil

--- a/pkg/assembler/backends/neo4j/ingest_testdata.go
+++ b/pkg/assembler/backends/neo4j/ingest_testdata.go
@@ -16,6 +16,7 @@
 package neo4jBackend
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler"
@@ -283,7 +284,7 @@ func (c *neo4jClient) registerArtifact(algorithm, digest string) error {
 	}
 	err := assembler.StoreGraph(assemblerinput, c.driver)
 	if err != nil {
-		return err
+		return fmt.Errorf("error storing graph: %w", err)
 	}
 	return nil
 }
@@ -297,7 +298,7 @@ func (c *neo4jClient) registerBuilder(uri string) error {
 	}
 	err := assembler.StoreGraph(assemblerinput, c.driver)
 	if err != nil {
-		return err
+		return fmt.Errorf("error storing graph: %w", err)
 	}
 	return nil
 }
@@ -315,7 +316,7 @@ func (c *neo4jClient) registerCVE(year, id string) error {
 	}
 	err := assembler.StoreGraph(assemblerinput, c.driver)
 	if err != nil {
-		return err
+		return fmt.Errorf("error storing graph: %w", err)
 	}
 	return nil
 }

--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -78,17 +78,17 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 			for i, query := range queries {
 				result, err := tx.Run(query, params[i])
 				if err != nil {
-					return nil, fmt.Errorf("failed to run query: %w", err)
+					return nil, err
 				}
 				_, err = result.Consume()
 				if err != nil {
-					return nil, fmt.Errorf("failed to consume result: %w", err)
+					return nil, err
 				}
 			}
 			return nil, nil
 		})
 
-	return fmt.Errorf("failed to write transaction: %w", err)
+	return err
 }
 
 // CreateIndexOn creates database indixes in the graph database given by Client
@@ -105,10 +105,10 @@ func CreateIndexOn(client graphdb.Client, nodeLabel string, nodeAttribute string
 
 	_, err := session.WriteTransaction(
 		func(tx graphdb.Transaction) (interface{}, error) {
-			return tx.Run(sb.String(), nil) // nolint:wrapcheck
+			return tx.Run(sb.String(), nil)
 		})
 
-	return fmt.Errorf("failed to write transaction: %w", err)
+	return err
 }
 
 // Creates the "MERGE (n:${NODE_TYPE} {${ATTR}:${VALUE}, ...})" part of the query

--- a/pkg/assembler/graphdb.go
+++ b/pkg/assembler/graphdb.go
@@ -78,17 +78,17 @@ func StoreGraph(g Graph, client graphdb.Client) error {
 			for i, query := range queries {
 				result, err := tx.Run(query, params[i])
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to run query: %w", err)
 				}
 				_, err = result.Consume()
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to consume result: %w", err)
 				}
 			}
 			return nil, nil
 		})
 
-	return err
+	return fmt.Errorf("failed to write transaction: %w", err)
 }
 
 // CreateIndexOn creates database indixes in the graph database given by Client
@@ -105,10 +105,10 @@ func CreateIndexOn(client graphdb.Client, nodeLabel string, nodeAttribute string
 
 	_, err := session.WriteTransaction(
 		func(tx graphdb.Transaction) (interface{}, error) {
-			return tx.Run(sb.String(), nil)
+			return tx.Run(sb.String(), nil) // nolint:wrapcheck
 		})
 
-	return err
+	return fmt.Errorf("failed to write transaction: %w", err)
 }
 
 // Creates the "MERGE (n:${NODE_TYPE} {${ATTR}:${VALUE}, ...})" part of the query

--- a/pkg/assembler/graphdb/graphdb.go
+++ b/pkg/assembler/graphdb/graphdb.go
@@ -46,12 +46,12 @@ func NewGraphClient(uri string, authToken AuthToken) (Client, error) {
 	// attributes of the connection (e.g., max connection pool size, etc.)
 	driver, err := neo4j.NewDriver(uri, authToken)
 	if err != nil {
-		return nil, fmt.Errorf("error creating driver: %v", err)
+		return nil, fmt.Errorf("error creating driver: %w", err)
 	}
 
 	if err = driver.VerifyConnectivity(); err != nil {
 		driver.Close()
-		return nil, fmt.Errorf("error verifying connectivity: %v", err)
+		return nil, fmt.Errorf("error verifying connectivity: %w", err)
 	}
 	return driver, nil
 }

--- a/pkg/assembler/graphdb/graphdb.go
+++ b/pkg/assembler/graphdb/graphdb.go
@@ -19,6 +19,8 @@
 package graphdb
 
 import (
+	"fmt"
+
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
@@ -44,12 +46,12 @@ func NewGraphClient(uri string, authToken AuthToken) (Client, error) {
 	// attributes of the connection (e.g., max connection pool size, etc.)
 	driver, err := neo4j.NewDriver(uri, authToken)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating driver: %v", err)
 	}
 
 	if err = driver.VerifyConnectivity(); err != nil {
 		driver.Close()
-		return nil, err
+		return nil, fmt.Errorf("error verifying connectivity: %v", err)
 	}
 	return driver, nil
 }

--- a/pkg/assembler/graphdb/graphdb_test_utils.go
+++ b/pkg/assembler/graphdb/graphdb_test_utils.go
@@ -19,6 +19,8 @@
 package graphdb
 
 import (
+	"fmt"
+
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
@@ -37,12 +39,12 @@ func WriteQueryForTesting(client Client, query string, args map[string]interface
 		func(tx Transaction) (interface{}, error) {
 			result, err := tx.Run(query, args)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error running query: %v", err)
 			}
 			_, err = result.Consume()
-			return nil, err
+			return nil, fmt.Errorf("error consuming result: %v", err)
 		})
-	return err
+	return fmt.Errorf("error writing transactions: %v", err)
 }
 
 // ReadQueryForTesting runs a simple read query against the graph database.
@@ -58,7 +60,7 @@ func ReadQueryForTesting(client Client, query string, args map[string]interface{
 		func(tx Transaction) (interface{}, error) {
 			records, err := tx.Run(query, args)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error running query: %v", err)
 			}
 			values := make([][]interface{}, 0)
 			// Since `records` is valid only while `tx` is in
@@ -68,13 +70,13 @@ func ReadQueryForTesting(client Client, query string, args map[string]interface{
 				values = append(values, record.Values)
 			}
 			if err = records.Err(); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error reading records: %v", err)
 			}
-			return values, err
+			return values, fmt.Errorf("error reading records: %v", err)
 		})
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading transactions: %v", err)
 	}
 	return result.([][]interface{}), nil
 }
@@ -88,7 +90,7 @@ func ReadQuery(client Client, query string, args map[string]interface{}) ([]inte
 		func(tx Transaction) (interface{}, error) {
 			records, err := tx.Run(query, args)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error running query: %v", err)
 			}
 			values := make([]interface{}, 0)
 			// Since `records` is valid only while `tx` is in
@@ -98,13 +100,13 @@ func ReadQuery(client Client, query string, args map[string]interface{}) ([]inte
 				values = append(values, record)
 			}
 			if err = records.Err(); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error reading records: %v", err)
 			}
 			return values, err
 		})
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading transactions: %v", err)
 	}
 	return result.([]interface{}), nil
 }
@@ -123,9 +125,9 @@ func ClearDBForTesting(client Client) error {
 				return nil, err
 			}
 			_, err = results.Consume()
-			return nil, err
+			return nil, fmt.Errorf("error consuming results: %v", err)
 		})
-	return err
+	return fmt.Errorf("error writing transactions: %v", err)
 }
 
 // EmptyClientForTesting returns a client to an empty database.

--- a/pkg/assembler/graphdb/graphdb_test_utils.go
+++ b/pkg/assembler/graphdb/graphdb_test_utils.go
@@ -39,12 +39,12 @@ func WriteQueryForTesting(client Client, query string, args map[string]interface
 		func(tx Transaction) (interface{}, error) {
 			result, err := tx.Run(query, args)
 			if err != nil {
-				return nil, fmt.Errorf("error running query: %v", err)
+				return nil, fmt.Errorf("error running query: %w", err)
 			}
 			_, err = result.Consume()
-			return nil, fmt.Errorf("error consuming result: %v", err)
+			return nil, fmt.Errorf("error consuming result: %w", err)
 		})
-	return fmt.Errorf("error writing transactions: %v", err)
+	return fmt.Errorf("error writing transactions: %w", err)
 }
 
 // ReadQueryForTesting runs a simple read query against the graph database.
@@ -60,7 +60,7 @@ func ReadQueryForTesting(client Client, query string, args map[string]interface{
 		func(tx Transaction) (interface{}, error) {
 			records, err := tx.Run(query, args)
 			if err != nil {
-				return nil, fmt.Errorf("error running query: %v", err)
+				return nil, fmt.Errorf("error running query: %w", err)
 			}
 			values := make([][]interface{}, 0)
 			// Since `records` is valid only while `tx` is in
@@ -70,13 +70,13 @@ func ReadQueryForTesting(client Client, query string, args map[string]interface{
 				values = append(values, record.Values)
 			}
 			if err = records.Err(); err != nil {
-				return nil, fmt.Errorf("error reading records: %v", err)
+				return nil, fmt.Errorf("error reading records: %w", err)
 			}
-			return values, fmt.Errorf("error reading records: %v", err)
+			return values, fmt.Errorf("error reading records: %w", err)
 		})
 
 	if err != nil {
-		return nil, fmt.Errorf("error reading transactions: %v", err)
+		return nil, fmt.Errorf("error reading transactions: %w", err)
 	}
 	return result.([][]interface{}), nil
 }
@@ -90,7 +90,7 @@ func ReadQuery(client Client, query string, args map[string]interface{}) ([]inte
 		func(tx Transaction) (interface{}, error) {
 			records, err := tx.Run(query, args)
 			if err != nil {
-				return nil, fmt.Errorf("error running query: %v", err)
+				return nil, fmt.Errorf("error running query: %w", err)
 			}
 			values := make([]interface{}, 0)
 			// Since `records` is valid only while `tx` is in
@@ -100,13 +100,13 @@ func ReadQuery(client Client, query string, args map[string]interface{}) ([]inte
 				values = append(values, record)
 			}
 			if err = records.Err(); err != nil {
-				return nil, fmt.Errorf("error reading records: %v", err)
+				return nil, fmt.Errorf("error reading records: %w", err)
 			}
 			return values, err
 		})
 
 	if err != nil {
-		return nil, fmt.Errorf("error reading transactions: %v", err)
+		return nil, fmt.Errorf("error reading transactions: %w", err)
 	}
 	return result.([]interface{}), nil
 }
@@ -125,9 +125,9 @@ func ClearDBForTesting(client Client) error {
 				return nil, err
 			}
 			_, err = results.Consume()
-			return nil, fmt.Errorf("error consuming results: %v", err)
+			return nil, fmt.Errorf("error consuming results: %w", err)
 		})
-	return fmt.Errorf("error writing transactions: %v", err)
+	return fmt.Errorf("error writing transactions: %w", err)
 }
 
 // EmptyClientForTesting returns a client to an empty database.

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -18,6 +18,7 @@ package root_package
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/graphdb"
@@ -51,7 +52,7 @@ func (q *packageQuery) GetComponents(ctx context.Context, compChan chan<- interf
 
 	roots, err := graphdb.ReadQuery(q.client, "MATCH (p:Package) WHERE NOT (p)<-[:DependsOn]-() return p", nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to query for root packages: %w", err)
 	}
 	for _, result := range roots {
 		foundNode, ok := result.(dbtype.Node)
@@ -80,7 +81,7 @@ func getCompHelper(ctx context.Context, client graphdb.Client, parentPurl string
 	dependencies, err := graphdb.ReadQuery(client, "MATCH (p:Package) WHERE p.purl = $rootPurl WITH p MATCH (p)-[:DependsOn]->(p2:Package) return p2",
 		map[string]any{"rootPurl": parentPurl})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read the query for dependencies of %s: %w", parentPurl, err)
 	}
 	depPackages := []*PackageComponent{}
 	for _, dep := range dependencies {

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -162,7 +162,7 @@ func getVulnerabilities(query osv_scanner.BatchedQuery, packDigest map[string][]
 func generateDocument(purl string, digest []string, vulns []osv_scanner.MinimalVulnerability) (*processor.Document, error) {
 	payload, err := json.Marshal(createAttestation(purl, digest, vulns))
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal attestation: %v", err)
+		return nil, fmt.Errorf("failed to marshal attestation: %w", err)
 	}
 	doc := &processor.Document{
 		Blob:   payload,

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -162,7 +162,7 @@ func getVulnerabilities(query osv_scanner.BatchedQuery, packDigest map[string][]
 func generateDocument(purl string, digest []string, vulns []osv_scanner.MinimalVulnerability) (*processor.Document, error) {
 	payload, err := json.Marshal(createAttestation(purl, digest, vulns))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal attestation: %v", err)
 	}
 	doc := &processor.Document{
 		Blob:   payload,

--- a/pkg/collectsub/client/client.go
+++ b/pkg/collectsub/client/client.go
@@ -59,7 +59,7 @@ func (c *client) AddCollectEntries(ctx context.Context, entries []*pb.CollectEnt
 		Entries: entries,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to add collect entries: %v", err)
 	}
 	if !res.Success {
 		return fmt.Errorf("add collect entry unsuccessful")
@@ -72,7 +72,7 @@ func (c *client) GetCollectEntries(ctx context.Context, filters []*pb.CollectEnt
 		Filters: filters,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get collect entries: %v", err)
 	}
 
 	return res.Entries, nil

--- a/pkg/collectsub/client/client.go
+++ b/pkg/collectsub/client/client.go
@@ -59,7 +59,7 @@ func (c *client) AddCollectEntries(ctx context.Context, entries []*pb.CollectEnt
 		Entries: entries,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to add collect entries: %v", err)
+		return fmt.Errorf("unable to add collect entries: %w", err)
 	}
 	if !res.Success {
 		return fmt.Errorf("add collect entry unsuccessful")
@@ -72,7 +72,7 @@ func (c *client) GetCollectEntries(ctx context.Context, filters []*pb.CollectEnt
 		Filters: filters,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get collect entries: %v", err)
+		return nil, fmt.Errorf("unable to get collect entries: %w", err)
 	}
 
 	return res.Entries, nil

--- a/pkg/collectsub/client/mock.go
+++ b/pkg/collectsub/client/mock.go
@@ -17,6 +17,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	pb "github.com/guacsec/guac/pkg/collectsub/collectsub"
 	"github.com/guacsec/guac/pkg/collectsub/server/db/simpledb"
@@ -31,7 +32,7 @@ type MockClient struct {
 func NewMockClient() (Client, error) {
 	sdb, err := simpledb.NewSimpleDb()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create simple db: %v", err)
 	}
 	return &MockClient{
 		db: sdb,
@@ -41,9 +42,9 @@ func NewMockClient() (Client, error) {
 func (c *MockClient) Close() {}
 
 func (c *MockClient) AddCollectEntries(ctx context.Context, entries []*pb.CollectEntry) error {
-	return c.db.AddCollectEntries(ctx, entries)
+	return c.db.AddCollectEntries(ctx, entries) // nolint:wrapcheck
 }
 
 func (c *MockClient) GetCollectEntries(ctx context.Context, filters []*pb.CollectEntryFilter) ([]*pb.CollectEntry, error) {
-	return c.db.GetCollectEntries(ctx, filters)
+	return c.db.GetCollectEntries(ctx, filters) // nolint:wrapcheck
 }

--- a/pkg/collectsub/client/mock.go
+++ b/pkg/collectsub/client/mock.go
@@ -32,7 +32,7 @@ type MockClient struct {
 func NewMockClient() (Client, error) {
 	sdb, err := simpledb.NewSimpleDb()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create simple db: %v", err)
+		return nil, fmt.Errorf("unable to create simple db: %w", err)
 	}
 	return &MockClient{
 		db: sdb,

--- a/pkg/collectsub/datasource/csubsource/csubsource.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource.go
@@ -52,7 +52,7 @@ func (d *csubDataSources) GetDataSources(ctx context.Context) (*datasource.DataS
 		{Type: pb.CollectDataType_DATATYPE_GIT, Glob: "*"},
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get collect entries: %w", err)
 	}
 	ds := entriesToSources(ctx, entries)
 	d.lastEntries = ds

--- a/pkg/collectsub/datasource/csubsource/csubsource_test.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource_test.go
@@ -30,7 +30,7 @@ import (
 func createSimpleCsubClient(ctx context.Context) (client.Client, error) {
 	c, err := client.NewMockClient()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create mock client: %v", err)
+		return nil, fmt.Errorf("unable to create mock client: %w", err)
 	}
 
 	err = c.AddCollectEntries(ctx, []*collectsub.CollectEntry{
@@ -39,7 +39,7 @@ func createSimpleCsubClient(ctx context.Context) (client.Client, error) {
 		{Type: collectsub.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to add collect entries: %v", err)
+		return nil, fmt.Errorf("unable to add collect entries: %w", err)
 	}
 	return c, nil
 }

--- a/pkg/collectsub/datasource/csubsource/csubsource_test.go
+++ b/pkg/collectsub/datasource/csubsource/csubsource_test.go
@@ -17,6 +17,7 @@ package csubsource
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ import (
 func createSimpleCsubClient(ctx context.Context) (client.Client, error) {
 	c, err := client.NewMockClient()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create mock client: %v", err)
 	}
 
 	err = c.AddCollectEntries(ctx, []*collectsub.CollectEntry{
@@ -38,7 +39,7 @@ func createSimpleCsubClient(ctx context.Context) (client.Client, error) {
 		{Type: collectsub.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to add collect entries: %v", err)
 	}
 	return c, nil
 }

--- a/pkg/collectsub/datasource/filesource/filesource.go
+++ b/pkg/collectsub/datasource/filesource/filesource.go
@@ -49,7 +49,7 @@ type FileFormat struct {
 // - git+https://github.com/...
 func NewFileDataSources(path string) (datasource.CollectSource, error) {
 	if _, err := os.Stat(path); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to stat file: %w", err)
 	}
 
 	return &fileDataSources{
@@ -62,17 +62,17 @@ func NewFileDataSources(path string) (datasource.CollectSource, error) {
 func (d *fileDataSources) GetDataSources(_ context.Context) (*datasource.DataSources, error) {
 	f, err := os.Open(d.filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to open file: %w", err)
 	}
 
 	b, err := io.ReadAll(f)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read file: %w", err)
 	}
 
 	var df FileFormat
 	if err := yaml.Unmarshal(b, &df); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to unmarshal file: %w", err)
 	}
 	return toDataSources(&df), nil
 }
@@ -85,12 +85,12 @@ func (d *fileDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, 
 	updateChan := make(chan error)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create watcher: %w", err)
 	}
 	err = watcher.Add(d.filePath)
 	if err != nil {
 		watcher.Close()
-		return nil, err
+		return nil, fmt.Errorf("unable to watch file: %w", err)
 	}
 
 	go func() {

--- a/pkg/collectsub/datasource/filesource/filesource_test.go
+++ b/pkg/collectsub/datasource/filesource/filesource_test.go
@@ -169,5 +169,5 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 
 func createTestFile(dir string, name string, content []byte) (string, error) {
 	path := filepath.Join(dir, name)
-	return path, os.WriteFile(path, content, 0644)
+	return path, os.WriteFile(path, content, 0644) // nolint:wrapcheck
 }

--- a/pkg/collectsub/server/server.go
+++ b/pkg/collectsub/server/server.go
@@ -38,7 +38,7 @@ type server struct {
 func NewServer(port int) (*server, error) {
 	db, err := simpledb.NewSimpleDb()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create new simple db: %w", err)
 	}
 
 	return &server{
@@ -72,13 +72,13 @@ func (s *server) Serve(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to listen: %w", err)
 	}
 	gs := grpc.NewServer()
 	pb.RegisterColectSubscriberServiceServer(gs, s)
 	logger.Infof("server listening at %v", lis.Addr())
 	if err := gs.Serve(lis); err != nil {
-		return err
+		return fmt.Errorf("failed to serve: %w", err)
 	}
 
 	return nil

--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -114,7 +114,7 @@ func createStreamOrExists(ctx context.Context, js nats.JetStreamContext) error {
 	_, err := js.StreamInfo(StreamName)
 
 	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
-		return err
+		return fmt.Errorf("failed to get stream info: %w", err)
 	}
 	// stream not found, create it
 	if errors.Is(err, nats.ErrStreamNotFound) {
@@ -128,7 +128,7 @@ func createStreamOrExists(ctx context.Context, js nats.JetStreamContext) error {
 			Duplicates: 5 * time.Minute,
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create stream: %w", err)
 		}
 	}
 	return nil
@@ -179,7 +179,7 @@ func createSubscriber(ctx context.Context, id string, subj string, durable strin
 	sub, err := js.PullSubscribe(subj, durable)
 	if err != nil {
 		logger.Errorf("%s subscribe failed: %w", durable, err)
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to subscribe to %s: %w", subj, err)
 	}
 	go func() {
 		for {

--- a/pkg/handler/collector/collector.go
+++ b/pkg/handler/collector/collector.go
@@ -112,7 +112,7 @@ func Publish(ctx context.Context, d *processor.Document) error {
 	}
 	err = emitter.Publish(ctx, emitter.SubjectNameDocCollected, docByte)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to publish document: %w", err)
 	}
 	logger.Debugf("doc published: %+v", d.SourceInformation.Source)
 	return nil

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -141,7 +141,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 
 	psub, err := emitter.NewPubSub(ctx, id, emitter.SubjectNameDocCollected, emitter.DurableProcessor, emitter.BackOffTimer)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to create new pubsub: %w", id, err)
 	}
 
 	processFunc := func(d []byte) error {
@@ -171,7 +171,7 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 
 	err = psub.GetDataFromNats(ctx, processFunc)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to get data from nats: %w", id, err)
 	}
 	return nil
 }

--- a/pkg/handler/processor/cyclonedx/cyclonedx.go
+++ b/pkg/handler/processor/cyclonedx/cyclonedx.go
@@ -39,7 +39,7 @@ func (p *CycloneDXProcessor) ValidateSchema(d *processor.Document) error {
 		bom := new(cdx.BOM)
 		decoder := cdx.NewBOMDecoder(reader, cdx.BOMFileFormatJSON)
 		err := decoder.Decode(bom)
-		return err
+		return fmt.Errorf("unable to decode CycloneDX document: %w", err)
 	}
 
 	return fmt.Errorf("unable to support parsing of CycloneDX document format: %v", d.Format)

--- a/pkg/handler/processor/cyclonedx/cyclonedx.go
+++ b/pkg/handler/processor/cyclonedx/cyclonedx.go
@@ -39,7 +39,10 @@ func (p *CycloneDXProcessor) ValidateSchema(d *processor.Document) error {
 		bom := new(cdx.BOM)
 		decoder := cdx.NewBOMDecoder(reader, cdx.BOMFileFormatJSON)
 		err := decoder.Decode(bom)
-		return fmt.Errorf("unable to decode CycloneDX document: %w", err)
+		if err != nil {
+			return fmt.Errorf("unable to decode CycloneDX document: %w", err)
+		}
+		return nil
 	}
 
 	return fmt.Errorf("unable to support parsing of CycloneDX document format: %v", d.Format)

--- a/pkg/handler/processor/dsse/dsse.go
+++ b/pkg/handler/processor/dsse/dsse.go
@@ -62,7 +62,7 @@ func (d *DSSEProcessor) Unpack(i *processor.Document) ([]*processor.Document, er
 	var doc *processor.Document
 	decodedPayload, err := base64.StdEncoding.DecodeString(envelope.Payload)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode payload: %w", err)
 	}
 	switch pt := envelope.PayloadType; pt {
 	case string(dsseITE6):
@@ -87,7 +87,7 @@ func (d *DSSEProcessor) Unpack(i *processor.Document) ([]*processor.Document, er
 func parseDSSE(b []byte) (*dsse.Envelope, error) {
 	envelope := dsse.Envelope{}
 	if err := json.Unmarshal(b, &envelope); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal envelope: %w", err)
 	}
 
 	return &envelope, nil

--- a/pkg/handler/processor/ite6/ite6.go
+++ b/pkg/handler/processor/ite6/ite6.go
@@ -48,7 +48,7 @@ func (e *ITE6Processor) Unpack(i *processor.Document) ([]*processor.Document, er
 func parseStatement(p []byte) (*in_toto.Statement, error) {
 	ps := in_toto.Statement{}
 	if err := json.Unmarshal(p, &ps); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal statement: %w", err)
 	}
 	return &ps, nil
 }

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -63,7 +63,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 	id := uuid.NewV4().String()
 	psub, err := emitter.NewPubSub(ctx, id, emitter.SubjectNameDocCollected, emitter.DurableProcessor, emitter.BackOffTimer)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to create new pubsub: %w", id, err)
 	}
 
 	processFunc := func(d []byte) error {
@@ -94,7 +94,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 
 	err = psub.GetDataFromNats(ctx, processFunc)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to get data from nats: %w", id, err)
 	}
 	return nil
 }
@@ -155,7 +155,7 @@ func processDocument(ctx context.Context, i *processor.Document) ([]*processor.D
 func preProcessDocument(ctx context.Context, i *processor.Document) error {
 	docType, format, err := guesser.GuessDocument(ctx, i)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to guess document type: %w", err)
 	}
 
 	i.Type = docType

--- a/pkg/handler/processor/spdx/spdx.go
+++ b/pkg/handler/processor/spdx/spdx.go
@@ -37,7 +37,7 @@ func (p *SPDXProcessor) ValidateSchema(d *processor.Document) error {
 	case processor.FormatJSON:
 		reader := bytes.NewReader(d.Blob)
 		_, err := spdx_json.Load2_2(reader)
-		return err
+		return fmt.Errorf("unable to parse SPDX document: %w", err)
 	}
 
 	return fmt.Errorf("unable to support parsing of SPDX document format: %v", d.Format)

--- a/pkg/handler/processor/spdx/spdx.go
+++ b/pkg/handler/processor/spdx/spdx.go
@@ -37,6 +37,9 @@ func (p *SPDXProcessor) ValidateSchema(d *processor.Document) error {
 	case processor.FormatJSON:
 		reader := bytes.NewReader(d.Blob)
 		_, err := spdx_json.Load2_2(reader)
+		if err == nil {
+			return nil
+		}
 		return fmt.Errorf("unable to parse SPDX document: %w", err)
 	}
 

--- a/pkg/ingestor/key/key.go
+++ b/pkg/ingestor/key/key.go
@@ -124,11 +124,11 @@ func Retrieve(ctx context.Context, id string, providerType KeyProviderType) (*Ke
 func Store(ctx context.Context, id string, pemBytes []byte, providerType KeyProviderType) error {
 	key, err := cryptoutils.UnmarshalPEMToPublicKey(pemBytes)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal PEM to public key: %w", err)
 	}
 	keyHash, err := dsse.SHA256KeyID(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get key hash: %w", err)
 	}
 	keyType, KeyScheme, err := getKeyInfo(key)
 	if err != nil {

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -76,7 +76,7 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 	id := uuid.NewV4().String()
 	psub, err := emitter.NewPubSub(ctx, id, emitter.SubjectNameDocProcessed, emitter.DurableIngestor, emitter.BackOffTimer)
 	if err != nil {
-		return err
+		return fmt.Errorf("[ingestor: %s] failed to create new pubsub: %w", id, err)
 	}
 
 	parserFunc := func(d []byte) error {
@@ -107,7 +107,7 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph) error)
 
 	err = psub.GetDataFromNats(ctx, parserFunc)
 	if err != nil {
-		return err
+		return fmt.Errorf("[ingestor: %s] failed to get data from nats: %w", id, err)
 	}
 	return nil
 }
@@ -158,7 +158,7 @@ func parseHelper(ctx context.Context, doc *processor.Document) (*common.GraphBui
 	p := pFunc()
 	err := p.Parse(ctx, doc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse document: %w", err)
 	}
 
 	graphBuilder := common.NewGenericGraphBuilder(p, p.GetIdentities(ctx))

--- a/pkg/ingestor/parser/parser_test.go
+++ b/pkg/ingestor/parser/parser_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -208,11 +209,11 @@ func Test_ParserSubscribe(t *testing.T) {
 func testPublish(ctx context.Context, documentTree processor.DocumentTree) error {
 	docTreeJSON, err := json.Marshal(documentTree)
 	if err != nil {
-		return err
+		return fmt.Errorf("error marshaling document tree: %w", err)
 	}
 	err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeJSON)
 	if err != nil {
-		return err
+		return fmt.Errorf("error publishing: %w", err)
 	}
 	return nil
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -128,7 +128,7 @@ func parseSpdxBlob(p []byte) (*v2_2.Document, error) {
 	reader := bytes.NewReader(p)
 	spdx, err := spdx_json.Load2_2(reader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse SPDX document: %w", err)
 	}
 	return spdx, nil
 }

--- a/pkg/ingestor/verifier/verifier.go
+++ b/pkg/ingestor/verifier/verifier.go
@@ -72,7 +72,7 @@ func VerifyIdentity(ctx context.Context, doc *processor.Document) ([]Identity, e
 	switch doc.Type {
 	case processor.DocumentDSSE:
 		if verifier, ok := verifierProviders["sigstore"]; ok {
-			return verifier.Verify(ctx, doc.Blob)
+			return verifier.Verify(ctx, doc.Blob) // nolint:wrapcheck
 		}
 	}
 	return nil, fmt.Errorf("failed verification for document type: %s", doc.Type)

--- a/pkg/ingestor/verifier/verifier_test.go
+++ b/pkg/ingestor/verifier/verifier_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -103,7 +104,7 @@ func newMockSigstoreVerifier() *mockSigstoreVerifier {
 func (m *mockSigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]Identity, error) {
 	keyHash, err := dsse.SHA256KeyID(ecdsaPubKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get key hash: %w", err)
 	}
 	return []Identity{
 		{


### PR DESCRIPTION
- Changed the errors from returning `return err` to `return fmt.Errorf()`.
- Only changed some of the errors because it would be too big of the PR otherwise and would take forever.
- Helps with https://github.com/guacsec/guac/pull/423#discussion_r1102924221

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>