### PR TITLE
create docker compose service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,17 @@ fmt-md:
 .PHONY: generate
 generate:
 	go generate ./...
+
+.PHONY: container
+container:
+	docker build -f dockerfiles/Dockerfile.guac-cont -t local-organic-guac .
+	docker build -f dockerfiles/Dockerfile.healthcheck -t local-healthcheck .
+
+
+# To run the service, run `make container` and then `make service`
+# making the container is a longer process and thus not a dependency of service.
+.PHONY: service
+service:
+	# requires force recreate since docker compose reuses containers and neo4j does
+	# not handle that well.
+	docker compose up --force-recreate	

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,6 @@ container:
 service:
 	# requires force recreate since docker compose reuses containers and neo4j does
 	# not handle that well.
+	#
+	# if container images are missing, run `make container` first
 	docker compose up --force-recreate	

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -1,0 +1,5 @@
+gdbuser: neo4j
+gdbpass: s3cr3t
+gdbaddr: neo4j://neo4j:7687
+realm: neo4j
+natsaddr: nats://nats:4222

--- a/container_files/nats/js.conf
+++ b/container_files/nats/js.conf
@@ -1,4 +1,4 @@
-// change max payload from default 1MB to 8MB
+// change max payload from default 1MB to 64MB
 max_payload: 64MB
 // enables jetstream, an empty block will enable and use defaults
 jetstream {}

--- a/container_files/nats/js.conf
+++ b/container_files/nats/js.conf
@@ -1,0 +1,4 @@
+// change max payload from default 1MB to 8MB
+max_payload: 64MB
+// enables jetstream, an empty block will enable and use defaults
+jetstream {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3"
+
+services:
+  neo4j:
+    image: "neo4j:4.4.9-community"
+    environment:
+      NEO4J_AUTH: "neo4j/s3cr3t"
+      NEO4J_apoc_export_file_enabled: true
+      NEO4J_apoc_import_file_enabled: true
+      NEO4J_apoc_import_file_use__neo4j__config: true
+      NEO4JLABS_PLUGINS: '["apoc"]'
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    restart: on-failure
+
+  nats:
+    image: "nats:2.9.14"
+    command: "--config /config/nats/js.conf -m 8222"
+    ports:
+      - "4222:4222"
+      # monitoring port
+      - "8222:8222"
+    volumes:
+      - ./container_files/nats:/config/nats
+    restart: on-failure
+
+  # Due to the following issues, we have another container to perform the healthcheck
+  #
+  # TODO(lumjjb): I attempted to do health check for neo4j as well, but
+  # the service running via neo4j status is not a good indication of if
+  # the service is ready for incoming requests.
+  # TODO(lumjjb): no good way right now to do a healtcheck for nats-server since
+  # it doesn't have utilities within it to perform the check from the container
+  # itself. 
+  service-health:
+    image: "local-healthcheck"
+    stdin_open: true
+    tty: true
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        echo "checking-for-services";
+        until curl -I http://nats:8222 > /dev/null 2>&1; do sleep 5; done; 
+        echo "nats-up";
+        until curl -I http://neo4j:7474> /dev/null 2>&1; do sleep 5; done; 
+        echo "neo4j-up";
+
+  guac-ingestor:
+    image: "local-organic-guac"
+    command: "/opt/guac/ingest ingest"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      service-health:
+        condition: service_completed_successfully
+    volumes:
+      - ./container_files/guac:/guac

--- a/dockerfiles/Dockerfile.guac-cont
+++ b/dockerfiles/Dockerfile.guac-cont
@@ -3,6 +3,6 @@ ADD . /go/src/github.com/guacsec/guac/
 WORKDIR /go/src/github.com/guacsec/guac/
 RUN rm -rf bin/ && make build
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 WORKDIR /root
 COPY --from=builder /go/src/github.com/guacsec/guac/bin/ /opt/guac/

--- a/dockerfiles/Dockerfile.guac-cont
+++ b/dockerfiles/Dockerfile.guac-cont
@@ -1,0 +1,8 @@
+FROM golang:1.19 as builder
+ADD . /go/src/github.com/guacsec/guac/
+WORKDIR /go/src/github.com/guacsec/guac/
+RUN rm -rf bin/ && make build
+
+FROM ubuntu:18.04
+WORKDIR /root
+COPY --from=builder /go/src/github.com/guacsec/guac/bin/ /opt/guac/

--- a/dockerfiles/Dockerfile.healthcheck
+++ b/dockerfiles/Dockerfile.healthcheck
@@ -1,2 +1,2 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt update && apt install -y curl

--- a/dockerfiles/Dockerfile.healthcheck
+++ b/dockerfiles/Dockerfile.healthcheck
@@ -1,2 +1,2 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt update && apt install -y curl

--- a/dockerfiles/Dockerfile.healthcheck
+++ b/dockerfiles/Dockerfile.healthcheck
@@ -1,0 +1,2 @@
+FROM ubuntu:18.04
+RUN apt update && apt install -y curl

--- a/guac.yaml
+++ b/guac.yaml
@@ -2,3 +2,4 @@ gdbuser: neo4j
 gdbpass: s3cr3t
 gdbaddr: neo4j://localhost:7687
 realm: neo4j
+natsaddr: nats://localhost:4222


### PR DESCRIPTION
This PR creates a docker compose container that will run neo4j, nats and the ingestor.

You can run this via `make service` command (and `make container` command to create the necessary containers to run the service). A run would look like this, and after the ingestor is up, a collector can be run (e.g. ` bin/collector files /path/to/guac-data/docs`)

```
$ make service
# requires force recreate since docker compose reuses containers and neo4j does
# not handle that well.
#
# if container images are missing, run `make container` first
docker compose up --force-recreate
[+] Running 4/3
 ⠿ Container guac-neo4j-1           Recreated                                                                                                                                 0.1s
 ⠿ Container guac-nats-1            Recreated                                                                                                                                 0.1s
 ⠿ Container guac-service-health-1  Recreated                                                                                                                                 0.1s
 ⠿ Container guac-guac-ingestor-1   Recreated                                                                                                                                 0.1s
Attaching to guac-guac-ingestor-1, guac-nats-1, guac-neo4j-1, guac-service-health-1
guac-service-health-1  | checking-for-services
guac-nats-1            | [1] 2023/02/10 17:41:51.255056 [INF] Starting nats-server
guac-nats-1            | [1] 2023/02/10 17:41:51.255317 [INF]   Version:  2.9.14
guac-nats-1            | [1] 2023/02/10 17:41:51.255351 [INF]   Git:      [74ae59a]
guac-nats-1            | [1] 2023/02/10 17:41:51.255402 [INF]   Name:     NAKXBUWF35FN3VRCMZLG2MCUWIPJLTAIPHS7ZNXDWUGAJACVEBU4E7XT
guac-nats-1            | [1] 2023/02/10 17:41:51.255410 [INF]   Node:     wBj6ffLM
guac-nats-1            | [1] 2023/02/10 17:41:51.255413 [INF]   ID:       NAKXBUWF35FN3VRCMZLG2MCUWIPJLTAIPHS7ZNXDWUGAJACVEBU4E7XT
guac-nats-1            | [1] 2023/02/10 17:41:51.255474 [INF] Using configuration file: /config/nats/js.conf
guac-nats-1            | [1] 2023/02/10 17:41:51.255567 [WRN] Maximum payloads over 8.00 MB are generally discouraged and could lead to poor performance
guac-nats-1            | [1] 2023/02/10 17:41:51.257192 [INF] Starting http monitor on 0.0.0.0:8222
guac-nats-1            | [1] 2023/02/10 17:41:51.257330 [INF] Starting JetStream
guac-nats-1            | [1] 2023/02/10 17:41:51.257851 [INF]     _ ___ _____ ___ _____ ___ ___   _   __  __
guac-nats-1            | [1] 2023/02/10 17:41:51.257859 [INF]  _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  |
guac-nats-1            | [1] 2023/02/10 17:41:51.257861 [INF] | || | _|  | | \__ \ | | |   / _| / _ \| |\/| |
guac-nats-1            | [1] 2023/02/10 17:41:51.257863 [INF]  \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_|
guac-nats-1            | [1] 2023/02/10 17:41:51.257864 [INF]
guac-nats-1            | [1] 2023/02/10 17:41:51.257866 [INF]          https://docs.nats.io/jetstream
guac-nats-1            | [1] 2023/02/10 17:41:51.257868 [INF]
guac-nats-1            | [1] 2023/02/10 17:41:51.257870 [INF] ---------------- JETSTREAM ----------------
guac-nats-1            | [1] 2023/02/10 17:41:51.257875 [INF]   Max Memory:      5.76 GB
guac-nats-1            | [1] 2023/02/10 17:41:51.257878 [INF]   Max Storage:     12.04 GB
guac-nats-1            | [1] 2023/02/10 17:41:51.257881 [INF]   Store Directory: "/tmp/nats/jetstream"
guac-nats-1            | [1] 2023/02/10 17:41:51.257882 [INF] -------------------------------------------
guac-nats-1            | [1] 2023/02/10 17:41:51.258249 [INF] Listening for client connections on 0.0.0.0:4222
guac-nats-1            | [1] 2023/02/10 17:41:51.258562 [INF] Server is ready
guac-neo4j-1           | Changed password for user 'neo4j'. IMPORTANT: this change will only take effect if performed before the database is started for the first time.
guac-neo4j-1           | Fetching versions.json for Plugin 'apoc' from https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json
guac-neo4j-1           | Installing Plugin 'apoc' from https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/4.4.0.9/apoc-4.4.0.9-all.jar to /var/lib/neo4j/plugins/apoc.jar
guac-neo4j-1           | Applying default values for plugin apoc to neo4j.conf
guac-service-health-1  | nats-up
guac-neo4j-1           | 2023-02-10 17:41:57.661+0000 INFO  Starting...
guac-neo4j-1           | 2023-02-10 17:41:58.052+0000 INFO  This instance is ServerId{8037b4e3} (8037b4e3-192b-46f3-99f2-e548c08e4501)
guac-neo4j-1           | 2023-02-10 17:41:59.247+0000 INFO  ======== Neo4j 4.4.9 ========
guac-neo4j-1           | 2023-02-10 17:42:04.612+0000 INFO  Performing postInitialization step for component 'security-users' with version 3 and status CURRENT
guac-neo4j-1           | 2023-02-10 17:42:04.612+0000 INFO  Updating the initial password in component 'security-users'
guac-neo4j-1           | 2023-02-10 17:42:06.090+0000 INFO  Called db.clearQueryCaches(): Query caches successfully cleared of 1 queries.
guac-neo4j-1           | 2023-02-10 17:42:06.148+0000 INFO  Bolt enabled on 0.0.0.0:7687.
guac-neo4j-1           | 2023-02-10 17:42:06.897+0000 INFO  Remote interface available at http://localhost:7474/
guac-neo4j-1           | 2023-02-10 17:42:06.901+0000 INFO  id: 030249234A8796D3DA4A72F6123CA534136F78D66D33A9C029D86CEA4F32FD01
guac-neo4j-1           | 2023-02-10 17:42:06.901+0000 INFO  name: system
guac-neo4j-1           | 2023-02-10 17:42:06.901+0000 INFO  creationDate: 2023-02-10T14:14:55.343Z
guac-neo4j-1           | 2023-02-10 17:42:06.901+0000 INFO  Started.
guac-service-health-1  | neo4j-up
guac-service-health-1 exited with code 0
guac-guac-ingestor-1   | {"level":"info","ts":1676050932.041539,"caller":"cmd/root.go:89","msg":"Using config file: /guac/guac.yaml"}
guac-guac-ingestor-1   | {"level":"info","ts":1676050932.0459363,"caller":"emitter/nats_emitter.go:121","msg":"creating stream \"DOCUMENTS\" and subjects \"DOCUMENTS.*\""}
guac-guac-ingestor-1   | {"level":"info","ts":1676050937.787074,"caller":"emitter/nats_emitter.go:193","msg":"[ingestor: df3a6c7f-65a6-4e0e-86a6-487dc0862859] nothing to consume, backing off for 1s: %!w(*errors.errorString=&{nats: timeout})"}
guac-guac-ingestor-1   | {"level":"info","ts":1676050937.788511,"caller":"emitter/nats_emitter.go:193","msg":"[processor: 76841ccf-ecf4-4f60-bcca-52c60479cf76] nothing to consume, backing off for 1s: %!w(*errors.errorString=&{nats: timeout})"}
```

Signed-off-by: Brandon Lum <lumjjb@gmail.com>