### PR TITLE
Add collectsub service and OCI collector to all-in-one deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,15 @@ container:
 
 # To run the service, run `make container` and then `make service`
 # making the container is a longer process and thus not a dependency of service.
-.PHONY: service
-service:
+.PHONY: start-service
+start-service:
 	# requires force recreate since docker compose reuses containers and neo4j does
 	# not handle that well.
 	#
 	# if container images are missing, run `make container` first
 	docker compose up --force-recreate	
+
+# to flush state, service-stop must be used else state is taken from old containers
+.PHONY: stop-service
+stop-service:
+	docker compose down

--- a/cmd/collector/cmd/files.go
+++ b/cmd/collector/cmd/files.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/file"
@@ -30,15 +29,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-type options struct {
-	// path to folder with documents to collect
-	path string
-	// datasource for the collector
-	dataSource datasource.CollectSource
-	// address for NATS connection
-	natsAddr string
-}
 
 var filesCmd = &cobra.Command{
 	Use:   "files [flags] file_path",

--- a/cmd/collector/cmd/oci.go
+++ b/cmd/collector/cmd/oci.go
@@ -62,7 +62,7 @@ var ociCmd = &cobra.Command{
 		}
 
 		// Register collector
-		ociCollector := oci.NewOCICollector(ctx, opts.dataSource, opts.poll, 10*time.Minute)
+		ociCollector := oci.NewOCICollector(ctx, opts.dataSource, opts.poll, 30*time.Second)
 		err = collector.RegisterDocumentCollector(ociCollector, oci.OCICollector)
 		if err != nil {
 			logger.Errorf("unable to register oci collector: %v", err)

--- a/cmd/collector/cmd/oci.go
+++ b/cmd/collector/cmd/oci.go
@@ -62,6 +62,9 @@ var ociCmd = &cobra.Command{
 		}
 
 		// Register collector
+		// TODO(lumjjb): Return this to a longer duration (~10 minutes) so as to not keep hitting
+		// the OCI server. This will require adding triggers to get new repos as they come up from
+		// the CollectSources so that there isn't a long delay from adding new data sources.
 		ociCollector := oci.NewOCICollector(ctx, opts.dataSource, opts.poll, 30*time.Second)
 		err = collector.RegisterDocumentCollector(ociCollector, oci.OCICollector)
 		if err != nil {

--- a/cmd/collector/cmd/root.go
+++ b/cmd/collector/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/logging"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -28,10 +29,21 @@ import (
 	"github.com/spf13/viper"
 )
 
+type options struct {
+	// path to folder with documents to collect
+	path string
+	// datasource for the collector
+	dataSource datasource.CollectSource
+	// address for NATS connection
+	natsAddr string
+}
+
 var flags = struct {
 	// collect-sub flags
-	collectSubAddr       string
-	collectSubListenPort int
+	// collectsub address if used
+	collectSubAddr string
+	// flag to use collectsub service for datasources
+	useCollectSub bool
 
 	// nats
 	natsAddr string
@@ -44,9 +56,9 @@ func init() {
 	persistentFlags := rootCmd.PersistentFlags()
 	persistentFlags.StringVar(&flags.natsAddr, "natsaddr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
 	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
-	persistentFlags.IntVar(&flags.collectSubListenPort, "csub-listen-port", 2782, "port to listen to on collect-sub service")
+	persistentFlags.BoolVar(&flags.useCollectSub, "use-csub", false, "use collectsub server for datasource (no positional arguments required)")
 
-	flagNames := []string{"natsaddr", "csub-addr", "csub-listen-port"}
+	flagNames := []string{"natsaddr", "csub-addr", "use-csub"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -70,7 +70,7 @@ func validateCsubClientFlags(addr string) (csubClientOptions, error) {
 Examples:
 
 # add two entries
-echo '[{"type":"DATATYPE_GIT", "value":"git+somerepo"},{"type":"DATATYPE_OCI", "value":"oci://abc"}]' | bin/guacone csub-client  add-collect-entries
+echo '[{"type":"DATATYPE_GIT", "value":"git+https://github.com/guacsec/guac"},{"type":"DATATYPE_OCI", "value":"ghcr.io/guacsec/go-multi-test"}]' | bin/guacone csub-client  add-collect-entries
 */
 var csubAddCollectEntriesCmd = &cobra.Command{
 	Use:   "add-collect-entries",

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -70,7 +70,7 @@ func validateCsubClientFlags(addr string) (csubClientOptions, error) {
 Examples:
 
 # add two entries
-echo '[{"type":"DATATYPE_GIT", "value":"git+https://github.com/guacsec/guac"},{"type":"DATATYPE_OCI", "value":"ghcr.io/guacsec/go-multi-test"}]' | bin/guacone csub-client  add-collect-entries
+echo '[{"type":"DATATYPE_GIT", "value":"git+https://github.com/guacsec/guac"},{"type":"DATATYPE_OCI", "value":"index.docker.io/lumjjb/local-organic-guac"}]' | bin/guacone csub-client  add-collect-entries
 */
 var csubAddCollectEntriesCmd = &cobra.Command{
 	Use:   "add-collect-entries",

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -1,5 +1,12 @@
+# neo4j
 gdbuser: neo4j
 gdbpass: s3cr3t
 gdbaddr: neo4j://neo4j:7687
 realm: neo4j
+
+# nats
 natsaddr: nats://nats:4222
+
+# collect-sub
+csub-addr: guac-collectsub:2782
+csub-listen-port: 2782

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,3 +57,27 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./container_files/guac:/guac
+
+  guac-collectsub:
+    image: "local-organic-guac"
+    command: "/opt/guac/guacone csub-server"
+    working_dir: /guac
+    restart: on-failure
+    ports:
+      - "2782:2782"
+    depends_on:
+      service-health:
+        condition: service_completed_successfully
+    volumes:
+      - ./container_files/guac:/guac
+
+  oci-collector:
+    image: "local-organic-guac"
+    command: "/opt/guac/collector image --use-csub"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      service-health:
+        condition: service_completed_successfully
+    volumes:
+      - ./container_files/guac:/guac

--- a/dockerfiles/Dockerfile.guac-cont
+++ b/dockerfiles/Dockerfile.guac-cont
@@ -4,5 +4,7 @@ WORKDIR /go/src/github.com/guacsec/guac/
 RUN rm -rf bin/ && make build
 
 FROM ubuntu:22.04
+RUN apt update
+RUN apt install -y ca-certificates
 WORKDIR /root
 COPY --from=builder /go/src/github.com/guacsec/guac/bin/ /opt/guac/

--- a/guac.yaml
+++ b/guac.yaml
@@ -3,3 +3,5 @@ gdbpass: s3cr3t
 gdbaddr: neo4j://localhost:7687
 realm: neo4j
 natsaddr: nats://localhost:4222
+csub-addr: localhost:2782
+csub-listen-port: 2782

--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -44,6 +44,8 @@ type ociCollector struct {
 // NewOCICollector initializes the oci collector by passing in the repo and tag being collected.
 // Note: OCI collector can be called upon by a upstream registry collector in the future to collect from all
 // repos in a given registry. For further details see issue #298
+//
+// Interval should be set to about 5 mins or more for production so that it doesn't clobber registries.
 func NewOCICollector(ctx context.Context, collectDataSource datasource.CollectSource, poll bool, interval time.Duration) *ociCollector {
 	return &ociCollector{
 		collectDataSource: collectDataSource,
@@ -104,9 +106,8 @@ func (o *ociCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- 
 				if err != nil {
 					return err
 				}
-				// set interval to about 5 mins or more
-				time.Sleep(o.interval)
 			}
+			time.Sleep(o.interval)
 		}
 	} else {
 		err := populateRepoTags()


### PR DESCRIPTION
This PR introduces two additional containers to the all-in-one service introduced in #425 
- Collectsub service to run the data subscription service
- OCI collector using the collectsub service (running as a daemon)

Starting up the service and registering a dataset to collect will result in nodes being populated! An example of doing this is with the `guacone` client:


Running 
`
echo '[{"type":"DATATYPE_GIT", "value":"git+https://github.com/guacsec/guac"},{"type":"DATATYPE_OCI", "value":"ghcr.io/guacsec/go-multi-test"}]' | bin/guacone csub-client  add-collect-entries
`

Signed-off-by: Brandon Lum <lumjjb@gmail.com>