### PR TITLE
Improve NATS Emitter Logging and Timeouts

### DIFF
--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -190,7 +190,7 @@ func createSubscriber(ctx context.Context, id string, subj string, durable strin
 			msgs, err := sub.Fetch(1)
 			if err != nil {
 				if errors.Is(err, nats.ErrTimeout) {
-					logger.Infof("[%s: %s] nothing to consume, backing off for %s: %w", durable, id, backOffTimer.String(), err)
+					// if we get a timeout, we want to try again
 					time.Sleep(backOffTimer)
 					continue
 				} else {


### PR DESCRIPTION
- Update logging message and add a comment to createSubscriber function in pkg/emitter/nats_emitter.go
- fixes https://github.com/guacsec/guac/issues/428
[pkg/emitter/nats_emitter.go]
- Added a comment to the createSubscriber function to explain the timeout behavior

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>