### PR TITLE
Improve logging for development mode

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -26,7 +26,7 @@ var logger *zap.SugaredLogger
 type loggerKey struct{}
 
 func init() {
-	zapLogger, _ := zap.NewProduction()
+	zapLogger, _ := zap.NewDevelopment(zap.AddCaller(), zap.AddStacktrace(zap.ErrorLevel))
 
 	// flushes buffer, if any
 	defer func() {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -17,6 +17,7 @@ package logging
 
 import (
 	"context"
+	"os"
 
 	"go.uber.org/zap"
 )
@@ -26,7 +27,14 @@ var logger *zap.SugaredLogger
 type loggerKey struct{}
 
 func init() {
-	zapLogger, _ := zap.NewDevelopment(zap.AddCaller(), zap.AddStacktrace(zap.ErrorLevel))
+	var zapLogger *zap.Logger
+	env := os.Getenv("ENVIRONMENT")
+
+	if env == "production" {
+		zapLogger, _ = zap.NewProduction(zap.AddCaller(), zap.AddStacktrace(zap.ErrorLevel))
+	} else {
+		zapLogger, _ = zap.NewDevelopment(zap.AddCaller(), zap.AddStacktrace(zap.ErrorLevel))
+	}
 
 	// flushes buffer, if any
 	defer func() {


### PR DESCRIPTION
- Change the logger from production to development mode
- Add caller and stacktrace for error level logging
- Fixes https://github.com/guacsec/guac/issues/429

[pkg/logging/logger.go]
- Change the logger from production to development mode
- Add caller and stacktrace for error level logging

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>