### PR TITLE
Change OCI Collector log messages from Error to Info for missing repo metadata

### DIFF
--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -81,7 +81,6 @@ func (o *ociCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- 
 				if repoTags[imagePath] == nil || len(repoTags[imagePath]) > 0 {
 					repoTags[imagePath] = append(repoTags[imagePath], imageRef.Tag)
 				}
-
 			}
 		}
 		return nil
@@ -227,7 +226,9 @@ func (o *ociCollector) fetchOCIArtifacts(ctx context.Context, repo string, rc *r
 			// log error and continue
 			m, err = rc.ManifestGet(ctx, r)
 			if err != nil {
-				logger.Error(err)
+				// this is a normal behavior, not an error when the digest does not have an attestation
+				// explicitly logging it as info to avoid call-stack when logging
+				logger.Infof("unable to get manifest for %v: %v", imageTag, err)
 				continue
 			}
 


### PR DESCRIPTION
- Change logging from error to info in `fetchOCIArtifacts` function
- Fixes https://github.com/guacsec/guac/issues/427

[pkg/handler/collector/oci/oci.go]
- Remove unnecessary line from `RetrieveArtifacts` function
- Change logging from error to info in `fetchOCIArtifacts` function

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>