### PR TITLE
add get-identifiers function to parser interface

### DIFF
--- a/pkg/ingestor/parser/common/types.go
+++ b/pkg/ingestor/parser/common/types.go
@@ -31,4 +31,25 @@ type DocumentParser interface {
 	CreateNodes(ctx context.Context) []assembler.GuacNode
 	// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
 	CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge
+	// GetIdentifiers returns a set of identifiers that the parser has found to help provide context
+	// for collectors to gather more information around found software identifiers.
+	// This is an optional function to implement and it should return an error if not implemented.
+	//
+	// Ref: https://github.com/guacsec/guac/issues/244
+	GetIdentifiers(ctx context.Context) (*IdentifierStrings, error)
+}
+
+// Identifiers represent a set of strings that can be used to a set of
+// identifiers that the parser has found to help provide context for collectors
+// to gather more information around found software identifiers.
+//
+// Ref: https://github.com/guacsec/guac/issues/244
+type IdentifierStrings struct {
+	// OciStrings should contain pointers to OCI packages
+	OciStrings []string
+	// VcsStrings should contain VCS strings for source control
+	VcsStrings []string
+	// UnclassifiedStrings contains other strings that have identifiers that
+	// parsers may not be sure what category they fall under.
+	UnclassifiedStrings []string
 }

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -211,3 +211,7 @@ func parseCycloneDXBOM(doc *processor.Document) (*cdx.BOM, error) {
 	}
 	return &bom, nil
 }
+
+func (c *cyclonedxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -90,3 +90,7 @@ func (d *dsseParser) CreateNodes(_ context.Context) []assembler.GuacNode {
 func (d *dsseParser) CreateEdges(_ context.Context, _ []assembler.IdentityNode) []assembler.GuacEdge {
 	return []assembler.GuacEdge{}
 }
+
+func (d *dsseParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -138,3 +138,7 @@ func hashToDigest(h string) string {
 	}
 	return h
 }
+
+func (p *scorecardParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -150,3 +150,7 @@ func (s *slsaParser) CreateEdges(ctx context.Context, foundIdentities []assemble
 func (s *slsaParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
 	return nil
 }
+
+func (s *slsaParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -283,3 +283,7 @@ func getDependsOnEdge(foundNode assembler.GuacNode, relatedNode assembler.GuacNo
 func (s *spdxParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
 	return nil
 }
+
+func (s *spdxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/ingestor/parser/vuln/cerify_vuln.go
+++ b/pkg/ingestor/parser/vuln/cerify_vuln.go
@@ -161,3 +161,7 @@ func (c *vulnCertificationParser) CreateEdges(ctx context.Context, foundIdentiti
 func (c *vulnCertificationParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
 	return nil
 }
+
+func (c *vulnCertificationParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}


### PR DESCRIPTION
Add to interface for parsers to implement returning a list of identifiers so they can be passed on to the collectsub / data subscription service (as per https://github.com/guacsec/guac/issues/244).

Signed-off-by: Brandon Lum <lumjjb@gmail.com>