### PR TITLE
Fixed error statments

### DIFF
--- a/pkg/handler/collector/file/file.go
+++ b/pkg/handler/collector/file/file.go
@@ -61,7 +61,7 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 		// When it gets thrown a second time will cancel the walk.
 		// See filepath.WalkDir for more info.
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return ctx.Err() // nolint:wrapcheck
 		}
 		// NOTE: Explicitly rethrowing new errors if a particular directory has an error.
 		// If we rethrow the error it kills the whole walk. Still useful to make it explicit that we ran into an error.
@@ -72,12 +72,12 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 			return nil
 		}
 		if info, err := dirEntry.Info(); !info.ModTime().After(f.lastChecked) || err != nil {
-			return err
+			return fmt.Errorf("file: %s has not been modified since last check", path)
 		}
 
 		blob, err := os.ReadFile(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading file: %s, err: %w", path, err)
 		}
 
 		doc := &processor.Document{
@@ -100,11 +100,11 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 			select {
 			// If the context has been canceled it contains an err which we can throw.
 			case <-ctx.Done():
-				return ctx.Err()
+				return ctx.Err() // nolint:wrapcheck
 			default:
 				err := filepath.WalkDir(f.path, readFunc)
 				if err != nil {
-					return err
+					return fmt.Errorf("error walking path: %s, err: %w", f.path, err)
 				}
 				f.lastChecked = time.Now()
 				time.Sleep(f.interval)
@@ -113,7 +113,7 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 	} else {
 		err := filepath.WalkDir(f.path, readFunc)
 		if err != nil {
-			return err
+			return fmt.Errorf("error walking path: %s, err: %w", f.path, err)
 		}
 		f.lastChecked = time.Now()
 	}

--- a/pkg/handler/processor/dsse/dsse.go
+++ b/pkg/handler/processor/dsse/dsse.go
@@ -62,7 +62,7 @@ func (d *DSSEProcessor) Unpack(i *processor.Document) ([]*processor.Document, er
 	var doc *processor.Document
 	decodedPayload, err := base64.StdEncoding.DecodeString(envelope.Payload)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode payload: %w", err)
 	}
 	switch pt := envelope.PayloadType; pt {
 	case string(dsseITE6):

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -63,7 +63,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 	id := uuid.NewV4().String()
 	psub, err := emitter.NewPubSub(ctx, id, emitter.SubjectNameDocCollected, emitter.DurableProcessor, emitter.BackOffTimer)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to create new pubsub: %w", id, err)
 	}
 
 	processFunc := func(d []byte) error {
@@ -94,7 +94,7 @@ func Subscribe(ctx context.Context, transportFunc func(processor.DocumentTree) e
 
 	err = psub.GetDataFromNats(ctx, processFunc)
 	if err != nil {
-		return err
+		return fmt.Errorf("[processor: %s] failed to get data from nats: %w", id, err)
 	}
 	return nil
 }
@@ -155,7 +155,7 @@ func processDocument(ctx context.Context, i *processor.Document) ([]*processor.D
 func preProcessDocument(ctx context.Context, i *processor.Document) error {
 	docType, format, err := guesser.GuessDocument(ctx, i)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to guess document type: %w", err)
 	}
 
 	i.Type = docType
@@ -184,7 +184,7 @@ func validateDocument(i *processor.Document) error {
 		return fmt.Errorf("no document processor registered for type: %s", i.Type)
 	}
 
-	return p.ValidateSchema(i)
+	return p.ValidateSchema(i) // nolint:wrapcheck
 }
 
 func unpackDocument(i *processor.Document) ([]*processor.Document, error) {
@@ -192,5 +192,5 @@ func unpackDocument(i *processor.Document) ([]*processor.Document, error) {
 	if !ok {
 		return nil, fmt.Errorf("no document processor registered for type: %s", i.Type)
 	}
-	return p.Unpack(i)
+	return p.Unpack(i) // nolint:wrapcheck
 }


### PR DESCRIPTION
- Changed the errors from returning `return err` to `return fmt.Errorf()`.
- Only changed some of the errors because it would be too big of the PR otherwise and would take forever.
- Helps with https://github.com/guacsec/guac/pull/423#discussion_r1102924221

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>