### PR TITLE
Add simple SLSA identifier strings and provide integration with ingestor

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -212,13 +212,11 @@ func getProcessor(ctx context.Context) (func(*processor.Document) (processor.Doc
 }
 func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler.Graph, error), error) {
 	return func(doc processor.DocumentTree) ([]assembler.Graph, error) {
-		inputs, idStrings, err := parser.ParseDocumentTree(ctx, doc)
+		// for guacone collectors, we do not integrate with the collectsub service
+		inputs, _, err := parser.ParseDocumentTree(ctx, doc)
 		if err != nil {
 			return nil, err
 		}
-
-		// for guacone collectors, we do not integrate with the collectsub service
-		_ = idStrings
 
 		return inputs, nil
 	}, nil

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -212,10 +212,14 @@ func getProcessor(ctx context.Context) (func(*processor.Document) (processor.Doc
 }
 func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler.Graph, error), error) {
 	return func(doc processor.DocumentTree) ([]assembler.Graph, error) {
-		inputs, err := parser.ParseDocumentTree(ctx, doc)
+		inputs, idStrings, err := parser.ParseDocumentTree(ctx, doc)
 		if err != nil {
 			return nil, err
 		}
+
+		// for guacone collectors, we do not integrate with the collectsub service
+		_ = idStrings
+
 		return inputs, nil
 	}, nil
 }

--- a/cmd/ingest/cmd/example.go
+++ b/cmd/ingest/cmd/example.go
@@ -44,6 +44,7 @@ var exampleCmd = &cobra.Command{
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
 			viper.GetString("natsaddr"),
+			viper.GetString("csub-addr"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -66,11 +67,14 @@ var exampleCmd = &cobra.Command{
 			Edges: []assembler.GuacEdge{},
 		}
 		for _, doc := range docs {
-			inputs, err := parser.ParseDocumentTree(ctx, doc)
+			inputs, idStrings, err := parser.ParseDocumentTree(ctx, doc)
 			if err != nil {
 				logger.Errorf("unable to parse document: %v", err)
 				os.Exit(1)
 			}
+
+			// This is a test example, so we will ignore calling out to a collectsub service
+			_ = idStrings
 
 			g.AppendGraph(inputs...)
 		}

--- a/cmd/ingest/cmd/example.go
+++ b/cmd/ingest/cmd/example.go
@@ -67,14 +67,12 @@ var exampleCmd = &cobra.Command{
 			Edges: []assembler.GuacEdge{},
 		}
 		for _, doc := range docs {
-			inputs, idStrings, err := parser.ParseDocumentTree(ctx, doc)
+			// This is a test example, so we will ignore calling out to a collectsub service
+			inputs, _, err := parser.ParseDocumentTree(ctx, doc)
 			if err != nil {
 				logger.Errorf("unable to parse document: %v", err)
 				os.Exit(1)
 			}
-
-			// This is a test example, so we will ignore calling out to a collectsub service
-			_ = idStrings
 
 			g.AppendGraph(inputs...)
 		}

--- a/cmd/ingest/cmd/root.go
+++ b/cmd/ingest/cmd/root.go
@@ -38,6 +38,9 @@ var flags = struct {
 
 	// nats
 	natsAddr string
+
+	// collectsub service
+	collectSubAddr string
 }{}
 
 func init() {
@@ -48,6 +51,7 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
 	persistentFlags.StringVar(&flags.natsAddr, "natsaddr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
+	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
 	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "natsaddr"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 	"github.com/spf13/cobra"
@@ -108,7 +109,8 @@ var certifierCmd = &cobra.Command{
 			return nil
 		}
 
-		ingestorTransportFunc := func(d []assembler.Graph) error {
+		// for pubsub_test we ignore identifier strings as we don't connect to a collectsub service
+		ingestorTransportFunc := func(d []assembler.Graph, i []*parser_common.IdentifierStrings) error {
 			err := assemblerFunc(d)
 			if err != nil {
 				return err

--- a/cmd/pubsub_test/cmd/files.go
+++ b/cmd/pubsub_test/cmd/files.go
@@ -31,6 +31,8 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/handler/processor/process"
 	"github.com/guacsec/guac/pkg/ingestor/parser"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
+	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -116,7 +118,8 @@ var filesCmd = &cobra.Command{
 			return nil
 		}
 
-		ingestorTransportFunc := func(d []assembler.Graph) error {
+		// for pubsub_test we ignore identifier strings as we don't connect to a collectsub service
+		ingestorTransportFunc := func(d []assembler.Graph, i []*common.IdentifierStrings) error {
 			err := assemblerFunc(d)
 			if err != nil {
 				return err
@@ -212,7 +215,7 @@ func getProcessor(ctx context.Context, transportFunc func(processor.DocumentTree
 	}, nil
 }
 
-func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph) error) (func() error, error) {
+func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph, []*parser_common.IdentifierStrings) error) (func() error, error) {
 	return func() error {
 		err := parser.Subscribe(ctx, transportFunc)
 		if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,30 +33,19 @@ services:
   # TODO(lumjjb): no good way right now to do a healtcheck for nats-server since
   # it doesn't have utilities within it to perform the check from the container
   # itself. 
-  service-health:
+  service-health-1:
     image: "local-healthcheck"
     stdin_open: true
     tty: true
-    command: 
+    command:
       - /bin/bash
       - -c
       - |
         echo "checking-for-services";
         until curl -I http://nats:8222 > /dev/null 2>&1; do sleep 5; done; 
         echo "nats-up";
-        until curl -I http://neo4j:7474> /dev/null 2>&1; do sleep 5; done; 
+        until curl -I http://neo4j:7474> /dev/null 2>&1; do sleep 5; done;
         echo "neo4j-up";
-
-  guac-ingestor:
-    image: "local-organic-guac"
-    command: "/opt/guac/ingest ingest"
-    working_dir: /guac
-    restart: on-failure
-    depends_on:
-      service-health:
-        condition: service_completed_successfully
-    volumes:
-      - ./container_files/guac:/guac
 
   guac-collectsub:
     image: "local-organic-guac"
@@ -66,10 +55,39 @@ services:
     ports:
       - "2782:2782"
     depends_on:
-      service-health:
+      service-health-1:
         condition: service_completed_successfully
     volumes:
       - ./container_files/guac:/guac
+
+  # GUAC ingestor and oci collector are dependent on the collectsub service to be up
+  service-health-2:
+    image: "local-healthcheck"
+    stdin_open: true
+    tty: true
+    command:
+      - /bin/bash
+      - -c
+      - |
+        echo "checking-for-services";
+        until nc -z guac-collectsub 2782 > /dev/null 2>&1; do sleep 5; done;
+        echo "guac collectsub up";
+    depends_on:
+      service-health-1:
+        condition: service_completed_successfully
+
+
+  guac-ingestor:
+    image: "local-organic-guac"
+    command: "/opt/guac/ingest ingest"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      service-health-2:
+        condition: service_completed_successfully
+    volumes:
+      - ./container_files/guac:/guac
+
 
   oci-collector:
     image: "local-organic-guac"
@@ -77,7 +95,7 @@ services:
     working_dir: /guac
     restart: on-failure
     depends_on:
-      service-health:
+      service-health-2:
         condition: service_completed_successfully
     volumes:
       - ./container_files/guac:/guac

--- a/dockerfiles/Dockerfile.healthcheck
+++ b/dockerfiles/Dockerfile.healthcheck
@@ -1,2 +1,2 @@
 FROM ubuntu:22.04
-RUN apt update && apt install -y curl
+RUN apt update && apt install -y curl netcat

--- a/pkg/collectsub/collectsub/input/identifier_strings.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings.go
@@ -1,0 +1,76 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// input defines collectsub structs that can be used for human/application inputs
+// that do not necessarily find it convenient to use protobuf (e.g.
+package input
+
+import (
+	"fmt"
+	"strings"
+
+	pb "github.com/guacsec/guac/pkg/collectsub/collectsub"
+	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
+)
+
+// TODO: write tests for this.
+func IdentifierStringsSliceToCollectEntries(i []*parser_common.IdentifierStrings) []*pb.CollectEntry {
+	entries := []*pb.CollectEntry{}
+	for _, ii := range i {
+		entries = append(entries, identifierStringsToCollectEntry(ii)...)
+	}
+	return entries
+}
+
+func identifierStringsToCollectEntry(i *parser_common.IdentifierStrings) []*pb.CollectEntry {
+	entries := []*pb.CollectEntry{}
+	for _, v := range i.OciStrings {
+		entries = append(entries, &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_OCI,
+			Value: v,
+		})
+	}
+
+	for _, v := range i.VcsStrings {
+		entries = append(entries, &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_GIT,
+			Value: v,
+		})
+	}
+
+	for _, v := range i.UnclassifiedStrings {
+		e, err := guessUnknownIdentifierString(v)
+		if err == nil {
+			entries = append(entries, e)
+		}
+	}
+
+	return entries
+}
+
+// tries to guess what the collect entry for the string is and returns
+// an error if it can't figure it out.
+func guessUnknownIdentifierString(s string) (*pb.CollectEntry, error) {
+	if strings.HasPrefix(s, "index.docker.io") ||
+		strings.HasPrefix(s, "ghcr.io") ||
+		strings.HasPrefix(s, "gcr.io") {
+		return &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_OCI,
+			Value: s,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unable to guess collect entry")
+}

--- a/pkg/collectsub/collectsub/input/identifier_strings_test.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings_test.go
@@ -1,0 +1,92 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// input defines collectsub structs that can be used for human/application inputs
+// that do not necessarily find it convenient to use protobuf (e.g.
+package input
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	pb "github.com/guacsec/guac/pkg/collectsub/collectsub"
+	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
+)
+
+func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []*parser_common.IdentifierStrings
+		expected []*pb.CollectEntry
+	}{{
+		name: "simple test",
+		input: []*parser_common.IdentifierStrings{
+			{
+				OciStrings: []string{"index.docker.io/guacsec/local-organic-guac"},
+				VcsStrings: []string{"git+https://github.com/guacsec/guac"},
+			},
+		},
+		expected: []*pb.CollectEntry{
+			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
+		},
+	}, {
+		name: "simple unclassified string test",
+		input: []*parser_common.IdentifierStrings{
+			{
+				UnclassifiedStrings: []string{"index.docker.io/guacsec/local-organic-guac",
+					"ghcr.io/guacsec/local-organic-guac",
+					"https://not-oci-registry.com/guacsec/local-organic-guac",
+					"gcr.io/guacsec/local-organic-guac"},
+			},
+		},
+		expected: []*pb.CollectEntry{
+			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "ghcr.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "gcr.io/guacsec/local-organic-guac"},
+		},
+	}, {
+		name: "simple slice test",
+		input: []*parser_common.IdentifierStrings{
+			{
+				OciStrings: []string{"index.docker.io/guacsec/local-organic-guac"},
+			}, {
+				VcsStrings: []string{"git+https://github.com/guacsec/guac"},
+			},
+		},
+		expected: []*pb.CollectEntry{
+			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
+		},
+	}}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := IdentifierStringsSliceToCollectEntries(tt.input)
+			if diff := cmp.Diff(got, tt.expected, cmpopts.EquateEmpty(), cmpopts.IgnoreUnexported(pb.CollectEntry{}), cmpopts.SortSlices(collectEntryLess)); len(diff) > 0 {
+				t.Errorf("collectentries mismatch (-want +got):\n%s", diff)
+				return
+			}
+
+		})
+	}
+
+}
+
+func collectEntryLess(e1, e2 *pb.CollectEntry) bool {
+	return e1.Type < e2.Type && e1.Value < e2.Value
+}

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -48,3 +48,7 @@ func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities
 func (b *GraphBuilder) GetIdentities() []assembler.IdentityNode {
 	return b.foundIdentities
 }
+
+func (b *GraphBuilder) GetIdentifiers(ctx context.Context) (*IdentifierStrings, error) {
+	return b.docParser.GetIdentifiers(ctx)
+}

--- a/pkg/ingestor/parser/parser_test.go
+++ b/pkg/ingestor/parser/parser_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/emitter"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/guacsec/guac/pkg/logging"
 )
@@ -98,7 +99,8 @@ func TestParseDocumentTree(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseDocumentTree(ctx, tt.tree)
+			// TODO: add tests for checking identifier strings
+			got, _, err := ParseDocumentTree(ctx, tt.tree)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseDocumentTree() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -182,7 +184,7 @@ func Test_ParserSubscribe(t *testing.T) {
 			ctx, cancel = context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
-			transportFunc := func(d []assembler.Graph) error {
+			transportFunc := func(d []assembler.Graph, _ []*parser_common.IdentifierStrings) error {
 				if len(d) != len(tt.want) {
 					t.Errorf("ParseDocumentTree() = %v, want %v", d, tt.want)
 				}

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -34,20 +34,22 @@ const (
 )
 
 type slsaParser struct {
-	doc          *processor.Document
-	subjects     []assembler.ArtifactNode
-	dependencies []assembler.ArtifactNode
-	attestations []assembler.AttestationNode
-	builders     []assembler.BuilderNode
+	doc               *processor.Document
+	subjects          []assembler.ArtifactNode
+	dependencies      []assembler.ArtifactNode
+	attestations      []assembler.AttestationNode
+	builders          []assembler.BuilderNode
+	identifierStrings *common.IdentifierStrings
 }
 
 // NewSLSAParser initializes the slsaParser
 func NewSLSAParser() common.DocumentParser {
 	return &slsaParser{
-		subjects:     []assembler.ArtifactNode{},
-		dependencies: []assembler.ArtifactNode{},
-		attestations: []assembler.AttestationNode{},
-		builders:     []assembler.BuilderNode{},
+		subjects:          []assembler.ArtifactNode{},
+		dependencies:      []assembler.ArtifactNode{},
+		attestations:      []assembler.AttestationNode{},
+		builders:          []assembler.BuilderNode{},
+		identifierStrings: &common.IdentifierStrings{},
 	}
 }
 
@@ -71,6 +73,7 @@ func (s *slsaParser) getSubject(statement *in_toto.ProvenanceStatement) {
 		for alg, ds := range sub.Digest {
 			s.subjects = append(s.subjects, assembler.ArtifactNode{
 				Name: sub.Name, Digest: alg + ":" + strings.Trim(ds, "'"), NodeData: *assembler.NewObjectMetadata(s.doc.SourceInformation)})
+			s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, sub.Name)
 		}
 	}
 }
@@ -79,9 +82,9 @@ func (s *slsaParser) getDependency(statement *in_toto.ProvenanceStatement) {
 	// append dependency nodes for the materials
 	for _, mat := range statement.Predicate.Materials {
 		for alg, ds := range mat.Digest {
-
 			s.dependencies = append(s.dependencies, assembler.ArtifactNode{
 				Name: mat.URI, Digest: alg + ":" + strings.Trim(ds, "'"), NodeData: *assembler.NewObjectMetadata(s.doc.SourceInformation)})
+			s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, mat.URI)
 		}
 	}
 }
@@ -152,5 +155,5 @@ func (s *slsaParser) GetIdentities(ctx context.Context) []assembler.IdentityNode
 }
 
 func (s *slsaParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	return s.identifierStrings, nil
 }


### PR DESCRIPTION
Implementing the parser side of the collectsub service where found string tokens that resemble potential metadata targets get registered in the collectsub service and the collectors are able to listen for. As part of #244 

Signed-off-by: Brandon Lum <lumjjb@gmail.com>