### PR TITLE
Fix issue when intermediate dependencies also contain vulnerabilities

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -802,6 +802,185 @@ var (
 		Package:     rootPackage,
 		DepPackages: []*root_package.PackageComponent{secondLevel, log4j},
 	}
+
+	VertxWebCommonAttestation = `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+		"subject": [
+			{
+				"name": "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+				"digest": null
+			}
+		],
+		"predicate": {
+			"invocation": {
+				"uri": "guac",
+				"producer_id": "guacsec/guac"
+			},
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"db": {}
+			},
+			"metadata": {
+				"scannedOn": "2023-02-15T11:10:08.986308-08:00"
+			}
+		}
+	}`
+
+	VertxAuthCommonAttestation = `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+		"subject": [
+			{
+				"name": "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+				"digest": null
+			}
+		],
+		"predicate": {
+			"invocation": {
+				"uri": "guac",
+				"producer_id": "guacsec/guac"
+			},
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"db": {}
+			},
+			"metadata": {
+				"scannedOn": "2023-02-15T11:10:08.986401-08:00"
+			}
+		}
+	}`
+
+	VertxBridgeCommonAttestation = `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+		"subject": [
+			{
+				"name": "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+				"digest": null
+			}
+		],
+		"predicate": {
+			"invocation": {
+				"uri": "guac",
+				"producer_id": "guacsec/guac"
+			},
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"db": {}
+			},
+			"metadata": {
+				"scannedOn": "2023-02-15T11:10:08.98646-08:00"
+			}
+		}
+	}`
+
+	VertxCoreCommonAttestation = `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+		"subject": [
+			{
+				"name": "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+				"digest": null
+			}
+		],
+		"predicate": {
+			"invocation": {
+				"uri": "guac",
+				"producer_id": "guacsec/guac"
+			},
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"db": {}
+			},
+			"metadata": {
+				"scannedOn": "2023-02-15T11:10:08.986506-08:00"
+			}
+		}
+	}`
+
+	VertxWebAttestation = `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+		"subject": [
+			{
+				"name": "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+				"digest": null
+			}
+		],
+		"predicate": {
+			"invocation": {
+				"uri": "guac",
+				"producer_id": "guacsec/guac"
+			},
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"db": {},
+				"result": [
+					{
+						"vulnerability_id": "GHSA-53jx-vvf9-4x38"
+					}
+				]
+			},
+			"metadata": {
+				"scannedOn": "2023-02-15T11:10:08.986592-08:00"
+			}
+		}
+	}`
+
+	vertxWebCommonPackage = assembler.PackageNode{
+		Purl: "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+	}
+
+	vertxAuthCommonPackage = assembler.PackageNode{
+		Purl: "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+	}
+
+	vertxBridgeCommonPackage = assembler.PackageNode{
+		Purl: "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+	}
+
+	vertxCoreCommonPackage = assembler.PackageNode{
+		Purl: "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+	}
+
+	vertxWebPackage = assembler.PackageNode{
+		Purl: "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+	}
+
+	// ignore dependencies for the test
+	vertxWebCommon = &root_package.PackageComponent{
+		Package:     vertxWebCommonPackage,
+		DepPackages: []*root_package.PackageComponent{},
+	}
+
+	// ignore dependencies for the test
+	vertxAuthCommon = &root_package.PackageComponent{
+		Package:     vertxAuthCommonPackage,
+		DepPackages: []*root_package.PackageComponent{},
+	}
+
+	// ignore dependencies for the test
+	vertxBridgeCommon = &root_package.PackageComponent{
+		Package:     vertxBridgeCommonPackage,
+		DepPackages: []*root_package.PackageComponent{},
+	}
+
+	// ignore dependencies for the test
+	vertxCore = &root_package.PackageComponent{
+		Package:     vertxCoreCommonPackage,
+		DepPackages: []*root_package.PackageComponent{},
+	}
+
+	VertxWeb = &root_package.PackageComponent{
+		Package:     vertxWebPackage,
+		DepPackages: []*root_package.PackageComponent{vertxWebCommon, vertxAuthCommon, vertxBridgeCommon, vertxCore},
+	}
 )
 
 func GuacNodeSliceEqual(slice1, slice2 []assembler.GuacNode) bool {

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -300,18 +300,18 @@ func TestCertifyHelperStackOverflow(t *testing.T) {
 	// Create a cyclical dependency between two components
 	A = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
-			Name: "example.com/A",
+			Purl: "pkg:example.com/A",
 		},
 	}
 
 	B = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
-			Purl: "example.com/B",
+			Purl: "pkg:example.com/B",
 		},
 	}
 	C = &root_package.PackageComponent{
 		Package: assembler.PackageNode{
-			Purl: "example.com/C",
+			Purl: "pkg:example.com/C",
 		},
 	}
 	A.DepPackages = []*root_package.PackageComponent{B, C}

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -92,6 +92,57 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 		rootComponent: assembler.AttestationNode{},
 		wantErr:       true,
 		errMessage:    ErrOSVComponenetTypeMismatch,
+	}, {
+		name:          "ensure intermediate vulnerabilities are reported",
+		rootComponent: testdata.VertxWeb,
+		want: []*processor.Document{
+			{
+				Blob:   []byte(testdata.VertxWebCommonAttestation),
+				Type:   processor.DocumentITE6Vul,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: INVOC_URI,
+					Source:    INVOC_URI,
+				},
+			},
+			{
+				Blob:   []byte(testdata.VertxAuthCommonAttestation),
+				Type:   processor.DocumentITE6Vul,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: INVOC_URI,
+					Source:    INVOC_URI,
+				},
+			},
+			{
+				Blob:   []byte(testdata.VertxBridgeCommonAttestation),
+				Type:   processor.DocumentITE6Vul,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: INVOC_URI,
+					Source:    INVOC_URI,
+				},
+			},
+			{
+				Blob:   []byte(testdata.VertxCoreCommonAttestation),
+				Type:   processor.DocumentITE6Vul,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: INVOC_URI,
+					Source:    INVOC_URI,
+				},
+			},
+			{
+				Blob:   []byte(testdata.VertxWebAttestation),
+				Type:   processor.DocumentITE6Vul,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: INVOC_URI,
+					Source:    INVOC_URI,
+				},
+			},
+		},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR addresses the scenario when the intermediate artifact contains vulnerabilities.  The current codebase ignores these vulnerabilities when running `certifier`, for example the vertx-web vulnerability in the test case.