### PR TITLE
Ingest packages (mutation) on both backends

### DIFF
--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -25,6 +25,7 @@ import (
 // GraphQL interface. All backends must implement all queries specified by the
 // GraphQL interface and this is enforced by this interface.
 type Backend interface {
+	// Retrieval read-only queries
 	Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error)
 	Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error)
 	Cve(ctx context.Context, cveSpec *model.CVESpec) ([]*model.Cve, error)
@@ -36,6 +37,8 @@ type Backend interface {
 	IsOccurrences(ctx context.Context, isOccurrenceSpec *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error)
 	HasSBOMs(ctx context.Context, hasSBOMSpec *model.HasSBOMSpec) ([]*model.HasSbom, error)
 	IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error)
+	// Mutations (read-write queries)
+	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -18,6 +18,7 @@ package neo4jBackend
 import (
 	"context"
 	"strings"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -698,4 +699,8 @@ func removeInvalidCharFromProperty(key string) string {
 	// neo4j does not accept "." in its properties. If the qualifier contains a "." that must
 	// be replaced by an "-"
 	return strings.ReplaceAll(key, ".", "_")
+}
+
+func (c *neo4jClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage - neo4j backend"))
 }

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -761,7 +761,7 @@ RETURN type.type, ns.namespace, name.name, version.version, version.subpath, qua
 
 			nameStr := record.Values[2].(string)
 			name := &model.PackageName{
-				Name: nameStr,
+				Name:     nameStr,
 				Versions: []*model.PackageVersion{version},
 			}
 
@@ -769,14 +769,14 @@ RETURN type.type, ns.namespace, name.name, version.version, version.subpath, qua
 			if record.Values[1] != nil {
 				namespaceStr = record.Values[1].(string)
 			}
-			namespace := &model.PackageNamespace {
+			namespace := &model.PackageNamespace{
 				Namespace: namespaceStr,
-				Names: []*model.PackageName{name},
+				Names:     []*model.PackageName{name},
 			}
 
 			pkgType := record.Values[0].(string)
 			pkg := model.Package{
-				Type: pkgType,
+				Type:       pkgType,
 				Namespaces: []*model.PackageNamespace{namespace},
 			}
 

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -18,7 +18,6 @@ package neo4jBackend
 import (
 	"context"
 	"strings"
-	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -702,5 +701,90 @@ func removeInvalidCharFromProperty(key string) string {
 }
 
 func (c *neo4jClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
-	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage - neo4j backend"))
+	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close()
+
+	values := map[string]any{}
+	values["pkgType"] = pkg.Type
+	values["name"] = pkg.Name
+	if pkg.Namespace != nil {
+		values["namespace"] = *pkg.Namespace
+	} else {
+		values["namespace"] = ""
+	}
+	if pkg.Version != nil {
+		values["version"] = *pkg.Version
+	} else {
+		values["version"] = ""
+	}
+	if pkg.Subpath != nil {
+		values["subpath"] = *pkg.Subpath
+	} else {
+		values["subpath"] = ""
+	}
+	// TODO(mihaimaruseac): Handle qualifiers
+
+	result, err := session.WriteTransaction(
+		func(tx neo4j.Transaction) (interface{}, error) {
+			query := `MERGE (root:Pkg)
+MERGE (root) -[:PkgHasType]-> (type:PkgType{type:$pkgType})
+MERGE (type) -[:PkgHasNamespace]-> (ns:PkgNamespace{namespace:$namespace})
+MERGE (ns) -[:PkgHasName]-> (name:PkgName{name:$name})
+MERGE (name) -[:PkgHasVersion]-> (version:PkgVersion{version:$version,subpath:$subpath})
+MERGE (version) -[:PkgHasQualifier]-> (qualifier:PkgQualifier)
+RETURN type.type, ns.namespace, name.name, version.version, version.subpath, qualifier`
+			result, err := tx.Run(query, values)
+			if err != nil {
+				return nil, err
+			}
+
+			// query returns a single record
+			record, err := result.Single()
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO(mihaimaruseac): Extract this to a utility since it is repeated
+			subPathStr := ""
+			if record.Values[4] != nil {
+				subPathStr = record.Values[4].(string)
+			}
+			versionStr := ""
+			if record.Values[3] != nil {
+				versionStr = record.Values[3].(string)
+			}
+			version := &model.PackageVersion{
+				Version: versionStr,
+				Subpath: subPathStr,
+				// TODO(mihaimaruseac): qualifiers
+			}
+
+			nameStr := record.Values[2].(string)
+			name := &model.PackageName{
+				Name: nameStr,
+				Versions: []*model.PackageVersion{version},
+			}
+
+			namespaceStr := ""
+			if record.Values[1] != nil {
+				namespaceStr = record.Values[1].(string)
+			}
+			namespace := &model.PackageNamespace {
+				Namespace: namespaceStr,
+				Names: []*model.PackageName{name},
+			}
+
+			pkgType := record.Values[0].(string)
+			pkg := model.Package{
+				Type: pkgType,
+				Namespaces: []*model.PackageNamespace{namespace},
+			}
+
+			return &pkg, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.(*model.Package), nil
 }

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -18,7 +18,6 @@ package testing
 import (
 	"context"
 	"strings"
-	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -583,5 +582,30 @@ func filterOSVID(ghsa *model.Osv, osvSpec *model.OSVSpec) (*model.Osv, error) {
 }
 
 func (c *demoClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
-	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage - test backend"))
+	pkgType := pkg.Type
+	name := pkg.Name
+
+	var namespace = ""
+	if pkg.Namespace != nil {
+		namespace = *pkg.Namespace
+	}
+
+	var version = ""
+	if pkg.Version != nil {
+		version = *pkg.Version
+	}
+
+	var subpath = ""
+	if pkg.Subpath != nil {
+		subpath = *pkg.Subpath
+	}
+
+	var qualifiers []string
+	for _, qualifier := range pkg.Qualifiers {
+		qualifiers = append(qualifiers, qualifier.Key, qualifier.Value)
+	}
+
+	newPkg := c.registerPackage(pkgType, namespace, name, version, subpath, qualifiers...)
+
+	return newPkg, nil
 }

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -585,17 +585,17 @@ func (c *demoClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec)
 	pkgType := pkg.Type
 	name := pkg.Name
 
-	var namespace = ""
+	namespace := ""
 	if pkg.Namespace != nil {
 		namespace = *pkg.Namespace
 	}
 
-	var version = ""
+	version := ""
 	if pkg.Version != nil {
 		version = *pkg.Version
 	}
 
-	var subpath = ""
+	subpath := ""
 	if pkg.Subpath != nil {
 		subpath = *pkg.Subpath
 	}

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -18,6 +18,7 @@ package testing
 import (
 	"context"
 	"strings"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -579,4 +580,8 @@ func filterOSVID(ghsa *model.Osv, osvSpec *model.OSVSpec) (*model.Osv, error) {
 	return &model.Osv{
 		OsvID: osvID,
 	}, nil
+}
+
+func (c *demoClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage - test backend"))
 }

--- a/pkg/assembler/backends/testing/ingest_hasSBOM.go
+++ b/pkg/assembler/backends/testing/ingest_hasSBOM.go
@@ -31,7 +31,7 @@ func registerAllhasSBOM(client *demoClient) error {
 	selectedVersion := "3.0.3"
 	qualifierA := "bincrafters"
 	qualifierB := "stable"
-	selectedQualifiers := []*model.PackageQualifierInput{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
+	selectedQualifiers := []*model.PackageQualifierSpec{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
 	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Qualifiers: selectedQualifiers}
 	selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
 	if err != nil {

--- a/pkg/assembler/backends/testing/ingest_isDependency.go
+++ b/pkg/assembler/backends/testing/ingest_isDependency.go
@@ -33,7 +33,7 @@ func registerAllIsDependency(client *demoClient) error {
 	selectedName := "dpkg"
 	selectedVersion := "1.19.0.4"
 	qualifierA := "amd64"
-	selectedQualifiers := []*model.PackageQualifierInput{{Key: "arch", Value: &qualifierA}}
+	selectedQualifiers := []*model.PackageQualifierSpec{{Key: "arch", Value: &qualifierA}}
 	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Qualifiers: selectedQualifiers}
 	selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
 	if err != nil {

--- a/pkg/assembler/backends/testing/ingest_isOccurrence.go
+++ b/pkg/assembler/backends/testing/ingest_isOccurrence.go
@@ -32,7 +32,7 @@ func registerAllIsOccurrence(client *demoClient) error {
 	selectedVersion := "3.0.3"
 	qualifierA := "bincrafters"
 	qualifierB := "stable"
-	selectedQualifiers := []*model.PackageQualifierInput{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
+	selectedQualifiers := []*model.PackageQualifierSpec{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
 	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Qualifiers: selectedQualifiers}
 	selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
 	if err != nil {

--- a/pkg/assembler/backends/testing/ingest_pkg.go
+++ b/pkg/assembler/backends/testing/ingest_pkg.go
@@ -71,17 +71,19 @@ func registerAllPackages(client *demoClient) {
 	client.registerPackage("pypi", "", "django", "1.11.1", "subpath")
 }
 
-func (c *demoClient) registerPackage(pkgType, namespace, name, version, subpath string, qualifiers ...string) {
+func (c *demoClient) registerPackage(pkgType, namespace, name, version, subpath string, qualifiers ...string) *model.Package {
 	for i, p := range c.packages {
 		if p.Type == pkgType {
 			c.packages[i] = registerNamespace(p, namespace, name, version, subpath, qualifiers...)
-			return
+			return c.packages[i]
 		}
 	}
 
 	newPkg := &model.Package{Type: pkgType}
 	newPkg = registerNamespace(newPkg, namespace, name, version, subpath, qualifiers...)
 	c.packages = append(c.packages, newPkg)
+
+	return newPkg
 }
 
 func registerNamespace(p *model.Package, namespace, name, version, subpath string, qualifiers ...string) *model.Package {

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -16,9 +16,28 @@ import (
 
 // region    ************************** generated!.gotpl **************************
 
+type MutationResolver interface {
+	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
+}
+
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_ingestPackage_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.PkgInputSpec
+	if tmp, ok := rawArgs["pkg"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkg"))
+		arg0, err = ec.unmarshalOPkgInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkg"] = arg0
+	return args, nil
+}
 
 // endregion ***************************** args.gotpl *****************************
 
@@ -27,6 +46,66 @@ import (
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _Mutation_ingestPackage(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestPackage(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestPackage(rctx, fc.Args["pkg"].(*model.PkgInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Package)
+	fc.Result = res
+	return ec.marshalNPackage2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackage(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestPackage(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "type":
+				return ec.fieldContext_Package_type(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_Package_namespaces(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestPackage_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Package_type(ctx context.Context, field graphql.CollectedField, obj *model.Package) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Package_type(ctx, field)
@@ -542,8 +621,44 @@ func (ec *executionContext) fieldContext_PackageVersion_subpath(ctx context.Cont
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputPackageQualifierInput(ctx context.Context, obj interface{}) (model.PackageQualifierInput, error) {
-	var it model.PackageQualifierInput
+func (ec *executionContext) unmarshalInputPackageQualifierInputSpec(ctx context.Context, obj interface{}) (model.PackageQualifierInputSpec, error) {
+	var it model.PackageQualifierInputSpec
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "value":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			it.Value, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputPackageQualifierSpec(ctx context.Context, obj interface{}) (model.PackageQualifierSpec, error) {
+	var it model.PackageQualifierSpec
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -569,6 +684,87 @@ func (ec *executionContext) unmarshalInputPackageQualifierInput(ctx context.Cont
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
 			it.Value, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputPkgInputSpec(ctx context.Context, obj interface{}) (model.PkgInputSpec, error) {
+	var it model.PkgInputSpec
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["namespace"]; !present {
+		asMap["namespace"] = ""
+	}
+	if _, present := asMap["version"]; !present {
+		asMap["version"] = ""
+	}
+	if _, present := asMap["qualifiers"]; !present {
+		asMap["qualifiers"] = []interface{}{}
+	}
+	if _, present := asMap["subpath"]; !present {
+		asMap["subpath"] = ""
+	}
+
+	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers", "subpath"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "type":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			it.Type, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "namespace":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+			it.Namespace, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "name":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			it.Name, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "version":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
+			it.Version, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "qualifiers":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qualifiers"))
+			it.Qualifiers, err = ec.unmarshalOPackageQualifierInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputSpecᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "subpath":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subpath"))
+			it.Subpath, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -635,7 +831,7 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qualifiers"))
-			it.Qualifiers, err = ec.unmarshalOPackageQualifierInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputᚄ(ctx, v)
+			it.Qualifiers, err = ec.unmarshalOPackageQualifierSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -668,6 +864,38 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var mutationImplementors = []string{"Mutation"}
+
+func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mutationImplementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Mutation",
+	})
+
+	out := graphql.NewFieldSet(fields)
+	for i, field := range fields {
+		innerCtx := graphql.WithRootFieldContext(ctx, &graphql.RootFieldContext{
+			Object: field.Name,
+			Field:  field,
+		})
+
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Mutation")
+		case "ingestPackage":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestPackage(ctx, field)
+			})
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	return out
+}
 
 var packageImplementors = []string{"Package"}
 
@@ -854,6 +1082,10 @@ func (ec *executionContext) _PackageVersion(ctx context.Context, sel ast.Selecti
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
+
+func (ec *executionContext) marshalNPackage2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackage(ctx context.Context, sel ast.SelectionSet, v model.Package) graphql.Marshaler {
+	return ec._Package(ctx, sel, &v)
+}
 
 func (ec *executionContext) marshalNPackage2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Package) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
@@ -1071,8 +1303,13 @@ func (ec *executionContext) marshalNPackageQualifier2ᚖgithubᚗcomᚋguacsec�
 	return ec._PackageQualifier(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNPackageQualifierInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInput(ctx context.Context, v interface{}) (*model.PackageQualifierInput, error) {
-	res, err := ec.unmarshalInputPackageQualifierInput(ctx, v)
+func (ec *executionContext) unmarshalNPackageQualifierInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputSpec(ctx context.Context, v interface{}) (*model.PackageQualifierInputSpec, error) {
+	res, err := ec.unmarshalInputPackageQualifierInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNPackageQualifierSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierSpec(ctx context.Context, v interface{}) (*model.PackageQualifierSpec, error) {
+	res, err := ec.unmarshalInputPackageQualifierSpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -1137,7 +1374,7 @@ func (ec *executionContext) marshalOPackage2ᚖgithubᚗcomᚋguacsecᚋguacᚋp
 	return ec._Package(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalOPackageQualifierInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputᚄ(ctx context.Context, v interface{}) ([]*model.PackageQualifierInput, error) {
+func (ec *executionContext) unmarshalOPackageQualifierInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.PackageQualifierInputSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -1146,15 +1383,43 @@ func (ec *executionContext) unmarshalOPackageQualifierInput2ᚕᚖgithubᚗcom�
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]*model.PackageQualifierInput, len(vSlice))
+	res := make([]*model.PackageQualifierInputSpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNPackageQualifierInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInput(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNPackageQualifierInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputSpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) unmarshalOPackageQualifierSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierSpecᚄ(ctx context.Context, v interface{}) ([]*model.PackageQualifierSpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.PackageQualifierSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNPackageQualifierSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOPkgInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx context.Context, v interface{}) (*model.PkgInputSpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputPkgInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOPkgSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx context.Context, v interface{}) (*model.PkgSpec, error) {

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -271,6 +271,19 @@ type PackageQualifier struct {
 	Value string `json:"value"`
 }
 
+// PackageQualifierInputSpec is the same as PackageQualifier, but usable as
+// mutation input.
+//
+// GraphQL does not allow input types to contain composite types and does not allow
+// composite types to contain input types. So, although in this case these two
+// types are semantically the same, we have to duplicate the definition.
+//
+// Both fields are mandatory.
+type PackageQualifierInputSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 // PackageQualifierSpec is the same as PackageQualifier, but usable as query
 // input.
 //
@@ -317,6 +330,19 @@ type PkgNameSpec struct {
 	Type      *string `json:"type"`
 	Namespace *string `json:"namespace"`
 	Name      *string `json:"name"`
+}
+
+// PkgInputSpec specifies a package for a mutation.
+//
+// This is different than PkgSpec because we want to encode mandatatory fields:
+// `type` and `name`. All optional fields are given empty default values.
+type PkgInputSpec struct {
+	Type       string                       `json:"type"`
+	Namespace  *string                      `json:"namespace"`
+	Name       string                       `json:"name"`
+	Version    *string                      `json:"version"`
+	Qualifiers []*PackageQualifierInputSpec `json:"qualifiers"`
+	Subpath    *string                      `json:"subpath"`
 }
 
 // PkgSpec allows filtering the list of packages to return.

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -323,15 +323,6 @@ type PackageVersion struct {
 	Subpath    string              `json:"subpath"`
 }
 
-// PkgNameSpec is used for IsDependency to input dependent packages. This is different from PkgSpec
-// as the IsDependency attestation should only be allowed to be made to the packageName node and not the
-// packageVersion node. Versions will be handled by the version_range in the IsDependency attestation node.
-type PkgNameSpec struct {
-	Type      *string `json:"type"`
-	Namespace *string `json:"namespace"`
-	Name      *string `json:"name"`
-}
-
 // PkgInputSpec specifies a package for a mutation.
 //
 // This is different than PkgSpec because we want to encode mandatatory fields:
@@ -343,6 +334,15 @@ type PkgInputSpec struct {
 	Version    *string                      `json:"version"`
 	Qualifiers []*PackageQualifierInputSpec `json:"qualifiers"`
 	Subpath    *string                      `json:"subpath"`
+}
+
+// PkgNameSpec is used for IsDependency to input dependent packages. This is different from PkgSpec
+// as the IsDependency attestation should only be allowed to be made to the packageName node and not the
+// packageVersion node. Versions will be handled by the version_range in the IsDependency attestation node.
+type PkgNameSpec struct {
+	Type      *string `json:"type"`
+	Namespace *string `json:"namespace"`
+	Name      *string `json:"name"`
 }
 
 // PkgSpec allows filtering the list of packages to return.

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -271,7 +271,7 @@ type PackageQualifier struct {
 	Value string `json:"value"`
 }
 
-// PackageQualifierInput is the same as PackageQualifier, but usable as query
+// PackageQualifierSpec is the same as PackageQualifier, but usable as query
 // input.
 //
 // GraphQL does not allow input types to contain composite types and does not allow
@@ -282,7 +282,7 @@ type PackageQualifier struct {
 // values for a specific key.
 //
 // TODO(mihaimaruseac): Formalize empty vs null when the schema is fully done
-type PackageQualifierInput struct {
+type PackageQualifierSpec struct {
 	Key   string  `json:"key"`
 	Value *string `json:"value"`
 }
@@ -332,13 +332,13 @@ type PkgNameSpec struct {
 // on nodes that don't contain any qualifier, set `matchOnlyEmptyQualifiers` to
 // true. If this field is true, then the qualifiers argument is ignored.
 type PkgSpec struct {
-	Type                     *string                  `json:"type"`
-	Namespace                *string                  `json:"namespace"`
-	Name                     *string                  `json:"name"`
-	Version                  *string                  `json:"version"`
-	Qualifiers               []*PackageQualifierInput `json:"qualifiers"`
-	MatchOnlyEmptyQualifiers *bool                    `json:"matchOnlyEmptyQualifiers"`
-	Subpath                  *string                  `json:"subpath"`
+	Type                     *string                 `json:"type"`
+	Namespace                *string                 `json:"namespace"`
+	Name                     *string                 `json:"name"`
+	Version                  *string                 `json:"version"`
+	Qualifiers               []*PackageQualifierSpec `json:"qualifiers"`
+	MatchOnlyEmptyQualifiers *bool                   `json:"matchOnlyEmptyQualifiers"`
+	Subpath                  *string                 `json:"subpath"`
 }
 
 // Source represents a source.

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -8,15 +8,21 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
+
+// IngestPackage is the resolver for the ingestPackage field.
+func (r *mutationResolver) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage"))
+}
 
 // Packages is the resolver for the packages field.
 func (r *queryResolver) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	return r.Backend.Packages(ctx, pkgSpec)
 }
 
-// IngestPackage is the resolver for the ingestPackage field.
-func (r *queryResolver) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
-	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage"))
-}
+// Mutation returns generated.MutationResolver implementation.
+func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
+
+type mutationResolver struct{ *Resolver }

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -6,6 +6,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -13,4 +14,9 @@ import (
 // Packages is the resolver for the packages field.
 func (r *queryResolver) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	return r.Backend.Packages(ctx, pkgSpec)
+}
+
+// IngestPackage is the resolver for the ingestPackage field.
+func (r *queryResolver) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage"))
 }

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -6,7 +6,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -14,7 +13,7 @@ import (
 
 // IngestPackage is the resolver for the ingestPackage field.
 func (r *mutationResolver) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
-	panic(fmt.Errorf("not implemented: IngestPackage - ingestPackage"))
+	return r.Backend.IngestPackage(ctx, pkg)
 }
 
 // Packages is the resolver for the packages field.

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -130,13 +130,13 @@ input PkgSpec {
   namespace: String
   name: String
   version: String
-  qualifiers: [PackageQualifierInput!] = []
+  qualifiers: [PackageQualifierSpec!] = []
   matchOnlyEmptyQualifiers: Boolean = false
   subpath: String
 }
 
 """
-PackageQualifierInput is the same as PackageQualifier, but usable as query
+PackageQualifierSpec is the same as PackageQualifier, but usable as query
 input.
 
 GraphQL does not allow input types to contain composite types and does not allow
@@ -148,7 +148,7 @@ values for a specific key.
 
 TODO(mihaimaruseac): Formalize empty vs null when the schema is fully done
 """
-input PackageQualifierInput {
+input PackageQualifierSpec {
   key: String!
   value: String
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -153,7 +153,39 @@ input PackageQualifierSpec {
   value: String
 }
 
+"""
+PkgInputSpec specifies a package for a mutation.
+
+This is different than PkgSpec because we want to encode mandatatory fields:
+`type` and `name`. All optional fields are given empty default values.
+"""
+input PkgInputSpec {
+  type: String!
+  namespace: String = ""
+  name: String!
+  version: String = ""
+  qualifiers: [PackageQualifierInputSpec!] = []
+  subpath: String = ""
+}
+
+"""
+PackageQualifierInputSpec is the same as PackageQualifier, but usable as
+mutation input.
+
+GraphQL does not allow input types to contain composite types and does not allow
+composite types to contain input types. So, although in this case these two
+types are semantically the same, we have to duplicate the definition.
+
+Both fields are mandatory.
+"""
+input PackageQualifierInputSpec {
+  key: String!
+  value: String!
+}
+
 extend type Query {
   "Returns all packages"
   packages(pkgSpec: PkgSpec): [Package!]!
+  "Ingest a new package. Returns the ingested package trie"
+  ingestPackage(pkg: PkgInputSpec): Package!
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -186,6 +186,9 @@ input PackageQualifierInputSpec {
 extend type Query {
   "Returns all packages"
   packages(pkgSpec: PkgSpec): [Package!]!
+}
+
+extend type Mutation {
   "Ingest a new package. Returns the ingested package trie"
   ingestPackage(pkg: PkgInputSpec): Package!
 }


### PR DESCRIPTION
Ingests packages on either backend. Testing queries/mutation:

```gql
fragment allPkgTree on Package {
  type
  namespaces {
    namespace
    names {
      name
      versions {
        version
        qualifiers {
          key
          value
        }
        subpath
      }
    }
  }
}

mutation PkgM1 {
  ingestPackage(pkg: {type: "pypi", name: "tensorflow"}) {
    ...allPkgTree
  }
}

query PkgQ1 {
  packages(pkgSpec: {}) {
    ...allPkgTree
  }
}
```

(run them in this order. For neo4j backend, to simplify testing you can skip ingesting test data or clear it)

Should be able to review commits individually if this is too large.

Left to do:
- [ ] handle qualifiers in neo4j backend
- [ ] handle cases when not all fields are requested
- [ ] some cleanup, maybe
- [ ] other ingestion mutations