### PR TITLE
[neo4j] Move qualifiers to a list within version

### DIFF
--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -102,22 +102,6 @@ func matchProperties(sb *strings.Builder, firstMatch bool, label, property strin
 	sb.WriteString(resolver)
 }
 
-func matchNotEdge(sb *strings.Builder, firstMatch bool, firstNodeLabel string, edgeLabel string, secondNodeLabel string) {
-	// -[:PkgHasQualifier]->(qualifier:PkgQualifier)
-	if firstMatch {
-		sb.WriteString(" WHERE ")
-	} else {
-		sb.WriteString(" AND ")
-	}
-	sb.WriteString("NOT (")
-	sb.WriteString(firstNodeLabel)
-	sb.WriteString(")-[:")
-	sb.WriteString(edgeLabel)
-	sb.WriteString("]->(:")
-	sb.WriteString(secondNodeLabel)
-	sb.WriteString(")")
-}
-
 // getPreloads get the specific graphQL query fields that are requested.
 // graphql.CollectAllFields only provides the top level fields and none of the nested fields below it.
 // getPreloads recursively goes through the fields and retrieves each nested field below it.

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -368,7 +368,7 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 			} else {
 				matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
 				firstMatch = false
-				queryValues["qualifier"] = []
+				queryValues["qualifier"] = []string{}
 			}
 
 			sb.WriteString(" RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, version.qualifier_list")

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -23,7 +23,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v4/neo4j/dbtype"
 )
 
 // pkgNode represents the top level pkg->Type->Namespace->Name->Version
@@ -323,34 +322,32 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 				firstMatch = false
 				queryValues["pkgType"] = pkgSpec.Type
 			}
-			if pkgSpec.Namespace != nil {
 
+			if pkgSpec.Namespace != nil {
 				matchProperties(&sb, firstMatch, "namespace", "namespace", "$pkgNamespace")
 				firstMatch = false
 				queryValues["pkgNamespace"] = pkgSpec.Namespace
 			}
-			if pkgSpec.Name != nil {
 
+			if pkgSpec.Name != nil {
 				matchProperties(&sb, firstMatch, "name", "name", "$pkgName")
 				firstMatch = false
 				queryValues["pkgName"] = pkgSpec.Name
 			}
-			if pkgSpec.Version != nil {
 
+			if pkgSpec.Version != nil {
 				matchProperties(&sb, firstMatch, "version", "version", "$pkgVerion")
 				firstMatch = false
 				queryValues["pkgVerion"] = pkgSpec.Version
 			}
 
 			if pkgSpec.Subpath != nil {
-
 				matchProperties(&sb, firstMatch, "version", "subpath", "$pkgSubpath")
 				firstMatch = false
 				queryValues["pkgSubpath"] = pkgSpec.Subpath
 			}
 
 			if pkgSpec.MatchOnlyEmptyQualifiers != nil && !*pkgSpec.MatchOnlyEmptyQualifiers {
-
 				if len(pkgSpec.Qualifiers) > 0 {
 					for _, qualifier := range pkgSpec.Qualifiers {
 						qualifierKey := removeInvalidCharFromProperty(qualifier.Key)

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -368,7 +368,7 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 			} else {
 				matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
 				firstMatch = false
-				queryValues["qualifier"] = qualifiers
+				queryValues["qualifier"] = []
 			}
 
 			sb.WriteString(" RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, version.qualifier_list")

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -118,8 +118,8 @@ func (pn *pkgName) IdentifiablePropertyNames() []string {
 }
 
 type pkgVersion struct {
-	version string
-	subpath string
+	version        string
+	subpath        string
 	qualifier_list []string
 }
 

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -366,7 +366,9 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 					queryValues["qualifier"] = qualifiers
 				}
 			} else {
-				matchProperties(&sb, firstMatch, "version", "qualifier_list", "[]")
+				matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
+				firstMatch = false
+				queryValues["qualifier"] = qualifiers
 			}
 
 			sb.WriteString(" RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, version.qualifier_list")

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -349,12 +349,21 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 
 			if pkgSpec.MatchOnlyEmptyQualifiers != nil && !*pkgSpec.MatchOnlyEmptyQualifiers {
 				if len(pkgSpec.Qualifiers) > 0 {
-					for _, qualifier := range pkgSpec.Qualifiers {
-						qualifierKey := removeInvalidCharFromProperty(qualifier.Key)
-						matchProperties(&sb, firstMatch, "qualifier", qualifierKey, "$"+qualifierKey)
-						firstMatch = false
-						queryValues[qualifierKey] = qualifier.Value
+					qualifiersMap := map[string]string{}
+					keys := []string{}
+					for _, kv := range pkgSpec.Qualifiers {
+						key := removeInvalidCharFromProperty(kv.Key)
+						qualifiersMap[key] = *kv.Value
+						keys = append(keys, key)
 					}
+					sort.Strings(keys)
+					qualifiers := []string{}
+					for _, k := range keys {
+						qualifiers = append(qualifiers, k, qualifiersMap[k])
+					}
+					matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
+					firstMatch = false
+					queryValues["qualifier"] = qualifiers
 				}
 			} else {
 				matchProperties(&sb, firstMatch, "version", "qualifier_list", "[]")

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -121,6 +121,7 @@ func (pn *pkgName) IdentifiablePropertyNames() []string {
 type pkgVersion struct {
 	version string
 	subpath string
+	qualifier_list []string
 }
 
 func (pv *pkgVersion) Type() string {
@@ -131,16 +132,17 @@ func (pv *pkgVersion) Properties() map[string]interface{} {
 	properties := make(map[string]interface{})
 	properties["version"] = pv.version
 	properties["subpath"] = pv.subpath
+	properties["qualifier_list"] = pv.qualifier_list
 	return properties
 }
 
 func (pv *pkgVersion) PropertyNames() []string {
-	fields := []string{"version", "subpath"}
+	fields := []string{"version", "subpath", "qualifier_list"}
 	return fields
 }
 
 func (pv *pkgVersion) IdentifiablePropertyNames() []string {
-	fields := []string{"version", "subpath"}
+	fields := []string{"version", "subpath", "qualifier_list"}
 	return fields
 }
 
@@ -273,31 +275,6 @@ func (e *nameToVersion) PropertyNames() []string {
 }
 
 func (e *nameToVersion) IdentifiablePropertyNames() []string {
-	return []string{}
-}
-
-type versionToQualifier struct {
-	version   *pkgVersion
-	qualifier *pkgQualifier
-}
-
-func (e *versionToQualifier) Type() string {
-	return "PkgHasQualifier"
-}
-
-func (e *versionToQualifier) Nodes() (v, u assembler.GuacNode) {
-	return e.version, e.qualifier
-}
-
-func (e *versionToQualifier) Properties() map[string]interface{} {
-	return map[string]interface{}{}
-}
-
-func (e *versionToQualifier) PropertyNames() []string {
-	return []string{}
-}
-
-func (e *versionToQualifier) IdentifiablePropertyNames() []string {
 	return []string{}
 }
 

--- a/pkg/assembler/graphql/examples/packages.gql
+++ b/pkg/assembler/graphql/examples/packages.gql
@@ -1,11 +1,3 @@
-query Q1 {
-  artifacts {
-    name
-    sourceInfo
-    collectorInfo
-  }
-}
-
 fragment allPkgTree on Package {
   type
   namespaces {
@@ -14,63 +6,163 @@ fragment allPkgTree on Package {
       name
       versions {
         version
+        qualifiers {
+          key
+          value
+        }
+        subpath
       }
     }
   }
 }
 
+query PkgQ1 {
+  artifacts {
+    name
+    sourceInfo
+    collectorInfo
+  }
+}
+
 # all packages
-query Q2 {
+query PkgQ2 {
   packages(pkgSpec: {}) {
     ...allPkgTree
   }
 }
 
 # only PyPI packages
-query Q3 {
+query PkgQ3 {
   packages(pkgSpec: {type: "pypi"}) {
     ...allPkgTree
   }
 }
 
 # PyPI packages in "debian" namespace (empty)
-query Q4 {
+query PkgQ4 {
   packages(pkgSpec: {type: "pypi", namespace: "debian"}) {
     ...allPkgTree
   }
 }
 
 # debian packages in "debian" namespace
-query Q5 {
+query PkgQ5 {
   packages(pkgSpec: {type: "deb", namespace: "debian"}) {
     ...allPkgTree
   }
 }
 
 # "dpkg" package from Ubuntu ("ubuntu" namespace on "deb" type)
-query Q6 {
+query PkgQ6 {
   packages(pkgSpec: {type: "deb", namespace: "ubuntu", name: "dpkg"}) {
     ...allPkgTree
   }
 }
 
 # All "deb" type packages named "dpkg"
-query Q7 {
+query PkgQ7 {
   packages(pkgSpec: {type: "deb", name:"dpkg"}) {
     ...allPkgTree
   }
 }
 
 # All occurrences of openssl-3.0.3
-query Q8 {
+query PkgQ8 {
   packages(pkgSpec: {name:"openssl", version:"3.0.3"}) {
     ...allPkgTree
   }
 }
 
 # All occurrences of openssl
-query Q9 {
+query PkgQ9 {
   packages(pkgSpec: {name:"openssl"}) {
     ...allPkgTree
+  }
+}
+
+query PkgQA {
+  packages(pkgSpec: {qualifiers: [{key: "arch", value: "amd64"}]}) {
+    ...allPkgTree
+  }
+}
+
+query PkgQB {
+  packages(
+    pkgSpec: {qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
+  ) {
+    ...allPkgTree
+  }
+}
+
+query PkgQC {
+  packages(pkgSpec: {subpath: "subpath"}) {
+    ...allPkgTree
+  }
+}
+
+query PkgQD {
+  packages(pkgSpec: {matchOnlyEmptyQualifiers: true}) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM1 {
+  ingestPackage(pkg: {type: "pypi", name: "tensorflow"}) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM2 {
+  ingestPackage(
+    pkg: {type: "pypi", name: "tensorflow", qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
+  ) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM3 {
+  ingestPackage(pkg: {type: "pypi", name: "tensorflow", version: "2.12.0"}) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM4 {
+  ingestPackage(
+    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
+  ) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM5 {
+  ingestPackage(
+    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
+  ) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM6 {
+  ingestPackage(
+    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", subpath: "foo", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
+  ) {
+    ...allPkgTree
+  }
+}
+
+mutation PkgM7 {
+  ingestPackage(
+    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", subpath: "foo", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
+  ) {
+    namespaces {
+      names {
+        versions {
+          qualifiers {
+            key
+            value
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
In neo4j backend, we are storing qualfiers as a list within the version node. So we need to change test ingestion to handle this scenario.

The code to generate `qualifier_list` is duplicated, there will be future work to remove all this duplication.