### PR TITLE
Merge SourceSpec and SourceQualifierInput

### DIFF
--- a/pkg/assembler/backends/testing/certifyBad.go
+++ b/pkg/assembler/backends/testing/certifyBad.go
@@ -48,8 +48,7 @@ func registerAllCertifyBad(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "github.com/guacsec/guac"
 	selectedTag := "v0.0.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/backends/testing/certifyScorecard.go
+++ b/pkg/assembler/backends/testing/certifyScorecard.go
@@ -30,8 +30,7 @@ func registerAllCertifyScorecard(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "https://github.com/django/django"
 	selectedTag := "1.11.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err
@@ -50,8 +49,7 @@ func registerAllCertifyScorecard(client *demoClient) error {
 	selectedSourceNameSpace = "github"
 	selectedSourceName = "https://github.com/vapor-ware/kubetest"
 	selectedTag = "0.9.5"
-	selectedSourceQualifiers = &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec = &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec = &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err = client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/backends/testing/hasSBOM.go
+++ b/pkg/assembler/backends/testing/hasSBOM.go
@@ -47,8 +47,7 @@ func registerAllhasSBOM(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "github.com/guacsec/guac"
 	selectedTag := "v0.0.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -43,8 +43,7 @@ func registerAllHasSLSA(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "https://github.com/django/django"
 	selectedTag := "1.11.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/backends/testing/hasSourceAt.go
+++ b/pkg/assembler/backends/testing/hasSourceAt.go
@@ -42,8 +42,7 @@ func registerAllHasSourceAt(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "https://github.com/django/django"
 	selectedTag := "1.11.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err
@@ -73,8 +72,7 @@ func registerAllHasSourceAt(client *demoClient) error {
 	selectedSourceNameSpace = "github"
 	selectedSourceName = "https://github.com/vapor-ware/kubetest"
 	selectedTag = "0.9.5"
-	selectedSourceQualifiers = &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec = &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec = &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err = client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/backends/testing/isOccurrence.go
+++ b/pkg/assembler/backends/testing/isOccurrence.go
@@ -49,8 +49,7 @@ func registerAllIsOccurrence(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "github.com/guacsec/guac"
 	selectedTag := "v0.0.1"
-	selectedSourceQualifiers := &model.SourceQualifierInput{Tag: &selectedTag}
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Qualifier: selectedSourceQualifiers}
+	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err

--- a/pkg/assembler/graphql/examples/source.gql
+++ b/pkg/assembler/graphql/examples/source.gql
@@ -10,52 +10,64 @@ fragment allSrcTree on Source {
   }
 }
 
-query Q1 {
-  sources(sourceSpec: {name: "github.com/guacsec/guac"}) {
-    ...allSrcTree
+query SrcQ1 {
+  sources(sourceSpec: {}) {
+    namespaces {
+      names {
+        name
+      }
+    }
   }
 }
 
-query Q2 {
-  sources(sourceSpec: {qualifier: {tag: "v0.0.1"}}) {
-    ...allSrcTree
-  }
-}
-
-query Q3 {
-  sources(
-    sourceSpec: {qualifier: {commit: "fcba958b73e27cad8b5c8655d46439984d27853b"}}
-  ) {
-    ...allSrcTree
-  }
-}
-
-query Q4 {
-  sources(sourceSpec: {qualifier: {}}) {
-    ...allSrcTree
-  }
-}
-
-query Q5 {
-  sources(sourceSpec: {type: "svn"}) {
-    ...allSrcTree
-  }
-}
-
-query Q6 {
-  sources(sourceSpec: {namespace: "gitlab"}) {
-    ...allSrcTree
-  }
-}
-
-query Q7 {
+query SrcQ2 {
   sources(sourceSpec: {}) {
     ...allSrcTree
   }
 }
 
-query Q8 {
-  sources(sourceSpec: {qualifier: {tag: "asd", commit: "sad"}}) {
+# Return only sources with neither tag nor commit
+query SrcQ3 {
+  sources(sourceSpec: {tag:"", commit:""}) {
+    ...allSrcTree
+  }
+}
+
+
+query SrcQ4 {
+  sources(sourceSpec: {name: "github.com/guacsec/guac"}) {
+    ...allSrcTree
+  }
+}
+
+query SrcQ5 {
+  sources(sourceSpec: {tag: "v0.0.1"}) {
+    ...allSrcTree
+  }
+}
+
+query SrcQ6 {
+  sources(
+    sourceSpec: {commit: "fcba958b73e27cad8b5c8655d46439984d27853b"}
+  ) {
+    ...allSrcTree
+  }
+}
+query SrcQ7 {
+  sources(sourceSpec: {type: "svn"}) {
+    ...allSrcTree
+  }
+}
+
+query SrcQ8 {
+  sources(sourceSpec: {namespace: "gitlab"}) {
+    ...allSrcTree
+  }
+}
+
+# this should error as both `tag` and `commit` are specified and not empty
+query SrcQ9 {
+  sources(sourceSpec: {tag: "asd", commit: "sad"}) {
     ...allSrcTree
   }
 }

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1266,7 +1266,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPkgSpec,
 		ec.unmarshalInputSLSAPredicateSpec,
 		ec.unmarshalInputScorecardCheckSpec,
-		ec.unmarshalInputSourceQualifierInput,
 		ec.unmarshalInputSourceSpec,
 	)
 	first := true
@@ -2415,8 +2414,8 @@ The ` + "`" + `type` + "`" + ` field matches the pURL types but we might also us
 cases where the pURL representation is not complete or when we have custom
 rules.
 
-This node is a singleton: backends guarantee that there is exactly one node with
-the same ` + "`" + `type` + "`" + ` value.
+This node is a singleton: backends guarantee that there is exactly one node
+with the same ` + "`" + `type` + "`" + ` value.
 
 Also note that this is named ` + "`" + `Package` + "`" + `, not ` + "`" + `PackageType` + "`" + `. This is only to make
 queries more readable.
@@ -2596,17 +2595,17 @@ extend type Mutation {
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines a GraphQL schema for the source trie/tree. This tree is a derivative of
-# the pURL specification where it has a type, namespace, name and finally a qualifier that
-# contain the tag or commit. 
+# Defines a GraphQL schema for the source trie/tree. This tree is a derivative
+# of the pURL specification where it has a type, namespace, name and finally a
+# qualifier that contain the tag or commit.
 
 """
 Source represents a source.
 
 This can be the version control system that is being used.
 
-This node is a singleton: backends guarantee that there is exactly one node with
-the same ` + "`" + `type` + "`" + ` value.
+This node is a singleton: backends guarantee that there is exactly one node
+with the same ` + "`" + `type` + "`" + ` value.
 
 Also note that this is named ` + "`" + `Source` + "`" + `, not ` + "`" + `SourceType` + "`" + `. This is only to make
 queries more readable.
@@ -2619,10 +2618,9 @@ type Source {
 """
 SourceNamespace is a namespace for sources.
 
-This can be represented as the location of the repo (such as github/gitlab/bitbucket)
+This is the location of the repository (such as github/gitlab/bitbucket).
 
-Namespaces are optional and type specific. Because they are optional, we use
-empty string to denote missing namespaces.
+The ` + "`" + `namespace` + "`" + ` field is mandatory.
 """
 type SourceNamespace {
   namespace: String!
@@ -2632,9 +2630,10 @@ type SourceNamespace {
 """
 SourceName is a url of the repository and its tag or commit.
 
-SourceName is mandatory. Either a tag or commit needs to be specified.
+The ` + "`" + `name` + "`" + ` field is mandatory. The ` + "`" + `tag` + "`" + ` and ` + "`" + `commit` + "`" + ` fields are optional, but
+it is an error to specify both.
 
-This is the first node in the trie that can be referred to by other parts of
+This is the only source trie node that can be referenced by other parts of
 GUAC.
 """
 type SourceName {
@@ -2646,20 +2645,17 @@ type SourceName {
 """
 SourceSpec allows filtering the list of sources to return.
 
-Empty string at a field means matching with the empty string.
+Empty string at a field means matching with the empty string. Missing field
+means retrieving all possible matches.
+
+It is an error to specify both tag and commit fields, except it both are set as
+empty string (in which case the returned sources are only those for which there
+is no tag/commit information).
 """
 input SourceSpec {
   type: String
   namespace: String
   name: String
-  qualifier: SourceQualifierInput
-}
-
-"""
-SourceQualifierInput is the same as SourceQualifier, but usable as query
-input.
-"""
-input SourceQualifierInput {
   tag: String
   commit: String
 }

--- a/pkg/assembler/graphql/generated/source.generated.go
+++ b/pkg/assembler/graphql/generated/source.generated.go
@@ -348,42 +348,6 @@ func (ec *executionContext) fieldContext_SourceNamespace_names(ctx context.Conte
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputSourceQualifierInput(ctx context.Context, obj interface{}) (model.SourceQualifierInput, error) {
-	var it model.SourceQualifierInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"tag", "commit"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "tag":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tag"))
-			it.Tag, err = ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "commit":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("commit"))
-			it.Commit, err = ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputSourceSpec(ctx context.Context, obj interface{}) (model.SourceSpec, error) {
 	var it model.SourceSpec
 	asMap := map[string]interface{}{}
@@ -391,7 +355,7 @@ func (ec *executionContext) unmarshalInputSourceSpec(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "namespace", "name", "qualifier"}
+	fieldsInOrder := [...]string{"type", "namespace", "name", "tag", "commit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -422,11 +386,19 @@ func (ec *executionContext) unmarshalInputSourceSpec(ctx context.Context, obj in
 			if err != nil {
 				return it, err
 			}
-		case "qualifier":
+		case "tag":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("qualifier"))
-			it.Qualifier, err = ec.unmarshalOSourceQualifierInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceQualifierInput(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tag"))
+			it.Tag, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "commit":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("commit"))
+			it.Commit, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -714,14 +686,6 @@ func (ec *executionContext) marshalNSourceNamespace2ᚖgithubᚗcomᚋguacsecᚋ
 		return graphql.Null
 	}
 	return ec._SourceNamespace(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOSourceQualifierInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceQualifierInput(ctx context.Context, v interface{}) (*model.SourceQualifierInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputSourceQualifierInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOSourceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx context.Context, v interface{}) ([]*model.SourceSpec, error) {

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -508,8 +508,8 @@ type OSVSpec struct {
 // cases where the pURL representation is not complete or when we have custom
 // rules.
 //
-// This node is a singleton: backends guarantee that there is exactly one node with
-// the same `type` value.
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
 //
 // Also note that this is named `Package`, not `PackageType`. This is only to make
 // queries more readable.
@@ -736,8 +736,8 @@ type ScorecardCheckSpec struct {
 //
 // This can be the version control system that is being used.
 //
-// This node is a singleton: backends guarantee that there is exactly one node with
-// the same `type` value.
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
 //
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
@@ -752,9 +752,10 @@ func (Source) IsPkgSrcObject() {}
 
 // SourceName is a url of the repository and its tag or commit.
 //
-// SourceName is mandatory. Either a tag or commit needs to be specified.
+// The `name` field is mandatory. The `tag` and `commit` fields are optional, but
+// it is an error to specify both.
 //
-// This is the first node in the trie that can be referred to by other parts of
+// This is the only source trie node that can be referenced by other parts of
 // GUAC.
 type SourceName struct {
 	Name   string  `json:"name"`
@@ -764,28 +765,26 @@ type SourceName struct {
 
 // SourceNamespace is a namespace for sources.
 //
-// This can be represented as the location of the repo (such as github/gitlab/bitbucket)
+// This is the location of the repository (such as github/gitlab/bitbucket).
 //
-// Namespaces are optional and type specific. Because they are optional, we use
-// empty string to denote missing namespaces.
+// The `namespace` field is mandatory.
 type SourceNamespace struct {
 	Namespace string        `json:"namespace"`
 	Names     []*SourceName `json:"names"`
 }
 
-// SourceQualifierInput is the same as SourceQualifier, but usable as query
-// input.
-type SourceQualifierInput struct {
-	Tag    *string `json:"tag"`
-	Commit *string `json:"commit"`
-}
-
 // SourceSpec allows filtering the list of sources to return.
 //
-// Empty string at a field means matching with the empty string.
+// Empty string at a field means matching with the empty string. Missing field
+// means retrieving all possible matches.
+//
+// It is an error to specify both tag and commit fields, except it both are set as
+// empty string (in which case the returned sources are only those for which there
+// is no tag/commit information).
 type SourceSpec struct {
-	Type      *string               `json:"type"`
-	Namespace *string               `json:"namespace"`
-	Name      *string               `json:"name"`
-	Qualifier *SourceQualifierInput `json:"qualifier"`
+	Type      *string `json:"type"`
+	Namespace *string `json:"namespace"`
+	Name      *string `json:"name"`
+	Tag       *string `json:"tag"`
+	Commit    *string `json:"commit"`
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -29,8 +29,8 @@ The `type` field matches the pURL types but we might also use `"guac"` for the
 cases where the pURL representation is not complete or when we have custom
 rules.
 
-This node is a singleton: backends guarantee that there is exactly one node with
-the same `type` value.
+This node is a singleton: backends guarantee that there is exactly one node
+with the same `type` value.
 
 Also note that this is named `Package`, not `PackageType`. This is only to make
 queries more readable.

--- a/pkg/assembler/graphql/schema/source.graphql
+++ b/pkg/assembler/graphql/schema/source.graphql
@@ -15,17 +15,17 @@
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines a GraphQL schema for the source trie/tree. This tree is a derivative of
-# the pURL specification where it has a type, namespace, name and finally a qualifier that
-# contain the tag or commit. 
+# Defines a GraphQL schema for the source trie/tree. This tree is a derivative
+# of the pURL specification where it has a type, namespace, name and finally a
+# qualifier that contain the tag or commit.
 
 """
 Source represents a source.
 
 This can be the version control system that is being used.
 
-This node is a singleton: backends guarantee that there is exactly one node with
-the same `type` value.
+This node is a singleton: backends guarantee that there is exactly one node
+with the same `type` value.
 
 Also note that this is named `Source`, not `SourceType`. This is only to make
 queries more readable.
@@ -38,10 +38,9 @@ type Source {
 """
 SourceNamespace is a namespace for sources.
 
-This can be represented as the location of the repo (such as github/gitlab/bitbucket)
+This is the location of the repository (such as github/gitlab/bitbucket).
 
-Namespaces are optional and type specific. Because they are optional, we use
-empty string to denote missing namespaces.
+The `namespace` field is mandatory.
 """
 type SourceNamespace {
   namespace: String!
@@ -51,9 +50,10 @@ type SourceNamespace {
 """
 SourceName is a url of the repository and its tag or commit.
 
-SourceName is mandatory. Either a tag or commit needs to be specified.
+The `name` field is mandatory. The `tag` and `commit` fields are optional, but
+it is an error to specify both.
 
-This is the first node in the trie that can be referred to by other parts of
+This is the only source trie node that can be referenced by other parts of
 GUAC.
 """
 type SourceName {
@@ -65,20 +65,17 @@ type SourceName {
 """
 SourceSpec allows filtering the list of sources to return.
 
-Empty string at a field means matching with the empty string.
+Empty string at a field means matching with the empty string. Missing field
+means retrieving all possible matches.
+
+It is an error to specify both tag and commit fields, except it both are set as
+empty string (in which case the returned sources are only those for which there
+is no tag/commit information).
 """
 input SourceSpec {
   type: String
   namespace: String
   name: String
-  qualifier: SourceQualifierInput
-}
-
-"""
-SourceQualifierInput is the same as SourceQualifier, but usable as query
-input.
-"""
-input SourceQualifierInput {
   tag: String
   commit: String
 }


### PR DESCRIPTION
This makes both backends respond correctly when we want sources with no qualifiers (tags/commits) vs when we want all sources.

This makes it easier to input sources, we don't need a separate node just for querying.