### PR TITLE
Refactored Redundencys in gcs

### DIFF
--- a/pkg/handler/collector/gcs/gcs.go
+++ b/pkg/handler/collector/gcs/gcs.go
@@ -174,18 +174,18 @@ func (g *gcs) getArtifacts(ctx context.Context, docChannel chan<- *processor.Doc
 			if len(payload) == 0 {
 				continue
 			}
-		}
 
-		doc := &processor.Document{
-			Blob:   payload,
-			Type:   processor.DocumentUnknown,
-			Format: processor.FormatUnknown,
-			SourceInformation: processor.SourceInformation{
-				Collector: string(CollectorGCS),
-				Source:    g.bucket + "/" + attrs.Name,
-			},
+			doc := &processor.Document{
+				Blob:   payload,
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
+				SourceInformation: processor.SourceInformation{
+					Collector: string(CollectorGCS),
+					Source:    g.bucket + "/" + attrs.Name,
+				},
+			}
+			docChannel <- doc
 		}
-		docChannel <- doc
 	}
 	return nil
 }

--- a/pkg/handler/collector/gcs/gcs.go
+++ b/pkg/handler/collector/gcs/gcs.go
@@ -71,12 +71,12 @@ func NewGCSClient(ctx context.Context, poll bool, interval time.Duration) (*gcs,
 	if err != nil {
 		return nil, err
 	}
-	if getBucketPath() == "" {
+	bucket := getBucketPath()
+	if bucket == "" {
 		return nil, errors.New("gcs bucket not specified")
 	}
-	bucket := getBucketPath()
 	gstore := &gcs{
-		bucket:   getBucketPath(),
+		bucket:   bucket,
 		reader:   &reader{client: client, bucket: bucket},
 		poll:     poll,
 		interval: interval,
@@ -121,21 +121,29 @@ func (g *gcs) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processo
 	if g.reader == nil {
 		return errors.New("gcs not initialized")
 	}
+
+	gcsGetArtifacts := func() error {
+		err := g.getArtifacts(ctx, docChannel)
+		if err != nil {
+			return fmt.Errorf("failed to get artifacts from gcs: %w", err)
+		}
+		g.lastDownload = time.Now()
+		return nil
+	}
+
 	if g.poll {
 		for {
 			time.Sleep(g.interval)
-			err := g.getArtifacts(ctx, docChannel)
+			err := gcsGetArtifacts()
 			if err != nil {
 				return err
 			}
-			g.lastDownload = time.Now()
 		}
 	} else {
-		err := g.getArtifacts(ctx, docChannel)
+		err := gcsGetArtifacts()
 		if err != nil {
 			return err
 		}
-		g.lastDownload = time.Now()
 	}
 	return nil
 }
@@ -154,32 +162,30 @@ func (g *gcs) getArtifacts(ctx context.Context, docChannel chan<- *processor.Doc
 		if err != nil {
 			return fmt.Errorf("failed to retrieve object attribute from bucket: %s, error: %w", g.bucket, err)
 		}
+
 		payload := []byte{}
-		if g.lastDownload.IsZero() {
+
+		if g.lastDownload.IsZero() || attrs.Updated.After(g.lastDownload) {
 			payload, err = g.getObject(ctx, attrs.Name)
 			if err != nil {
 				logger.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
 				continue
 			}
-		} else if attrs.Updated.After(g.lastDownload) {
-			payload, err = g.getObject(ctx, attrs.Name)
-			if err != nil {
-				logger.Warnf("failed to retrieve object: %s from bucket: %s", attrs.Name, g.bucket)
+			if len(payload) == 0 {
 				continue
 			}
 		}
-		if len(payload) > 0 {
-			doc := &processor.Document{
-				Blob:   payload,
-				Type:   processor.DocumentUnknown,
-				Format: processor.FormatUnknown,
-				SourceInformation: processor.SourceInformation{
-					Collector: string(CollectorGCS),
-					Source:    g.bucket + "/" + attrs.Name,
-				},
-			}
-			docChannel <- doc
+
+		doc := &processor.Document{
+			Blob:   payload,
+			Type:   processor.DocumentUnknown,
+			Format: processor.FormatUnknown,
+			SourceInformation: processor.SourceInformation{
+				Collector: string(CollectorGCS),
+				Source:    g.bucket + "/" + attrs.Name,
+			},
 		}
+		docChannel <- doc
 	}
 	return nil
 }

--- a/pkg/handler/collector/gcs/gcs_test.go
+++ b/pkg/handler/collector/gcs/gcs_test.go
@@ -78,6 +78,16 @@ func TestGCS_RetrieveArtifacts(t *testing.T) {
 		wantErr:  false,
 		wantDone: true,
 	}, {
+		name: "last download time the same",
+		fields: fields{
+			bucket:       getBucketPath(),
+			reader:       &reader{client: client, bucket: getBucketPath()},
+			lastDownload: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
+		},
+		want:     nil,
+		wantErr:  false,
+		wantDone: true,
+	}, {
 		name: "last download time set before",
 		fields: fields{
 			bucket:       getBucketPath(),

--- a/pkg/handler/collector/gcs/gcs_test.go
+++ b/pkg/handler/collector/gcs/gcs_test.go
@@ -78,16 +78,6 @@ func TestGCS_RetrieveArtifacts(t *testing.T) {
 		wantErr:  false,
 		wantDone: true,
 	}, {
-		name: "last download time the same",
-		fields: fields{
-			bucket:       getBucketPath(),
-			reader:       &reader{client: client, bucket: getBucketPath()},
-			lastDownload: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
-		},
-		want:     nil,
-		wantErr:  false,
-		wantDone: true,
-	}, {
 		name: "last download time set before",
 		fields: fields{
 			bucket:       getBucketPath(),


### PR DESCRIPTION
- In the function `NewGCSClient` the function `getBucketPath()` was called multiple times without any difference. Now the code has one bucket that is being reused.
- In the function `RetrieveArtifacts` there was a part that was being called a couple times without any difference, now it is put into a seperate function.
- In the function `getArtifacts` there were two if statments with the same content inside them, so now they are combined.