### PR TITLE
Ensure artifacts are treated the same on both backends:

### DIFF
--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -41,7 +41,10 @@ func (c *demoClient) registerArtifact(algorithm, digest string) {
 			return
 		}
 	}
-	newArtifact := &model.Artifact{Digest: lowerCaseDigest, Algorithm: lowerCaseAlgorithm}
+	newArtifact := &model.Artifact{
+		Digest: lowerCaseDigest,
+		Algorithm: lowerCaseAlgorithm,
+	}
 	c.artifacts = append(c.artifacts, newArtifact)
 }
 
@@ -52,13 +55,21 @@ func (c *demoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifact
 
 	// enforce lowercase for both the algorithm and digest when querying
 	for _, a := range c.artifacts {
-		if artifactSpec.Digest == nil && artifactSpec.Algorithm == nil {
-			artifacts = append(artifacts, a)
-		} else if artifactSpec.Digest != nil && artifactSpec.Algorithm == nil && a.Digest == strings.ToLower(*artifactSpec.Digest) {
-			artifacts = append(artifacts, a)
-		} else if artifactSpec.Digest == nil && artifactSpec.Algorithm != nil && a.Algorithm == strings.ToLower(*artifactSpec.Algorithm) {
-			artifacts = append(artifacts, a)
-		} else if artifactSpec.Digest != nil && artifactSpec.Algorithm != nil && a.Algorithm == strings.ToLower(*artifactSpec.Algorithm) && a.Digest == strings.ToLower(*artifactSpec.Digest) {
+		matchDigest := false
+		if artifactSpec.Digest == nil {
+			matchDigest = true
+		} else if a.Digest == strings.ToLower(*artifactSpec.Digest) {
+			matchDigest = true
+		}
+
+		matchAlgorithm := false
+		if artifactSpec.Algorithm == nil {
+			matchAlgorithm = true
+		} else if a.Algorithm == strings.ToLower(*artifactSpec.Algorithm) {
+			matchAlgorithm = true
+		}
+
+		if matchDigest && matchAlgorithm {
 			artifacts = append(artifacts, a)
 		}
 	}

--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -42,7 +42,7 @@ func (c *demoClient) registerArtifact(algorithm, digest string) {
 		}
 	}
 	newArtifact := &model.Artifact{
-		Digest: lowerCaseDigest,
+		Digest:    lowerCaseDigest,
 		Algorithm: lowerCaseAlgorithm,
 	}
 	c.artifacts = append(c.artifacts, newArtifact)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1359,11 +1359,15 @@ var sources = []*ast.Source{
 # NOTE: This is experimental and might change in the future!
 
 # Defines a GraphQL schema for the artifact. It contains the algorithm and digest fields
+
 """
 Artifact represents the artifact and contains a digest field
 
-algorithm is mandatory in the from strings.ToLower(string(checksum.Algorithm)) (sha256, sha1...etc)
-digest is mandatory in the form checksum.Value.
+Both field are mandatory and canonicalized to be lowercase.
+
+If having a ` + "`" + `checksum` + "`" + ` Go object, ` + "`" + `algorithm` + "`" + ` can be
+` + "`" + `strings.ToLower(string(checksum.Algorithm))` + "`" + ` and ` + "`" + `digest` + "`" + ` can be
+` + "`" + `checksum.Value` + "`" + `.
 """
 type Artifact {
   algorithm: String!
@@ -1372,12 +1376,13 @@ type Artifact {
 
 """
 ArtifactSpec allows filtering the list of artifacts to return.
+
+Both arguments will be canonicalized to lowercase.
 """
 input ArtifactSpec {
   algorithm: String
   digest: String
 }
-
 
 extend type Query {
   "Returns all artifacts"

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -29,8 +29,11 @@ type PkgSrcObject interface {
 
 // Artifact represents the artifact and contains a digest field
 //
-// algorithm is mandatory in the from strings.ToLower(string(checksum.Algorithm)) (sha256, sha1...etc)
-// digest is mandatory in the form checksum.Value.
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
 type Artifact struct {
 	Algorithm string `json:"algorithm"`
 	Digest    string `json:"digest"`
@@ -41,6 +44,8 @@ func (Artifact) IsPkgSrcArtObject() {}
 func (Artifact) IsPkgArtObject() {}
 
 // ArtifactSpec allows filtering the list of artifacts to return.
+//
+// Both arguments will be canonicalized to lowercase.
 type ArtifactSpec struct {
 	Algorithm *string `json:"algorithm"`
 	Digest    *string `json:"digest"`

--- a/pkg/assembler/graphql/schema/artifact.graphql
+++ b/pkg/assembler/graphql/schema/artifact.graphql
@@ -16,11 +16,15 @@
 # NOTE: This is experimental and might change in the future!
 
 # Defines a GraphQL schema for the artifact. It contains the algorithm and digest fields
+
 """
 Artifact represents the artifact and contains a digest field
 
-algorithm is mandatory in the from strings.ToLower(string(checksum.Algorithm)) (sha256, sha1...etc)
-digest is mandatory in the form checksum.Value.
+Both field are mandatory and canonicalized to be lowercase.
+
+If having a `checksum` Go object, `algorithm` can be
+`strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+`checksum.Value`.
 """
 type Artifact {
   algorithm: String!
@@ -29,12 +33,13 @@ type Artifact {
 
 """
 ArtifactSpec allows filtering the list of artifacts to return.
+
+Both arguments will be canonicalized to lowercase.
 """
 input ArtifactSpec {
   algorithm: String
   digest: String
 }
-
 
 extend type Query {
   "Returns all artifacts"


### PR DESCRIPTION
- [x] force canonicalization to lower case
- [x] ensure we can query all artifacts instead of returning error

Also did minor refactoring to code:

- [x] move query formation outside of Neo4j transaction
- [x] separate matching algorithm/digest in in-memory backend to only have a single `append` at the end