### PR TITLE
Added checks for isDependency and certifyPkg

### DIFF
--- a/pkg/assembler/backends/neo4j/certifyPkg.go
+++ b/pkg/assembler/backends/neo4j/certifyPkg.go
@@ -17,7 +17,6 @@ package neo4jBackend
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -130,7 +129,6 @@ func (c *neo4jClient) CertifyPkg(ctx context.Context, certifyPkgSpec *model.Cert
 
 				sb.WriteString(returnValue)
 			}
-			fmt.Println(sb.String())
 
 			result, err := tx.Run(sb.String(), queryValues)
 			if err != nil {

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -17,7 +17,6 @@ package neo4jBackend
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -47,6 +46,8 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 					Type:      isDependencySpec.DependentPackage.Type,
 					Namespace: isDependencySpec.DependentPackage.Namespace,
 					Name:      isDependencySpec.DependentPackage.Name,
+					// remove version, subpath and set qualifiers to empty list
+					Qualifiers: []*model.PackageQualifierSpec{},
 					// setting to default value of false as package version is not checked for dependent packages
 					MatchOnlyEmptyQualifiers: &depMatchOnlyEmptyQualifiers,
 				}
@@ -86,7 +87,7 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 
 				sb.WriteString(returnValue)
 			}
-			fmt.Println(sb.String())
+
 			result, err := tx.Run(sb.String(), queryValues)
 			if err != nil {
 				return nil, err

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -40,11 +41,14 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 
 			selectedPkg := isDependencySpec.Package
 			var dependentPkg *model.PkgSpec = nil
+			depMatchOnlyEmptyQualifiers := false
 			if isDependencySpec.DependentPackage != nil {
 				dependentPkg = &model.PkgSpec{
 					Type:      isDependencySpec.DependentPackage.Type,
 					Namespace: isDependencySpec.DependentPackage.Namespace,
 					Name:      isDependencySpec.DependentPackage.Name,
+					// setting to default value of false as package version is not checked for dependent packages
+					MatchOnlyEmptyQualifiers: &depMatchOnlyEmptyQualifiers,
 				}
 			}
 
@@ -64,21 +68,25 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 
 			sb.WriteString(returnValue)
 
-			sb.WriteString("\nUNION")
-			// query without pkgVersion
-			query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
-				"-[:PkgHasName]->(name:PkgName)" +
-				"-[isDependency:IsDependency]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-				"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
-				"\nWITH *, null AS version"
-			sb.WriteString(query)
+			if selectedPkg == nil || selectedPkg != nil && selectedPkg.Version == nil && selectedPkg.Subpath == nil &&
+				len(selectedPkg.Qualifiers) == 0 && !*selectedPkg.MatchOnlyEmptyQualifiers {
 
-			firstMatch = true
-			setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
-			setIsDependencyValues(&sb, isDependencySpec, firstMatch, queryValues)
+				sb.WriteString("\nUNION")
+				// query without pkgVersion
+				query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+					"-[:PkgHasName]->(name:PkgName)" +
+					"-[isDependency:IsDependency]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+					"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
+					"\nWITH *, null AS version"
+				sb.WriteString(query)
 
-			sb.WriteString(returnValue)
+				firstMatch = true
+				setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+				setIsDependencyValues(&sb, isDependencySpec, firstMatch, queryValues)
 
+				sb.WriteString(returnValue)
+			}
+			fmt.Println(sb.String())
 			result, err := tx.Run(sb.String(), queryValues)
 			if err != nil {
 				return nil, err
@@ -88,31 +96,12 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 
 			for result.Next() {
 
-				pkgQualifiers := []*model.PackageQualifier{}
-				if result.Record().Values[5] != nil {
-					pkgQualifiers = getCollectedPackageQualifiers(result.Record().Values[5].([]interface{}))
-				}
-
-				subPathString := ""
-				if result.Record().Values[4] != nil {
-					subPathString = result.Record().Values[4].(string)
-				}
-				versionString := ""
-				if result.Record().Values[3] != nil {
-					versionString = result.Record().Values[3].(string)
-				}
-				nameString := ""
-				if result.Record().Values[2] != nil {
-					nameString = result.Record().Values[2].(string)
-				}
-				namespaceString := ""
-				if result.Record().Values[1] != nil {
-					namespaceString = result.Record().Values[1].(string)
-				}
-				typeString := ""
-				if result.Record().Values[0] != nil {
-					typeString = result.Record().Values[0].(string)
-				}
+				pkgQualifiers := getCollectedPackageQualifiers(result.Record().Values[5].([]interface{}))
+				subPathString := result.Record().Values[4].(string)
+				versionString := result.Record().Values[3].(string)
+				nameString := result.Record().Values[2].(string)
+				namespaceString := result.Record().Values[1].(string)
+				typeString := result.Record().Values[0].(string)
 
 				version := &model.PackageVersion{
 					Version:    versionString,
@@ -134,18 +123,9 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 					Namespaces: []*model.PackageNamespace{namespace},
 				}
 
-				nameString = ""
-				if result.Record().Values[9] != nil {
-					nameString = result.Record().Values[9].(string)
-				}
-				namespaceString = ""
-				if result.Record().Values[8] != nil {
-					namespaceString = result.Record().Values[8].(string)
-				}
-				typeString = ""
-				if result.Record().Values[7] != nil {
-					typeString = result.Record().Values[7].(string)
-				}
+				nameString = result.Record().Values[9].(string)
+				namespaceString = result.Record().Values[8].(string)
+				typeString = result.Record().Values[7].(string)
 
 				name = &model.PackageName{
 					Name:     nameString,
@@ -245,7 +225,7 @@ func setMatchValues(sb *strings.Builder, pkg *model.PkgSpec, depPkg *model.PkgSp
 			queryValues["pkgSubpath"] = pkg.Subpath
 		}
 
-		if pkg.MatchOnlyEmptyQualifiers != nil && !*pkg.MatchOnlyEmptyQualifiers {
+		if !*pkg.MatchOnlyEmptyQualifiers {
 
 			if len(pkg.Qualifiers) > 0 {
 				qualifiers := getQualifiers(pkg.Qualifiers)
@@ -294,13 +274,13 @@ func setMatchValues(sb *strings.Builder, pkg *model.PkgSpec, depPkg *model.PkgSp
 			queryValues["depSubpath"] = depPkg.Subpath
 		}
 
-		if depPkg.MatchOnlyEmptyQualifiers != nil && !*depPkg.MatchOnlyEmptyQualifiers {
-
-			qualifiers := getQualifiers(depPkg.Qualifiers)
-			matchProperties(sb, firstMatch, "depVersion", "qualifier_list", "$depQualifierList")
-			firstMatch = false
-			queryValues["depQualifierList"] = qualifiers
-
+		if !*depPkg.MatchOnlyEmptyQualifiers {
+			if len(depPkg.Qualifiers) > 0 {
+				qualifiers := getQualifiers(depPkg.Qualifiers)
+				matchProperties(sb, firstMatch, "depVersion", "qualifier_list", "$depQualifierList")
+				firstMatch = false
+				queryValues["depQualifierList"] = qualifiers
+			}
 		} else {
 			matchProperties(sb, firstMatch, "depVersion", "qualifier_list", "$depQualifierList")
 			firstMatch = false

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -315,7 +315,7 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 				queryValues["pkgSubpath"] = pkgSpec.Subpath
 			}
 
-			if pkgSpec.MatchOnlyEmptyQualifiers != nil && !*pkgSpec.MatchOnlyEmptyQualifiers {
+			if !*pkgSpec.MatchOnlyEmptyQualifiers {
 				if len(pkgSpec.Qualifiers) > 0 {
 					qualifiers := getQualifiers(pkgSpec.Qualifiers)
 					matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")

--- a/pkg/assembler/graphql/examples/is_dependency.gql
+++ b/pkg/assembler/graphql/examples/is_dependency.gql
@@ -58,25 +58,13 @@ query Q3 {
 }
 
 query Q4 {
-  IsDependency(isDependencySpec: {package: {name: "dpkg"}}) {
+  IsDependency(isDependencySpec: {package: {name: "openssl", version: "3.0.3"}}) {
     ...allIsDependencyTree
   }
 }
 
 query Q5 {
   IsDependency(isDependencySpec: {dependentPackage: {name: "openssl"}}) {
-    ...allIsDependencyTree
-  }
-}
-
-query Q6 {
-  IsDependency(isDependencySpec: {dependentPackage: {name: "openssl"}, versionRange: "3.0.3"}) {
-    ...allIsDependencyTree
-  }
-}
-
-query Q7 {
-  IsDependency(isDependencySpec: {dependentPackage: {name: "openssl"}, versionRange: "3.0.5"}) {
     ...allIsDependencyTree
   }
 }


### PR DESCRIPTION
- Added check if version is specified only query at pkg version level and not at pkg name level
- Removed unneeded nil value checks
- Removed unneeded `pkg.MatchOnlyEmptyQualifiers != nil` as it will default to false
- Removed bad query tests for isDependency (as dependent package would not have version)