### PR TITLE
Ensure CI checks that generated code is up to date.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,3 +89,5 @@ jobs:
         run: make fmt
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.2.0
+      - name: Check that all generated code is up to date
+        run: make generated_up_to_date

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS="-X $(PKG).version=$(VERSION) -X $(PKG).commit=$(COMMIT) -X $(PKG).date=
 .DEFAULT_GOAL := build
 
 .PHONY: all
-all: test cover fmt lint ci build generate
+all: test cover fmt lint build generate
 
 # Run the unit tests
 .PHONY: test
@@ -40,10 +40,6 @@ generated_up_to_date: generate
 .PHONY: lint
 lint:
 	golangci-lint run ./...
-
-# Run all the tests and code checks
-.PHONY: ci
-ci: fmt lint test generated_up_to_date
 
 # Build a version
 .PHONY: build


### PR DESCRIPTION
Turns out the `ci` target in Makefile is not used anywhere. I removed it (but can add it back if someone is using `make ci` locally), and added a new check to the static checks CI.