### PR TITLE
Refactor MATCH values such that they can be used by other verbs

### DIFF
--- a/pkg/assembler/backends/neo4j/certifyPkg.go
+++ b/pkg/assembler/backends/neo4j/certifyPkg.go
@@ -51,21 +51,21 @@ func (c *neo4jClient) CertifyPkg(ctx context.Context, certifyPkgSpec *model.Cert
 			}
 
 			returnValue := " RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, " +
-				"version.qualifier_list, certifyPkg, depType.type, depNamespace.namespace, depName.name, " +
-				"depVersion.version, depVersion.subpath, depVersion.qualifier_list"
+				"version.qualifier_list, certifyPkg, objPkgType.type, objPkgNamespace.namespace, objPkgName.name, " +
+				"objPkgVersion.version, objPkgVersion.subpath, objPkgVersion.qualifier_list"
 
 			queryValues := map[string]any{}
 
 			// query with pkgVersion
-			query := "MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+			query := "MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 				"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)" +
-				"-[certifyPkg:CertifyPkg]-(depVersion:PkgVersion)<-[:PkgHasVersion]-(depName:PkgName)<-[:PkgHasName]" +
-				"-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-				"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)"
+				"-[certifyPkg:CertifyPkg]-(objPkgVersion:PkgVersion)<-[:PkgHasVersion]-(objPkgName:PkgName)<-[:PkgHasName]" +
+				"-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+				"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)"
 			sb.WriteString(query)
 
-			firstMatch = true
-			setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+			setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+			setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 			setCertifyPkgValues(&sb, certifyPkgSpec, firstMatch, queryValues)
 
 			sb.WriteString(returnValue)
@@ -75,14 +75,16 @@ func (c *neo4jClient) CertifyPkg(ctx context.Context, certifyPkgSpec *model.Cert
 
 				sb.WriteString("\nUNION")
 				// query with pkgVersion
-				query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+				query = "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 					"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)" +
-					"-[certifyPkg:CertifyPkg]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-					"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
-					"\nWITH *, null AS depVersion"
+					"-[certifyPkg:CertifyPkg]-(objPkgName:PkgName)<-[:PkgHasName]-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+					"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)" +
+					"\nWITH *, null AS objPkgVersion"
 				sb.WriteString(query)
 
-				setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+				firstMatch = true
+				setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+				setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 				setCertifyPkgValues(&sb, certifyPkgSpec, firstMatch, queryValues)
 
 				sb.WriteString(returnValue)
@@ -96,15 +98,16 @@ func (c *neo4jClient) CertifyPkg(ctx context.Context, certifyPkgSpec *model.Cert
 
 				sb.WriteString("\nUNION")
 				// query without pkgVersion
-				query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+				query = "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 					"-[:PkgHasName]->(name:PkgName)" +
-					"-[certifyPkg:CertifyPkg]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-					"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
-					"\nWITH *, null AS version, null AS depVersion"
+					"-[certifyPkg:CertifyPkg]-(objPkgName:PkgName)<-[:PkgHasName]-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+					"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)" +
+					"\nWITH *, null AS version, null AS objPkgVersion"
 				sb.WriteString(query)
 
 				firstMatch = true
-				setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+				setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+				setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 				setCertifyPkgValues(&sb, certifyPkgSpec, firstMatch, queryValues)
 
 				sb.WriteString(returnValue)
@@ -115,16 +118,17 @@ func (c *neo4jClient) CertifyPkg(ctx context.Context, certifyPkgSpec *model.Cert
 
 				sb.WriteString("\nUNION")
 				// query without pkgVersion
-				query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+				query = "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 					"-[:PkgHasName]->(name:PkgName)" +
-					"-[certifyPkg:CertifyPkg]-(depVersion:PkgVersion)<-[:PkgHasVersion]-(depName:PkgName)<-[:PkgHasName]" +
-					"-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-					"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
+					"-[certifyPkg:CertifyPkg]-(objPkgVersion:PkgVersion)<-[:PkgHasVersion]-(objPkgName:PkgName)<-[:PkgHasName]" +
+					"-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+					"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)" +
 					"\nWITH *, null AS version"
 				sb.WriteString(query)
 
 				firstMatch = true
-				setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+				setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+				setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 				setCertifyPkgValues(&sb, certifyPkgSpec, firstMatch, queryValues)
 
 				sb.WriteString(returnValue)

--- a/pkg/assembler/backends/neo4j/hasSourceAt.go
+++ b/pkg/assembler/backends/neo4j/hasSourceAt.go
@@ -37,17 +37,18 @@ func (c *neo4jClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.Ha
 	var firstMatch bool = true
 
 	returnValue := " RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, " +
-		"version.qualifier_list, hasSourceAt, srcType.type, srcNamespace.namespace, srcName.name, srcName.tag, srcName.commit"
+		"version.qualifier_list, hasSourceAt, objSrcType.type, objSrcNamespace.namespace, objSrcName.name, objSrcName.tag, objSrcName.commit"
 
 	queryValues := map[string]any{}
 	// query with pkgVersion
-	query := "MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+	query := "MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 		"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)" +
-		"-[hasSourceAt:HasSourceAt]-(srcName:SrcName)<-[:SrcHasName]-(srcNamespace:SrcNamespace)<-[:SrcHasNamespace]" +
-		"-(srcType:SrcType)<-[:SrcHasType]-(src:Src)"
+		"-[hasSourceAt:HasSourceAt]-(objSrcName:SrcName)<-[:SrcHasName]-(objSrcNamespace:SrcNamespace)<-[:SrcHasNamespace]" +
+		"-(objSrcType:SrcType)<-[:SrcHasType]-(objSrcRoot:Src)"
 	sb.WriteString(query)
 
-	setPkgSrcMatchValues(&sb, hasSourceAtSpec.Package, hasSourceAtSpec.Source, firstMatch, queryValues)
+	setPkgMatchValues(&sb, hasSourceAtSpec.Package, false, firstMatch, queryValues)
+	setSrcMatchValues(&sb, hasSourceAtSpec.Source, true, firstMatch, queryValues)
 	setHasSourceAtValues(&sb, hasSourceAtSpec, firstMatch, queryValues)
 	sb.WriteString(returnValue)
 
@@ -56,15 +57,16 @@ func (c *neo4jClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.Ha
 
 		sb.WriteString("\nUNION")
 		// query without pkgVersion
-		query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+		query = "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 			"-[:PkgHasName]->(name:PkgName)" +
-			"-[hasSourceAt:HasSourceAt]-(srcName:SrcName)<-[:SrcHasName]-(srcNamespace:SrcNamespace)<-[:SrcHasNamespace]" +
-			"-(srcType:SrcType)<-[:SrcHasType]-(src:Src)" +
+			"-[hasSourceAt:HasSourceAt]-(objSrcName:SrcName)<-[:SrcHasName]-(objSrcNamespace:SrcNamespace)<-[:SrcHasNamespace]" +
+			"-(objSrcType:SrcType)<-[:SrcHasType]-(objSrcRoot:Src)" +
 			"\nWITH *, null AS version"
 		sb.WriteString(query)
 
 		firstMatch = true
-		setPkgSrcMatchValues(&sb, hasSourceAtSpec.Package, hasSourceAtSpec.Source, firstMatch, queryValues)
+		setPkgMatchValues(&sb, hasSourceAtSpec.Package, false, firstMatch, queryValues)
+		setSrcMatchValues(&sb, hasSourceAtSpec.Source, true, firstMatch, queryValues)
 		setHasSourceAtValues(&sb, hasSourceAtSpec, firstMatch, queryValues)
 		sb.WriteString(returnValue)
 	}
@@ -189,88 +191,5 @@ func setHasSourceAtValues(sb *strings.Builder, hasSourceAtSpec *model.HasSourceA
 		matchProperties(sb, firstMatch, "hasSourceAt", "collector", "$collector")
 		firstMatch = false
 		queryValues["collector"] = hasSourceAtSpec.Collector
-	}
-}
-
-// TODO (parth): Refactor to remove reused code by multiple verbs
-func setPkgSrcMatchValues(sb *strings.Builder, pkg *model.PkgSpec, src *model.SourceSpec, firstMatch bool, queryValues map[string]any) {
-	if pkg != nil {
-		if pkg.Type != nil {
-
-			matchProperties(sb, firstMatch, "type", "type", "$pkgType")
-			firstMatch = false
-			queryValues["pkgType"] = pkg.Type
-		}
-		if pkg.Namespace != nil {
-
-			matchProperties(sb, firstMatch, "namespace", "namespace", "$pkgNamespace")
-			firstMatch = false
-			queryValues["pkgNamespace"] = pkg.Namespace
-		}
-		if pkg.Name != nil {
-
-			matchProperties(sb, firstMatch, "name", "name", "$pkgName")
-			firstMatch = false
-			queryValues["pkgName"] = pkg.Name
-		}
-		if pkg.Version != nil {
-
-			matchProperties(sb, firstMatch, "version", "version", "$pkgVersion")
-			firstMatch = false
-			queryValues["pkgVersion"] = pkg.Version
-		}
-
-		if pkg.Subpath != nil {
-
-			matchProperties(sb, firstMatch, "version", "subpath", "$pkgSubpath")
-			firstMatch = false
-			queryValues["pkgSubpath"] = pkg.Subpath
-		}
-
-		if !*pkg.MatchOnlyEmptyQualifiers {
-
-			if len(pkg.Qualifiers) > 0 {
-				qualifiers := getQualifiers(pkg.Qualifiers)
-				matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
-				firstMatch = false
-				queryValues["pkgQualifierList"] = qualifiers
-			}
-
-		} else {
-			matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
-			firstMatch = false
-			queryValues["pkgQualifierList"] = []string{}
-		}
-	}
-	if src != nil {
-		if src.Type != nil {
-
-			matchProperties(sb, firstMatch, "srcType", "type", "$srcType")
-			firstMatch = false
-			queryValues["srcType"] = src.Type
-		}
-		if src.Namespace != nil {
-
-			matchProperties(sb, firstMatch, "srcNamespace", "namespace", "$srcNamespace")
-			firstMatch = false
-			queryValues["srcNamespace"] = src.Namespace
-		}
-		if src.Name != nil {
-
-			matchProperties(sb, firstMatch, "srcName", "name", "$srcName")
-			firstMatch = false
-			queryValues["srcName"] = src.Name
-		}
-
-		if src.Tag != nil {
-			matchProperties(sb, firstMatch, "srcName", "tag", "$srcTag")
-			firstMatch = false
-			queryValues["srcTag"] = src.Tag
-		}
-
-		if src.Commit != nil {
-			matchProperties(sb, firstMatch, "srcName", "commit", "$srcCommit")
-			queryValues["srcCommit"] = src.Commit
-		}
 	}
 }

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -54,17 +54,18 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 			}
 
 			returnValue := " RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, " +
-				"version.qualifier_list, isDependency, depType.type, depNamespace.namespace, depName.name"
+				"version.qualifier_list, isDependency, objPkgType.type, objPkgNamespace.namespace, objPkgName.name"
 
 			queryValues := map[string]any{}
 			// query with pkgVersion
-			query := "MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+			query := "MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 				"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)" +
-				"-[isDependency:IsDependency]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-				"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)"
+				"-[isDependency:IsDependency]-(objPkgName:PkgName)<-[:PkgHasName]-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+				"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)"
 			sb.WriteString(query)
 
-			setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+			setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+			setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 			setIsDependencyValues(&sb, isDependencySpec, firstMatch, queryValues)
 
 			sb.WriteString(returnValue)
@@ -74,15 +75,16 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 
 				sb.WriteString("\nUNION")
 				// query without pkgVersion
-				query = "\nMATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+				query = "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 					"-[:PkgHasName]->(name:PkgName)" +
-					"-[isDependency:IsDependency]-(depName:PkgName)<-[:PkgHasName]-(depNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
-					"-(depType:PkgType)<-[:PkgHasType]-(depPkg:Pkg)" +
+					"-[isDependency:IsDependency]-(objPkgName:PkgName)<-[:PkgHasName]-(objPkgNamespace:PkgNamespace)<-[:PkgHasNamespace]" +
+					"-(objPkgType:PkgType)<-[:PkgHasType]-(objPkgRoot:Pkg)" +
 					"\nWITH *, null AS version"
 				sb.WriteString(query)
 
 				firstMatch = true
-				setMatchValues(&sb, selectedPkg, dependentPkg, firstMatch, queryValues)
+				setPkgMatchValues(&sb, selectedPkg, false, firstMatch, queryValues)
+				setPkgMatchValues(&sb, dependentPkg, true, firstMatch, queryValues)
 				setIsDependencyValues(&sb, isDependencySpec, firstMatch, queryValues)
 
 				sb.WriteString(returnValue)
@@ -189,104 +191,5 @@ func setIsDependencyValues(sb *strings.Builder, isDependencySpec *model.IsDepend
 		matchProperties(sb, firstMatch, "isDependency", "collector", "$collector")
 		firstMatch = false
 		queryValues["collector"] = isDependencySpec.Collector
-	}
-}
-
-// TODO: Refactor to remove reused code by multiple verbs
-func setMatchValues(sb *strings.Builder, pkg *model.PkgSpec, depPkg *model.PkgSpec, firstMatch bool, queryValues map[string]any) {
-	if pkg != nil {
-		if pkg.Type != nil {
-
-			matchProperties(sb, firstMatch, "type", "type", "$pkgType")
-			firstMatch = false
-			queryValues["pkgType"] = pkg.Type
-		}
-		if pkg.Namespace != nil {
-
-			matchProperties(sb, firstMatch, "namespace", "namespace", "$pkgNamespace")
-			firstMatch = false
-			queryValues["pkgNamespace"] = pkg.Namespace
-		}
-		if pkg.Name != nil {
-
-			matchProperties(sb, firstMatch, "name", "name", "$pkgName")
-			firstMatch = false
-			queryValues["pkgName"] = pkg.Name
-		}
-		if pkg.Version != nil {
-
-			matchProperties(sb, firstMatch, "version", "version", "$pkgVersion")
-			firstMatch = false
-			queryValues["pkgVersion"] = pkg.Version
-		}
-
-		if pkg.Subpath != nil {
-
-			matchProperties(sb, firstMatch, "version", "subpath", "$pkgSubpath")
-			firstMatch = false
-			queryValues["pkgSubpath"] = pkg.Subpath
-		}
-
-		if !*pkg.MatchOnlyEmptyQualifiers {
-
-			if len(pkg.Qualifiers) > 0 {
-				qualifiers := getQualifiers(pkg.Qualifiers)
-				matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
-				firstMatch = false
-				queryValues["pkgQualifierList"] = qualifiers
-			}
-
-		} else {
-			matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
-			firstMatch = false
-			queryValues["pkgQualifierList"] = []string{}
-		}
-	}
-	if depPkg != nil {
-		if depPkg.Type != nil {
-
-			matchProperties(sb, firstMatch, "depType", "type", "$depType")
-			firstMatch = false
-			queryValues["depType"] = depPkg.Type
-		}
-		if depPkg.Namespace != nil {
-
-			matchProperties(sb, firstMatch, "depNamespace", "namespace", "$depNamespace")
-			firstMatch = false
-			queryValues["depNamespace"] = depPkg.Namespace
-		}
-		if depPkg.Name != nil {
-
-			matchProperties(sb, firstMatch, "depName", "name", "$depName")
-			firstMatch = false
-			queryValues["depName"] = depPkg.Name
-		}
-
-		if depPkg.Version != nil {
-
-			matchProperties(sb, firstMatch, "depVersion", "version", "$depVersion")
-			firstMatch = false
-			queryValues["depVersion"] = depPkg.Version
-		}
-
-		if depPkg.Subpath != nil {
-
-			matchProperties(sb, firstMatch, "depVersion", "subpath", "$depSubpath")
-			firstMatch = false
-			queryValues["depSubpath"] = depPkg.Subpath
-		}
-
-		if !*depPkg.MatchOnlyEmptyQualifiers {
-			if len(depPkg.Qualifiers) > 0 {
-				qualifiers := getQualifiers(depPkg.Qualifiers)
-				matchProperties(sb, firstMatch, "depVersion", "qualifier_list", "$depQualifierList")
-				firstMatch = false
-				queryValues["depQualifierList"] = qualifiers
-			}
-		} else {
-			matchProperties(sb, firstMatch, "depVersion", "qualifier_list", "$depQualifierList")
-			firstMatch = false
-			queryValues["depQualifierList"] = []string{}
-		}
 	}
 }

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -283,50 +283,9 @@ func (c *neo4jClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*
 			var firstMatch bool = true
 			queryValues := map[string]any{}
 
-			sb.WriteString("MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)")
+			sb.WriteString("MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion)")
 
-			if pkgSpec.Type != nil {
-				matchProperties(&sb, firstMatch, "type", "type", "$pkgType")
-				firstMatch = false
-				queryValues["pkgType"] = pkgSpec.Type
-			}
-
-			if pkgSpec.Namespace != nil {
-				matchProperties(&sb, firstMatch, "namespace", "namespace", "$pkgNamespace")
-				firstMatch = false
-				queryValues["pkgNamespace"] = pkgSpec.Namespace
-			}
-
-			if pkgSpec.Name != nil {
-				matchProperties(&sb, firstMatch, "name", "name", "$pkgName")
-				firstMatch = false
-				queryValues["pkgName"] = pkgSpec.Name
-			}
-
-			if pkgSpec.Version != nil {
-				matchProperties(&sb, firstMatch, "version", "version", "$pkgVersion")
-				firstMatch = false
-				queryValues["pkgVersion"] = pkgSpec.Version
-			}
-
-			if pkgSpec.Subpath != nil {
-				matchProperties(&sb, firstMatch, "version", "subpath", "$pkgSubpath")
-				firstMatch = false
-				queryValues["pkgSubpath"] = pkgSpec.Subpath
-			}
-
-			if !*pkgSpec.MatchOnlyEmptyQualifiers {
-				if len(pkgSpec.Qualifiers) > 0 {
-					qualifiers := getQualifiers(pkgSpec.Qualifiers)
-					matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
-					firstMatch = false
-					queryValues["qualifier"] = qualifiers
-				}
-			} else {
-				matchProperties(&sb, firstMatch, "version", "qualifier_list", "$qualifier")
-				firstMatch = false
-				queryValues["qualifier"] = []string{}
-			}
+			setPkgMatchValues(&sb, pkgSpec, false, firstMatch, queryValues)
 
 			sb.WriteString(" RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, version.qualifier_list")
 
@@ -421,7 +380,7 @@ func (c *neo4jClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec) 
 			var firstMatch bool = true
 			queryValues := map[string]any{}
 
-			sb.WriteString("MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)")
+			sb.WriteString("MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)")
 
 			if pkgSpec.Type != nil {
 
@@ -467,7 +426,7 @@ func (c *neo4jClient) packagesNamespace(ctx context.Context, pkgSpec *model.PkgS
 			var firstMatch bool = true
 			queryValues := map[string]any{}
 
-			sb.WriteString("MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)")
+			sb.WriteString("MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)")
 
 			if pkgSpec.Type != nil {
 
@@ -533,7 +492,7 @@ func (c *neo4jClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec) 
 			var firstMatch bool = true
 			queryValues := map[string]any{}
 
-			sb.WriteString("MATCH (n:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)-[:PkgHasName]->(name:PkgName)")
+			sb.WriteString("MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)-[:PkgHasName]->(name:PkgName)")
 			if pkgSpec.Type != nil {
 
 				matchProperties(&sb, firstMatch, "type", "type", "$pkgType")
@@ -736,4 +695,84 @@ func getQualifiers(qualifiersSpec []*model.PackageQualifierSpec) []string {
 		qualifiers = append(qualifiers, k, qualifiersMap[k])
 	}
 	return qualifiers
+}
+
+func setPkgMatchValues(sb *strings.Builder, pkg *model.PkgSpec, objectPkg bool, firstMatch bool, queryValues map[string]any) {
+	if pkg != nil {
+		if pkg.Type != nil {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "type", "type", "$pkgType")
+				queryValues["pkgType"] = pkg.Type
+			} else {
+				matchProperties(sb, firstMatch, "objPkgType", "type", "$objPkgType")
+				queryValues["objPkgType"] = pkg.Type
+			}
+			firstMatch = false
+		}
+		if pkg.Namespace != nil {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "namespace", "namespace", "$pkgNamespace")
+				queryValues["pkgNamespace"] = pkg.Namespace
+			} else {
+				matchProperties(sb, firstMatch, "objPkgNamespace", "namespace", "$objPkgNamespace")
+				queryValues["objPkgNamespace"] = pkg.Namespace
+			}
+			firstMatch = false
+		}
+		if pkg.Name != nil {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "name", "name", "$pkgName")
+				queryValues["pkgName"] = pkg.Name
+			} else {
+				matchProperties(sb, firstMatch, "objPkgName", "name", "$objPkgName")
+				queryValues["objPkgName"] = pkg.Name
+			}
+			firstMatch = false
+		}
+		if pkg.Version != nil {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "version", "version", "$pkgVersion")
+				queryValues["pkgVersion"] = pkg.Version
+			} else {
+				matchProperties(sb, firstMatch, "objPkgVersion", "version", "$objPkgVersion")
+				queryValues["objPkgVersion"] = pkg.Version
+			}
+			firstMatch = false
+		}
+
+		if pkg.Subpath != nil {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "version", "subpath", "$pkgSubpath")
+				queryValues["pkgSubpath"] = pkg.Subpath
+			} else {
+				matchProperties(sb, firstMatch, "objPkgVersion", "subpath", "$objPkgSubpath")
+				queryValues["objPkgSubpath"] = pkg.Subpath
+			}
+			firstMatch = false
+		}
+
+		if !*pkg.MatchOnlyEmptyQualifiers {
+			if len(pkg.Qualifiers) > 0 {
+				if !objectPkg {
+					qualifiers := getQualifiers(pkg.Qualifiers)
+					matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
+					queryValues["pkgQualifierList"] = qualifiers
+				} else {
+					qualifiers := getQualifiers(pkg.Qualifiers)
+					matchProperties(sb, firstMatch, "objPkgVersion", "qualifier_list", "$objPkgQualifierList")
+					queryValues["objPkgQualifierList"] = qualifiers
+				}
+				firstMatch = false
+			}
+		} else {
+			if !objectPkg {
+				matchProperties(sb, firstMatch, "version", "qualifier_list", "$pkgQualifierList")
+				queryValues["pkgQualifierList"] = []string{}
+			} else {
+				matchProperties(sb, firstMatch, "objPkgVersion", "qualifier_list", "$objPkgQualifierList")
+				queryValues["objPkgQualifierList"] = []string{}
+			}
+			firstMatch = false
+		}
+	}
 }

--- a/pkg/assembler/backends/neo4j/src.go
+++ b/pkg/assembler/backends/neo4j/src.go
@@ -235,36 +235,10 @@ func (c *neo4jClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec)
 
 			var firstMatch bool = true
 			queryValues := map[string]any{}
-			sb.WriteString("MATCH (n:Src)-[:SrcHasType]->(type:SrcType)-[:SrcHasNamespace]->(namespace:SrcNamespace)-[:SrcHasName]->(name:SrcName)")
 
-			if sourceSpec.Type != nil {
-				matchProperties(&sb, firstMatch, "type", "type", "$srcType")
-				firstMatch = false
-				queryValues["srcType"] = sourceSpec.Type
-			}
+			sb.WriteString("MATCH (root:Src)-[:SrcHasType]->(type:SrcType)-[:SrcHasNamespace]->(namespace:SrcNamespace)-[:SrcHasName]->(name:SrcName)")
 
-			if sourceSpec.Namespace != nil {
-				matchProperties(&sb, firstMatch, "namespace", "namespace", "$srcNamespace")
-				firstMatch = false
-				queryValues["srcNamespace"] = sourceSpec.Namespace
-			}
-
-			if sourceSpec.Name != nil {
-				matchProperties(&sb, firstMatch, "name", "name", "$srcName")
-				firstMatch = false
-				queryValues["srcName"] = sourceSpec.Name
-			}
-
-			if sourceSpec.Tag != nil {
-				matchProperties(&sb, firstMatch, "name", "tag", "$srcTag")
-				firstMatch = false
-				queryValues["srcTag"] = sourceSpec.Tag
-			}
-
-			if sourceSpec.Commit != nil {
-				matchProperties(&sb, firstMatch, "name", "commit", "$srcCommit")
-				queryValues["srcCommit"] = sourceSpec.Commit
-			}
+			setSrcMatchValues(&sb, sourceSpec, false, firstMatch, queryValues)
 
 			sb.WriteString(" RETURN type.type, namespace.namespace, name.name, name.tag, name.commit")
 
@@ -338,7 +312,7 @@ func (c *neo4jClient) sourcesType(ctx context.Context, sourceSpec *model.SourceS
 
 			var firstMatch bool = true
 			queryValues := map[string]any{}
-			sb.WriteString("MATCH (n:Src)-[:SrcHasType]->(type:SrcType)")
+			sb.WriteString("MATCH (root:Src)-[:SrcHasType]->(type:SrcType)")
 
 			if sourceSpec.Type != nil {
 
@@ -388,7 +362,7 @@ func (c *neo4jClient) sourcesNamespace(ctx context.Context, sourceSpec *model.So
 
 			var firstMatch bool = true
 			queryValues := map[string]any{}
-			sb.WriteString("MATCH (n:Src)-[:SrcHasType]->(type:SrcType)-[:SrcHasNamespace]->(namespace:SrcNamespace)")
+			sb.WriteString("MATCH (root:Src)-[:SrcHasType]->(type:SrcType)-[:SrcHasNamespace]->(namespace:SrcNamespace)")
 
 			if sourceSpec.Type != nil {
 
@@ -523,4 +497,60 @@ RETURN type.type, ns.namespace, name.name, name.commit, name.tag`
 	}
 
 	return result.(*model.Source), nil
+}
+
+func setSrcMatchValues(sb *strings.Builder, src *model.SourceSpec, objectSrc bool, firstMatch bool, queryValues map[string]any) {
+	if src != nil {
+		if src.Type != nil {
+			if !objectSrc {
+				matchProperties(sb, firstMatch, "type", "type", "$srcType")
+				queryValues["srcType"] = src.Type
+			} else {
+				matchProperties(sb, firstMatch, "objSrcType", "type", "$objSrcType")
+				queryValues["objSrcType"] = src.Type
+			}
+			firstMatch = false
+		}
+		if src.Namespace != nil {
+			if !objectSrc {
+				matchProperties(sb, firstMatch, "namespace", "namespace", "$srcNamespace")
+				queryValues["srcNamespace"] = src.Namespace
+			} else {
+				matchProperties(sb, firstMatch, "objSrcNamespace", "namespace", "$objSrcNamespace")
+				queryValues["objSrcNamespace"] = src.Namespace
+			}
+			firstMatch = false
+		}
+		if src.Name != nil {
+			if !objectSrc {
+				matchProperties(sb, firstMatch, "name", "name", "$srcName")
+				queryValues["srcName"] = src.Name
+			} else {
+				matchProperties(sb, firstMatch, "objSrcName", "name", "$objSrcName")
+				queryValues["objSrcName"] = src.Name
+			}
+			firstMatch = false
+		}
+
+		if src.Tag != nil {
+			if !objectSrc {
+				matchProperties(sb, firstMatch, "name", "tag", "$srcTag")
+				queryValues["srcTag"] = src.Tag
+			} else {
+				matchProperties(sb, firstMatch, "objSrcName", "tag", "$objSrcTag")
+				queryValues["objSrcTag"] = src.Tag
+			}
+			firstMatch = false
+		}
+
+		if src.Commit != nil {
+			if !objectSrc {
+				matchProperties(sb, firstMatch, "name", "commit", "$srcCommit")
+				queryValues["srcCommit"] = src.Commit
+			} else {
+				matchProperties(sb, firstMatch, "objSrcName", "commit", "$objSrcCommit")
+				queryValues["objSrcCommit"] = src.Commit
+			}
+		}
+	}
 }


### PR DESCRIPTION
Refactor set `MATCH` values for package, source and artifact such that it can be used by other verbs. For example: `certifyBad`, `hasSBOM`...etc