### PR TITLE
Use RFC 3339 time format in the API

### DIFF
--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -104,7 +105,7 @@ func (c *neo4jClient) Scorecards(ctx context.Context, certifyScorecardSpec *mode
 				}
 
 				scorecard := model.Scorecard{
-					TimeScanned:      certifyScorecardNode.Props[timeScanned].(string),
+					TimeScanned:      certifyScorecardNode.Props[timeScanned].(time.Time),
 					AggregateScore:   certifyScorecardNode.Props[aggregateScore].(float64),
 					Checks:           checks,
 					ScorecardVersion: certifyScorecardNode.Props[scorecardVersion].(string),
@@ -282,7 +283,7 @@ RETURN type.type, ns.namespace, name.name, name.commit, name.tag, certifyScoreca
 			}
 
 			scorecard := model.Scorecard{
-				TimeScanned:      certifyScorecardNode.Props[timeScanned].(string),
+				TimeScanned:      certifyScorecardNode.Props[timeScanned].(time.Time),
 				AggregateScore:   certifyScorecardNode.Props[aggregateScore].(float64),
 				Checks:           checks,
 				ScorecardVersion: certifyScorecardNode.Props[scorecardVersion].(string),

--- a/pkg/assembler/backends/neo4j/certifyVuln.go
+++ b/pkg/assembler/backends/neo4j/certifyVuln.go
@@ -18,6 +18,7 @@ package neo4jBackend
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -145,7 +146,7 @@ func (c *neo4jClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.Ce
 					certifyVuln := &model.CertifyVuln{
 						Package:        &pkg,
 						Vulnerability:  cve,
-						TimeScanned:    certifyVulnNode.Props[timeScanned].(string),
+						TimeScanned:    certifyVulnNode.Props[timeScanned].(time.Time),
 						DbURI:          certifyVulnNode.Props[dbUri].(string),
 						DbVersion:      certifyVulnNode.Props[dbVersion].(string),
 						ScannerURI:     certifyVulnNode.Props[scannerUri].(string),
@@ -264,7 +265,7 @@ func (c *neo4jClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.Ce
 					certifyVuln := &model.CertifyVuln{
 						Package:        &pkg,
 						Vulnerability:  ghsa,
-						TimeScanned:    certifyVulnNode.Props[timeScanned].(string),
+						TimeScanned:    certifyVulnNode.Props[timeScanned].(time.Time),
 						DbURI:          certifyVulnNode.Props[dbUri].(string),
 						DbVersion:      certifyVulnNode.Props[dbVersion].(string),
 						ScannerURI:     certifyVulnNode.Props[scannerUri].(string),
@@ -384,7 +385,7 @@ func (c *neo4jClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.Ce
 					certifyVuln := &model.CertifyVuln{
 						Package:        &pkg,
 						Vulnerability:  osv,
-						TimeScanned:    certifyVulnNode.Props[timeScanned].(string),
+						TimeScanned:    certifyVulnNode.Props[timeScanned].(time.Time),
 						DbURI:          certifyVulnNode.Props[dbUri].(string),
 						DbVersion:      certifyVulnNode.Props[dbVersion].(string),
 						ScannerURI:     certifyVulnNode.Props[scannerUri].(string),

--- a/pkg/assembler/backends/testing/certifyScorecard.go
+++ b/pkg/assembler/backends/testing/certifyScorecard.go
@@ -48,7 +48,7 @@ func registerAllCertifyScorecard(client *demoClient) error {
 	}
 	_, err = client.registerCertifyScorecard(
 		selectedSource[0],
-		time.Now().String(),
+		time.Now(),
 		7.9,
 		checkResults,
 		"v4.10.2",
@@ -83,7 +83,7 @@ func registerAllCertifyScorecard(client *demoClient) error {
 	}
 	_, err = client.registerCertifyScorecard(
 		selectedSource[0],
-		time.Now().String(),
+		time.Now(),
 		7.9,
 		checkResults,
 		"v4.10.2",
@@ -98,7 +98,7 @@ func registerAllCertifyScorecard(client *demoClient) error {
 
 // Ingest CertifyScorecard
 
-func (c *demoClient) registerCertifyScorecard(selectedSource *model.Source, timeScanned string, aggregateScore float64, collectedChecks []*model.ScorecardCheckInputSpec, scorecardVersion, scorecardCommit, origin, collector string) (*model.CertifyScorecard, error) {
+func (c *demoClient) registerCertifyScorecard(selectedSource *model.Source, timeScanned time.Time, aggregateScore float64, collectedChecks []*model.ScorecardCheckInputSpec, scorecardVersion, scorecardCommit, origin, collector string) (*model.CertifyScorecard, error) {
 	for _, h := range c.certifyScorecard {
 		if h.Source == selectedSource &&
 			h.Scorecard.AggregateScore == aggregateScore &&

--- a/pkg/assembler/backends/testing/certifyVEXStatement.go
+++ b/pkg/assembler/backends/testing/certifyVEXStatement.go
@@ -99,7 +99,7 @@ func (c *demoClient) registerCertifyVEXStatement(selectedPackage *model.Package,
 	}
 
 	newCertifyVEXStatement := &model.CertifyVEXStatement{
-		KnownSince:    timestamp.String(),
+		KnownSince:    timestamp,
 		Justification: justification,
 		Origin:        "testing backend",
 		Collector:     "testing backend",

--- a/pkg/assembler/backends/testing/certifyVuln.go
+++ b/pkg/assembler/backends/testing/certifyVuln.go
@@ -108,7 +108,7 @@ func (c *demoClient) registerCertifyVuln(selectedPackage *model.Package, selecte
 
 	newCertifyVuln := &model.CertifyVuln{
 		Package:        selectedPackage,
-		TimeScanned:    timeScanned.String(),
+		TimeScanned:    timeScanned,
 		DbURI:          dbUri,
 		DbVersion:      dbVersion,
 		ScannerURI:     scannerUri,
@@ -130,7 +130,6 @@ func (c *demoClient) registerCertifyVuln(selectedPackage *model.Package, selecte
 // Query CertifyPkg
 
 func (c *demoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
-
 	if certifyVulnSpec.Cve != nil && certifyVulnSpec.Osv != nil && certifyVulnSpec.Ghsa != nil {
 		return nil, gqlerror.Errorf("cannot specify cve, osv and ghsa together for CertifyVuln")
 	}

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -50,7 +50,7 @@ func registerAllHasSLSA(client *demoClient) error {
 	}
 	predicateValues := []*model.SLSAPredicate{{Key: "buildDefinition.externalParameters.repository", Value: "https://github.com/octocat/hello-world"}, {Key: "buildDefinition.externalParameters.ref", Value: "refs/heads/main"}, {Key: "buildDefinition.resolvedDependencies.uri", Value: "git+https://github.com/octocat/hello-world@refs/heads/main"}}
 
-	err = client.registerHasSLSA(selectedPackage[0], nil, nil, nil, selectedSource, nil, &model.Builder{URI: "https://github.com/Attestations/GitHubHostedActions@v1"}, "https://github.com/Attestations/GitHubActionsWorkflow@v1", predicateValues, "v1", time.Now().String(), time.Now().String())
+	err = client.registerHasSLSA(selectedPackage[0], nil, nil, nil, selectedSource, nil, &model.Builder{URI: "https://github.com/Attestations/GitHubHostedActions@v1"}, "https://github.com/Attestations/GitHubActionsWorkflow@v1", predicateValues, "v1", time.Now(), time.Now())
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func registerAllHasSLSA(client *demoClient) error {
 // Ingest HasSlsa
 
 func (c *demoClient) registerHasSLSA(selectedPackage *model.Package, selectedSource *model.Source, selectedArtifact *model.Artifact, builtFromPackages []*model.Package,
-	builtFromSouces []*model.Source, builtFromArtifacts []*model.Artifact, builtBy *model.Builder, buildType string, predicate []*model.SLSAPredicate, slsaVersion string, startOn string, finishOn string) error {
+	builtFromSouces []*model.Source, builtFromArtifacts []*model.Artifact, builtBy *model.Builder, buildType string, predicate []*model.SLSAPredicate, slsaVersion string, startOn time.Time, finishOn time.Time) error {
 
 	for _, h := range c.hasSLSA {
 		if h.BuildType == buildType && h.SlsaVersion == slsaVersion {

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -258,9 +259,9 @@ func (ec *executionContext) _Scorecard_timeScanned(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Scorecard_timeScanned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -270,7 +271,7 @@ func (ec *executionContext) fieldContext_Scorecard_timeScanned(ctx context.Conte
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -574,7 +575,7 @@ func (ec *executionContext) unmarshalInputCertifyScorecardSpec(ctx context.Conte
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("timeScanned"))
-			it.TimeScanned, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.TimeScanned, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -738,7 +739,7 @@ func (ec *executionContext) unmarshalInputScorecardInputSpec(ctx context.Context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("timeScanned"))
-			it.TimeScanned, err = ec.unmarshalNString2string(ctx, v)
+			it.TimeScanned, err = ec.unmarshalNTime2timeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -186,9 +187,9 @@ func (ec *executionContext) _CertifyVEXStatement_knownSince(ctx context.Context,
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyVEXStatement_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -198,7 +199,7 @@ func (ec *executionContext) fieldContext_CertifyVEXStatement_knownSince(ctx cont
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -354,7 +355,7 @@ func (ec *executionContext) unmarshalInputCertifyVEXStatementSpec(ctx context.Co
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			it.KnownSince, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.KnownSince, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -148,9 +149,9 @@ func (ec *executionContext) _CertifyVuln_timeScanned(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyVuln_timeScanned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -160,7 +161,7 @@ func (ec *executionContext) fieldContext_CertifyVuln_timeScanned(ctx context.Con
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -484,7 +485,7 @@ func (ec *executionContext) unmarshalInputCertifyVulnSpec(ctx context.Context, o
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("timeScanned"))
-			it.TimeScanned, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.TimeScanned, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -732,12 +733,43 @@ func (ec *executionContext) marshalNOsvCveGhsaObject2githubᚗcomᚋguacsecᚋgu
 	return ec._OsvCveGhsaObject(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	res, err := graphql.UnmarshalTime(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	res := graphql.MarshalTime(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalOCertifyVulnSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnSpec(ctx context.Context, v interface{}) (*model.CertifyVulnSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputCertifyVulnSpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalTime(*v)
+	return res
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -328,9 +329,9 @@ func (ec *executionContext) _HasSLSA_startedOn(ctx context.Context, field graphq
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSLSA_startedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -340,7 +341,7 @@ func (ec *executionContext) fieldContext_HasSLSA_startedOn(ctx context.Context, 
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -372,9 +373,9 @@ func (ec *executionContext) _HasSLSA_finishedOn(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSLSA_finishedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -384,7 +385,7 @@ func (ec *executionContext) fieldContext_HasSLSA_finishedOn(ctx context.Context,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -672,7 +673,7 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("startedOn"))
-			it.StartedOn, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.StartedOn, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -680,7 +681,7 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("finishedOn"))
-			it.FinishedOn, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.FinishedOn, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1707,8 +1707,8 @@ type Scorecard {
   checks: [ScorecardCheck!]!
   "Overall Scorecard score for the source"
   aggregateScore: Float!
-  "Exact timestamp when the source was last scanned"
-  timeScanned: String!
+  "Exact timestamp when the source was last scanned (in RFC 3339 format)"
+  timeScanned: Time!
   "Version of the Scorecard scanner used to analyze the source"
   scorecardVersion: String!
   "Commit of the Scorecards repository at the time of scanning the source"
@@ -1745,7 +1745,7 @@ CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
 """
 input CertifyScorecardSpec {
   source: SourceSpec
-  timeScanned: String
+  timeScanned: Time
   aggregateScore: Float
   checks: [ScorecardCheckSpec!] = []
   scorecardVersion: String
@@ -1770,7 +1770,7 @@ All fields are required.
 input ScorecardInputSpec {
   checks: [ScorecardCheckInputSpec!]!
   aggregateScore: Float!
-  timeScanned: String!
+  timeScanned: Time!
   scorecardVersion: String!
   scorecardCommit: String!
   origin: String!
@@ -1820,7 +1820,7 @@ CertifyVEXStatement is an attestation that represents when a package or artifact
 subject - union type that represents a package or artifact
 vulnerability (object) - union type that consists of cve or ghsa
 justification (property) - justification for VEX
-knownSince (property) - timestamp of the VEX (exact time)
+knownSince (property) - timestamp of the VEX (exact time in RFC 3339 format)
 origin (property) - where this attestation was generated from (based on which document)
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
@@ -1828,7 +1828,7 @@ type CertifyVEXStatement {
   subject: PkgArtObject!
   vulnerability: CveGhsaObject!
   justification: String!
-  knownSince: String!
+  knownSince: Time!
   origin: String!
   collector: String!
 }
@@ -1843,7 +1843,7 @@ input CertifyVEXStatementSpec {
   cve: CVESpec
   ghsa: GHSASpec
   justification: String
-  knownSince: String
+  knownSince: Time
   origin: String
   collector: String
 }
@@ -1856,7 +1856,8 @@ union PkgArtObject = Package | Artifact
 extend type Query {
   "Returns all CertifyVEXStatement"
   CertifyVEXStatement(certifyVEXStatementSpec: CertifyVEXStatementSpec): [CertifyVEXStatement!]!
-}`, BuiltIn: false},
+}
+`, BuiltIn: false},
 	{Name: "../schema/certifyVuln.graphql", Input: `#
 # Copyright 2023 The GUAC Authors.
 #
@@ -1892,7 +1893,7 @@ collector (property) - the GUAC collector that collected the document that gener
 type CertifyVuln {
   package: Package!
   vulnerability: OsvCveGhsaObject!
-  timeScanned: String!
+  timeScanned: Time!
   dbUri: String!
   dbVersion: String!
   scannerUri: String!
@@ -1912,7 +1913,7 @@ input CertifyVulnSpec {
   osv: OSVSpec
   cve: CVESpec
   ghsa: GHSASpec
-  timeScanned: String
+  timeScanned: Time
   dbUri: String
   dbVersion: String
   scannerUri: String
@@ -1930,6 +1931,8 @@ extend type Query {
   "Returns all CertifyVuln"
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec): [CertifyVuln!]!
 }
+
+scalar Time
 `, BuiltIn: false},
 	{Name: "../schema/cve.graphql", Input: `#
 # Copyright 2023 The GUAC Authors.
@@ -2157,8 +2160,8 @@ builtBy (object) - represents the builder that was used to build the subject
 buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
 slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
 slsaVersion (property) - version of the SLSA predicate
-startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject
-finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject
+startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
+finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
 origin (property) - where this attestation was generated from (based on which document)
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
@@ -2169,8 +2172,8 @@ type HasSLSA {
   buildType: String!
   slsaPredicate: [SLSAPredicate!]!
   slsaVersion: String!
-  startedOn: String!
-  finishedOn: String!
+  startedOn: Time!
+  finishedOn: Time!
   origin: String!
   collector: String!
 }
@@ -2228,8 +2231,8 @@ input HasSLSASpec {
   buildType: String
   predicate: [SLSAPredicateSpec!] = []
   slsaVersion: String
-  startedOn: String
-  finishedOn: String
+  startedOn: Time
+  finishedOn: Time
   origin: String
   collector: String
 }

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -2,6 +2,10 @@
 
 package model
 
+import (
+	"time"
+)
+
 // CveGhsaObject is a union of CVE and GHSA.
 type CveGhsaObject interface {
 	IsCveGhsaObject()
@@ -176,7 +180,7 @@ type CertifyScorecard struct {
 // CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
 type CertifyScorecardSpec struct {
 	Source           *SourceSpec           `json:"source"`
-	TimeScanned      *string               `json:"timeScanned"`
+	TimeScanned      *time.Time            `json:"timeScanned"`
 	AggregateScore   *float64              `json:"aggregateScore"`
 	Checks           []*ScorecardCheckSpec `json:"checks"`
 	ScorecardVersion *string               `json:"scorecardVersion"`
@@ -190,14 +194,14 @@ type CertifyScorecardSpec struct {
 // subject - union type that represents a package or artifact
 // vulnerability (object) - union type that consists of cve or ghsa
 // justification (property) - justification for VEX
-// knownSince (property) - timestamp of the VEX (exact time)
+// knownSince (property) - timestamp of the VEX (exact time in RFC 3339 format)
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type CertifyVEXStatement struct {
 	Subject       PkgArtObject  `json:"subject"`
 	Vulnerability CveGhsaObject `json:"vulnerability"`
 	Justification string        `json:"justification"`
-	KnownSince    string        `json:"knownSince"`
+	KnownSince    time.Time     `json:"knownSince"`
 	Origin        string        `json:"origin"`
 	Collector     string        `json:"collector"`
 }
@@ -210,7 +214,7 @@ type CertifyVEXStatementSpec struct {
 	Cve           *CVESpec      `json:"cve"`
 	Ghsa          *GHSASpec     `json:"ghsa"`
 	Justification *string       `json:"justification"`
-	KnownSince    *string       `json:"knownSince"`
+	KnownSince    *time.Time    `json:"knownSince"`
 	Origin        *string       `json:"origin"`
 	Collector     *string       `json:"collector"`
 }
@@ -229,7 +233,7 @@ type CertifyVEXStatementSpec struct {
 type CertifyVuln struct {
 	Package        *Package         `json:"package"`
 	Vulnerability  OsvCveGhsaObject `json:"vulnerability"`
-	TimeScanned    string           `json:"timeScanned"`
+	TimeScanned    time.Time        `json:"timeScanned"`
 	DbURI          string           `json:"dbUri"`
 	DbVersion      string           `json:"dbVersion"`
 	ScannerURI     string           `json:"scannerUri"`
@@ -243,17 +247,17 @@ type CertifyVuln struct {
 // Specifying just the package allows to query for all vulnerabilities associated with the package.
 // Only OSV, CVE or GHSA can be specified at once
 type CertifyVulnSpec struct {
-	Package        *PkgSpec  `json:"package"`
-	Osv            *OSVSpec  `json:"osv"`
-	Cve            *CVESpec  `json:"cve"`
-	Ghsa           *GHSASpec `json:"ghsa"`
-	TimeScanned    *string   `json:"timeScanned"`
-	DbURI          *string   `json:"dbUri"`
-	DbVersion      *string   `json:"dbVersion"`
-	ScannerURI     *string   `json:"scannerUri"`
-	ScannerVersion *string   `json:"scannerVersion"`
-	Origin         *string   `json:"origin"`
-	Collector      *string   `json:"collector"`
+	Package        *PkgSpec   `json:"package"`
+	Osv            *OSVSpec   `json:"osv"`
+	Cve            *CVESpec   `json:"cve"`
+	Ghsa           *GHSASpec  `json:"ghsa"`
+	TimeScanned    *time.Time `json:"timeScanned"`
+	DbURI          *string    `json:"dbUri"`
+	DbVersion      *string    `json:"dbVersion"`
+	ScannerURI     *string    `json:"scannerUri"`
+	ScannerVersion *string    `json:"scannerVersion"`
+	Origin         *string    `json:"origin"`
+	Collector      *string    `json:"collector"`
 }
 
 // GHSA represents GitHub security advisories.
@@ -323,8 +327,8 @@ type HasSBOMSpec struct {
 // buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
 // slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
 // slsaVersion (property) - version of the SLSA predicate
-// startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject
-// finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject
+// startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
+// finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type HasSlsa struct {
@@ -334,8 +338,8 @@ type HasSlsa struct {
 	BuildType     string            `json:"buildType"`
 	SlsaPredicate []*SLSAPredicate  `json:"slsaPredicate"`
 	SlsaVersion   string            `json:"slsaVersion"`
-	StartedOn     string            `json:"startedOn"`
-	FinishedOn    string            `json:"finishedOn"`
+	StartedOn     time.Time         `json:"startedOn"`
+	FinishedOn    time.Time         `json:"finishedOn"`
 	Origin        string            `json:"origin"`
 	Collector     string            `json:"collector"`
 }
@@ -352,8 +356,8 @@ type HasSLSASpec struct {
 	BuildType         *string              `json:"buildType"`
 	Predicate         []*SLSAPredicateSpec `json:"predicate"`
 	SlsaVersion       *string              `json:"slsaVersion"`
-	StartedOn         *string              `json:"startedOn"`
-	FinishedOn        *string              `json:"finishedOn"`
+	StartedOn         *time.Time           `json:"startedOn"`
+	FinishedOn        *time.Time           `json:"finishedOn"`
 	Origin            *string              `json:"origin"`
 	Collector         *string              `json:"collector"`
 }
@@ -748,8 +752,8 @@ type Scorecard struct {
 	Checks []*ScorecardCheck `json:"checks"`
 	// Overall Scorecard score for the source
 	AggregateScore float64 `json:"aggregateScore"`
-	// Exact timestamp when the source was last scanned
-	TimeScanned string `json:"timeScanned"`
+	// Exact timestamp when the source was last scanned (in RFC 3339 format)
+	TimeScanned time.Time `json:"timeScanned"`
 	// Version of the Scorecard scanner used to analyze the source
 	ScorecardVersion string `json:"scorecardVersion"`
 	// Commit of the Scorecards repository at the time of scanning the source
@@ -799,7 +803,7 @@ type ScorecardCheckSpec struct {
 type ScorecardInputSpec struct {
 	Checks           []*ScorecardCheckInputSpec `json:"checks"`
 	AggregateScore   float64                    `json:"aggregateScore"`
-	TimeScanned      string                     `json:"timeScanned"`
+	TimeScanned      time.Time                  `json:"timeScanned"`
 	ScorecardVersion string                     `json:"scorecardVersion"`
 	ScorecardCommit  string                     `json:"scorecardCommit"`
 	Origin           string                     `json:"origin"`

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -40,8 +40,8 @@ type Scorecard {
   checks: [ScorecardCheck!]!
   "Overall Scorecard score for the source"
   aggregateScore: Float!
-  "Exact timestamp when the source was last scanned"
-  timeScanned: String!
+  "Exact timestamp when the source was last scanned (in RFC 3339 format)"
+  timeScanned: Time!
   "Version of the Scorecard scanner used to analyze the source"
   scorecardVersion: String!
   "Commit of the Scorecards repository at the time of scanning the source"
@@ -78,7 +78,7 @@ CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
 """
 input CertifyScorecardSpec {
   source: SourceSpec
-  timeScanned: String
+  timeScanned: Time
   aggregateScore: Float
   checks: [ScorecardCheckSpec!] = []
   scorecardVersion: String
@@ -103,7 +103,7 @@ All fields are required.
 input ScorecardInputSpec {
   checks: [ScorecardCheckInputSpec!]!
   aggregateScore: Float!
-  timeScanned: String!
+  timeScanned: Time!
   scorecardVersion: String!
   scorecardCommit: String!
   origin: String!

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -23,7 +23,7 @@ CertifyVEXStatement is an attestation that represents when a package or artifact
 subject - union type that represents a package or artifact
 vulnerability (object) - union type that consists of cve or ghsa
 justification (property) - justification for VEX
-knownSince (property) - timestamp of the VEX (exact time)
+knownSince (property) - timestamp of the VEX (exact time in RFC 3339 format)
 origin (property) - where this attestation was generated from (based on which document)
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
@@ -31,7 +31,7 @@ type CertifyVEXStatement {
   subject: PkgArtObject!
   vulnerability: CveGhsaObject!
   justification: String!
-  knownSince: String!
+  knownSince: Time!
   origin: String!
   collector: String!
 }
@@ -46,7 +46,7 @@ input CertifyVEXStatementSpec {
   cve: CVESpec
   ghsa: GHSASpec
   justification: String
-  knownSince: String
+  knownSince: Time
   origin: String
   collector: String
 }

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -33,7 +33,7 @@ collector (property) - the GUAC collector that collected the document that gener
 type CertifyVuln {
   package: Package!
   vulnerability: OsvCveGhsaObject!
-  timeScanned: String!
+  timeScanned: Time!
   dbUri: String!
   dbVersion: String!
   scannerUri: String!
@@ -53,7 +53,7 @@ input CertifyVulnSpec {
   osv: OSVSpec
   cve: CVESpec
   ghsa: GHSASpec
-  timeScanned: String
+  timeScanned: Time
   dbUri: String
   dbVersion: String
   scannerUri: String
@@ -71,3 +71,5 @@ extend type Query {
   "Returns all CertifyVuln"
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec): [CertifyVuln!]!
 }
+
+scalar Time

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -27,8 +27,8 @@ builtBy (object) - represents the builder that was used to build the subject
 buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
 slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
 slsaVersion (property) - version of the SLSA predicate
-startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject
-finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject
+startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
+finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
 origin (property) - where this attestation was generated from (based on which document)
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
@@ -39,8 +39,8 @@ type HasSLSA {
   buildType: String!
   slsaPredicate: [SLSAPredicate!]!
   slsaVersion: String!
-  startedOn: String!
-  finishedOn: String!
+  startedOn: Time!
+  finishedOn: Time!
   origin: String!
   collector: String!
 }
@@ -98,8 +98,8 @@ input HasSLSASpec {
   buildType: String
   predicate: [SLSAPredicateSpec!] = []
   slsaVersion: String
-  startedOn: String
-  finishedOn: String
+  startedOn: Time
+  finishedOn: Time
   origin: String
   collector: String
 }


### PR DESCRIPTION
I think it'd be good to define that user facing APIs return timestamps in RFC 3339 format. I stumbled upon this trying to parse payload in Rust which didn't like default Go "monotonic" time format. RFC 3339 is pretty much recommended for all API use cases.

The current commit is only to show how the change would look like. The default support in gqlgen is using RFC3339Nano format which works but might be a bit overkill. Anyway, it's a good first step for now and we can discuss if we should do something else.

If everyone is supportive of this change, I would go and continue to implement and document this for the whole API.