### PR TITLE
Bulldoze existing integration from ingestor to assembler to make way for graphQL

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -210,8 +210,8 @@ func getProcessor(ctx context.Context) (func(*processor.Document) (processor.Doc
 		return process.Process(ctx, d)
 	}, nil
 }
-func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler.Graph, error), error) {
-	return func(doc processor.DocumentTree) ([]assembler.Graph, error) {
+func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler.PlaceholderStruct, error), error) {
+	return func(doc processor.DocumentTree) ([]assembler.PlaceholderStruct, error) {
 		// for guacone collectors, we do not integrate with the collectsub service
 		inputs, _, err := parser.ParseDocumentTree(ctx, doc)
 		if err != nil {
@@ -222,37 +222,39 @@ func getIngestor(ctx context.Context) (func(processor.DocumentTree) ([]assembler
 	}, nil
 }
 
-func getAssembler(opts options) (func([]assembler.Graph) error, error) {
-	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
-		opts.user,
-		opts.pass,
-		opts.realm,
-	)
-
-	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
-	if err != nil {
-		return nil, err
-	}
-
-	err = createIndices(client)
-	if err != nil {
-		return nil, err
-	}
-
-	return func(gs []assembler.Graph) error {
-		combined := assembler.Graph{
-			Nodes: []assembler.GuacNode{},
-			Edges: []assembler.GuacEdge{},
-		}
-		for _, g := range gs {
-			combined.AppendGraph(g)
-		}
-		if err := assembler.StoreGraph(combined, client); err != nil {
-			return err
-		}
-
-		return nil
-	}, nil
+func getAssembler(opts options) (func([]assembler.PlaceholderStruct) error, error) {
+	// TODO(bulldozer): create an assbebler function to call graphQL ingestion
+	// 	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
+	// 		opts.user,
+	// 		opts.pass,
+	// 		opts.realm,
+	// 	)
+	//
+	// 	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	//
+	// 	err = createIndices(client)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	//
+	// 	return func(gs []assembler.Graph) error {
+	// 		combined := assembler.Graph{
+	// 			Nodes: []assembler.GuacNode{},
+	// 			Edges: []assembler.GuacEdge{},
+	// 		}
+	// 		for _, g := range gs {
+	// 			combined.AppendGraph(g)
+	// 		}
+	// 		if err := assembler.StoreGraph(combined, client); err != nil {
+	// 			return err
+	// 		}
+	//
+	// 		return nil
+	// 	}, nil
+	return func(_ []assembler.PlaceholderStruct) error { return nil }, nil
 }
 
 func createIndices(client graphdb.Client) error {

--- a/cmd/ingest/cmd/example.go
+++ b/cmd/ingest/cmd/example.go
@@ -74,14 +74,18 @@ var exampleCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			g.AppendGraph(inputs...)
+			// TODO(bulldozer): collate inputs
+			// g.AppendGraph(inputs...)
+			_ = inputs
 		}
 		logger.Infof("graph nodes: %v, edges: %v", len(g.Nodes), len(g.Edges))
 
-		if err := assembler.StoreGraph(g, client); err != nil {
-			logger.Errorf("unable to store graph: %v", err)
-			os.Exit(1)
-		}
+		// TODO(bulldozer): call routine to ingest
+		// if err := assembler.StoreGraph(g, client); err != nil {
+		// 	logger.Errorf("unable to store graph: %v", err)
+		// 	os.Exit(1)
+		// }
+		_ = client
 	},
 }
 

--- a/cmd/ingest/cmd/ingest.go
+++ b/cmd/ingest/cmd/ingest.go
@@ -103,7 +103,7 @@ var ingestCmd = &cobra.Command{
 			return nil
 		}
 
-		ingestorTransportFunc := func(d []assembler.Graph, i []*parser_common.IdentifierStrings) error {
+		ingestorTransportFunc := func(d []assembler.PlaceholderStruct, i []*parser_common.IdentifierStrings) error {
 			err := assemblerFunc(d)
 			if err != nil {
 				return err
@@ -173,7 +173,7 @@ func getProcessor(ctx context.Context, transportFunc func(processor.DocumentTree
 	}, nil
 }
 
-func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph, []*parser_common.IdentifierStrings) error) (func() error, error) {
+func getIngestor(ctx context.Context, transportFunc func([]assembler.PlaceholderStruct, []*parser_common.IdentifierStrings) error) (func() error, error) {
 	return func() error {
 		err := parser.Subscribe(ctx, transportFunc)
 		if err != nil {
@@ -183,37 +183,38 @@ func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph, []*p
 	}, nil
 }
 
-func getAssembler(opts options) (func([]assembler.Graph) error, error) {
-	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
-		opts.user,
-		opts.pass,
-		opts.realm,
-	)
-
-	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
-	if err != nil {
-		return nil, err
-	}
-
-	err = createIndices(client)
-	if err != nil {
-		return nil, err
-	}
-
-	return func(gs []assembler.Graph) error {
-		combined := assembler.Graph{
-			Nodes: []assembler.GuacNode{},
-			Edges: []assembler.GuacEdge{},
-		}
-		for _, g := range gs {
-			combined.AppendGraph(g)
-		}
-		if err := assembler.StoreGraph(combined, client); err != nil {
-			return err
-		}
-
-		return nil
-	}, nil
+func getAssembler(opts options) (func([]assembler.PlaceholderStruct) error, error) {
+	// TODO(bulldozer): return function to talk to graphQL
+	// 	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
+	// 		opts.user,
+	// 		opts.pass,
+	// 		opts.realm,
+	// 	)
+	//
+	// 	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	//
+	// 	err = createIndices(client)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	//
+	// return func(gs []assembler.Graph) error {
+	// 	combined := assembler.Graph{
+	// 		Nodes: []assembler.GuacNode{},
+	// 		Edges: []assembler.GuacEdge{},
+	// 	}
+	// 	for _, g := range gs {
+	// 		combined.AppendGraph(g)
+	// 	}
+	// 	if err := assembler.StoreGraph(combined, client); err != nil {
+	// 		return err
+	// 	}
+	// 	return nil
+	// }, nil
+	return func(_ []assembler.PlaceholderStruct) error { return nil }, nil
 }
 
 func createIndices(client graphdb.Client) error {

--- a/cmd/pubsub_test/cmd/certifier.go
+++ b/cmd/pubsub_test/cmd/certifier.go
@@ -110,7 +110,7 @@ var certifierCmd = &cobra.Command{
 		}
 
 		// for pubsub_test we ignore identifier strings as we don't connect to a collectsub service
-		ingestorTransportFunc := func(d []assembler.Graph, i []*parser_common.IdentifierStrings) error {
+		ingestorTransportFunc := func(d []assembler.PlaceholderStruct, i []*parser_common.IdentifierStrings) error {
 			err := assemblerFunc(d)
 			if err != nil {
 				return err

--- a/cmd/pubsub_test/cmd/files.go
+++ b/cmd/pubsub_test/cmd/files.go
@@ -119,7 +119,7 @@ var filesCmd = &cobra.Command{
 		}
 
 		// for pubsub_test we ignore identifier strings as we don't connect to a collectsub service
-		ingestorTransportFunc := func(d []assembler.Graph, i []*common.IdentifierStrings) error {
+		ingestorTransportFunc := func(d []assembler.PlaceholderStruct, i []*common.IdentifierStrings) error {
 			err := assemblerFunc(d)
 			if err != nil {
 				return err
@@ -215,7 +215,7 @@ func getProcessor(ctx context.Context, transportFunc func(processor.DocumentTree
 	}, nil
 }
 
-func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph, []*parser_common.IdentifierStrings) error) (func() error, error) {
+func getIngestor(ctx context.Context, transportFunc func([]assembler.PlaceholderStruct, []*parser_common.IdentifierStrings) error) (func() error, error) {
 	return func() error {
 		err := parser.Subscribe(ctx, transportFunc)
 		if err != nil {
@@ -225,37 +225,38 @@ func getIngestor(ctx context.Context, transportFunc func([]assembler.Graph, []*p
 	}, nil
 }
 
-func getAssembler(opts options) (func([]assembler.Graph) error, error) {
-	authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
-		opts.user,
-		opts.pass,
-		opts.realm,
-	)
+func getAssembler(opts options) (func([]assembler.PlaceholderStruct) error, error) {
+	// TODO(bulldozer): return assembler func to talk to graphQL ingestion
+	// authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(
+	// 	opts.user,
+	// 	opts.pass,
+	// 	opts.realm,
+	// )
 
-	client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
-	if err != nil {
-		return nil, err
-	}
+	// client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	err = createIndices(client)
-	if err != nil {
-		return nil, err
-	}
+	// err = createIndices(client)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return func(gs []assembler.Graph) error {
-		combined := assembler.Graph{
-			Nodes: []assembler.GuacNode{},
-			Edges: []assembler.GuacEdge{},
-		}
-		for _, g := range gs {
-			combined.AppendGraph(g)
-		}
-		if err := assembler.StoreGraph(combined, client); err != nil {
-			return err
-		}
-
-		return nil
-	}, nil
+	// return func(gs []assembler.Graph) error {
+	// 	combined := assembler.Graph{
+	// 		Nodes: []assembler.GuacNode{},
+	// 		Edges: []assembler.GuacEdge{},
+	// 	}
+	// 	for _, g := range gs {
+	// 		combined.AppendGraph(g)
+	// 	}
+	// 	if err := assembler.StoreGraph(combined, client); err != nil {
+	// 		return err
+	// 	}
+	// 	return nil
+	// }, nil
+	return func(_ []assembler.PlaceholderStruct) error { return nil }, nil
 }
 
 func createIndices(client graphdb.Client) error {

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -138,5 +138,9 @@ func (g *Graph) AppendGraph(gs ...Graph) {
 
 // TODO(mihaimaruseac): Write queries to write/read subgraphs from DB?
 
+type PlaceholderStruct struct {
+	Tmp any
+}
+
 // AssemblerInput represents the inputs to add to the graph
-type AssemblerInput = Graph
+type AssemblerInput = PlaceholderStruct

--- a/pkg/assembler/backends/neo4j/ingest_testdata.go
+++ b/pkg/assembler/backends/neo4j/ingest_testdata.go
@@ -271,7 +271,7 @@ func (c *neo4jClient) registerArtifact(algorithm, digest string) error {
 		algorithm: strings.ToLower(algorithm),
 		digest:    strings.ToLower(digest),
 	}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedArtifact},
 	}
 	err := assembler.StoreGraph(assemblerinput, c.driver)
@@ -285,7 +285,7 @@ func (c *neo4jClient) registerBuilder(uri string) error {
 	collectedBuilder := &builderNode{
 		uri: uri,
 	}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedBuilder},
 	}
 	err := assembler.StoreGraph(assemblerinput, c.driver)
@@ -302,7 +302,7 @@ func (c *neo4jClient) registerCVE(year, id string) error {
 
 	cveToYearEdge := &cveToYear{collectedCve, collectedYear}
 	cveYearToIDEdge := &cveYearToCveID{collectedYear, collecteCveId}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedCve, collectedYear, collecteCveId},
 		Edges: []assembler.GuacEdge{cveToYearEdge, cveYearToIDEdge},
 	}
@@ -318,7 +318,7 @@ func (c *neo4jClient) registerGhsa(id string) error {
 	collecteGhsaId := &ghsaID{id: strings.ToLower(id)}
 
 	ghsaToIDEdge := &ghsaToID{collectedGhsa, collecteGhsaId}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedGhsa, collecteGhsaId},
 		Edges: []assembler.GuacEdge{ghsaToIDEdge},
 	}
@@ -334,7 +334,7 @@ func (c *neo4jClient) registerOSV(id string) error {
 	collecteOsvId := &osvID{id: strings.ToLower(id)}
 
 	osvToIDEdge := &osvToID{collectedOsv, collecteOsvId}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedOsv, collecteOsvId},
 		Edges: []assembler.GuacEdge{osvToIDEdge},
 	}
@@ -372,7 +372,7 @@ func (c *neo4jClient) registerPackage(packageType, namespace, name, version, sub
 	typeToNamespaceEdge := &typeToNamespace{collectedType, collectedNamespace}
 	namespaceToNameEdge := &namespaceToName{collectedNamespace, collectedName}
 	nameToVersionEdge := &nameToVersion{collectedName, collectedVersion}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedPkg, collectedType, collectedNamespace, collectedName, collectedVersion},
 		Edges: []assembler.GuacEdge{pkgToTypeEdge, typeToNamespaceEdge, namespaceToNameEdge, nameToVersionEdge},
 	}
@@ -401,7 +401,7 @@ func (c *neo4jClient) registerSource(sourceType, namespace, name, qualifier stri
 	srcToTypeEdge := &srcToType{collectedSrc, collectedType}
 	typetoNamespaceEdge := &srcTypeToNamespace{collectedType, collectedNamespace}
 	namespaceToNameEdge := &srcNamespaceToName{collectedNamespace, collectedName}
-	assemblerinput := assembler.AssemblerInput{
+	assemblerinput := assembler.Graph{
 		Nodes: []assembler.GuacNode{collectedSrc, collectedType, collectedNamespace, collectedName},
 		Edges: []assembler.GuacEdge{srcToTypeEdge, typetoNamespaceEdge, namespaceToNameEdge},
 	}

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -24,11 +24,11 @@ import (
 // GraphBuilder creates the assembler inputs based on the documents being parsed
 type GraphBuilder struct {
 	docParser       DocumentParser
-	foundIdentities []assembler.IdentityNode
+	foundIdentities []TrustInformation
 }
 
 // NewGenericGraphBuilder initializes the graphbulder
-func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []assembler.IdentityNode) *GraphBuilder {
+func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []TrustInformation) *GraphBuilder {
 	return &GraphBuilder{
 		docParser:       docParser,
 		foundIdentities: foundIdentities,
@@ -36,13 +36,14 @@ func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []assemble
 }
 
 // CreateAssemblerInput creates the GuacNodes and GuacEdges that are needed by the assembler
-func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []assembler.IdentityNode) assembler.AssemblerInput {
+func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation) assembler.AssemblerInput {
+	// TODO(bulldozer): call docParser to get assemblerinput, add trust information when needed
 	assemblerinput := assembler.AssemblerInput{}
 	return assemblerinput
 }
 
 // GetIdentities returns the identity that is found when parsing a document
-func (b *GraphBuilder) GetIdentities() []assembler.IdentityNode {
+func (b *GraphBuilder) GetIdentities() []TrustInformation {
 	return b.foundIdentities
 }
 

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -37,10 +37,7 @@ func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []assemble
 
 // CreateAssemblerInput creates the GuacNodes and GuacEdges that are needed by the assembler
 func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []assembler.IdentityNode) assembler.AssemblerInput {
-	assemblerinput := assembler.AssemblerInput{
-		Nodes: b.docParser.CreateNodes(ctx),
-		Edges: b.docParser.CreateEdges(ctx, foundIdentities),
-	}
+	assemblerinput := assembler.AssemblerInput{}
 	return assemblerinput
 }
 

--- a/pkg/ingestor/parser/common/types.go
+++ b/pkg/ingestor/parser/common/types.go
@@ -25,12 +25,13 @@ import (
 type DocumentParser interface {
 	// Parse breaks out the document into the graph components
 	Parse(ctx context.Context, doc *processor.Document) error
+
 	// GetIdentities gets the identity node from the document if they exist
-	GetIdentities(ctx context.Context) []assembler.IdentityNode
-	// CreateNodes creates the GuacNode for the graph inputs
-	CreateNodes(ctx context.Context) []assembler.GuacNode
-	// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-	CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge
+	GetIdentities(ctx context.Context) []TrustInformation
+
+	// CreatePredicates returns the predicates of the GUAC ontology to be created
+	GetPredicates(ctx context.Context) []assembler.PlaceholderStruct
+
 	// GetIdentifiers returns a set of identifiers that the parser has found to help provide context
 	// for collectors to gather more information around found software identifiers.
 	// This is an optional function to implement and it should return an error if not implemented.
@@ -53,3 +54,5 @@ type IdentifierStrings struct {
 	// parsers may not be sure what category they fall under.
 	UnclassifiedStrings []string
 }
+
+type TrustInformation struct{}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -46,14 +46,15 @@ func NewCycloneDXParser() common.DocumentParser {
 	}
 }
 
-func (c *cyclonedxParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
-	nodes := []assembler.GuacNode{}
-	nodes = append(nodes, c.rootComponent.curPackage)
-	for _, p := range c.rootComponent.depPackages {
-		nodes = append(nodes, p.curPackage)
-	}
-	return nodes
-}
+// TODO(bulldozer): replace with GetPredicates
+// func (c *cyclonedxParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
+// 	nodes := []assembler.GuacNode{}
+// 	nodes = append(nodes, c.rootComponent.curPackage)
+// 	for _, p := range c.rootComponent.depPackages {
+// 		nodes = append(nodes, p.curPackage)
+// 	}
+// 	return nodes
+// }
 
 func addEdges(curPkg component, edges *[]assembler.GuacEdge, visited map[string]bool) {
 	// this could happen if we image purl creation fails for rootPackage
@@ -90,16 +91,17 @@ func (c *cyclonedxParser) Parse(ctx context.Context, doc *processor.Document) er
 }
 
 // GetIdentities gets the identity node from the document if they exist
-func (c *cyclonedxParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
+func (c *cyclonedxParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return nil
 }
 
-func (c *cyclonedxParser) CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge {
-	edges := []assembler.GuacEdge{}
-	visited := make(map[string]bool)
-	addEdges(c.rootComponent, &edges, visited)
-	return edges
-}
+// TODO(bulldozer): replace with GetPredicates
+// func (c *cyclonedxParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
+// 	edges := []assembler.GuacEdge{}
+// 	visited := make(map[string]bool)
+// 	addEdges(c.rootComponent, &edges, visited)
+// 	return edges
+// }
 
 func (c *cyclonedxParser) addRootPackage(cdxBom *cdx.BOM) {
 	// oci purl: pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
@@ -216,4 +218,8 @@ func parseCycloneDXBOM(doc *processor.Document) (*cdx.BOM, error) {
 
 func (c *cyclonedxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	return nil, fmt.Errorf("not yet implemented")
+}
+
+func (c *cyclonedxParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -15,6 +15,8 @@
 
 package cyclonedx
 
+// TODO(bulldozer): freeze test
+/*
 import (
 	"context"
 	"reflect"
@@ -123,10 +125,10 @@ func Test_addEdgesRecursive(t *testing.T) {
 	packageB.depPackages = []*component{&packageC}
 	packageC.depPackages = []*component{&packageD}
 	packageD.depPackages = []*component{&packageA}
-	/*
-		A -> B -> C -> D -> A
-		This should result in a cycle, and it shouldn't blow up the stack.
-	*/
+	//
+	// 	  A -> B -> C -> D -> A
+	// 	  This should result in a cycle, and it shouldn't blow up the stack.
+	//
 	var edges []assembler.GuacEdge
 	visited := make(map[string]bool)
 	addEdges(packageA, &edges, visited)
@@ -134,12 +136,12 @@ func Test_addEdgesRecursive(t *testing.T) {
 	packageE := component{curPackage: assembler.PackageNode{Name: "E"}}
 	packageF := component{curPackage: assembler.PackageNode{Name: "F"}}
 	packageG := component{curPackage: assembler.PackageNode{Name: "G"}}
-	/*
-		This test case creates seven packages: A, B, C, D, E, F, and G.
-		It sets up a cycle in the dependencies such that D, E, F, and G depend on A, B and C depend on D, E, F, and G.
-		Calling addEdges(packageA, &edges) should not cause the function to recursively call itself indefinitely,
-		leading to a stack overflow.
-	*/
+	//
+	// This test case creates seven packages: A, B, C, D, E, F, and G.
+	// It sets up a cycle in the dependencies such that D, E, F, and G depend on A, B and C depend on D, E, F, and G.
+	// Calling addEdges(packageA, &edges) should not cause the function to recursively call itself indefinitely,
+	// leading to a stack overflow.
+	//
 	packageA.depPackages = []*component{&packageB, &packageC}
 	packageB.depPackages = []*component{&packageD, &packageE}
 	packageC.depPackages = []*component{&packageF, &packageG}
@@ -285,3 +287,4 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 		})
 	}
 }
+*/

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -17,7 +17,6 @@ package dsse
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler"
@@ -30,13 +29,13 @@ import (
 
 type dsseParser struct {
 	doc        *processor.Document
-	identities []assembler.IdentityNode
+	identities []common.TrustInformation
 }
 
 // NewDSSEParser initializes the dsseParser
 func NewDSSEParser() common.DocumentParser {
 	return &dsseParser{
-		identities: []assembler.IdentityNode{},
+		identities: []common.TrustInformation{},
 	}
 }
 
@@ -61,9 +60,11 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("MarshalPublicKeyToPEM returned error: %w", err)
 			}
-			d.identities = append(d.identities, assembler.IdentityNode{
-				ID: i.ID, Digest: i.Key.Hash, Key: base64.StdEncoding.EncodeToString(pemBytes),
-				KeyType: string(i.Key.Type), KeyScheme: string(i.Key.Scheme), NodeData: *assembler.NewObjectMetadata(d.doc.SourceInformation)})
+			// TODO(bulldozer): change this to new TrustInformation struct
+			// d.identities = append(d.identities, common.TrustInformation{
+			// 	ID: i.ID, Digest: i.Key.Hash, Key: base64.StdEncoding.EncodeToString(pemBytes),
+			// 	KeyType: string(i.Key.Type), KeyScheme: string(i.Key.Scheme), NodeData: *assembler.NewObjectMetadata(d.doc.SourceInformation)})
+			_ = pemBytes
 		} else {
 			logger := logging.FromContext(ctx)
 			logger.Errorf("failed to verify DSSE with provided key: %w", i.ID)
@@ -72,25 +73,32 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 	return nil
 }
 
+// TODO(bulldozer): implement GetIdentities
 // GetIdentities gets the identity node from the document if they exist
-func (d *dsseParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
-	return d.identities
+func (d *dsseParser) GetIdentities(ctx context.Context) []common.TrustInformation {
+	return []common.TrustInformation{}
+	//return d.identities
 }
 
-// CreateNodes creates the GuacNode for the graph inputs
-func (d *dsseParser) CreateNodes(_ context.Context) []assembler.GuacNode {
-	nodes := []assembler.GuacNode{}
-	for _, i := range d.identities {
-		nodes = append(nodes, i)
-	}
-	return nodes
-}
-
-// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-func (d *dsseParser) CreateEdges(_ context.Context, _ []assembler.IdentityNode) []assembler.GuacEdge {
-	return []assembler.GuacEdge{}
-}
+// TODO(bulldozer): replace with GetPredicates
+// // CreateNodes creates the GuacNode for the graph inputs
+// func (d *dsseParser) CreateNodes(_ context.Context) []assembler.GuacNode {
+// 	nodes := []assembler.GuacNode{}
+// 	for _, i := range d.identities {
+// 		nodes = append(nodes, i)
+// 	}
+// 	return nodes
+// }
+//
+// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
+// func (d *dsseParser) CreateEdges(_ context.Context, _ []common.TrustInformation) []assembler.GuacEdge {
+// 	return []assembler.GuacEdge{}
+// }
 
 func (d *dsseParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	return nil, fmt.Errorf("not yet implemented")
+}
+
+func (d *dsseParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }

--- a/pkg/ingestor/parser/dsse/parser_dsse_test.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse_test.go
@@ -15,6 +15,8 @@
 
 package dsse
 
+// TODO(bulldozer): freeze tests
+/*
 import (
 	"context"
 	"reflect"
@@ -72,3 +74,4 @@ func Test_DsseParser(t *testing.T) {
 		})
 	}
 }
+*/

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -70,7 +70,7 @@ func RegisterDocumentParser(p func() common.DocumentParser, d processor.Document
 
 // Subscribe is used by NATS JetStream to stream the documents received from the processor
 // and parse them them via ParseDocumentTree
-func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph, []*common.IdentifierStrings) error) error {
+func Subscribe(ctx context.Context, transportFunc func([]assembler.PlaceholderStruct, []*common.IdentifierStrings) error) error {
 	logger := logging.FromContext(ctx)
 
 	id := uuid.NewV4().String()
@@ -113,8 +113,8 @@ func Subscribe(ctx context.Context, transportFunc func([]assembler.Graph, []*com
 }
 
 // ParseDocumentTree takes the DocumentTree and create graph inputs (nodes and edges) per document node.
-func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree) ([]assembler.Graph, []*common.IdentifierStrings, error) {
-	assemblerInputs := []assembler.Graph{}
+func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree) ([]assembler.PlaceholderStruct, []*common.IdentifierStrings, error) {
+	assemblerInputs := []assembler.PlaceholderStruct{}
 	identifierStrings := []*common.IdentifierStrings{}
 	logger := logging.FromContext(ctx)
 	docTreeBuilder := newDocTreeBuilder()

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -48,13 +48,13 @@ var (
 )
 
 type docTreeBuilder struct {
-	identities    []assembler.IdentityNode
+	identities    []common.TrustInformation
 	graphBuilders []*common.GraphBuilder
 }
 
 func newDocTreeBuilder() *docTreeBuilder {
 	return &docTreeBuilder{
-		identities:    []assembler.IdentityNode{},
+		identities:    []common.TrustInformation{},
 		graphBuilders: []*common.GraphBuilder{},
 	}
 }

--- a/pkg/ingestor/parser/parser_test.go
+++ b/pkg/ingestor/parser/parser_test.go
@@ -15,206 +15,209 @@
 
 package parser
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"strings"
-	"testing"
-	"time"
-
-	"github.com/guacsec/guac/internal/testing/mockverifier"
-	nats_test "github.com/guacsec/guac/internal/testing/nats"
-	"github.com/guacsec/guac/internal/testing/testdata"
-	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/emitter"
-	"github.com/guacsec/guac/pkg/handler/processor"
-	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
-	"github.com/guacsec/guac/pkg/ingestor/verifier"
-	"github.com/guacsec/guac/pkg/logging"
-)
-
-var (
-	dsseDocTree = processor.DocumentNode{
-		Document: &testdata.Ite6DSSEDoc,
-		Children: []*processor.DocumentNode{
-			{
-				Document: &testdata.Ite6SLSADoc,
-				Children: []*processor.DocumentNode{},
-			},
-		},
-	}
-
-	spdxDocTree = processor.DocumentNode{
-		Document: &processor.Document{
-			Blob:   testdata.SpdxExampleAlpine,
-			Format: processor.FormatJSON,
-			Type:   processor.DocumentSPDX,
-			SourceInformation: processor.SourceInformation{
-				Collector: "TestCollector",
-				Source:    "TestSource",
-			},
-		},
-		Children: []*processor.DocumentNode{},
-	}
-
-	graphInput = []assembler.AssemblerInput{{
-		Nodes: testdata.DsseNodes,
-		Edges: testdata.DsseEdges,
-	}, {
-		Nodes: testdata.SlsaNodes,
-		Edges: testdata.SlsaEdges,
-	}}
-
-	spdxGraphInput = []assembler.AssemblerInput{{
-		Nodes: testdata.SpdxNodes,
-		Edges: testdata.SpdxEdges,
-	}}
-)
-
-func TestParseDocumentTree(t *testing.T) {
-	ctx := logging.WithLogger(context.Background())
-	err := verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
-	if err != nil {
-		if !strings.Contains(err.Error(), "the verification provider is being overwritten") {
-			t.Errorf("unexpected error: %v", err)
-		}
-	}
-
-	tests := []struct {
-		name    string
-		tree    processor.DocumentTree
-		want    []assembler.AssemblerInput
-		wantErr bool
-	}{{
-		name:    "valid dsse",
-		tree:    processor.DocumentTree(&dsseDocTree),
-		want:    graphInput,
-		wantErr: false,
-	}, {
-		name:    "valid big SPDX document",
-		tree:    processor.DocumentTree(&spdxDocTree),
-		want:    spdxGraphInput,
-		wantErr: false,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// TODO: add tests for checking identifier strings
-			got, _, err := ParseDocumentTree(ctx, tt.tree)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseDocumentTree() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if err != nil {
-				return
-			}
-			if len(got) != len(tt.want) {
-				t.Errorf("ParseDocumentTree() = %v, want %v", got, tt.want)
-				return
-			}
-			for i := range got {
-				compare(t, got[i].Edges, tt.want[i].Edges, got[i].Nodes, tt.want[i].Nodes)
-			}
-		})
-	}
-}
-
-func compare(t *testing.T, gotEdges, wantEdges []assembler.GuacEdge, gotNodes, wantNodes []assembler.GuacNode) {
-	if !testdata.GuacEdgeSliceEqual(gotEdges, wantEdges) {
-		t.Errorf("ParseDocumentTree() = %v, want %v", gotEdges, wantEdges)
-	}
-	if !testdata.GuacNodeSliceEqual(gotNodes, wantNodes) {
-		t.Errorf("ParseDocumentTree() = %v, want %v", gotNodes, wantNodes)
-	}
-}
-
-func Test_ParserSubscribe(t *testing.T) {
-	ctx := logging.WithLogger(context.Background())
-	err := verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
-	if err != nil {
-		if !strings.Contains(err.Error(), "the verification provider is being overwritten") {
-			t.Errorf("unexpected error: %v", err)
-		}
-	}
-
-	natsTest := nats_test.NewNatsTestServer()
-	url, err := natsTest.EnableJetStreamForTest()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer natsTest.Shutdown()
-
-	testCases := []struct {
-		name       string
-		tree       processor.DocumentTree
-		want       []assembler.AssemblerInput
-		wantErr    bool
-		errMessage error
-	}{{
-		name:       "valid dsse",
-		tree:       processor.DocumentTree(&dsseDocTree),
-		want:       graphInput,
-		wantErr:    true,
-		errMessage: context.DeadlineExceeded,
-	}, {
-		name:       "valid big SPDX document",
-		tree:       processor.DocumentTree(&spdxDocTree),
-		want:       spdxGraphInput,
-		wantErr:    true,
-		errMessage: context.DeadlineExceeded,
-	}}
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			jetStream := emitter.NewJetStream(url, "", "")
-			ctx, err = jetStream.JetStreamInit(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error initializing jetstream: %v", err)
-			}
-			err = jetStream.RecreateStream(ctx)
-			if err != nil {
-				t.Fatalf("unexpected error recreating jetstream: %v", err)
-			}
-			defer jetStream.Close()
-			err := testPublish(ctx, tt.tree)
-			if err != nil {
-				t.Fatalf("unexpected error on emit: %v", err)
-			}
-			var cancel context.CancelFunc
-
-			ctx, cancel = context.WithTimeout(ctx, time.Second)
-			defer cancel()
-
-			transportFunc := func(d []assembler.Graph, _ []*parser_common.IdentifierStrings) error {
-				if len(d) != len(tt.want) {
-					t.Errorf("ParseDocumentTree() = %v, want %v", d, tt.want)
-				}
-				for i := range d {
-					compare(t, d[i].Edges, tt.want[i].Edges, d[i].Nodes, tt.want[i].Nodes)
-				}
-				return nil
-			}
-
-			err = Subscribe(ctx, transportFunc)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("nats emitter Subscribe test errored = %v, want %v", err, tt.wantErr)
-			}
-			if err != nil {
-				if !errors.Is(err, tt.errMessage) {
-					t.Errorf("nats emitter Subscribe test errored = %v, want %v", err, tt.errMessage)
-				}
-			}
-		})
-	}
-}
-
-func testPublish(ctx context.Context, documentTree processor.DocumentTree) error {
-	docTreeJSON, err := json.Marshal(documentTree)
-	if err != nil {
-		return err
-	}
-	err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeJSON)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// TODO(bulldozer): PAUSE TESTING
+//
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"errors"
+// 	"strings"
+// 	"testing"
+// 	"time"
+//
+// 	"github.com/guacsec/guac/internal/testing/mockverifier"
+// 	nats_test "github.com/guacsec/guac/internal/testing/nats"
+// 	"github.com/guacsec/guac/internal/testing/testdata"
+// 	"github.com/guacsec/guac/pkg/assembler"
+// 	"github.com/guacsec/guac/pkg/emitter"
+// 	"github.com/guacsec/guac/pkg/handler/processor"
+// 	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
+// 	"github.com/guacsec/guac/pkg/ingestor/verifier"
+// 	"github.com/guacsec/guac/pkg/logging"
+// )
+//
+// var (
+// 	dsseDocTree = processor.DocumentNode{
+// 		Document: &testdata.Ite6DSSEDoc,
+// 		Children: []*processor.DocumentNode{
+// 			{
+// 				Document: &testdata.Ite6SLSADoc,
+// 				Children: []*processor.DocumentNode{},
+// 			},
+// 		},
+// 	}
+//
+// 	spdxDocTree = processor.DocumentNode{
+// 		Document: &processor.Document{
+// 			Blob:   testdata.SpdxExampleAlpine,
+// 			Format: processor.FormatJSON,
+// 			Type:   processor.DocumentSPDX,
+// 			SourceInformation: processor.SourceInformation{
+// 				Collector: "TestCollector",
+// 				Source:    "TestSource",
+// 			},
+// 		},
+// 		Children: []*processor.DocumentNode{},
+// 	}
+//
+// 	// TODO(bulldozer): update test graph inputs
+// 	graphInput = []assembler.AssemblerInput{{
+// 		Nodes: testdata.DsseNodes,
+// 		Edges: testdata.DsseEdges,
+// 	}, {
+// 		Nodes: testdata.SlsaNodes,
+// 		Edges: testdata.SlsaEdges,
+// 	}}
+//
+// 	spdxGraphInput = []assembler.AssemblerInput{{
+// 		Nodes: testdata.SpdxNodes,
+// 		Edges: testdata.SpdxEdges,
+// 	}}
+// )
+//
+// func TestParseDocumentTree(t *testing.T) {
+// 	ctx := logging.WithLogger(context.Background())
+// 	err := verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
+// 	if err != nil {
+// 		if !strings.Contains(err.Error(), "the verification provider is being overwritten") {
+// 			t.Errorf("unexpected error: %v", err)
+// 		}
+// 	}
+//
+// 	tests := []struct {
+// 		name    string
+// 		tree    processor.DocumentTree
+// 		want    []assembler.AssemblerInput
+// 		wantErr bool
+// 	}{{
+// 		name:    "valid dsse",
+// 		tree:    processor.DocumentTree(&dsseDocTree),
+// 		want:    graphInput,
+// 		wantErr: false,
+// 	}, {
+// 		name:    "valid big SPDX document",
+// 		tree:    processor.DocumentTree(&spdxDocTree),
+// 		want:    spdxGraphInput,
+// 		wantErr: false,
+// 	}}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			// TODO: add tests for checking identifier strings
+// 			got, _, err := ParseDocumentTree(ctx, tt.tree)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("ParseDocumentTree() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if err != nil {
+// 				return
+// 			}
+// 			if len(got) != len(tt.want) {
+// 				t.Errorf("ParseDocumentTree() = %v, want %v", got, tt.want)
+// 				return
+// 			}
+// 			for i := range got {
+// 				compare(t, got[i].Edges, tt.want[i].Edges, got[i].Nodes, tt.want[i].Nodes)
+// 			}
+// 		})
+// 	}
+// }
+//
+// func compare(t *testing.T, gotEdges, wantEdges []assembler.GuacEdge, gotNodes, wantNodes []assembler.GuacNode) {
+// 	if !testdata.GuacEdgeSliceEqual(gotEdges, wantEdges) {
+// 		t.Errorf("ParseDocumentTree() = %v, want %v", gotEdges, wantEdges)
+// 	}
+// 	if !testdata.GuacNodeSliceEqual(gotNodes, wantNodes) {
+// 		t.Errorf("ParseDocumentTree() = %v, want %v", gotNodes, wantNodes)
+// 	}
+// }
+//
+// func Test_ParserSubscribe(t *testing.T) {
+// 	ctx := logging.WithLogger(context.Background())
+// 	err := verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
+// 	if err != nil {
+// 		if !strings.Contains(err.Error(), "the verification provider is being overwritten") {
+// 			t.Errorf("unexpected error: %v", err)
+// 		}
+// 	}
+//
+// 	natsTest := nats_test.NewNatsTestServer()
+// 	url, err := natsTest.EnableJetStreamForTest()
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	defer natsTest.Shutdown()
+//
+// 	testCases := []struct {
+// 		name       string
+// 		tree       processor.DocumentTree
+// 		want       []assembler.AssemblerInput
+// 		wantErr    bool
+// 		errMessage error
+// 	}{{
+// 		name:       "valid dsse",
+// 		tree:       processor.DocumentTree(&dsseDocTree),
+// 		want:       graphInput,
+// 		wantErr:    true,
+// 		errMessage: context.DeadlineExceeded,
+// 	}, {
+// 		name:       "valid big SPDX document",
+// 		tree:       processor.DocumentTree(&spdxDocTree),
+// 		want:       spdxGraphInput,
+// 		wantErr:    true,
+// 		errMessage: context.DeadlineExceeded,
+// 	}}
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			jetStream := emitter.NewJetStream(url, "", "")
+// 			ctx, err = jetStream.JetStreamInit(ctx)
+// 			if err != nil {
+// 				t.Fatalf("unexpected error initializing jetstream: %v", err)
+// 			}
+// 			err = jetStream.RecreateStream(ctx)
+// 			if err != nil {
+// 				t.Fatalf("unexpected error recreating jetstream: %v", err)
+// 			}
+// 			defer jetStream.Close()
+// 			err := testPublish(ctx, tt.tree)
+// 			if err != nil {
+// 				t.Fatalf("unexpected error on emit: %v", err)
+// 			}
+// 			var cancel context.CancelFunc
+//
+// 			ctx, cancel = context.WithTimeout(ctx, time.Second)
+// 			defer cancel()
+//
+// 			transportFunc := func(d []assembler.Graph, _ []*parser_common.IdentifierStrings) error {
+// 				if len(d) != len(tt.want) {
+// 					t.Errorf("ParseDocumentTree() = %v, want %v", d, tt.want)
+// 				}
+// 				for i := range d {
+// 					compare(t, d[i].Edges, tt.want[i].Edges, d[i].Nodes, tt.want[i].Nodes)
+// 				}
+// 				return nil
+// 			}
+//
+// 			err = Subscribe(ctx, transportFunc)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("nats emitter Subscribe test errored = %v, want %v", err, tt.wantErr)
+// 			}
+// 			if err != nil {
+// 				if !errors.Is(err, tt.errMessage) {
+// 					t.Errorf("nats emitter Subscribe test errored = %v, want %v", err, tt.errMessage)
+// 				}
+// 			}
+// 		})
+// 	}
+// }
+//
+// func testPublish(ctx context.Context, documentTree processor.DocumentTree) error {
+// 	docTreeJSON, err := json.Marshal(documentTree)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	err = emitter.Publish(ctx, emitter.SubjectNameDocProcessed, docTreeJSON)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -62,34 +62,39 @@ func (p *scorecardParser) Parse(ctx context.Context, doc *processor.Document) er
 	return fmt.Errorf("unable to support parsing of Scorecard document format: %v", doc.Format)
 }
 
-// CreateNodes creates the GuacNode for the graph inputs
-func (p *scorecardParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
-	nodes := []assembler.GuacNode{}
-	for _, n := range p.scorecardNodes {
-		nodes = append(nodes, n)
-	}
-	for _, n := range p.artifactNodes {
-		nodes = append(nodes, n)
-	}
+// TODO(bulldozer): replace with GetPredicates
+// // CreateNodes creates the GuacNode for the graph inputs
+// func (p *scorecardParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
+// 	nodes := []assembler.GuacNode{}
+// 	for _, n := range p.scorecardNodes {
+// 		nodes = append(nodes, n)
+// 	}
+// 	for _, n := range p.artifactNodes {
+// 		nodes = append(nodes, n)
+// 	}
+//
+// 	return nodes
+// }
+//
+// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
+// func (p *scorecardParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
+// 	// TODO: handle identity for edges (https://github.com/guacsec/guac/issues/128)
+// 	edges := []assembler.GuacEdge{}
+// 	for i, s := range p.scorecardNodes {
+// 		edges = append(edges, assembler.MetadataForEdge{
+// 			MetadataNode: s,
+// 			ForArtifact:  p.artifactNodes[i],
+// 		})
+// 	}
+// 	return edges
+// }
 
-	return nodes
-}
-
-// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-func (p *scorecardParser) CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge {
-	// TODO: handle identity for edges (https://github.com/guacsec/guac/issues/128)
-	edges := []assembler.GuacEdge{}
-	for i, s := range p.scorecardNodes {
-		edges = append(edges, assembler.MetadataForEdge{
-			MetadataNode: s,
-			ForArtifact:  p.artifactNodes[i],
-		})
-	}
-	return edges
+func (p *scorecardParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }
 
 // GetIdentities gets the identity node from the document if they exist
-func (p *scorecardParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
+func (p *scorecardParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return nil
 }
 

--- a/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
@@ -15,6 +15,8 @@
 
 package scorecard
 
+// TODO(bulldozer): freeze test
+/*
 import (
 	"context"
 	"reflect"
@@ -113,3 +115,4 @@ func Test_scorecardParser(t *testing.T) {
 		})
 	}
 }
+*/

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -109,48 +109,53 @@ func parseSlsaPredicate(p []byte) (*in_toto.ProvenanceStatement, error) {
 	return &predicate, nil
 }
 
-// CreateNodes creates the GuacNode for the graph inputs
-func (s *slsaParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
-	nodes := []assembler.GuacNode{}
-	for _, sub := range s.subjects {
-		nodes = append(nodes, sub)
-	}
-	for _, a := range s.attestations {
-		nodes = append(nodes, a)
-	}
-	for _, d := range s.dependencies {
-		nodes = append(nodes, d)
-	}
-	for _, b := range s.builders {
-		nodes = append(nodes, b)
-	}
-	return nodes
-}
+// TODO(bulldozer): replace with GetPredicates
+// // CreateNodes creates the GuacNode for the graph inputs
+// func (s *slsaParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
+// 	nodes := []assembler.GuacNode{}
+// 	for _, sub := range s.subjects {
+// 		nodes = append(nodes, sub)
+// 	}
+// 	for _, a := range s.attestations {
+// 		nodes = append(nodes, a)
+// 	}
+// 	for _, d := range s.dependencies {
+// 		nodes = append(nodes, d)
+// 	}
+// 	for _, b := range s.builders {
+// 		nodes = append(nodes, b)
+// 	}
+// 	return nodes
+// }
+//
+// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
+// func (s *slsaParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
+// 	edges := []assembler.GuacEdge{}
+// 	for _, i := range foundIdentities {
+// 		for _, a := range s.attestations {
+// 			edges = append(edges, assembler.IdentityForEdge{IdentityNode: i, AttestationNode: a})
+// 		}
+// 	}
+// 	for _, sub := range s.subjects {
+// 		for _, build := range s.builders {
+// 			edges = append(edges, assembler.BuiltByEdge{ArtifactNode: sub, BuilderNode: build})
+// 		}
+// 		for _, a := range s.attestations {
+// 			edges = append(edges, assembler.AttestationForEdge{AttestationNode: a, ForArtifact: sub})
+// 		}
+// 		for _, d := range s.dependencies {
+// 			edges = append(edges, assembler.DependsOnEdge{ArtifactNode: sub, ArtifactDependency: d})
+// 		}
+// 	}
+// 	return edges
+// }
 
-// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-func (s *slsaParser) CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge {
-	edges := []assembler.GuacEdge{}
-	for _, i := range foundIdentities {
-		for _, a := range s.attestations {
-			edges = append(edges, assembler.IdentityForEdge{IdentityNode: i, AttestationNode: a})
-		}
-	}
-	for _, sub := range s.subjects {
-		for _, build := range s.builders {
-			edges = append(edges, assembler.BuiltByEdge{ArtifactNode: sub, BuilderNode: build})
-		}
-		for _, a := range s.attestations {
-			edges = append(edges, assembler.AttestationForEdge{AttestationNode: a, ForArtifact: sub})
-		}
-		for _, d := range s.dependencies {
-			edges = append(edges, assembler.DependsOnEdge{ArtifactNode: sub, ArtifactDependency: d})
-		}
-	}
-	return edges
+func (s *slsaParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }
 
 // GetIdentities gets the identity node from the document if they exist
-func (s *slsaParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
+func (s *slsaParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return nil
 }
 

--- a/pkg/ingestor/parser/slsa/parser_slsa_test.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa_test.go
@@ -15,6 +15,8 @@
 
 package slsa
 
+// TODO(bulldozer): freeze test
+/*
 import (
 	"context"
 	"reflect"
@@ -61,3 +63,4 @@ func Test_slsaParser(t *testing.T) {
 		})
 	}
 }
+*/

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -25,7 +25,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
-	"github.com/guacsec/guac/pkg/logging"
 	spdx_json "github.com/spdx/tools-golang/json"
 	spdx_common "github.com/spdx/tools-golang/spdx/common"
 	"github.com/spdx/tools-golang/spdx/v2_2"
@@ -133,20 +132,21 @@ func parseSpdxBlob(p []byte) (*v2_2.Document, error) {
 	return spdx, nil
 }
 
-func (s *spdxParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
-	nodes := []assembler.GuacNode{}
-	for _, packNodes := range s.packages {
-		for _, packNode := range packNodes {
-			nodes = append(nodes, packNode)
-		}
-	}
-	for _, fileNodes := range s.files {
-		for _, fileNode := range fileNodes {
-			nodes = append(nodes, fileNode)
-		}
-	}
-	return nodes
-}
+// TODO(bulldozer): replace with GetPredicates
+// func (s *spdxParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
+// 	nodes := []assembler.GuacNode{}
+// 	for _, packNodes := range s.packages {
+// 		for _, packNode := range packNodes {
+// 			nodes = append(nodes, packNode)
+// 		}
+// 	}
+// 	for _, fileNodes := range s.files {
+// 		for _, fileNode := range fileNodes {
+// 			nodes = append(nodes, fileNode)
+// 		}
+// 	}
+// 	return nodes
+// }
 
 func (s *spdxParser) getPackageElement(elementID string) []assembler.PackageNode {
 	if packNode, ok := s.packages[string(elementID)]; ok {
@@ -162,42 +162,43 @@ func (s *spdxParser) getFileElement(elementID string) []assembler.ArtifactNode {
 	return nil
 }
 
-func (s *spdxParser) CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge {
-	logger := logging.FromContext(ctx)
-	edges := []assembler.GuacEdge{}
-	toplevel := s.getPackageElement("SPDXRef-DOCUMENT")
-	// adding top level package edge manually for all depends on package
-	if toplevel != nil {
-		edges = append(edges, createTopLevelEdges(toplevel[0], s.packages, s.files)...)
-	}
-	for _, rel := range s.spdxDoc.Relationships {
-		foundPackNodes := s.getPackageElement("SPDXRef-" + string(rel.RefA.ElementRefID))
-		foundFileNodes := s.getFileElement("SPDXRef-" + string(rel.RefA.ElementRefID))
-		relatedPackNodes := s.getPackageElement("SPDXRef-" + string(rel.RefB.ElementRefID))
-		relatedFileNodes := s.getFileElement("SPDXRef-" + string(rel.RefB.ElementRefID))
-		for _, packNode := range foundPackNodes {
-			createdEdge, err := getEdge(packNode, rel.Relationship, relatedPackNodes, relatedFileNodes)
-			if err != nil {
-				logger.Errorf("error generating spdx edge %v", err)
-				continue
-			}
-			if createdEdge != nil {
-				edges = append(edges, createdEdge)
-			}
-		}
-		for _, fileNode := range foundFileNodes {
-			createdEdge, err := getEdge(fileNode, rel.Relationship, relatedPackNodes, relatedFileNodes)
-			if err != nil {
-				logger.Errorf("error generating spdx edge %v", err)
-				continue
-			}
-			if createdEdge != nil {
-				edges = append(edges, createdEdge)
-			}
-		}
-	}
-	return edges
-}
+// TODO(bulldozer): replace with GetPredicates
+// func (s *spdxParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
+// 	logger := logging.FromContext(ctx)
+// 	edges := []assembler.GuacEdge{}
+// 	toplevel := s.getPackageElement("SPDXRef-DOCUMENT")
+// 	// adding top level package edge manually for all depends on package
+// 	if toplevel != nil {
+// 		edges = append(edges, createTopLevelEdges(toplevel[0], s.packages, s.files)...)
+// 	}
+// 	for _, rel := range s.spdxDoc.Relationships {
+// 		foundPackNodes := s.getPackageElement("SPDXRef-" + string(rel.RefA.ElementRefID))
+// 		foundFileNodes := s.getFileElement("SPDXRef-" + string(rel.RefA.ElementRefID))
+// 		relatedPackNodes := s.getPackageElement("SPDXRef-" + string(rel.RefB.ElementRefID))
+// 		relatedFileNodes := s.getFileElement("SPDXRef-" + string(rel.RefB.ElementRefID))
+// 		for _, packNode := range foundPackNodes {
+// 			createdEdge, err := getEdge(packNode, rel.Relationship, relatedPackNodes, relatedFileNodes)
+// 			if err != nil {
+// 				logger.Errorf("error generating spdx edge %v", err)
+// 				continue
+// 			}
+// 			if createdEdge != nil {
+// 				edges = append(edges, createdEdge)
+// 			}
+// 		}
+// 		for _, fileNode := range foundFileNodes {
+// 			createdEdge, err := getEdge(fileNode, rel.Relationship, relatedPackNodes, relatedFileNodes)
+// 			if err != nil {
+// 				logger.Errorf("error generating spdx edge %v", err)
+// 				continue
+// 			}
+// 			if createdEdge != nil {
+// 				edges = append(edges, createdEdge)
+// 			}
+// 		}
+// 	}
+// 	return edges
+// }
 
 func createTopLevelEdges(toplevel assembler.PackageNode, packages map[string][]assembler.PackageNode, files map[string][]assembler.ArtifactNode) []assembler.GuacEdge {
 	edges := []assembler.GuacEdge{}
@@ -280,10 +281,14 @@ func getDependsOnEdge(foundNode assembler.GuacNode, relatedNode assembler.GuacNo
 	return e
 }
 
-func (s *spdxParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
+func (s *spdxParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return nil
 }
 
 func (s *spdxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	return nil, fmt.Errorf("not yet implemented")
+}
+
+func (s *spdxParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -15,6 +15,8 @@
 
 package spdx
 
+// TODO(bulldozer): freeze test until next implementation
+/*
 import (
 	"context"
 	"testing"
@@ -68,3 +70,4 @@ func Test_spdxParser(t *testing.T) {
 		})
 	}
 }
+*/

--- a/pkg/ingestor/parser/vuln/cerify_vuln.go
+++ b/pkg/ingestor/parser/vuln/cerify_vuln.go
@@ -142,23 +142,29 @@ func (c *vulnCertificationParser) CreateNodes(ctx context.Context) []assembler.G
 	return nodes
 }
 
-// CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-func (c *vulnCertificationParser) CreateEdges(ctx context.Context, foundIdentities []assembler.IdentityNode) []assembler.GuacEdge {
-	edges := []assembler.GuacEdge{}
-	for _, i := range foundIdentities {
-		edges = append(edges, assembler.IdentityForEdge{IdentityNode: i, AttestationNode: c.attestation})
-	}
-	for _, pack := range c.packageNode {
-		edges = append(edges, assembler.AttestationForEdge{AttestationNode: c.attestation, ForPackage: pack})
-	}
-	for _, vuln := range c.vulns {
-		edges = append(edges, assembler.VulnerableEdge{VulnerabilityNode: vuln, AttestationNode: c.attestation})
-	}
-	return edges
+// TODO(bulldozer): replace with GetPredicate
+// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
+// func (c *vulnCertificationParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
+// 	edges := []assembler.GuacEdge{}
+// 	for _, i := range foundIdentities {
+// 		edges = append(edges, assembler.IdentityForEdge{IdentityNode: i, AttestationNode: c.attestation})
+// 	}
+// 	for _, pack := range c.packageNode {
+// 		edges = append(edges, assembler.AttestationForEdge{AttestationNode: c.attestation, ForPackage: pack})
+// 	}
+// 	for _, vuln := range c.vulns {
+// 		edges = append(edges, assembler.VulnerableEdge{VulnerabilityNode: vuln, AttestationNode: c.attestation})
+// 	}
+// 	return edges
+// }
+
+// TODO(bulldozer)
+func (c *vulnCertificationParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+	return nil
 }
 
 // GetIdentities gets the identity node from the document if they exist
-func (c *vulnCertificationParser) GetIdentities(ctx context.Context) []assembler.IdentityNode {
+func (c *vulnCertificationParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return nil
 }
 

--- a/pkg/ingestor/parser/vuln/certify_vuln_test.go
+++ b/pkg/ingestor/parser/vuln/certify_vuln_test.go
@@ -15,6 +15,8 @@
 
 package certify_vuln
 
+// TODO(bulldozer): freeze tests
+/*
 import (
 	"context"
 	"testing"
@@ -206,3 +208,4 @@ func Test_vulnCertificationParser(t *testing.T) {
 		})
 	}
 }
+*/


### PR DESCRIPTION
### Bulldoze existing integration from ingestor to assembler to make way for graphQL. 

All changes needed to do are marked with comment TODO(bulldozer). 

**THIS IS A BREAKING CHANGE, GUAC will no longer be able to assemble the graph since the integration between ingestor and assembler is torn down**

> “Isn’t it nice to think that tomorrow is a new day with no mistakes in it yet?”
― L.M. Montgomery

And why not a cheesy inspirational quote :)


### This change includes
- changing the `assembler.AssemblerInput` to `assembler.PlaceholderStruct`, removing all uses of `assembler.Graph` in the ingestor.
- change interfaces of `DocumentParser` to not use `CreateEdges` and `CreateNodes` and create placeholders for the replacing `GetPredicates`
- change Identity/Trust structs from `assembler.IdentityNode` to `TrustInformation`
- interface changes imply moving adding of trust information from `DocumentParser` to `GraphBuilder`
- commented out old code (not removed due to routines still being useful in future implementation)