### PR TITLE
Fix package filtering in testing server

### DIFF
--- a/pkg/assembler/backends/testing/certifyVuln.go
+++ b/pkg/assembler/backends/testing/certifyVuln.go
@@ -174,6 +174,8 @@ func (c *demoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.Cer
 				if newPkg == nil {
 					matchOrSkip = false
 				}
+			} else {
+				matchOrSkip = false
 			}
 		}
 


### PR DESCRIPTION
Small fix in inMemory server regarding filtering package names