### PR TITLE
Add scorecard parser integration

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -15,6 +15,8 @@
 
 package assembler
 
+import "github.com/guacsec/guac/pkg/assembler/graphql/model"
+
 type assembler struct{} //nolint: unused
 
 // NOTE: `GuacNode` and `GuacEdge` interfaces are very experimental and might
@@ -138,8 +140,17 @@ func (g *Graph) AppendGraph(gs ...Graph) {
 
 // TODO(mihaimaruseac): Write queries to write/read subgraphs from DB?
 
+// PlaceholderStruct contains the set of predicates that want to be
+// ingested based on the GUAC ontology. It only has evidence trees as
+// ingestion of the software trees are implicit and handled by the
+// client library.
 type PlaceholderStruct struct {
-	Tmp any
+	CertifyScorecard []CertifyScorecardIngest
+}
+
+type CertifyScorecardIngest struct {
+	Source    *model.SourceInputSpec
+	Scorecard *model.ScorecardInputSpec
 }
 
 // AssemblerInput represents the inputs to add to the graph

--- a/pkg/ingestor/parser/common/types.go
+++ b/pkg/ingestor/parser/common/types.go
@@ -30,7 +30,7 @@ type DocumentParser interface {
 	GetIdentities(ctx context.Context) []TrustInformation
 
 	// CreatePredicates returns the predicates of the GUAC ontology to be created
-	GetPredicates(ctx context.Context) []assembler.PlaceholderStruct
+	GetPredicates(ctx context.Context) *assembler.PlaceholderStruct
 
 	// GetIdentifiers returns a set of identifiers that the parser has found to help provide context
 	// for collectors to gather more information around found software identifiers.

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -220,6 +220,6 @@ func (c *cyclonedxParser) GetIdentifiers(ctx context.Context) (*common.Identifie
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func (c *cyclonedxParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	return nil
 }

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -99,6 +99,6 @@ func (d *dsseParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStri
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func (d *dsseParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (d *dsseParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	return nil
 }

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -80,52 +80,6 @@ func (p *scorecardParser) GetIdentities(ctx context.Context) []common.TrustInfor
 	return nil
 }
 
-func metadataId(s *sc.JSONScorecardResultV2) string {
-	return fmt.Sprintf("%v:%v", s.Repo.Name, s.Repo.Commit)
-}
-
-func getMetadataNode(s *sc.JSONScorecardResultV2) assembler.MetadataNode {
-	mnNode := assembler.MetadataNode{
-		MetadataType: "scorecard",
-		ID:           metadataId(s),
-		Details:      map[string]interface{}{},
-	}
-
-	for _, c := range s.Checks {
-		mnNode.Details[strings.ReplaceAll(c.Name, "-", "_")] = c.Score
-	}
-	mnNode.Details["repo"] = sourceUri(s.Repo.Name)
-	mnNode.Details["commit"] = hashToDigest(s.Repo.Commit)
-	mnNode.Details["scorecard_version"] = s.Scorecard.Version
-	mnNode.Details["scorecard_commit"] = hashToDigest(s.Scorecard.Commit)
-	mnNode.Details["score"] = float64(s.AggregateScore)
-
-	return mnNode
-}
-
-func getArtifactNode(s *sc.JSONScorecardResultV2) assembler.ArtifactNode {
-	return assembler.ArtifactNode{
-		Name:   sourceUri(s.Repo.Name),
-		Digest: hashToDigest(s.Repo.Commit),
-	}
-}
-
-func sourceUri(s string) string {
-	return "git+https://" + s
-}
-
-func hashToDigest(h string) string {
-	switch len(h) {
-	case 40:
-		return "sha1:" + h
-	case 64:
-		return "sha256:" + h
-	case 128:
-		return "sha512:" + h
-	}
-	return h
-}
-
 func (p *scorecardParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	return nil, fmt.Errorf("not yet implemented")
 }

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -89,7 +89,7 @@ func (p *scorecardParser) Parse(ctx context.Context, doc *processor.Document) er
 // 	return edges
 // }
 
-func (p *scorecardParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (p *scorecardParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	var preds []assembler.CertifyScorecardIngest
 	for i, scPred := range p.scorecardPredicates {
 		preds = append(preds, assembler.CertifyScorecardIngest{
@@ -97,8 +97,8 @@ func (p *scorecardParser) GetPredicates(ctx context.Context) []assembler.Placeho
 			Source:    p.srcPredicates[i],
 		})
 	}
-	return []assembler.PlaceholderStruct{
-		{CertifyScorecard: preds},
+	return &assembler.PlaceholderStruct{
+		CertifyScorecard: preds,
 	}
 }
 
@@ -183,9 +183,7 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *mod
 		})
 	}
 
-	// TODO: will become CertifyScorecardInputSpec
 	scInput := model.ScorecardInputSpec{
-		// TODO: Put the above source input here
 		TimeScanned:      s.Date,
 		AggregateScore:   (float64)(s.AggregateScore),
 		Checks:           checks,

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -62,33 +62,6 @@ func (p *scorecardParser) Parse(ctx context.Context, doc *processor.Document) er
 	return fmt.Errorf("unable to support parsing of Scorecard document format: %v", doc.Format)
 }
 
-// TODO(bulldozer): replace with GetPredicates
-// // CreateNodes creates the GuacNode for the graph inputs
-// func (p *scorecardParser) CreateNodes(ctx context.Context) []assembler.GuacNode {
-// 	nodes := []assembler.GuacNode{}
-// 	for _, n := range p.scorecardNodes {
-// 		nodes = append(nodes, n)
-// 	}
-// 	for _, n := range p.artifactNodes {
-// 		nodes = append(nodes, n)
-// 	}
-//
-// 	return nodes
-// }
-//
-// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-// func (p *scorecardParser) CreateEdges(ctx context.Context, foundIdentities []common.TrustInformation) []assembler.GuacEdge {
-// 	// TODO: handle identity for edges (https://github.com/guacsec/guac/issues/128)
-// 	edges := []assembler.GuacEdge{}
-// 	for i, s := range p.scorecardNodes {
-// 		edges = append(edges, assembler.MetadataForEdge{
-// 			MetadataNode: s,
-// 			ForArtifact:  p.artifactNodes[i],
-// 		})
-// 	}
-// 	return edges
-// }
-
 func (p *scorecardParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	var preds []assembler.CertifyScorecardIngest
 	for i, scPred := range p.scorecardPredicates {

--- a/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
@@ -63,8 +63,7 @@ func Test_scorecardParser(t *testing.T) {
 							{Check: "Token-Permissions", Score: 10},
 							{Check: "Vulnerabilities", Score: 10},
 						},
-						AggregateScore: 8.9,
-						// TODO
+						AggregateScore:   8.9,
 						TimeScanned:      "2022-10-06",
 						ScorecardVersion: "v4.7.0",
 						ScorecardCommit:  "7cd6406aef0b80a819402e631919293d5eb6adcf",
@@ -72,62 +71,6 @@ func Test_scorecardParser(t *testing.T) {
 				},
 			},
 		},
-		/*
-			wantNodes: []assembler.GuacNode{
-				assembler.MetadataNode{
-					MetadataType: "scorecard",
-					ID:           "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
-					Details: map[string]interface{}{
-						"repo":                "git+https://github.com/kubernetes/kubernetes",
-						"commit":              "sha1:5835544ca568b757a8ecae5c153f317e5736700e",
-						"scorecard_version":   "v4.7.0",
-						"scorecard_commit":    "sha1:7cd6406aef0b80a819402e631919293d5eb6adcf",
-						"score":               8.9,
-						"Binary_Artifacts":    10,
-						"CI_Tests":            10,
-						"Code_Review":         7,
-						"Dangerous_Workflow":  10,
-						"License":             10,
-						"Pinned_Dependencies": 2,
-						"Security_Policy":     10,
-						"Token_Permissions":   10,
-						"Vulnerabilities":     10,
-					},
-				},
-				assembler.ArtifactNode{
-					Name:   "git+https://github.com/kubernetes/kubernetes",
-					Digest: "sha1:5835544ca568b757a8ecae5c153f317e5736700e",
-				},
-			},
-			wantEdges: []assembler.GuacEdge{
-				assembler.MetadataForEdge{
-					MetadataNode: assembler.MetadataNode{
-						MetadataType: "scorecard",
-						ID:           "github.com/kubernetes/kubernetes:5835544ca568b757a8ecae5c153f317e5736700e",
-						Details: map[string]interface{}{
-							"repo":                "git+https://github.com/kubernetes/kubernetes",
-							"commit":              "sha1:5835544ca568b757a8ecae5c153f317e5736700e",
-							"scorecard_version":   "v4.7.0",
-							"scorecard_commit":    "sha1:7cd6406aef0b80a819402e631919293d5eb6adcf",
-							"score":               8.9,
-							"Binary_Artifacts":    10,
-							"CI_Tests":            10,
-							"Code_Review":         7,
-							"Dangerous_Workflow":  10,
-							"License":             10,
-							"Pinned_Dependencies": 2,
-							"Security_Policy":     10,
-							"Token_Permissions":   10,
-							"Vulnerabilities":     10,
-						},
-					},
-					ForArtifact: assembler.ArtifactNode{
-						Name:   "git+https://github.com/kubernetes/kubernetes",
-						Digest: "sha1:5835544ca568b757a8ecae5c153f317e5736700e",
-					},
-				},
-			},
-		*/
 		wantErr: false,
 	}}
 	for _, tt := range tests {

--- a/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
@@ -18,6 +18,7 @@ package scorecard
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/testdata"
@@ -64,7 +65,7 @@ func Test_scorecardParser(t *testing.T) {
 							{Check: "Vulnerabilities", Score: 10},
 						},
 						AggregateScore:   8.9,
-						TimeScanned:      "2022-10-06",
+						TimeScanned:      toTime("2022-10-06"),
 						ScorecardVersion: "v4.7.0",
 						ScorecardCommit:  "7cd6406aef0b80a819402e631919293d5eb6adcf",
 					},
@@ -89,4 +90,12 @@ func Test_scorecardParser(t *testing.T) {
 
 func strP(s string) *string {
 	return &s
+}
+
+func toTime(s string) time.Time {
+	timeScanned, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return timeScanned
 }

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -150,7 +150,7 @@ func parseSlsaPredicate(p []byte) (*in_toto.ProvenanceStatement, error) {
 // 	return edges
 // }
 
-func (s *slsaParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (s *slsaParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	return nil
 }
 

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -289,6 +289,6 @@ func (s *spdxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStri
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func (s *spdxParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	return nil
 }

--- a/pkg/ingestor/parser/vuln/cerify_vuln.go
+++ b/pkg/ingestor/parser/vuln/cerify_vuln.go
@@ -159,7 +159,7 @@ func (c *vulnCertificationParser) CreateNodes(ctx context.Context) []assembler.G
 // }
 
 // TODO(bulldozer)
-func (c *vulnCertificationParser) GetPredicates(ctx context.Context) []assembler.PlaceholderStruct {
+func (c *vulnCertificationParser) GetPredicates(ctx context.Context) *assembler.PlaceholderStruct {
 	return nil
 }
 


### PR DESCRIPTION
This PR implements scorecard with the new interface:
- Define fields of placeholder (another PR to rename Placeholder to another name right after for ease of review)
- Add parsing to predicates for scorecards
- Changing of DocumentParser interface to take `*Placeholder` instead of `[]assembler.Placeholder`
- Unfreeze test for scorecards parser