### PR TITLE
add gql-server cmd to guacone

### DIFF
--- a/cmd/guacone/cmd/graphql_server.go
+++ b/cmd/guacone/cmd/graphql_server.go
@@ -1,0 +1,169 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/playground"
+	neo4j "github.com/guacsec/guac/pkg/assembler/backends/neo4j"
+	"github.com/guacsec/guac/pkg/assembler/backends/testing"
+	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	gqlBackendNeo4j   = "neo4j"
+	gqlBackendInmem   = "inmem"
+	gqlBackendTesting = "testing"
+)
+
+type graphqlServerOptions struct {
+	// generic options
+	graphqlBackend string
+	graphqlPort    int
+	graphqlDebug   bool
+
+	// neo4j specific
+	dbAddr string
+	user   string
+	pass   string
+	realm  string
+}
+
+var graphqlServerCmd = &cobra.Command{
+	Use:   "gql-server [flags]",
+	Short: "runs the graphql server for GUAC",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateGraphqlServerFlags(
+			viper.GetString("gdbuser"),
+			viper.GetString("gdbpass"),
+			viper.GetString("gdbaddr"),
+			viper.GetString("realm"),
+			viper.GetString("gql-backend"),
+			viper.GetInt("gql-port"),
+			viper.GetBool("gql-debug"),
+			args)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		srv, err := getGraphqlServer(opts)
+		if err != nil {
+			logger.Errorf("unable to initialize graphql server: %v", err)
+			os.Exit(1)
+		}
+		http.Handle("/query", srv)
+
+		logger.Infof("graphql server running with %v backend at http://localhost:%d/query", opts.graphqlBackend, opts.graphqlPort)
+		if opts.graphqlDebug {
+			http.Handle("/", playground.Handler("GraphQL playground", "/query"))
+			logger.Infof("connect to http://localhost:%d/ for GraphQL playground", opts.graphqlPort)
+		}
+		if opts.graphqlBackend == gqlBackendTesting {
+			logger.Infof("using testing backend, test data will be bootstrapped in the API")
+		}
+
+		logger.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", opts.graphqlPort), nil))
+
+	},
+}
+
+func validateGraphqlServerFlags(user string, pass string, dbAddr string, realm string,
+	graphqlBackend string, graphqlPort int, graphqlDebug bool, args []string) (graphqlServerOptions, error) {
+
+	var opts graphqlServerOptions
+	opts.user = user
+	opts.pass = pass
+	opts.dbAddr = dbAddr
+	opts.realm = realm
+
+	if graphqlBackend != gqlBackendNeo4j &&
+		graphqlBackend != gqlBackendInmem &&
+		graphqlBackend != gqlBackendTesting {
+		return opts, fmt.Errorf("invalid graphql backend specified: %v", graphqlBackend)
+	}
+
+	opts.graphqlBackend = graphqlBackend
+	opts.graphqlPort = graphqlPort
+	opts.graphqlDebug = graphqlDebug
+
+	return opts, nil
+}
+
+func getGraphqlServer(opts graphqlServerOptions) (*handler.Server, error) {
+	var topResolver resolvers.Resolver
+
+	switch opts.graphqlBackend {
+
+	case gqlBackendNeo4j:
+		args := neo4j.Neo4jConfig{
+			User:   opts.user,
+			Pass:   opts.pass,
+			Realm:  opts.realm,
+			DBAddr: opts.dbAddr,
+		}
+
+		backend, err := neo4j.GetBackend(&args)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating neo4j backend: %w", err)
+		}
+
+		topResolver = resolvers.Resolver{Backend: backend}
+
+	case gqlBackendTesting:
+		args := testing.DemoCredentials{}
+		backend, err := testing.GetBackend(&args)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating testing backend: %w", err)
+		}
+
+		topResolver = resolvers.Resolver{Backend: backend}
+
+	case gqlBackendInmem:
+		args := testing.DemoCredentials{}
+		backend, err := testing.GetEmptyBackend(&args)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating inmem backend: %w", err)
+		}
+
+		topResolver = resolvers.Resolver{Backend: backend}
+	default:
+		return nil, fmt.Errorf("invalid backend specified: %v", opts.graphqlBackend)
+	}
+
+	config := generated.Config{Resolvers: &topResolver}
+	srv := handler.NewDefaultServer(generated.NewExecutableSchema(config))
+
+	return srv, nil
+}
+
+func init() {
+	rootCmd.AddCommand(graphqlServerCmd)
+}

--- a/cmd/guacone/cmd/graphql_server.go
+++ b/cmd/guacone/cmd/graphql_server.go
@@ -33,9 +33,8 @@ import (
 )
 
 const (
-	gqlBackendNeo4j   = "neo4j"
-	gqlBackendInmem   = "inmem"
-	gqlBackendTesting = "testing"
+	gqlBackendNeo4j = "neo4j"
+	gqlBackendInmem = "inmem"
 )
 
 type graphqlServerOptions struct {
@@ -86,10 +85,6 @@ var graphqlServerCmd = &cobra.Command{
 			http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 			logger.Infof("connect to http://localhost:%d/ for GraphQL playground", opts.graphqlPort)
 		}
-		if opts.graphqlBackend == gqlBackendTesting {
-			logger.Infof("using testing backend, test data will be bootstrapped in the API")
-		}
-
 		logger.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", opts.graphqlPort), nil))
 
 	},
@@ -105,8 +100,7 @@ func validateGraphqlServerFlags(user string, pass string, dbAddr string, realm s
 	opts.realm = realm
 
 	if graphqlBackend != gqlBackendNeo4j &&
-		graphqlBackend != gqlBackendInmem &&
-		graphqlBackend != gqlBackendTesting {
+		graphqlBackend != gqlBackendInmem {
 		return opts, fmt.Errorf("invalid graphql backend specified: %v", graphqlBackend)
 	}
 
@@ -136,16 +130,6 @@ func getGraphqlServer(opts graphqlServerOptions) (*handler.Server, error) {
 		}
 
 		topResolver = resolvers.Resolver{Backend: backend}
-
-	case gqlBackendTesting:
-		args := testing.DemoCredentials{}
-		backend, err := testing.GetBackend(&args)
-		if err != nil {
-			return nil, fmt.Errorf("Error creating testing backend: %w", err)
-		}
-
-		topResolver = resolvers.Resolver{Backend: backend}
-
 	case gqlBackendInmem:
 		args := testing.DemoCredentials{}
 		backend, err := testing.GetEmptyBackend(&args)

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -39,6 +39,11 @@ var flags = struct {
 	// collect-sub flags
 	collectSubAddr       string
 	collectSubListenPort int
+
+	// graphQL server flags
+	graphqlBackend string
+	graphqlPort    int
+	graphqlDebug   bool
 }{}
 
 var cfgFile string
@@ -52,12 +57,19 @@ func init() {
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
 	persistentFlags.StringVar(&flags.keyPath, "verifier-keyPath", "", "path to pem file to verify dsse")
 	persistentFlags.StringVar(&flags.keyID, "verifier-keyID", "", "ID of the key to be stored")
+	// collectsub flags
 	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
 	persistentFlags.IntVar(&flags.collectSubListenPort, "csub-listen-port", 2782, "port to listen to on collect-sub service")
+	// graphql flags
+	persistentFlags.StringVar(&flags.graphqlBackend, "gql-backend", "neo4j", "backend used for graphql api server: [neo4j | inmem | testing]")
+	persistentFlags.IntVar(&flags.graphqlPort, "gql-port", 8080, "port used for graphql api server")
+	persistentFlags.BoolVar(&flags.graphqlDebug, "gql-debug", false, "debug flag which enables the graphQL playground")
 
 	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm",
 		"verifier-keyPath", "verifier-keyID",
-		"csub-addr", "csub-listen-port"}
+		"csub-addr", "csub-listen-port",
+		"gql-backend", "gql-port", "gql-debug",
+	}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -61,7 +61,7 @@ func init() {
 	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
 	persistentFlags.IntVar(&flags.collectSubListenPort, "csub-listen-port", 2782, "port to listen to on collect-sub service")
 	// graphql flags
-	persistentFlags.StringVar(&flags.graphqlBackend, "gql-backend", "neo4j", "backend used for graphql api server: [neo4j | inmem | testing]")
+	persistentFlags.StringVar(&flags.graphqlBackend, "gql-backend", "neo4j", "backend used for graphql api server: [neo4j | inmem]")
 	persistentFlags.IntVar(&flags.graphqlPort, "gql-port", 8080, "port used for graphql api server")
 	persistentFlags.BoolVar(&flags.graphqlDebug, "gql-debug", false, "debug flag which enables the graphQL playground")
 

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -120,3 +120,28 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 	}
 	return client, nil
 }
+
+func GetEmptyBackend(args backends.BackendArgs) (backends.Backend, error) {
+	client := &demoClient{
+		packages:            []*model.Package{},
+		sources:             []*model.Source{},
+		cve:                 []*model.Cve{},
+		ghsa:                []*model.Ghsa{},
+		osv:                 []*model.Osv{},
+		artifacts:           []*model.Artifact{},
+		builders:            []*model.Builder{},
+		hashEquals:          []*model.HashEqual{},
+		isOccurrence:        []*model.IsOccurrence{},
+		hasSBOM:             []*model.HasSbom{},
+		isDependency:        []*model.IsDependency{},
+		certifyPkg:          []*model.CertifyPkg{},
+		certifyVuln:         []*model.CertifyVuln{},
+		hasSourceAt:         []*model.HasSourceAt{},
+		certifyScorecard:    []*model.CertifyScorecard{},
+		certifyBad:          []*model.CertifyBad{},
+		isVulnerability:     []*model.IsVulnerability{},
+		certifyVEXStatement: []*model.CertifyVEXStatement{},
+		hasSLSA:             []*model.HasSlsa{},
+	}
+	return client, nil
+}


### PR DESCRIPTION
Added `guacone gql-server` command with the following flags:
- gql-backend: backend used for graphql api server: [neo4j | inmem | testing]
- gql-port: port used for graphql api server")
- gql-debug: debug flag which enables the graphQL playground

example comand::
```
$ bin/guacone --gql-backend inmem  gql-server --gql-debug
{"level":"info","ts":1677788627.2500522,"caller":"cmd/root.go:106","msg":"Using config file: /Users/lumb/go/src/github.com/guacsec/guac/guac.yaml"}
{"level":"info","ts":1677788627.250664,"caller":"cmd/graphql_server.go:84","msg":"graphql server running with inmem backend at http://localhost:8080/query"}
{"level":"info","ts":1677788627.2508001,"caller":"cmd/graphql_server.go:87","msg":"connect to http://localhost:8080/ for GraphQL playground"}
```

With testing db
```
$ bin/guacone --gql-backend testing  gql-server --gql-debug
{"level":"info","ts":1677788667.970688,"caller":"cmd/root.go:106","msg":"Using config file: /Users/lumb/go/src/github.com/guacsec/guac/guac.yaml"}
{"level":"info","ts":1677788667.9719412,"caller":"cmd/graphql_server.go:84","msg":"graphql server running with testing backend at http://localhost:8080/query"}
{"level":"info","ts":1677788667.972001,"caller":"cmd/graphql_server.go:87","msg":"connect to http://localhost:8080/ for GraphQL playground"}
{"level":"info","ts":1677788667.972009,"caller":"cmd/graphql_server.go:90","msg":"using testing backend, test data will be bootstrapped in the API"}
```