### PR TITLE
Add graphql server server to docker compose

### DIFF
--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -10,3 +10,8 @@ natsaddr: nats://nats:4222
 # collect-sub
 csub-addr: guac-collectsub:2782
 csub-listen-port: 2782
+
+# graphql
+gql-backend: neo4j
+gql-port: 8080
+gql-debug: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,19 @@ services:
     volumes:
       - ./container_files/guac:/guac
 
+  guac-graphql:
+    image: "local-organic-guac"
+    command: "/opt/guac/guacone gql-server"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      service-health-1:
+        condition: service_completed_successfully
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./container_files/guac:/guac
+
   # GUAC ingestor and oci collector are dependent on the collectsub service to be up
   service-health-2:
     image: "local-healthcheck"
@@ -72,6 +85,9 @@ services:
         echo "checking-for-services";
         until nc -z guac-collectsub 2782 > /dev/null 2>&1; do sleep 5; done;
         echo "guac collectsub up";
+        until curl -I http://guac-graphql:8080/query > /dev/null 2>&1; do sleep 5; done;
+        echo "graphql up";
+
     depends_on:
       service-health-1:
         condition: service_completed_successfully


### PR DESCRIPTION
Dependent on #523. Runs the graphql server as part of `make start-service`