### PR TITLE
added ingest isDependency for neo4j

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ build: generate
 	go build -ldflags ${LDFLAGS} -o bin/ingest cmd/ingest/main.go
 	go build -ldflags ${LDFLAGS} -o bin/guacone cmd/guacone/main.go
 	go build -ldflags ${LDFLAGS} -o bin/pubsub_test cmd/pubsub_test/main.go
+	go build -ldflags ${LDFLAGS} -o bin/graphql_playground cmd/graphql_playground/main.go
 
 .PHONY: proto
 proto: pkg/collectsub/collectsub/collectsub.proto check-protoc-tool-check

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -59,6 +59,7 @@ type Backend interface {
 
 	// Mutations for evidence trees (read-write queries, assume software trees ingested)
 	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
+	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -59,7 +59,7 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 		return nil, err
 	}
 	client := &neo4jClient{driver}
-	if config.TestData {
+	/* if config.TestData {
 		err = registerAllPackages(client)
 		if err != nil {
 			return nil, err
@@ -88,7 +88,7 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
+	} */
 	return client, nil
 }
 

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -218,7 +218,7 @@ func (c *neo4jClient) IngestDependency(ctx context.Context, pkg model.PkgInputSp
 		sb.WriteString(merge)
 		sb.WriteString(returnValue)
 	} else {
-		query := "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+		query := "MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
 			"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion), (objPkgRoot:Pkg)-[:PkgHasType]->(objPkgType:PkgType)-[:PkgHasNamespace]->(objPkgNamespace:PkgNamespace)" +
 			"-[:PkgHasName]->(objPkgName:PkgName)"
 

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -29,6 +29,8 @@ const (
 	versionRange string = "versionRange"
 )
 
+// Query IsDependency
+
 func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error) {
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
@@ -146,20 +148,138 @@ func (c *neo4jClient) IsDependency(ctx context.Context, isDependencySpec *model.
 func setIsDependencyValues(sb *strings.Builder, isDependencySpec *model.IsDependencySpec, firstMatch *bool, queryValues map[string]any) {
 	if isDependencySpec.VersionRange != nil {
 
-		matchProperties(sb, *firstMatch, "isDependency", "versionRange", "$versionRange")
+		matchProperties(sb, *firstMatch, "isDependency", versionRange, "$"+versionRange)
 		*firstMatch = false
-		queryValues["versionRange"] = isDependencySpec.VersionRange
+		queryValues[versionRange] = isDependencySpec.VersionRange
 	}
 	if isDependencySpec.Origin != nil {
 
-		matchProperties(sb, *firstMatch, "isDependency", "origin", "$origin")
+		matchProperties(sb, *firstMatch, "isDependency", origin, "$"+origin)
 		*firstMatch = false
-		queryValues["origin"] = isDependencySpec.Origin
+		queryValues[origin] = isDependencySpec.Origin
 	}
 	if isDependencySpec.Collector != nil {
 
-		matchProperties(sb, *firstMatch, "isDependency", "collector", "$collector")
+		matchProperties(sb, *firstMatch, "isDependency", collector, "$"+collector)
 		*firstMatch = false
-		queryValues["collector"] = isDependencySpec.Collector
+		queryValues[collector] = isDependencySpec.Collector
 	}
+}
+
+// Ingest IsDependency
+
+func (c *neo4jClient) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
+	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close()
+
+	var sb strings.Builder
+	var firstMatch bool = true
+	queryValues := map[string]any{}
+
+	// TODO: use generics here between PkgInputSpec and PkgSpec?
+	selectedPkgSpec := convertPkgInputSpecToPkgSpec(pkg)
+	// Note: depPkgSpec only takes up to the pkgName as IsDependency does not allow for the attestation
+	// to be made at the pkgVersion level. Version range for the dependent package is defined as a property
+	// on IsDependency.
+	matchEmpty := false
+	depPkgSpec := model.PkgSpec{
+		Type:                     &depPkg.Type,
+		Namespace:                depPkg.Namespace,
+		Name:                     &depPkg.Name,
+		Version:                  nil,
+		Subpath:                  nil,
+		Qualifiers:               nil,
+		MatchOnlyEmptyQualifiers: &matchEmpty,
+	}
+
+	queryValues[versionRange] = dependency.VersionRange
+	queryValues[justification] = dependency.Justification
+	queryValues[origin] = dependency.Origin
+	queryValues[collector] = dependency.Collector
+
+	returnValue := " RETURN type.type, namespace.namespace, name.name, version.version, version.subpath, " +
+		"version.qualifier_list, isDependency, objPkgType.type, objPkgNamespace.namespace, objPkgName.name"
+
+	if selectedPkgSpec.Version == nil && selectedPkgSpec.Subpath == nil &&
+		len(selectedPkgSpec.Qualifiers) == 0 && !*selectedPkgSpec.MatchOnlyEmptyQualifiers {
+
+		query := "MATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+			"-[:PkgHasName]->(name:PkgName), (objPkgRoot:Pkg)-[:PkgHasType]->(objPkgType:PkgType)-[:PkgHasNamespace]->(objPkgNamespace:PkgNamespace)" +
+			"-[:PkgHasName]->(objPkgName:PkgName)" +
+			"\nWITH *, null AS version"
+
+		sb.WriteString(query)
+		setPkgMatchValues(&sb, &selectedPkgSpec, false, &firstMatch, queryValues)
+		setPkgMatchValues(&sb, &depPkgSpec, true, &firstMatch, queryValues)
+
+		merge := "\nMERGE (name)<-[:subject]-(isDependency:IsDependency{versionRange:$versionRange,justification:$justification,origin:$origin,collector:$collector})" +
+			"-[:dependency]->(objPkgName)" +
+			"\nRETURN RETURN type.type, namespace.namespace, name.name, isDependency, objPkgType.type, objPkgNamespace.namespace, objPkgName.name"
+		sb.WriteString(merge)
+		sb.WriteString(returnValue)
+	} else {
+		query := "\nMATCH (root:Pkg)-[:PkgHasType]->(type:PkgType)-[:PkgHasNamespace]->(namespace:PkgNamespace)" +
+			"-[:PkgHasName]->(name:PkgName)-[:PkgHasVersion]->(version:PkgVersion), (objPkgRoot:Pkg)-[:PkgHasType]->(objPkgType:PkgType)-[:PkgHasNamespace]->(objPkgNamespace:PkgNamespace)" +
+			"-[:PkgHasName]->(objPkgName:PkgName)"
+
+		sb.WriteString(query)
+		setPkgMatchValues(&sb, &selectedPkgSpec, false, &firstMatch, queryValues)
+		setPkgMatchValues(&sb, &depPkgSpec, true, &firstMatch, queryValues)
+
+		merge := "\nMERGE (version)<-[:subject]-(isDependency:IsDependency{versionRange:$versionRange,origin:$origin,collector:$collector})" +
+			"-[:dependency]->(objPkgName)"
+		sb.WriteString(merge)
+		sb.WriteString(returnValue)
+	}
+
+	result, err := session.WriteTransaction(
+		func(tx neo4j.Transaction) (interface{}, error) {
+			result, err := tx.Run(sb.String(), queryValues)
+			if err != nil {
+				return nil, err
+			}
+
+			// query returns a single record
+			record, err := result.Single()
+			if err != nil {
+				return nil, err
+			}
+
+			pkgQualifiers := record.Values[5]
+			subPath := record.Values[4]
+			version := record.Values[3]
+			nameString := record.Values[2].(string)
+			namespaceString := record.Values[1].(string)
+			typeString := record.Values[0].(string)
+
+			pkg := generateModelPackage(typeString, namespaceString, nameString, version, subPath, pkgQualifiers)
+
+			nameString = record.Values[9].(string)
+			namespaceString = record.Values[8].(string)
+			typeString = record.Values[7].(string)
+
+			depPkg := generateModelPackage(typeString, namespaceString, nameString, nil, nil, nil)
+
+			isDependencyNode := dbtype.Node{}
+			if record.Values[6] != nil {
+				isDependencyNode = record.Values[6].(dbtype.Node)
+			} else {
+				return nil, gqlerror.Errorf("isDependency Node not found in neo4j")
+			}
+
+			isDependency := &model.IsDependency{
+				Package:          pkg,
+				DependentPackage: depPkg,
+				VersionRange:     isDependencyNode.Props[versionRange].(string),
+				Origin:           isDependencyNode.Props[origin].(string),
+				Collector:        isDependencyNode.Props[collector].(string),
+			}
+
+			return isDependency, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.(*model.IsDependency), nil
 }

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -790,3 +790,30 @@ func generateModelPackage(pkgType, namespaceStr, nameStr string, versionValue, s
 	}
 	return &pkg
 }
+
+// TODO: maybe use generics for PkgInputSpec and PkgSpec?
+func convertPkgInputSpecToPkgSpec(pkgInput model.PkgInputSpec) model.PkgSpec {
+	matchEmpty := false
+	pkgSpec := model.PkgSpec{
+		Type:                     &pkgInput.Type,
+		Namespace:                pkgInput.Namespace,
+		Name:                     &pkgInput.Name,
+		Version:                  pkgInput.Version,
+		Subpath:                  pkgInput.Subpath,
+		Qualifiers:               convertQualifierInputToQualifierSpec(pkgInput.Qualifiers),
+		MatchOnlyEmptyQualifiers: &matchEmpty,
+	}
+	return pkgSpec
+}
+
+func convertQualifierInputToQualifierSpec(qualifiers []*model.PackageQualifierInputSpec) []*model.PackageQualifierSpec {
+	pkgQualifiers := []*model.PackageQualifierSpec{}
+	for _, quali := range qualifiers {
+		pkgQualifier := &model.PackageQualifierSpec{
+			Key:   quali.Key,
+			Value: &quali.Value,
+		}
+		pkgQualifiers = append(pkgQualifiers, pkgQualifier)
+	}
+	return pkgQualifiers
+}

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -10,6 +10,353 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// IsDependencyDependentPkgPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type IsDependencyDependentPkgPackage struct {
+	allPkgTree `json:"-"`
+}
+
+// GetType returns IsDependencyDependentPkgPackage.Type, and is useful for accessing the field via an interface.
+func (v *IsDependencyDependentPkgPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns IsDependencyDependentPkgPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *IsDependencyDependentPkgPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *IsDependencyDependentPkgPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IsDependencyDependentPkgPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IsDependencyDependentPkgPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIsDependencyDependentPkgPackage struct {
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *IsDependencyDependentPkgPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IsDependencyDependentPkgPackage) __premarshalJSON() (*__premarshalIsDependencyDependentPkgPackage, error) {
+	var retval __premarshalIsDependencyDependentPkgPackage
+
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// IsDependencyIngestDependencyIsDependency includes the requested fields of the GraphQL type IsDependency.
+// The GraphQL type's documentation follows.
+//
+// # IsDependency is an attestation that represents when a package is dependent on another package
+//
+// package (subject) - the package object type that represents the package
+// dependentPackage (object) - the package object type that represents the packageName (cannot be to the packageVersion)
+// versionRange (property) - string value for version range that applies to the dependent package
+// justification (property) - string value representing why the artifacts are the equal
+// origin (property) - where this attestation was generated from (based on which document)
+// collector (property) - the GUAC collector that collected the document that generated this attestation
+type IsDependencyIngestDependencyIsDependency struct {
+	allIsDependencyTree `json:"-"`
+}
+
+// GetJustification returns IsDependencyIngestDependencyIsDependency.Justification, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetJustification() string {
+	return v.allIsDependencyTree.Justification
+}
+
+// GetPackage returns IsDependencyIngestDependencyIsDependency.Package, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetPackage() allIsDependencyTreePackage {
+	return v.allIsDependencyTree.Package
+}
+
+// GetDependentPackage returns IsDependencyIngestDependencyIsDependency.DependentPackage, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
+	return v.allIsDependencyTree.DependentPackage
+}
+
+// GetVersionRange returns IsDependencyIngestDependencyIsDependency.VersionRange, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetVersionRange() string {
+	return v.allIsDependencyTree.VersionRange
+}
+
+// GetOrigin returns IsDependencyIngestDependencyIsDependency.Origin, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetOrigin() string {
+	return v.allIsDependencyTree.Origin
+}
+
+// GetCollector returns IsDependencyIngestDependencyIsDependency.Collector, and is useful for accessing the field via an interface.
+func (v *IsDependencyIngestDependencyIsDependency) GetCollector() string {
+	return v.allIsDependencyTree.Collector
+}
+
+func (v *IsDependencyIngestDependencyIsDependency) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IsDependencyIngestDependencyIsDependency
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IsDependencyIngestDependencyIsDependency = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allIsDependencyTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIsDependencyIngestDependencyIsDependency struct {
+	Justification string `json:"justification"`
+
+	Package allIsDependencyTreePackage `json:"package"`
+
+	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+
+	VersionRange string `json:"versionRange"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *IsDependencyIngestDependencyIsDependency) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IsDependencyIngestDependencyIsDependency) __premarshalJSON() (*__premarshalIsDependencyIngestDependencyIsDependency, error) {
+	var retval __premarshalIsDependencyIngestDependencyIsDependency
+
+	retval.Justification = v.allIsDependencyTree.Justification
+	retval.Package = v.allIsDependencyTree.Package
+	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
+	retval.VersionRange = v.allIsDependencyTree.VersionRange
+	retval.Origin = v.allIsDependencyTree.Origin
+	retval.Collector = v.allIsDependencyTree.Collector
+	return &retval, nil
+}
+
+// IsDependencyInputSpec is the same as IsDependency but for mutation input.
+//
+// All fields are required.
+type IsDependencyInputSpec struct {
+	VersionRange  string `json:"versionRange"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+}
+
+// GetVersionRange returns IsDependencyInputSpec.VersionRange, and is useful for accessing the field via an interface.
+func (v *IsDependencyInputSpec) GetVersionRange() string { return v.VersionRange }
+
+// GetJustification returns IsDependencyInputSpec.Justification, and is useful for accessing the field via an interface.
+func (v *IsDependencyInputSpec) GetJustification() string { return v.Justification }
+
+// GetOrigin returns IsDependencyInputSpec.Origin, and is useful for accessing the field via an interface.
+func (v *IsDependencyInputSpec) GetOrigin() string { return v.Origin }
+
+// GetCollector returns IsDependencyInputSpec.Collector, and is useful for accessing the field via an interface.
+func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
+
+// IsDependencyPkgPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type IsDependencyPkgPackage struct {
+	allPkgTree `json:"-"`
+}
+
+// GetType returns IsDependencyPkgPackage.Type, and is useful for accessing the field via an interface.
+func (v *IsDependencyPkgPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns IsDependencyPkgPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *IsDependencyPkgPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *IsDependencyPkgPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IsDependencyPkgPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IsDependencyPkgPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIsDependencyPkgPackage struct {
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *IsDependencyPkgPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IsDependencyPkgPackage) __premarshalJSON() (*__premarshalIsDependencyPkgPackage, error) {
+	var retval __premarshalIsDependencyPkgPackage
+
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// IsDependencyResponse is returned by IsDependency on success.
+type IsDependencyResponse struct {
+	// Ingest a new package. Returns the ingested package trie
+	Pkg IsDependencyPkgPackage `json:"pkg"`
+	// Ingest a new package. Returns the ingested package trie
+	DependentPkg IsDependencyDependentPkgPackage `json:"dependentPkg"`
+	// Adds dependency between two packages
+	IngestDependency IsDependencyIngestDependencyIsDependency `json:"ingestDependency"`
+}
+
+// GetPkg returns IsDependencyResponse.Pkg, and is useful for accessing the field via an interface.
+func (v *IsDependencyResponse) GetPkg() IsDependencyPkgPackage { return v.Pkg }
+
+// GetDependentPkg returns IsDependencyResponse.DependentPkg, and is useful for accessing the field via an interface.
+func (v *IsDependencyResponse) GetDependentPkg() IsDependencyDependentPkgPackage {
+	return v.DependentPkg
+}
+
+// GetIngestDependency returns IsDependencyResponse.IngestDependency, and is useful for accessing the field via an interface.
+func (v *IsDependencyResponse) GetIngestDependency() IsDependencyIngestDependencyIsDependency {
+	return v.IngestDependency
+}
+
+// PackageQualifierInputSpec is the same as PackageQualifier, but usable as
+// mutation input.
+//
+// GraphQL does not allow input types to contain composite types and does not allow
+// composite types to contain input types. So, although in this case these two
+// types are semantically the same, we have to duplicate the definition.
+//
+// Both fields are mandatory.
+type PackageQualifierInputSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns PackageQualifierInputSpec.Key, and is useful for accessing the field via an interface.
+func (v *PackageQualifierInputSpec) GetKey() string { return v.Key }
+
+// GetValue returns PackageQualifierInputSpec.Value, and is useful for accessing the field via an interface.
+func (v *PackageQualifierInputSpec) GetValue() string { return v.Value }
+
+// PkgInputSpec specifies a package for a mutation.
+//
+// This is different than PkgSpec because we want to encode mandatory fields:
+// `type` and `name`. All optional fields are given empty default values.
+type PkgInputSpec struct {
+	Type       string                      `json:"type"`
+	Namespace  string                      `json:"namespace"`
+	Name       string                      `json:"name"`
+	Version    string                      `json:"version"`
+	Qualifiers []PackageQualifierInputSpec `json:"qualifiers"`
+	Subpath    string                      `json:"subpath"`
+}
+
+// GetType returns PkgInputSpec.Type, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetType() string { return v.Type }
+
+// GetNamespace returns PkgInputSpec.Namespace, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetNamespace() string { return v.Namespace }
+
+// GetName returns PkgInputSpec.Name, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetName() string { return v.Name }
+
+// GetVersion returns PkgInputSpec.Version, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetVersion() string { return v.Version }
+
+// GetQualifiers returns PkgInputSpec.Qualifiers, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetQualifiers() []PackageQualifierInputSpec { return v.Qualifiers }
+
+// GetSubpath returns PkgInputSpec.Subpath, and is useful for accessing the field via an interface.
+func (v *PkgInputSpec) GetSubpath() string { return v.Subpath }
+
 // ScorecardCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
 // The GraphQL type's documentation follows.
 //
@@ -240,6 +587,22 @@ func (v *SourceInputSpec) GetTag() string { return v.Tag }
 // GetCommit returns SourceInputSpec.Commit, and is useful for accessing the field via an interface.
 func (v *SourceInputSpec) GetCommit() string { return v.Commit }
 
+// __IsDependencyInput is used internally by genqlient
+type __IsDependencyInput struct {
+	Pkg        PkgInputSpec          `json:"pkg"`
+	DepPkg     PkgInputSpec          `json:"depPkg"`
+	Dependency IsDependencyInputSpec `json:"dependency"`
+}
+
+// GetPkg returns __IsDependencyInput.Pkg, and is useful for accessing the field via an interface.
+func (v *__IsDependencyInput) GetPkg() PkgInputSpec { return v.Pkg }
+
+// GetDepPkg returns __IsDependencyInput.DepPkg, and is useful for accessing the field via an interface.
+func (v *__IsDependencyInput) GetDepPkg() PkgInputSpec { return v.DepPkg }
+
+// GetDependency returns __IsDependencyInput.Dependency, and is useful for accessing the field via an interface.
+func (v *__IsDependencyInput) GetDependency() IsDependencyInputSpec { return v.Dependency }
+
 // __ScorecardInput is used internally by genqlient
 type __ScorecardInput struct {
 	Source    SourceInputSpec    `json:"source"`
@@ -417,6 +780,336 @@ func (v *allCertifyScorecardSource) __premarshalJSON() (*__premarshalallCertifyS
 	return &retval, nil
 }
 
+// allIsDependencyTree includes the GraphQL fields of IsDependency requested by the fragment allIsDependencyTree.
+// The GraphQL type's documentation follows.
+//
+// # IsDependency is an attestation that represents when a package is dependent on another package
+//
+// package (subject) - the package object type that represents the package
+// dependentPackage (object) - the package object type that represents the packageName (cannot be to the packageVersion)
+// versionRange (property) - string value for version range that applies to the dependent package
+// justification (property) - string value representing why the artifacts are the equal
+// origin (property) - where this attestation was generated from (based on which document)
+// collector (property) - the GUAC collector that collected the document that generated this attestation
+type allIsDependencyTree struct {
+	Justification    string                              `json:"justification"`
+	Package          allIsDependencyTreePackage          `json:"package"`
+	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	VersionRange     string                              `json:"versionRange"`
+	Origin           string                              `json:"origin"`
+	Collector        string                              `json:"collector"`
+}
+
+// GetJustification returns allIsDependencyTree.Justification, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetJustification() string { return v.Justification }
+
+// GetPackage returns allIsDependencyTree.Package, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetPackage() allIsDependencyTreePackage { return v.Package }
+
+// GetDependentPackage returns allIsDependencyTree.DependentPackage, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetDependentPackage() allIsDependencyTreeDependentPackage {
+	return v.DependentPackage
+}
+
+// GetVersionRange returns allIsDependencyTree.VersionRange, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetVersionRange() string { return v.VersionRange }
+
+// GetOrigin returns allIsDependencyTree.Origin, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetOrigin() string { return v.Origin }
+
+// GetCollector returns allIsDependencyTree.Collector, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTree) GetCollector() string { return v.Collector }
+
+// allIsDependencyTreeDependentPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type allIsDependencyTreeDependentPackage struct {
+	allPkgTree `json:"-"`
+}
+
+// GetType returns allIsDependencyTreeDependentPackage.Type, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTreeDependentPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns allIsDependencyTreeDependentPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTreeDependentPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *allIsDependencyTreeDependentPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allIsDependencyTreeDependentPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allIsDependencyTreeDependentPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallIsDependencyTreeDependentPackage struct {
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *allIsDependencyTreeDependentPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allIsDependencyTreeDependentPackage) __premarshalJSON() (*__premarshalallIsDependencyTreeDependentPackage, error) {
+	var retval __premarshalallIsDependencyTreeDependentPackage
+
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// allIsDependencyTreePackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type allIsDependencyTreePackage struct {
+	allPkgTree `json:"-"`
+}
+
+// GetType returns allIsDependencyTreePackage.Type, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTreePackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns allIsDependencyTreePackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *allIsDependencyTreePackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *allIsDependencyTreePackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allIsDependencyTreePackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allIsDependencyTreePackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallIsDependencyTreePackage struct {
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *allIsDependencyTreePackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allIsDependencyTreePackage) __premarshalJSON() (*__premarshalallIsDependencyTreePackage, error) {
+	var retval __premarshalallIsDependencyTreePackage
+
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// allPkgTree includes the GraphQL fields of Package requested by the fragment allPkgTree.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type allPkgTree struct {
+	Type       string                                 `json:"type"`
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+// GetType returns allPkgTree.Type, and is useful for accessing the field via an interface.
+func (v *allPkgTree) GetType() string { return v.Type }
+
+// GetNamespaces returns allPkgTree.Namespaces, and is useful for accessing the field via an interface.
+func (v *allPkgTree) GetNamespaces() []allPkgTreeNamespacesPackageNamespace { return v.Namespaces }
+
+// allPkgTreeNamespacesPackageNamespace includes the requested fields of the GraphQL type PackageNamespace.
+// The GraphQL type's documentation follows.
+//
+// PackageNamespace is a namespace for packages.
+//
+// In the pURL representation, each PackageNamespace matches the
+// `pkg:<type>/<namespace>/` partial pURL.
+//
+// Namespaces are optional and type specific. Because they are optional, we use
+// empty string to denote missing namespaces.
+type allPkgTreeNamespacesPackageNamespace struct {
+	Namespace string                                                 `json:"namespace"`
+	Names     []allPkgTreeNamespacesPackageNamespaceNamesPackageName `json:"names"`
+}
+
+// GetNamespace returns allPkgTreeNamespacesPackageNamespace.Namespace, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespace) GetNamespace() string { return v.Namespace }
+
+// GetNames returns allPkgTreeNamespacesPackageNamespace.Names, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespace) GetNames() []allPkgTreeNamespacesPackageNamespaceNamesPackageName {
+	return v.Names
+}
+
+// allPkgTreeNamespacesPackageNamespaceNamesPackageName includes the requested fields of the GraphQL type PackageName.
+// The GraphQL type's documentation follows.
+//
+// PackageName is a name for packages.
+//
+// In the pURL representation, each PackageName matches the
+// `pkg:<type>/<namespace>/<name>` pURL.
+//
+// Names are always mandatory.
+//
+// This is the first node in the trie that can be referred to by other parts of
+// GUAC.
+type allPkgTreeNamespacesPackageNamespaceNamesPackageName struct {
+	Name     string                                                                       `json:"name"`
+	Versions []allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion `json:"versions"`
+}
+
+// GetName returns allPkgTreeNamespacesPackageNamespaceNamesPackageName.Name, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageName) GetName() string { return v.Name }
+
+// GetVersions returns allPkgTreeNamespacesPackageNamespaceNamesPackageName.Versions, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageName) GetVersions() []allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion {
+	return v.Versions
+}
+
+// allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion includes the requested fields of the GraphQL type PackageVersion.
+// The GraphQL type's documentation follows.
+//
+// PackageVersion is a package version.
+//
+// In the pURL representation, each PackageName matches the
+// `pkg:<type>/<namespace>/<name>@<version>` pURL.
+//
+// Versions are optional and each Package type defines own rules for handling them.
+// For this level of GUAC, these are just opaque strings.
+//
+// This node can be referred to by other parts of GUAC.
+//
+// Subpath and qualifiers are optional. Lack of qualifiers is represented by an
+// empty list and lack of subpath by empty string (to be consistent with
+// optionality of namespace and version). Two nodes that have different qualifiers
+// and/or subpath but the same version mean two different packages in the trie
+// (they are different). Two nodes that have same version but qualifiers of one are
+// a subset of the qualifier of the other also mean two different packages in the
+// trie.
+type allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion struct {
+	Version    string                                                                                                 `json:"version"`
+	Qualifiers []allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier `json:"qualifiers"`
+	Subpath    string                                                                                                 `json:"subpath"`
+}
+
+// GetVersion returns allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Version, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion) GetVersion() string {
+	return v.Version
+}
+
+// GetQualifiers returns allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Qualifiers, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion) GetQualifiers() []allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier {
+	return v.Qualifiers
+}
+
+// GetSubpath returns allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Subpath, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion) GetSubpath() string {
+	return v.Subpath
+}
+
+// allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier includes the requested fields of the GraphQL type PackageQualifier.
+// The GraphQL type's documentation follows.
+//
+// PackageQualifier is a qualifier for a package, a key-value pair.
+//
+// In the pURL representation, it is a part of the `<qualifiers>` part of the
+// `pkg:<type>/<namespace>/<name>@<version>?<qualifiers>` pURL.
+//
+// Qualifiers are optional, each Package type defines own rules for handling them,
+// and multiple qualifiers could be attached to the same package.
+//
+// This node cannot be directly referred by other parts of GUAC.
+type allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier.Key, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier) GetKey() string {
+	return v.Key
+}
+
+// GetValue returns allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier.Value, and is useful for accessing the field via an interface.
+func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier) GetValue() string {
+	return v.Value
+}
+
 // allSrcTree includes the GraphQL fields of Source requested by the fragment allSrcTree.
 // The GraphQL type's documentation follows.
 //
@@ -485,6 +1178,77 @@ func (v *allSrcTreeNamespacesSourceNamespaceNamesSourceName) GetTag() string { r
 
 // GetCommit returns allSrcTreeNamespacesSourceNamespaceNamesSourceName.Commit, and is useful for accessing the field via an interface.
 func (v *allSrcTreeNamespacesSourceNamespaceNamesSourceName) GetCommit() string { return v.Commit }
+
+func IsDependency(
+	ctx context.Context,
+	client graphql.Client,
+	pkg PkgInputSpec,
+	depPkg PkgInputSpec,
+	dependency IsDependencyInputSpec,
+) (*IsDependencyResponse, error) {
+	req := &graphql.Request{
+		OpName: "IsDependency",
+		Query: `
+mutation IsDependency ($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: IsDependencyInputSpec!) {
+	pkg: ingestPackage(pkg: $pkg) {
+		... allPkgTree
+	}
+	dependentPkg: ingestPackage(pkg: $depPkg) {
+		... allPkgTree
+	}
+	ingestDependency(pkg: $pkg, depPkg: $depPkg, dependency: $dependency) {
+		... allIsDependencyTree
+	}
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allIsDependencyTree on IsDependency {
+	justification
+	package {
+		... allPkgTree
+	}
+	dependentPackage {
+		... allPkgTree
+	}
+	versionRange
+	origin
+	collector
+}
+`,
+		Variables: &__IsDependencyInput{
+			Pkg:        pkg,
+			DepPkg:     depPkg,
+			Dependency: dependency,
+		},
+	}
+	var err error
+
+	var data IsDependencyResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 func Scorecard(
 	ctx context.Context,

--- a/pkg/assembler/clients/operations/isDependency.graphql
+++ b/pkg/assembler/clients/operations/isDependency.graphql
@@ -1,0 +1,61 @@
+#
+# Copyright 2023 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This is experimental and might change in the future!
+
+# Defines the GraphQL operations to ingest a IsDependency into GUAC
+
+fragment allPkgTree on Package {
+  type
+  namespaces {
+    namespace
+    names {
+      name
+      versions {
+        version
+        qualifiers {
+          key
+          value
+        }
+        subpath
+      }
+    }
+  }
+}
+
+fragment allIsDependencyTree on IsDependency {
+  justification
+  package {
+    ...allPkgTree
+  }
+  dependentPackage {
+    ...allPkgTree
+  }
+  versionRange
+  origin
+  collector
+}
+
+mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: IsDependencyInputSpec!) {
+  pkg: ingestPackage(pkg: $pkg) {
+    ...allPkgTree
+  }
+  dependentPkg: ingestPackage(pkg: $depPkg) {
+    ...allPkgTree
+  }
+  ingestDependency(pkg: $pkg, depPkg: $depPkg, dependency: $dependency) {
+    ...allIsDependencyTree
+  }
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -23,6 +23,7 @@ type MutationResolver interface {
 	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
 	IngestCve(ctx context.Context, cve *model.CVEInputSpec) (*model.Cve, error)
 	IngestGhsa(ctx context.Context, ghsa *model.GHSAInputSpec) (*model.Ghsa, error)
+	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)
 	IngestOsv(ctx context.Context, osv *model.OSVInputSpec) (*model.Osv, error)
 	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
 	IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error)
@@ -119,6 +120,39 @@ func (ec *executionContext) field_Mutation_ingestCVE_args(ctx context.Context, r
 		}
 	}
 	args["cve"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestDependency_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.PkgInputSpec
+	if tmp, ok := rawArgs["pkg"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkg"))
+		arg0, err = ec.unmarshalNPkgInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkg"] = arg0
+	var arg1 model.PkgInputSpec
+	if tmp, ok := rawArgs["depPkg"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("depPkg"))
+		arg1, err = ec.unmarshalNPkgInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["depPkg"] = arg1
+	var arg2 model.IsDependencyInputSpec
+	if tmp, ok := rawArgs["dependency"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dependency"))
+		arg2, err = ec.unmarshalNIsDependencyInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["dependency"] = arg2
 	return args, nil
 }
 
@@ -868,6 +902,74 @@ func (ec *executionContext) fieldContext_Mutation_ingestGHSA(ctx context.Context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestGHSA_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestDependency(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestDependency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestDependency(rctx, fc.Args["pkg"].(model.PkgInputSpec), fc.Args["depPkg"].(model.PkgInputSpec), fc.Args["dependency"].(model.IsDependencyInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.IsDependency)
+	fc.Result = res
+	return ec.marshalNIsDependency2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependency(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "package":
+				return ec.fieldContext_IsDependency_package(ctx, field)
+			case "dependentPackage":
+				return ec.fieldContext_IsDependency_dependentPackage(ctx, field)
+			case "versionRange":
+				return ec.fieldContext_IsDependency_versionRange(ctx, field)
+			case "justification":
+				return ec.fieldContext_IsDependency_justification(ctx, field)
+			case "origin":
+				return ec.fieldContext_IsDependency_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_IsDependency_collector(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestDependency_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -2560,6 +2662,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestGHSA(ctx, field)
+			})
+
+		case "ingestDependency":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestDependency(ctx, field)
 			})
 
 		case "ingestOSV":

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -308,6 +308,58 @@ func (ec *executionContext) fieldContext_IsDependency_collector(ctx context.Cont
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputIsDependencyInputSpec(ctx context.Context, obj interface{}) (model.IsDependencyInputSpec, error) {
+	var it model.IsDependencyInputSpec
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"versionRange", "justification", "origin", "collector"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "versionRange":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("versionRange"))
+			it.VersionRange, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "justification":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("justification"))
+			it.Justification, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "origin":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
+			it.Origin, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "collector":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("collector"))
+			it.Collector, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputIsDependencySpec(ctx context.Context, obj interface{}) (model.IsDependencySpec, error) {
 	var it model.IsDependencySpec
 	asMap := map[string]interface{}{}
@@ -495,6 +547,10 @@ func (ec *executionContext) _IsDependency(ctx context.Context, sel ast.Selection
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) marshalNIsDependency2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependency(ctx context.Context, sel ast.SelectionSet, v model.IsDependency) graphql.Marshaler {
+	return ec._IsDependency(ctx, sel, &v)
+}
+
 func (ec *executionContext) marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.IsDependency) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -547,6 +603,11 @@ func (ec *executionContext) marshalNIsDependency2ᚖgithubᚗcomᚋguacsecᚋgua
 		return graphql.Null
 	}
 	return ec._IsDependency(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNIsDependencyInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyInputSpec(ctx context.Context, v interface{}) (model.IsDependencyInputSpec, error) {
+	res, err := ec.unmarshalInputIsDependencyInputSpec(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) (*model.IsDependencySpec, error) {

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -1256,6 +1256,11 @@ func (ec *executionContext) marshalNPackageVersion2ᚖgithubᚗcomᚋguacsecᚋg
 	return ec._PackageVersion(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNPkgInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx context.Context, v interface{}) (model.PkgInputSpec, error) {
+	res, err := ec.unmarshalInputPkgInputSpec(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOPackageQualifierInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageQualifierInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.PackageQualifierInputSpec, error) {
 	if v == nil {
 		return nil, nil

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -429,6 +429,16 @@ type IsDependency struct {
 	Collector        string   `json:"collector"`
 }
 
+// IsDependencyInputSpec is the same as IsDependency but for mutation input.
+//
+// All fields are required.
+type IsDependencyInputSpec struct {
+	VersionRange  string `json:"versionRange"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+}
+
 // IsDependencySpec allows filtering the list of IsDependency to return.
 //
 // Note: the package object must be defined to return its dependent packages.

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
@@ -10,6 +10,11 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+// IngestDependency is the resolver for the ingestDependency field.
+func (r *mutationResolver) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
+	return r.Backend.IngestDependency(ctx, pkg, depPkg, dependency)
+}
+
 // IsDependency is the resolver for the IsDependency field.
 func (r *queryResolver) IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error) {
 	return r.Backend.IsDependency(ctx, isDependencySpec)

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -62,8 +62,26 @@ input PkgNameSpec {
   name: String
 }
 
+"""
+IsDependencyInputSpec is the same as IsDependency but for mutation input.
+
+All fields are required.
+"""
+input IsDependencyInputSpec {
+  versionRange: String!
+  justification: String!
+  origin: String!
+  collector: String!
+}
+
 
 extend type Query {
   "Returns all IsDependency"
   IsDependency(isDependencySpec: IsDependencySpec): [IsDependency!]!
 }
+
+extend type Mutation {
+  "Adds dependency between two packages"
+  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, dependency: IsDependencyInputSpec!): IsDependency!
+}
+


### PR DESCRIPTION
- added `graphql_playground` to make file
- commented out neo4j testdata registration (will remove in another PR)
- generated code to ingest `isDependency` on client side
- backend implementation of `isDependency`
- testdata added to cmd
- tested query against `isDependency` for functionality check