### PR TITLE
Change assembler/ingestion plumbing to use client gql model

### DIFF
--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -35,7 +35,7 @@ import (
 
 var certifierCmd = &cobra.Command{
 	Use:   "certifier",
-	Short: "certifies packages in GUAC graph",
+	Short: "certifies packages in GUAC graph, this command talks directly to the graphQL endpoint",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)

--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -75,7 +75,7 @@ var certifierCmd = &cobra.Command{
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
 		}
-		assemblerFunc, err := getAssembler(opts)
+		assemblerFunc, err := getAssembler(ctx, opts)
 		if err != nil {
 			logger.Errorf("error: %v", err)
 			os.Exit(1)

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -63,7 +63,7 @@ type options struct {
 
 var exampleCmd = &cobra.Command{
 	Use:   "files [flags] file_path",
-	Short: "take a folder of files and create a GUAC graph",
+	Short: "take a folder of files and create a GUAC graph, this command talks directly to the graphQL endpoint",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -34,7 +34,7 @@ import (
 
 var ociCmd = &cobra.Command{
 	Use:   "image [flags] image_path1 image_path2...",
-	Short: "takes images to download sbom and attestation stored in OCI to add to GUAC graph",
+	Short: "takes images to download sbom and attestation stored in OCI to add to GUAC graph, this command talks directly to the graphQL endpoint",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -70,7 +70,7 @@ var ociCmd = &cobra.Command{
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
 		}
-		assemblerFunc, err := getAssembler(opts)
+		assemblerFunc, err := getAssembler(ctx, opts)
 		if err != nil {
 			logger.Errorf("error: %v", err)
 			os.Exit(1)

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -44,6 +44,9 @@ var flags = struct {
 	graphqlBackend string
 	graphqlPort    int
 	graphqlDebug   bool
+
+	// graphQL client flags
+	graphqlEndpoint string
 }{}
 
 var cfgFile string
@@ -57,18 +60,23 @@ func init() {
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
 	persistentFlags.StringVar(&flags.keyPath, "verifier-keyPath", "", "path to pem file to verify dsse")
 	persistentFlags.StringVar(&flags.keyID, "verifier-keyID", "", "ID of the key to be stored")
+
 	// collectsub flags
 	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
 	persistentFlags.IntVar(&flags.collectSubListenPort, "csub-listen-port", 2782, "port to listen to on collect-sub service")
-	// graphql flags
+
+	// graphql server flags
 	persistentFlags.StringVar(&flags.graphqlBackend, "gql-backend", "neo4j", "backend used for graphql api server: [neo4j | inmem]")
 	persistentFlags.IntVar(&flags.graphqlPort, "gql-port", 8080, "port used for graphql api server")
 	persistentFlags.BoolVar(&flags.graphqlDebug, "gql-debug", false, "debug flag which enables the graphQL playground")
 
+	// graphql client flags
+	persistentFlags.StringVar(&flags.graphqlEndpoint, "gql-endpoint", "http://localhost:8080/query", "endpoint used to connect to graphQL server")
+
 	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm",
 		"verifier-keyPath", "verifier-keyID",
 		"csub-addr", "csub-listen-port",
-		"gql-backend", "gql-port", "gql-debug",
+		"gql-backend", "gql-port", "gql-debug", "gql-endpoint",
 	}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -15,3 +15,4 @@ csub-listen-port: 2782
 gql-backend: neo4j
 gql-port: 8080
 gql-debug: false
+gql-endpoint: http://guac-graphql:8080/query

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -15,7 +15,7 @@
 
 package assembler
 
-import "github.com/guacsec/guac/pkg/assembler/graphql/model"
+import "github.com/guacsec/guac/pkg/assembler/clients/generated"
 
 type assembler struct{} //nolint: unused
 
@@ -149,8 +149,8 @@ type IngestPredicates struct {
 }
 
 type CertifyScorecardIngest struct {
-	Source    *model.SourceInputSpec
-	Scorecard *model.ScorecardInputSpec
+	Source    *generated.SourceInputSpec
+	Scorecard *generated.ScorecardInputSpec
 }
 
 // AssemblerInput represents the inputs to add to the graph

--- a/pkg/assembler/clients/README.md
+++ b/pkg/assembler/clients/README.md
@@ -23,6 +23,8 @@ documents that we want to send to the server.
   GraphQL schema specification and the operation queries
 - `operations/`: the GraphQL queries that the client (e.g., GUAC) sends to the
   server (e.g., GUAC database backend, via GraphQL)
+- `helpers/`: the GraphQL helper functions to return an assembler function given
+  a graphql client.
 
 ## GraphQL client code generation
 

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -1,0 +1,48 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/assembler"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+)
+
+func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assembler.AssemblerInput) error {
+
+	return func(preds []assembler.IngestPredicates) error {
+		for _, p := range preds {
+			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func ingestCertifyScorecards(ctx context.Context, client graphql.Client, vs []assembler.CertifyScorecardIngest) error {
+	for _, v := range vs {
+		_, err := model.Scorecard(context.Background(), client, *v.Source, *v.Scorecard)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TODO(lumjjb): add more ingestion verbs as they come up

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler"
+	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
 // GraphBuilder creates the assembler inputs based on the documents being parsed
@@ -36,10 +37,11 @@ func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []TrustInf
 }
 
 // CreateAssemblerInput creates the GuacNodes and GuacEdges that are needed by the assembler
-func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation) assembler.AssemblerInput {
-	// TODO(bulldozer): call docParser to get assemblerinput, add trust information when needed
-	assemblerinput := assembler.AssemblerInput{}
-	return assemblerinput
+func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation, srcInfo processor.SourceInformation) *assembler.AssemblerInput {
+	predicates := b.docParser.GetPredicates(ctx)
+	addMetadata(predicates, foundIdentities, srcInfo)
+
+	return predicates
 }
 
 // GetIdentities returns the identity that is found when parsing a document
@@ -49,4 +51,16 @@ func (b *GraphBuilder) GetIdentities() []TrustInformation {
 
 func (b *GraphBuilder) GetIdentifiers(ctx context.Context) (*IdentifierStrings, error) {
 	return b.docParser.GetIdentifiers(ctx)
+}
+
+// addMetadata adds trust and source collector metadata
+func addMetadata(predicates *assembler.IngestPredicates, foundIdentities []TrustInformation, srcInfo processor.SourceInformation) {
+	// TODO: when trust information fields need to be added to GQL nodes
+	// and added here.
+	_ = foundIdentities
+
+	for _, v := range predicates.CertifyScorecard {
+		v.Scorecard.Collector = srcInfo.Collector
+		v.Scorecard.Origin = srcInfo.Source
+	}
 }

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -126,8 +126,8 @@ func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree) ([]a
 	}
 
 	for _, builder := range docTreeBuilder.graphBuilders {
-		assemblerInput := builder.CreateAssemblerInput(ctx, docTreeBuilder.identities)
-		assemblerInputs = append(assemblerInputs, assemblerInput)
+		assemblerInput := builder.CreateAssemblerInput(ctx, docTreeBuilder.identities, docTree.Document.SourceInformation)
+		assemblerInputs = append(assemblerInputs, *assemblerInput)
 		if idStrings, err := builder.GetIdentifiers(ctx); err == nil {
 			identifierStrings = append(identifierStrings, idStrings)
 			logger.Debugf("found ID strings: %+v", idStrings)

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -103,9 +103,7 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *mod
 		Type:      "git",
 		Namespace: ns,
 		Name:      name,
-		Commit:    s.Repo.Commit,
-		// TODO: fix after update model
-		//Commit:    &s.Repo.Commit,
+		Commit:    &s.Repo.Commit,
 	}
 
 	var checks []model.ScorecardCheckInputSpec

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -23,22 +23,22 @@ import (
 	"time"
 
 	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	sc "github.com/ossf/scorecard/v4/pkg"
 )
 
 type scorecardParser struct {
-	scorecardPredicates []*model.ScorecardInputSpec
-	srcPredicates       []*model.SourceInputSpec
+	scorecardPredicates []*generated.ScorecardInputSpec
+	srcPredicates       []*generated.SourceInputSpec
 }
 
 // NewSLSAParser initializes the slsaParser
 func NewScorecardParser() common.DocumentParser {
 	return &scorecardParser{
-		scorecardPredicates: []*model.ScorecardInputSpec{},
-		srcPredicates:       []*model.SourceInputSpec{},
+		scorecardPredicates: []*generated.ScorecardInputSpec{},
+		srcPredicates:       []*generated.SourceInputSpec{},
 	}
 }
 
@@ -88,7 +88,7 @@ func (p *scorecardParser) GetIdentifiers(ctx context.Context) (*common.Identifie
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *model.SourceInputSpec, error) {
+func getPredicates(s *sc.JSONScorecardResultV2) (*generated.ScorecardInputSpec, *generated.SourceInputSpec, error) {
 	var ns, name string
 	idx := strings.LastIndex(s.Repo.Name, "/")
 	if idx < 0 {
@@ -98,17 +98,19 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *mod
 	ns = s.Repo.Name[:idx]
 	name = s.Repo.Name[idx+1:]
 
-	srcInput := model.SourceInputSpec{
+	srcInput := generated.SourceInputSpec{
 		// assuming scorecards is only git
 		Type:      "git",
 		Namespace: ns,
 		Name:      name,
-		Commit:    &s.Repo.Commit,
+		Commit:    s.Repo.Commit,
+		// TODO: fix after update model
+		//Commit:    &s.Repo.Commit,
 	}
 
-	var checks []*model.ScorecardCheckInputSpec
+	var checks []generated.ScorecardCheckInputSpec
 	for _, c := range s.Checks {
-		checks = append(checks, &model.ScorecardCheckInputSpec{
+		checks = append(checks, generated.ScorecardCheckInputSpec{
 			Check: c.Name,
 			Score: c.Score,
 		})
@@ -130,7 +132,7 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *mod
 		}
 	}
 
-	scInput := model.ScorecardInputSpec{
+	scInput := generated.ScorecardInputSpec{
 		TimeScanned:      timeScanned,
 		AggregateScore:   (float64)(s.AggregateScore),
 		Checks:           checks,

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -23,22 +23,22 @@ import (
 	"time"
 
 	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	sc "github.com/ossf/scorecard/v4/pkg"
 )
 
 type scorecardParser struct {
-	scorecardPredicates []*generated.ScorecardInputSpec
-	srcPredicates       []*generated.SourceInputSpec
+	scorecardPredicates []*model.ScorecardInputSpec
+	srcPredicates       []*model.SourceInputSpec
 }
 
 // NewSLSAParser initializes the slsaParser
 func NewScorecardParser() common.DocumentParser {
 	return &scorecardParser{
-		scorecardPredicates: []*generated.ScorecardInputSpec{},
-		srcPredicates:       []*generated.SourceInputSpec{},
+		scorecardPredicates: []*model.ScorecardInputSpec{},
+		srcPredicates:       []*model.SourceInputSpec{},
 	}
 }
 
@@ -88,7 +88,7 @@ func (p *scorecardParser) GetIdentifiers(ctx context.Context) (*common.Identifie
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func getPredicates(s *sc.JSONScorecardResultV2) (*generated.ScorecardInputSpec, *generated.SourceInputSpec, error) {
+func getPredicates(s *sc.JSONScorecardResultV2) (*model.ScorecardInputSpec, *model.SourceInputSpec, error) {
 	var ns, name string
 	idx := strings.LastIndex(s.Repo.Name, "/")
 	if idx < 0 {
@@ -98,7 +98,7 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*generated.ScorecardInputSpec, 
 	ns = s.Repo.Name[:idx]
 	name = s.Repo.Name[idx+1:]
 
-	srcInput := generated.SourceInputSpec{
+	srcInput := model.SourceInputSpec{
 		// assuming scorecards is only git
 		Type:      "git",
 		Namespace: ns,
@@ -108,9 +108,9 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*generated.ScorecardInputSpec, 
 		//Commit:    &s.Repo.Commit,
 	}
 
-	var checks []generated.ScorecardCheckInputSpec
+	var checks []model.ScorecardCheckInputSpec
 	for _, c := range s.Checks {
-		checks = append(checks, generated.ScorecardCheckInputSpec{
+		checks = append(checks, model.ScorecardCheckInputSpec{
 			Check: c.Name,
 			Score: c.Score,
 		})
@@ -132,7 +132,7 @@ func getPredicates(s *sc.JSONScorecardResultV2) (*generated.ScorecardInputSpec, 
 		}
 	}
 
-	scInput := generated.ScorecardInputSpec{
+	scInput := model.ScorecardInputSpec{
 		TimeScanned:      timeScanned,
 		AggregateScore:   (float64)(s.AggregateScore),
 		Checks:           checks,

--- a/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
 )
@@ -53,7 +53,7 @@ func Test_scorecardParser(t *testing.T) {
 						Commit:    strP("5835544ca568b757a8ecae5c153f317e5736700e"),
 					},
 					Scorecard: &model.ScorecardInputSpec{
-						Checks: []*model.ScorecardCheckInputSpec{
+						Checks: []model.ScorecardCheckInputSpec{
 							{Check: "Binary-Artifacts", Score: 10},
 							{Check: "CI-Tests", Score: 10},
 							{Check: "Code-Review", Score: 7},


### PR DESCRIPTION
Implement plumbing for `guacone` for CertifyScorecards:

```
$ bin/guacone files ~/git/guac-data/docs/scorecard
{"level":"info","ts":1677870827.4946592,"caller":"cmd/root.go:114","msg":"Using config file: /Users/lumb/go/src/github.com/guacsec/guac/guac.yaml"}
{"level":"info","ts":1677870827.495598,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.518416,"caller":"cmd/files.go:163","msg":"[23.389925ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-140c27533044e9e00f800d3ad0517540e3e4ecad.json}"}
{"level":"info","ts":1677870827.51866,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.5387678,"caller":"cmd/files.go:163","msg":"[20.301058ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-1ff66136acfd7717292f65447b2ebff162570f46.json}"}
{"level":"info","ts":1677870827.539026,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.56806,"caller":"cmd/files.go:163","msg":"[29.250028ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-252935368ab67f38cb252df0a961a6dcb81d20eb.json}"}
{"level":"info","ts":1677870827.568094,"caller":"cmd/files.go:170","msg":"collector ended gracefully"}
{"level":"info","ts":1677870827.568884,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.5901692,"caller":"cmd/files.go:163","msg":"[22.050655ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3985f0a87ba4277b561e0cac9fba4f594eb8228a.json}"}
{"level":"info","ts":1677870827.59044,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.612854,"caller":"cmd/files.go:163","msg":"[22.643321ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3c7da84d8fc03c30d3409e9c846ae4bc2de0b4d5.json}"}
{"level":"info","ts":1677870827.613216,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.635206,"caller":"cmd/files.go:163","msg":"[22.305559ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3d3ac0431b6b56adc06a948a9aeb24757f643249.json}"}
{"level":"info","ts":1677870827.635388,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.656022,"caller":"cmd/files.go:163","msg":"[20.75022ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-9ea33a8d02b38a2ac996f4328e7b1449f2cbc888.json}"}
{"level":"info","ts":1677870827.656197,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
{"level":"info","ts":1677870827.6779552,"caller":"cmd/files.go:163","msg":"[21.88425ms] completed doc {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-aaf024b5e8dc5e08e4414583203968ca0a5ec043.json}"}
{"level":"info","ts":1677870827.677993,"caller":"cmd/files.go:183","msg":"completed ingesting 8 documents"}
```

![image](https://user-images.githubusercontent.com/3060102/222807126-137afbed-468d-40ad-b56e-2fd8a05951f6.png)
