### PR TITLE
temp fix for missing default values in gql

### DIFF
--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -202,10 +202,14 @@ func (c *neo4jClient) CertifyScorecard(ctx context.Context, source model.SourceI
 
 	if source.Commit != nil {
 		values["commit"] = *source.Commit
+	} else {
+		values["commit"] = ""
 	}
 
 	if source.Tag != nil {
 		values["tag"] = *source.Tag
+	} else {
+		values["tag"] = ""
 	}
 
 	values[timeScanned] = scorecard.TimeScanned

--- a/pkg/assembler/backends/neo4j/src.go
+++ b/pkg/assembler/backends/neo4j/src.go
@@ -428,10 +428,14 @@ func (c *neo4jClient) IngestSource(ctx context.Context, source *model.SourceInpu
 
 	if source.Commit != nil {
 		values["commit"] = *source.Commit
+	} else {
+		values["commit"] = ""
 	}
 
 	if source.Tag != nil {
 		values["tag"] = *source.Tag
+	} else {
+		values["tag"] = ""
 	}
 
 	result, err := session.WriteTransaction(


### PR DESCRIPTION
For some reason the optional parameters are not given their default values and end up being passed to the resolvers as nil pointers

```
input SourceInputSpec {
  type: String!
  namespace: String!
  name: String!
  tag: String = ""
  commit: String = ""
}
```


This is causing the values map for the neo4j command parameters to fail due to missing parameters. This is a interim fix to that.