### PR TITLE
cmd/ingestor plumbing to gql

### DIFF
--- a/cmd/ingest/cmd/root.go
+++ b/cmd/ingest/cmd/root.go
@@ -41,6 +41,9 @@ var flags = struct {
 
 	// collectsub service
 	collectSubAddr string
+
+	// graphql client
+	graphqlEndpoint string
 }{}
 
 func init() {
@@ -52,7 +55,8 @@ func init() {
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
 	persistentFlags.StringVar(&flags.natsAddr, "natsaddr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
 	persistentFlags.StringVar(&flags.collectSubAddr, "csub-addr", "localhost:2782", "address to connect to collect-sub service")
-	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "natsaddr"}
+	persistentFlags.StringVar(&flags.graphqlEndpoint, "gql-endpoint", "http://localhost:8080/query", "endpoint used to connect to graphQL server")
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "natsaddr", "csub-addr", "gql-endpoint"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -40,7 +40,7 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 
 func ingestCertifyScorecards(ctx context.Context, client graphql.Client, vs []assembler.CertifyScorecardIngest) error {
 	for _, v := range vs {
-		_, err := model.Scorecard(context.Background(), client, *v.Source, *v.Scorecard)
+		_, err := model.Scorecard(ctx, client, *v.Source, *v.Scorecard)
 		if err != nil {
 			return err
 		}

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -21,12 +21,15 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/guacsec/guac/pkg/assembler"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assembler.AssemblerInput) error {
 
+	logger := logging.FromContext(ctx)
 	return func(preds []assembler.IngestPredicates) error {
 		for _, p := range preds {
+			logger.Infof("assembling CertifyScorecard: %+v", p.CertifyScorecard)
 			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
 				return err
 			}

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -39,6 +39,10 @@ func NewGenericGraphBuilder(docParser DocumentParser, foundIdentities []TrustInf
 // CreateAssemblerInput creates the GuacNodes and GuacEdges that are needed by the assembler
 func (b *GraphBuilder) CreateAssemblerInput(ctx context.Context, foundIdentities []TrustInformation, srcInfo processor.SourceInformation) *assembler.AssemblerInput {
 	predicates := b.docParser.GetPredicates(ctx)
+
+	if predicates == nil {
+		predicates = &assembler.IngestPredicates{}
+	}
 	addMetadata(predicates, foundIdentities, srcInfo)
 
 	return predicates


### PR DESCRIPTION
Dependent on #530 

This PR implements the ingestor plumbing to gql. With this, we can exercise the whole path using the collector with a running infrastructure (using `make start-service`). And running the following collector creates nodes in neo4j.

Running:
```
$ bin/collector files ~/git/guac-data/docs/scorecard
{"level":"info","ts":1677880066.5106711,"caller":"cmd/root.go:99","msg":"Using config file: /Users/lumb/go/src/github.com/guacsec/guac/guac.yaml"}
{"level":"info","ts":1677880066.519712,"caller":"cmd/files.go:112","msg":"collector ended gracefully"}
```

Shows logs (in docker compose):
```
guac-guac-ingestor-1     | {"level":"info","ts":1677880056.223648,"caller":"cmd/root.go:97","msg":"Using config file: /guac/guac.yaml"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5360544,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-140c27533044e9e00f800d3ad0517540e3e4ecad.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5362022,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5363007,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc00004a3c0 Scorecard:0xc0000e0200}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5388772,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-1ff66136acfd7717292f65447b2ebff162570f46.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5400403,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-252935368ab67f38cb252df0a961a6dcb81d20eb.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5409567,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3985f0a87ba4277b561e0cac9fba4f594eb8228a.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.542088,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3c7da84d8fc03c30d3409e9c846ae4bc2de0b4d5.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.542873,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3d3ac0431b6b56adc06a948a9aeb24757f643249.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.545248,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-9ea33a8d02b38a2ac996f4328e7b1449f2cbc888.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880066.5461905,"caller":"process/process.go:91","msg":"[processor: 11de3052-c884-4616-a907-c20412e189a8] docTree Processed: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-aaf024b5e8dc5e08e4414583203968ca0a5ec043.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.44414,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-140c27533044e9e00f800d3ad0517540e3e4ecad.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.444224,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.444285,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc00004aa80 Scorecard:0xc0000e0480}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.4830918,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-1ff66136acfd7717292f65447b2ebff162570f46.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.4832075,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.4832733,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc000386b00 Scorecard:0xc000552380}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.522302,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-252935368ab67f38cb252df0a961a6dcb81d20eb.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.5224028,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.5224752,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc00004afc0 Scorecard:0xc0000e0600}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.5661995,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3985f0a87ba4277b561e0cac9fba4f594eb8228a.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.5663345,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.566429,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc000386d80 Scorecard:0xc000552500}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6129403,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3c7da84d8fc03c30d3409e9c846ae4bc2de0b4d5.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6131408,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6132083,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc00004b2c0 Scorecard:0xc0000e0780}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6452134,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-3d3ac0431b6b56adc06a948a9aeb24757f643249.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6453013,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6453786,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc000387000 Scorecard:0xc000552680}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6783268,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-9ea33a8d02b38a2ac996f4328e7b1449f2cbc888.json}"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.678411,"caller":"parser/parser.go:122","msg":"parsing document tree with root type: SCORECARD"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.6784756,"caller":"helpers/assembler.go:32","msg":"assembling CertifyScorecard: [{Source:0xc00004b540 Scorecard:0xc0000e0980}]"}
guac-guac-ingestor-1     | {"level":"info","ts":1677880067.7098155,"caller":"parser/parser.go:104","msg":"[ingestor: 18ca8112-7845-4ad4-96b5-4e6a177a8927] ingested docTree: {Collector:FileCollector Source:file:////Users/lumb/git/guac-data/docs/scorecard/scorecard-kubernetes-aaf024b5e8dc5e08e4414583203968ca0a5ec043.json}"}
```