### PR TITLE
Fix issue with Time in Neo4j backend.

### DIFF
--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -212,7 +212,7 @@ func (c *neo4jClient) CertifyScorecard(ctx context.Context, source model.SourceI
 		values["tag"] = ""
 	}
 
-	values[timeScanned] = scorecard.TimeScanned
+	values[timeScanned] = scorecard.TimeScanned.UTC()
 	values[aggregateScore] = scorecard.AggregateScore
 	values[scorecardVersion] = scorecard.ScorecardVersion
 	values[scorecardCommit] = scorecard.ScorecardCommit

--- a/pkg/assembler/graphql/examples/certify_scorecard.gql
+++ b/pkg/assembler/graphql/examples/certify_scorecard.gql
@@ -72,7 +72,7 @@ mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
     "tag": "v2.12.0"
   },
   "scorecard": {
-    "timeScanned": "2023-02-28 15:51:26.960629544 -0800 PST m=+0.002464876",
+    "timeScanned": "2023-03-06T10:55:55.804914034Z",
     "aggregateScore": 2.9,
     "checks": [
       {

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -1087,6 +1087,21 @@ func (ec *executionContext) unmarshalNScorecardInputSpec2githubᚗcomᚋguacsec�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	res, err := graphql.UnmarshalTime(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	res := graphql.MarshalTime(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalOCertifyScorecardSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecardSpec(ctx context.Context, v interface{}) (*model.CertifyScorecardSpec, error) {
 	if v == nil {
 		return nil, nil
@@ -1113,6 +1128,22 @@ func (ec *executionContext) unmarshalOScorecardCheckSpec2ᚕᚖgithubᚗcomᚋgu
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalTime(*v)
+	return res
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -733,43 +733,12 @@ func (ec *executionContext) marshalNOsvCveGhsaObject2githubᚗcomᚋguacsecᚋgu
 	return ec._OsvCveGhsaObject(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
-	res, err := graphql.UnmarshalTime(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
-	res := graphql.MarshalTime(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
 func (ec *executionContext) unmarshalOCertifyVulnSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnSpec(ctx context.Context, v interface{}) (*model.CertifyVulnSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputCertifyVulnSpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := graphql.UnmarshalTime(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	res := graphql.MarshalTime(*v)
-	return res
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1713,6 +1713,15 @@ extend type Query {
 # Defines a GraphQL schema to certify Scorecard for a source repository.
 
 """
+Define the Time scalar, to be used across GUAC. It follows RFC3339Nano format.
+
+This is implicit via https://gqlgen.com/reference/scalars/#time
+
+For GUAC, we assume that all times are stored in UTC format.
+"""
+scalar Time
+
+"""
 CertifyScorecard is an attestation which represents the scorecard of a
 particular source repository.
 """
@@ -1959,8 +1968,6 @@ extend type Query {
   "Returns all CertifyVuln"
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec): [CertifyVuln!]!
 }
-
-scalar Time
 `, BuiltIn: false},
 	{Name: "../schema/cve.graphql", Input: `#
 # Copyright 2023 The GUAC Authors.

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -18,6 +18,15 @@
 # Defines a GraphQL schema to certify Scorecard for a source repository.
 
 """
+Define the Time scalar, to be used across GUAC. It follows RFC3339Nano format.
+
+This is implicit via https://gqlgen.com/reference/scalars/#time
+
+For GUAC, we assume that all times are stored in UTC format.
+"""
+scalar Time
+
+"""
 CertifyScorecard is an attestation which represents the scorecard of a
 particular source repository.
 """

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -71,5 +71,3 @@ extend type Query {
   "Returns all CertifyVuln"
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec): [CertifyVuln!]!
 }
-
-scalar Time


### PR DESCRIPTION
The issue is neither on neo4j nor in ingestion. It is in the way go treats the time field. That is, `time.Now()` returns time in the current local timezone but that contains a confusing `Offset()`. Neo4j wants to store local times as `LocalTime`, mapped to `neo4j.LocalTime` in Go, which is not what we want.

Instead, and to solve issues with timezones, let's just enforce that all GUAC times are in UTC.  Added comments to this end to the schema.

While here, I also changed the example ingestion parameters as the old ones would not parse under Go's `time.Time` rules.