### PR TITLE
Plumb IsOccurence/IsDependency to assembler

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -317,6 +317,14 @@ var (
 		Justification: "Derived from SPDX DEPENDS_ON relationship",
 	}
 
+	isOccJustifyFile = &model.IsOccurrenceSpecInputSpec{
+		Justification: "spdx file with checksum",
+	}
+
+	isOccJustifyPkg = &model.IsOccurrenceSpecInputSpec{
+		Justification: "spdx package with checksum",
+	}
+
 	SpdxDeps = []assembler.IsDependencyIngest{
 		{
 			Pkg:          topLevelPack,
@@ -377,20 +385,24 @@ var (
 
 	SpdxOccurences = []assembler.IsOccurenceIngest{
 		{
-			Pkg:      worldFilePack,
-			Artifact: worldFileArtifact,
+			Pkg:         worldFilePack,
+			Artifact:    worldFileArtifact,
+			IsOccurence: isOccJustifyFile,
 		},
 		{
-			Pkg:      rootFilePack,
-			Artifact: rootFileArtifact,
+			Pkg:         rootFilePack,
+			Artifact:    rootFileArtifact,
+			IsOccurence: isOccJustifyFile,
 		},
 		{
-			Pkg:      rsaPubFilePack,
-			Artifact: rsaPubFileArtifact,
+			Pkg:         rsaPubFilePack,
+			Artifact:    rsaPubFileArtifact,
+			IsOccurence: isOccJustifyFile,
 		},
 		{
-			Pkg:      triggersFilePack,
-			Artifact: triggersFileArtifact,
+			Pkg:         triggersFilePack,
+			Artifact:    triggersFileArtifact,
+			IsOccurence: isOccJustifyFile,
 		},
 	}
 

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -317,11 +317,11 @@ var (
 		Justification: "Derived from SPDX DEPENDS_ON relationship",
 	}
 
-	isOccJustifyFile = &model.IsOccurrenceSpecInputSpec{
+	isOccJustifyFile = &model.IsOccurrenceInputSpec{
 		Justification: "spdx file with checksum",
 	}
 
-	isOccJustifyPkg = &model.IsOccurrenceSpecInputSpec{
+	isOccJustifyPkg = &model.IsOccurrenceInputSpec{
 		Justification: "spdx package with checksum",
 	}
 

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -168,6 +168,8 @@ type IsOccurenceIngest struct {
 
 	// Artifact is the required object of the occurence
 	Artifact *generated.ArtifactInputSpec
+
+	IsOccurence *generated.IsOccurrenceSpecInputSpec
 }
 
 // AssemblerInput represents the inputs to add to the graph

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -169,7 +169,7 @@ type IsOccurenceIngest struct {
 	// Artifact is the required object of the occurence
 	Artifact *generated.ArtifactInputSpec
 
-	IsOccurence *generated.IsOccurrenceSpecInputSpec
+	IsOccurence *generated.IsOccurrenceInputSpec
 }
 
 // AssemblerInput represents the inputs to add to the graph

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -30,17 +30,17 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 	logger := logging.FromContext(ctx)
 	return func(preds []assembler.IngestPredicates) error {
 		for _, p := range preds {
-			logger.Infof("assembling CertifyScorecard: %+v", p.CertifyScorecard)
+			logger.Infof("assembling CertifyScorecard: %v", len(p.CertifyScorecard))
 			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
 				return err
 			}
 
-			logger.Infof("assembling IsDependency: %+v", p.IsDependency)
+			logger.Infof("assembling IsDependency: %v", len(p.IsDependency))
 			if err := ingestIsDependency(ctx, gqlclient, p.IsDependency); err != nil {
 				return err
 			}
 
-			logger.Infof("assembling IsOccurence: %+v", p.IsOccurence)
+			logger.Infof("assembling IsOccurence: %v", len(p.IsOccurence))
 			if err := ingestIsOccurence(ctx, gqlclient, p.IsOccurence); err != nil {
 				return err
 			}

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -81,12 +81,12 @@ func ingestIsOccurence(ctx context.Context, client graphql.Client, vs []assemble
 		}
 
 		if v.Src != nil {
-			_, err := model.IsOccurrenceSrc(ctx, client, v.Src, *v.Artifact, *v.IsOccurence)
+			_, err := model.IsOccurrenceSrc(ctx, client, *v.Src, *v.Artifact, *v.IsOccurence)
 			if err != nil {
 				return err
 			}
 		} else {
-			_, err := model.IsOccurrencePkg(ctx, client, v.Pkg, *v.Artifact, *v.IsOccurence)
+			_, err := model.IsOccurrencePkg(ctx, client, *v.Pkg, *v.Artifact, *v.IsOccurence)
 			if err != nil {
 				return err
 			}

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -17,6 +17,7 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/guacsec/guac/pkg/assembler"
@@ -33,6 +34,17 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
 				return err
 			}
+
+			logger.Infof("assembling IsDependency: %+v", p.IsDependency)
+			if err := ingestIsDependency(ctx, gqlclient, p.IsDependency); err != nil {
+				return err
+			}
+
+			logger.Infof("assembling IsOccurence: %+v", p.IsOccurence)
+			if err := ingestIsOccurence(ctx, gqlclient, p.IsOccurence); err != nil {
+				return err
+			}
+
 		}
 		return nil
 	}
@@ -44,6 +56,43 @@ func ingestCertifyScorecards(ctx context.Context, client graphql.Client, vs []as
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func ingestIsDependency(ctx context.Context, client graphql.Client, vs []assembler.IsDependencyIngest) error {
+	for _, v := range vs {
+		_, err := model.IsDependency(ctx, client, *v.Pkg, *v.DepPkg, *v.IsDependency)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ingestIsOccurence(ctx context.Context, client graphql.Client, vs []assembler.IsOccurenceIngest) error {
+	for _, v := range vs {
+		if v.Pkg != nil && v.Src != nil {
+			return fmt.Errorf("unable to create IsOccurence with both Src and Pkg subject specified")
+		}
+
+		if v.Pkg == nil && v.Src == nil {
+			return fmt.Errorf("unable to create IsOccurence without either Src and Pkg subject specified")
+		}
+
+		if v.Src != nil {
+			_, err := model.IsOccurrenceSrc(ctx, client, v.Src, *v.Artifact, *v.IsOccurence)
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err := model.IsOccurrencePkg(ctx, client, v.Pkg, *v.Artifact, *v.IsOccurence)
+			if err != nil {
+				return err
+			}
+
+		}
+
 	}
 	return nil
 }

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -67,4 +67,14 @@ func addMetadata(predicates *assembler.IngestPredicates, foundIdentities []Trust
 		v.Scorecard.Collector = srcInfo.Collector
 		v.Scorecard.Origin = srcInfo.Source
 	}
+
+	for _, v := range predicates.IsDependency {
+		v.IsDependency.Collector = srcInfo.Collector
+		v.IsDependency.Origin = srcInfo.Source
+	}
+
+	for _, v := range predicates.IsOccurence {
+		v.IsOccurence.Collector = srcInfo.Collector
+		v.IsOccurence.Origin = srcInfo.Source
+	}
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -233,7 +233,7 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				preds.IsOccurence = append(preds.IsOccurence, assembler.IsOccurenceIngest{
 					Pkg:      &pkg,
 					Artifact: &art,
-					IsOccurence: &model.IsOccurrenceSpecInputSpec{
+					IsOccurence: &model.IsOccurrenceInputSpec{
 						Justification: "spdx file with checksum",
 					},
 				})
@@ -247,7 +247,7 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				preds.IsOccurence = append(preds.IsOccurence, assembler.IsOccurenceIngest{
 					Pkg:      &pkg,
 					Artifact: &art,
-					IsOccurence: &model.IsOccurrenceSpecInputSpec{
+					IsOccurence: &model.IsOccurrenceInputSpec{
 						Justification: "spdx package with checksum",
 					},
 				})

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -233,6 +233,9 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				preds.IsOccurence = append(preds.IsOccurence, assembler.IsOccurenceIngest{
 					Pkg:      &pkg,
 					Artifact: &art,
+					IsOccurence: &model.IsOccurrenceSpecInputSpec{
+						Justification: "spdx file with checksum",
+					},
 				})
 			}
 		}
@@ -244,6 +247,9 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				preds.IsOccurence = append(preds.IsOccurence, assembler.IsOccurenceIngest{
 					Pkg:      &pkg,
 					Artifact: &art,
+					IsOccurence: &model.IsOccurrenceSpecInputSpec{
+						Justification: "spdx package with checksum",
+					},
 				})
 			}
 		}


### PR DESCRIPTION
This PR contains changes:
- add IsOccurrence field to assembler ingest
-  graphbuilder adds srcInfo to IsDependency and IsOccurrence
- make assembler handle IsDependency and IsOccurrence
- make logging less verbose in assembler glue code


This allows running collectors on SPDX files with current infrastructure (`make start-service`)

by running:

```
bin/collector files ~/git/guac-data/docs/spdx/
```

Resulting in a graph (subset of which contains depedency and occurence info:

![image](https://user-images.githubusercontent.com/3060102/223560014-9f90ff8c-dff1-4709-a7f7-370bfaf8ace4.png)
