### PR TITLE
Prepare for SLSA ingestion

### DIFF
--- a/pkg/assembler/backends/neo4j/cerifyBad.go
+++ b/pkg/assembler/backends/neo4j/cerifyBad.go
@@ -262,7 +262,7 @@ func setCertifyBadValues(sb *strings.Builder, certifyBadSpec *model.CertifyBadSp
 	}
 }
 
-func generateModelCertifyBad(subject model.PkgSrcArtObject, justification, origin, collector string) *model.CertifyBad {
+func generateModelCertifyBad(subject model.PackageSourceOrArtifact, justification, origin, collector string) *model.CertifyBad {
 	certifyBad := model.CertifyBad{
 		Subject:       subject,
 		Justification: justification,

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -54,7 +54,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 
 	aggregateHasSLSA := []*model.HasSlsa{}
 
-	if queryAll || hasSLSASpec.Subject.Package != nil {
+	if queryAll || hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Package != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -223,7 +223,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if queryAll || hasSLSASpec.Subject.Source != nil {
+	if queryAll || hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Source != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -357,7 +357,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if queryAll || hasSLSASpec.Subject.Artifact != nil {
+	if queryAll || hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Artifact != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -45,13 +45,13 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 	}
 
 	queryAll := false
-	if hasSLSASpec.Package == nil && hasSLSASpec.Source == nil && hasSLSASpec.Artifact == nil {
+	if hasSLSASpec.Subject.Package == nil && hasSLSASpec.Subject.Source == nil && hasSLSASpec.Subject.Artifact == nil {
 		queryAll = true
 	}
 
 	aggregateHasSLSA := []*model.HasSlsa{}
 
-	if hasSLSASpec.Package != nil || queryAll {
+	if hasSLSASpec.Subject.Package != nil || queryAll {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -83,12 +83,12 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 			"\nWITH *, hasSLSA, null AS objPkgVersion"
 
 		sb.WriteString(query)
-		setPkgMatchValues(&sb, hasSLSASpec.Package, false, &firstMatch, queryValues)
+		setPkgMatchValues(&sb, hasSLSASpec.Subject.Package, false, &firstMatch, queryValues)
 		setHasSLSAValues(&sb, hasSLSASpec, &firstMatch, queryValues)
 		sb.WriteString(returnValue)
 
-		if hasSLSASpec.Package == nil || hasSLSASpec.Package != nil && hasSLSASpec.Package.Version == nil && hasSLSASpec.Package.Subpath == nil &&
-			len(hasSLSASpec.Package.Qualifiers) == 0 && !*hasSLSASpec.Package.MatchOnlyEmptyQualifiers {
+		if hasSLSASpec.Subject.Package == nil || hasSLSASpec.Subject.Package != nil && hasSLSASpec.Subject.Package.Version == nil && hasSLSASpec.Subject.Package.Subpath == nil &&
+			len(hasSLSASpec.Subject.Package.Qualifiers) == 0 && !*hasSLSASpec.Subject.Package.MatchOnlyEmptyQualifiers {
 
 			sb.WriteString("\nUNION")
 			// query without pkgVersion
@@ -114,7 +114,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 
 			sb.WriteString(query)
 			firstMatch = true
-			setPkgMatchValues(&sb, hasSLSASpec.Package, false, &firstMatch, queryValues)
+			setPkgMatchValues(&sb, hasSLSASpec.Subject.Package, false, &firstMatch, queryValues)
 			setHasSLSAValues(&sb, hasSLSASpec, &firstMatch, queryValues)
 			sb.WriteString(returnValue)
 		}
@@ -220,7 +220,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if hasSLSASpec.Source != nil || queryAll {
+	if hasSLSASpec.Subject.Source != nil || queryAll {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -252,7 +252,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 			"\nWITH *, hasSLSA, null AS objPkgVersion"
 
 		sb.WriteString(query)
-		setSrcMatchValues(&sb, hasSLSASpec.Source, false, &firstMatch, queryValues)
+		setSrcMatchValues(&sb, hasSLSASpec.Subject.Source, false, &firstMatch, queryValues)
 		setHasSLSAValues(&sb, hasSLSASpec, &firstMatch, queryValues)
 		sb.WriteString(returnValue)
 
@@ -354,7 +354,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if hasSLSASpec.Artifact != nil || queryAll {
+	if hasSLSASpec.Subject.Artifact != nil || queryAll {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -384,7 +384,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 			"\nWITH *, hasSLSA, null AS objPkgVersion"
 
 		sb.WriteString(query)
-		setArtifactMatchValues(&sb, hasSLSASpec.Artifact, false, &firstMatch, queryValues)
+		setArtifactMatchValues(&sb, hasSLSASpec.Subject.Artifact, false, &firstMatch, queryValues)
 		setHasSLSAValues(&sb, hasSLSASpec, &firstMatch, queryValues)
 		sb.WriteString(returnValue)
 
@@ -491,13 +491,13 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 // TODO(pxp928): combine with testing backend in shared utility
 func checkHasSLSAInputs(hasSLSASpec *model.HasSLSASpec) error {
 	subjectsDefined := 0
-	if hasSLSASpec.Package != nil {
+	if hasSLSASpec.Subject.Package != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Source != nil {
+	if hasSLSASpec.Subject.Source != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Artifact != nil {
+	if hasSLSASpec.Subject.Artifact != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
 	if subjectsDefined > 1 {

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -488,23 +488,20 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 
 }
 
-// TODO (pxp928): combine with testing backend in shared utility
+// TODO(pxp928): combine with testing backend in shared utility
 func checkHasSLSAInputs(hasSLSASpec *model.HasSLSASpec) error {
-	invalidSubject := false
-	if hasSLSASpec.Package != nil && hasSLSASpec.Source != nil && hasSLSASpec.Artifact != nil {
-		invalidSubject = true
+	subjectsDefined := 0
+	if hasSLSASpec.Package != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Package != nil && hasSLSASpec.Source != nil {
-		invalidSubject = true
+	if hasSLSASpec.Source != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Package != nil && hasSLSASpec.Artifact != nil {
-		invalidSubject = true
+	if hasSLSASpec.Artifact != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Source != nil && hasSLSASpec.Artifact != nil {
-		invalidSubject = true
-	}
-	if invalidSubject {
-		return gqlerror.Errorf("cannot specify more than one subject for CertifyBad query")
+	if subjectsDefined > 1 {
+		return gqlerror.Errorf("Must specify at most one subject (package, source, or artifact)")
 	}
 	return nil
 }

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -39,19 +39,22 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	err := checkHasSLSAInputs(hasSLSASpec)
-	if err != nil {
-		return nil, err
-	}
-
 	queryAll := false
-	if hasSLSASpec.Subject.Package == nil && hasSLSASpec.Subject.Source == nil && hasSLSASpec.Subject.Artifact == nil {
+	//TODO(mihaimaruseac): Review this in e2e
+	if hasSLSASpec.Subject == nil {
 		queryAll = true
+	} else if hasSLSASpec.Subject.Package == nil && hasSLSASpec.Subject.Source == nil && hasSLSASpec.Subject.Artifact == nil {
+		queryAll = true
+	} else {
+		err := checkHasSLSAInputs(hasSLSASpec)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	aggregateHasSLSA := []*model.HasSlsa{}
 
-	if hasSLSASpec.Subject.Package != nil || queryAll {
+	if queryAll || hasSLSASpec.Subject.Package != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -220,7 +223,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if hasSLSASpec.Subject.Source != nil || queryAll {
+	if queryAll || hasSLSASpec.Subject.Source != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}
@@ -354,7 +357,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 		aggregateHasSLSA = append(aggregateHasSLSA, result.([]*model.HasSlsa)...)
 	}
 
-	if hasSLSASpec.Subject.Artifact != nil || queryAll {
+	if queryAll || hasSLSASpec.Subject.Artifact != nil {
 		var sb strings.Builder
 		var firstMatch bool = true
 		queryValues := map[string]any{}

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -127,8 +127,8 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					return nil, err
 				}
 
-				resultBuiltFromMap := map[model.PkgSrcArtObject][]model.PkgSrcArtObject{}
-				resultHasSlsaMap := map[model.PkgSrcArtObject]*model.HasSlsa{}
+				resultBuiltFromMap := map[model.PackageSourceOrArtifact][]model.PackageSourceOrArtifact{}
+				resultHasSlsaMap := map[model.PackageSourceOrArtifact]*model.HasSlsa{}
 				for result.Next() {
 					pkgQualifiers := result.Record().Values[5]
 					subPath := result.Record().Values[4]
@@ -156,7 +156,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					}
 
 					if _, ok := resultBuiltFromMap[pkg]; !ok {
-						resultBuiltFromMap[pkg] = []model.PkgSrcArtObject{}
+						resultBuiltFromMap[pkg] = []model.PackageSourceOrArtifact{}
 					}
 
 					if result.Record().Values[8] != nil && result.Record().Values[9] != nil {
@@ -264,8 +264,8 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					return nil, err
 				}
 
-				resultBuiltFromMap := map[model.PkgSrcArtObject][]model.PkgSrcArtObject{}
-				resultHasSlsaMap := map[model.PkgSrcArtObject]*model.HasSlsa{}
+				resultBuiltFromMap := map[model.PackageSourceOrArtifact][]model.PackageSourceOrArtifact{}
+				resultHasSlsaMap := map[model.PackageSourceOrArtifact]*model.HasSlsa{}
 
 				for result.Next() {
 					tag := result.Record().Values[3]
@@ -294,7 +294,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					}
 
 					if _, ok := resultBuiltFromMap[src]; !ok {
-						resultBuiltFromMap[src] = []model.PkgSrcArtObject{}
+						resultBuiltFromMap[src] = []model.PackageSourceOrArtifact{}
 					}
 
 					if result.Record().Values[7] != nil && result.Record().Values[8] != nil {
@@ -396,8 +396,8 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					return nil, err
 				}
 
-				resultBuiltFromMap := map[model.PkgSrcArtObject][]model.PkgSrcArtObject{}
-				resultHasSlsaMap := map[model.PkgSrcArtObject]*model.HasSlsa{}
+				resultBuiltFromMap := map[model.PackageSourceOrArtifact][]model.PackageSourceOrArtifact{}
+				resultHasSlsaMap := map[model.PackageSourceOrArtifact]*model.HasSlsa{}
 
 				for result.Next() {
 					algorithm := result.Record().Values[0].(string)
@@ -422,7 +422,7 @@ func (c *neo4jClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpe
 					}
 
 					if _, ok := resultBuiltFromMap[artifact]; !ok {
-						resultBuiltFromMap[artifact] = []model.PkgSrcArtObject{}
+						resultBuiltFromMap[artifact] = []model.PackageSourceOrArtifact{}
 					}
 
 					if result.Record().Values[4] != nil && result.Record().Values[5] != nil {
@@ -578,7 +578,7 @@ func setHasSLSAValues(sb *strings.Builder, hasSLSASpec *model.HasSLSASpec, first
 	}
 }
 
-func generateModelHasSLSA(subject model.PkgSrcArtObject, builder *model.Builder, slsaPredicate []interface{}, buildType,
+func generateModelHasSLSA(subject model.PackageSourceOrArtifact, builder *model.Builder, slsaPredicate []interface{}, buildType,
 	slsaVersion, origin, collector string, startedOn, finishedOn time.Time) *model.HasSlsa {
 	hasSLSA := model.HasSlsa{
 		Subject:       subject,

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -32,7 +32,13 @@ func registerAllHasSLSA(client *demoClient) error {
 	selectedName := "django"
 	selectedVersion := "1.11.1"
 	selectedSubpath := ""
-	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Subpath: &selectedSubpath}
+	selectedPkgSpec := &model.PkgSpec{
+		Type:      &selectedType,
+		Namespace: &selectedNameSpace,
+		Name:      &selectedName,
+		Version:   &selectedVersion,
+		Subpath:   &selectedSubpath,
+	}
 	selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
 	if err != nil {
 		return err
@@ -43,14 +49,39 @@ func registerAllHasSLSA(client *demoClient) error {
 	selectedSourceNameSpace := "github"
 	selectedSourceName := "https://github.com/django/django"
 	selectedTag := "1.11.1"
-	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
+	selectedSourceSpec := &model.SourceSpec{
+		Type:      &selectedSourceType,
+		Namespace: &selectedSourceNameSpace,
+		Name:      &selectedSourceName,
+		Tag:       &selectedTag,
+	}
 	selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
 	if err != nil {
 		return err
 	}
-	predicateValues := []*model.SLSAPredicate{{Key: "buildDefinition.externalParameters.repository", Value: "https://github.com/octocat/hello-world"}, {Key: "buildDefinition.externalParameters.ref", Value: "refs/heads/main"}, {Key: "buildDefinition.resolvedDependencies.uri", Value: "git+https://github.com/octocat/hello-world@refs/heads/main"}}
+	predicateValues := []*model.SLSAPredicate{
+		{
+			Key:   "buildDefinition.externalParameters.repository",
+			Value: "https://github.com/octocat/hello-world",
+		},
+		{
+			Key:   "buildDefinition.externalParameters.ref",
+			Value: "refs/heads/main",
+		},
+		{
+			Key:   "buildDefinition.resolvedDependencies.uri",
+			Value: "git+https://github.com/octocat/hello-world@refs/heads/main",
+		},
+	}
 
-	err = client.registerHasSLSA(selectedPackage[0], nil, nil, nil, selectedSource, nil, &model.Builder{URI: "https://github.com/Attestations/GitHubHostedActions@v1"}, "https://github.com/Attestations/GitHubActionsWorkflow@v1", predicateValues, "v1", time.Now(), time.Now())
+	builder := &model.Builder{
+		URI: "https://github.com/Attestations/GitHubHostedActions@v1",
+	}
+
+	err = client.registerHasSLSA(
+		selectedPackage[0], nil, nil, nil, selectedSource, nil, builder,
+		"https://github.com/Attestations/GitHubActionsWorkflow@v1",
+		predicateValues, "v1", time.Now(), time.Now())
 	if err != nil {
 		return err
 	}
@@ -59,11 +90,15 @@ func registerAllHasSLSA(client *demoClient) error {
 
 // Ingest HasSlsa
 
-func (c *demoClient) registerHasSLSA(selectedPackage *model.Package, selectedSource *model.Source, selectedArtifact *model.Artifact, builtFromPackages []*model.Package,
-	builtFromSouces []*model.Source, builtFromArtifacts []*model.Artifact, builtBy *model.Builder, buildType string, predicate []*model.SLSAPredicate, slsaVersion string, startOn time.Time, finishOn time.Time) error {
-
+func (c *demoClient) registerHasSLSA(
+	selectedPackage *model.Package, selectedSource *model.Source, selectedArtifact *model.Artifact,
+	builtFromPackages []*model.Package, builtFromSouces []*model.Source, builtFromArtifacts []*model.Artifact,
+	builtBy *model.Builder, buildType string,
+	predicate []*model.SLSAPredicate, slsaVersion string,
+	startOn time.Time, finishOn time.Time) error {
 	for _, h := range c.hasSLSA {
-		if h.BuildType == buildType && h.SlsaVersion == slsaVersion {
+		slsa := h.Slsa
+		if slsa.BuildType == buildType && slsa.SlsaVersion == slsaVersion {
 			if val, ok := h.Subject.(model.Package); ok {
 				if &val == selectedPackage {
 					return nil
@@ -80,7 +115,18 @@ func (c *demoClient) registerHasSLSA(selectedPackage *model.Package, selectedSou
 		}
 	}
 
-	newHasSlsa := &model.HasSlsa{
+	materials := []model.PackageSourceOrArtifact{}
+	for _, pack := range builtFromPackages {
+		materials = append(materials, pack)
+	}
+	for _, source := range builtFromSouces {
+		materials = append(materials, source)
+	}
+	for _, art := range builtFromArtifacts {
+		materials = append(materials, art)
+	}
+	newSlsa := &model.Slsa{
+		BuiltFrom:     materials,
 		BuiltBy:       builtBy,
 		BuildType:     buildType,
 		SlsaPredicate: predicate,
@@ -90,22 +136,14 @@ func (c *demoClient) registerHasSLSA(selectedPackage *model.Package, selectedSou
 		Origin:        "testing backend",
 		Collector:     "testing backend",
 	}
+
+	newHasSlsa := &model.HasSlsa{Slsa: newSlsa}
 	if selectedPackage != nil {
 		newHasSlsa.Subject = selectedPackage
 	} else if selectedSource != nil {
 		newHasSlsa.Subject = selectedSource
 	} else {
 		newHasSlsa.Subject = selectedArtifact
-	}
-
-	for _, pack := range builtFromPackages {
-		newHasSlsa.BuiltFrom = append(newHasSlsa.BuiltFrom, pack)
-	}
-	for _, source := range builtFromSouces {
-		newHasSlsa.BuiltFrom = append(newHasSlsa.BuiltFrom, source)
-	}
-	for _, art := range builtFromArtifacts {
-		newHasSlsa.BuiltFrom = append(newHasSlsa.BuiltFrom, art)
 	}
 
 	c.hasSLSA = append(c.hasSLSA, newHasSlsa)
@@ -115,7 +153,7 @@ func (c *demoClient) registerHasSLSA(selectedPackage *model.Package, selectedSou
 // Query HasSlsa
 
 func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
-
+	// TODO
 	if hasSLSASpec.Package != nil && hasSLSASpec.Source != nil && hasSLSASpec.Artifact != nil {
 		return nil, gqlerror.Errorf("cannot specify package, source and artifact together for hasSLSASpec")
 	}
@@ -134,21 +172,22 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 	for _, h := range c.hasSLSA {
 		matchOrSkip := true
 
-		if hasSLSASpec.BuildType != nil && h.BuildType != *hasSLSASpec.BuildType {
+		slsa := h.Slsa
+		if hasSLSASpec.BuildType != nil && slsa.BuildType != *hasSLSASpec.BuildType {
 			matchOrSkip = false
 		}
-		if hasSLSASpec.SlsaVersion != nil && h.SlsaVersion != *hasSLSASpec.SlsaVersion {
+		if hasSLSASpec.SlsaVersion != nil && slsa.SlsaVersion != *hasSLSASpec.SlsaVersion {
 			matchOrSkip = false
 		}
-		if hasSLSASpec.Collector != nil && h.Collector != *hasSLSASpec.Collector {
+		if hasSLSASpec.Collector != nil && slsa.Collector != *hasSLSASpec.Collector {
 			matchOrSkip = false
 		}
-		if hasSLSASpec.Origin != nil && h.Origin != *hasSLSASpec.Origin {
+		if hasSLSASpec.Origin != nil && slsa.Origin != *hasSLSASpec.Origin {
 			matchOrSkip = false
 		}
 
-		if hasSLSASpec.BuiltBy != nil && h.BuiltBy != nil {
-			if hasSLSASpec.BuiltBy.URI != nil && h.BuiltBy.URI != *hasSLSASpec.BuiltBy.URI {
+		if hasSLSASpec.BuiltBy != nil && slsa.BuiltBy != nil {
+			if hasSLSASpec.BuiltBy.URI != nil && slsa.BuiltBy.URI != *hasSLSASpec.BuiltBy.URI {
 				matchOrSkip = false
 			}
 		}

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -154,14 +154,17 @@ func (c *demoClient) registerHasSLSA(
 
 func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
 	subjectsDefined := 0
-	if hasSLSASpec.Subject.Package != nil {
-		subjectsDefined = subjectsDefined + 1
-	}
-	if hasSLSASpec.Subject.Source != nil {
-		subjectsDefined = subjectsDefined + 1
-	}
-	if hasSLSASpec.Subject.Artifact != nil {
-		subjectsDefined = subjectsDefined + 1
+	// TODO(mihaimaruseac): Revisit e2e
+	if hasSLSASpec.Subject != nil {
+		if hasSLSASpec.Subject.Package != nil {
+			subjectsDefined = subjectsDefined + 1
+		}
+		if hasSLSASpec.Subject.Source != nil {
+			subjectsDefined = subjectsDefined + 1
+		}
+		if hasSLSASpec.Subject.Artifact != nil {
+			subjectsDefined = subjectsDefined + 1
+		}
 	}
 	if subjectsDefined > 1 {
 		return nil, gqlerror.Errorf("Must specify at most one subject (package, source, or artifact)")
@@ -192,7 +195,7 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Subject.Package != nil && h.Subject != nil {
+		if hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Package != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Package); ok {
 				if hasSLSASpec.Subject.Package.Type == nil || val.Type == *hasSLSASpec.Subject.Package.Type {
 					newPkg := filterPackageNamespace(val, hasSLSASpec.Subject.Package)
@@ -205,7 +208,7 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Subject.Source != nil && h.Subject != nil {
+		if hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Source != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Source); ok {
 				if hasSLSASpec.Subject.Source.Type == nil || val.Type == *hasSLSASpec.Subject.Source.Type {
 					newSource, err := filterSourceNamespace(val, hasSLSASpec.Subject.Source)
@@ -221,7 +224,7 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Subject.Artifact != nil && h.Subject != nil {
+		if hasSLSASpec.Subject != nil && hasSLSASpec.Subject.Artifact != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Artifact); ok {
 				queryArt := &model.Artifact{
 					Algorithm: strings.ToLower(*hasSLSASpec.Subject.Artifact.Algorithm),

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -154,13 +154,13 @@ func (c *demoClient) registerHasSLSA(
 
 func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
 	subjectsDefined := 0
-	if hasSLSASpec.Package != nil {
+	if hasSLSASpec.Subject.Package != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Source != nil {
+	if hasSLSASpec.Subject.Source != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Artifact != nil {
+	if hasSLSASpec.Subject.Artifact != nil {
 		subjectsDefined = subjectsDefined + 1
 	}
 	if subjectsDefined > 1 {
@@ -192,10 +192,10 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Package != nil && h.Subject != nil {
+		if hasSLSASpec.Subject.Package != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Package); ok {
-				if hasSLSASpec.Package.Type == nil || val.Type == *hasSLSASpec.Package.Type {
-					newPkg := filterPackageNamespace(val, hasSLSASpec.Package)
+				if hasSLSASpec.Subject.Package.Type == nil || val.Type == *hasSLSASpec.Subject.Package.Type {
+					newPkg := filterPackageNamespace(val, hasSLSASpec.Subject.Package)
 					if newPkg == nil {
 						matchOrSkip = false
 					}
@@ -205,10 +205,10 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Source != nil && h.Subject != nil {
+		if hasSLSASpec.Subject.Source != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Source); ok {
-				if hasSLSASpec.Source.Type == nil || val.Type == *hasSLSASpec.Source.Type {
-					newSource, err := filterSourceNamespace(val, hasSLSASpec.Source)
+				if hasSLSASpec.Subject.Source.Type == nil || val.Type == *hasSLSASpec.Subject.Source.Type {
+					newSource, err := filterSourceNamespace(val, hasSLSASpec.Subject.Source)
 					if err != nil {
 						return nil, err
 					}
@@ -221,11 +221,11 @@ func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec
 			}
 		}
 
-		if hasSLSASpec.Artifact != nil && h.Subject != nil {
+		if hasSLSASpec.Subject.Artifact != nil && h.Subject != nil {
 			if val, ok := h.Subject.(*model.Artifact); ok {
 				queryArt := &model.Artifact{
-					Algorithm: strings.ToLower(*hasSLSASpec.Artifact.Algorithm),
-					Digest:    strings.ToLower(*hasSLSASpec.Artifact.Digest),
+					Algorithm: strings.ToLower(*hasSLSASpec.Subject.Artifact.Algorithm),
+					Digest:    strings.ToLower(*hasSLSASpec.Subject.Artifact.Digest),
 				}
 				if *queryArt != *val {
 					matchOrSkip = false

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -153,18 +153,18 @@ func (c *demoClient) registerHasSLSA(
 // Query HasSlsa
 
 func (c *demoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
-	// TODO
-	if hasSLSASpec.Package != nil && hasSLSASpec.Source != nil && hasSLSASpec.Artifact != nil {
-		return nil, gqlerror.Errorf("cannot specify package, source and artifact together for hasSLSASpec")
+	subjectsDefined := 0
+	if hasSLSASpec.Package != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Package != nil && hasSLSASpec.Source != nil {
-		return nil, gqlerror.Errorf("cannot specify package and source together for hasSLSASpec")
+	if hasSLSASpec.Source != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Package != nil && hasSLSASpec.Artifact != nil {
-		return nil, gqlerror.Errorf("cannot specify package and artifact together for hasSLSASpec")
+	if hasSLSASpec.Artifact != nil {
+		subjectsDefined = subjectsDefined + 1
 	}
-	if hasSLSASpec.Source != nil && hasSLSASpec.Artifact != nil {
-		return nil, gqlerror.Errorf("cannot specify source and artifact together for hasSLSASpec")
+	if subjectsDefined > 1 {
+		return nil, gqlerror.Errorf("Must specify at most one subject (package, source, or artifact)")
 	}
 
 	var collectedHasSLSA []*model.HasSlsa

--- a/pkg/assembler/graphql/examples/has_slsa.gql
+++ b/pkg/assembler/graphql/examples/has_slsa.gql
@@ -1,33 +1,41 @@
-fragment allHasSLSA on HasSLSA {
+fragment allPkgTree on Package {
+  type
+  namespaces {
+    namespace
+    names {
+      name
+      versions {
+        version
+        qualifiers {
+          key
+          value
+        }
+        subpath
+      }
+    }
+  }
+}
+
+fragment allSrcTree on Source {
+  type
+  namespaces {
+    namespace
+    names {
+      name
+      tag
+      commit
+    }
+  }
+}
+
+fragment allSLSATree on HasSLSA {
   subject {
     __typename
     ... on Package {
-      type
-      namespaces {
-        namespace
-        names {
-          name
-          versions {
-            version
-            qualifiers {
-              key
-              value
-            }
-            subpath
-          }
-        }
-      }
+      ...allPkgTree
     }
     ... on Source {
-      type
-      namespaces {
-        namespace
-        names {
-          name
-          tag
-          commit
-        }
-      }
+      ...allSrcTree
     }
     ... on Artifact {
       algorithm
@@ -35,34 +43,12 @@ fragment allHasSLSA on HasSLSA {
     }
   }
   builtFrom {
-       __typename
+    __typename
     ... on Package {
-      type
-      namespaces {
-        namespace
-        names {
-          name
-          versions {
-            version
-            qualifiers {
-              key
-              value
-            }
-            subpath
-          }
-        }
-      }
+      ...allPkgTree
     }
     ... on Source {
-      type
-      namespaces {
-        namespace
-        names {
-          name
-          tag
-          commit
-        }
-      }
+      ...allSrcTree
     }
     ... on Artifact {
       algorithm
@@ -73,7 +59,7 @@ fragment allHasSLSA on HasSLSA {
     uri
   }
   buildType
-  slsaPredicate{
+  slsaPredicate {
     key
     value
   }
@@ -84,20 +70,20 @@ fragment allHasSLSA on HasSLSA {
   collector
 }
 
-query Q1 {
+query SLSAQ1 {
   HasSLSA(hasSLSASpec: {}) {
-    ...allHasSLSA
+    ...allSLSATree
   }
 }
 
-query Q2 {
+query SLSAQ2 {
   HasSLSA(hasSLSASpec: {origin: "testing backend"}) {
-    ...allHasSLSA
+    ...allSLSATree
   }
 }
 
-query Q3 {
+query SLSAQ3 {
   HasSLSA(hasSLSASpec: {package: {name: "django"}}) {
-    ...allHasSLSA
+    ...allSLSATree
   }
 }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -2774,7 +2774,7 @@ func (ec *executionContext) unmarshalInputArtifactSpec(ctx context.Context, obj 
 
 // region    **************************** object.gotpl ****************************
 
-var artifactImplementors = []string{"Artifact", "PkgSrcArtObject", "PkgArtObject"}
+var artifactImplementors = []string{"Artifact", "PkgArtObject", "PackageSourceOrArtifact"}
 
 func (ec *executionContext) _Artifact(ctx context.Context, sel ast.SelectionSet, obj *model.Artifact) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, artifactImplementors)

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -2017,24 +2017,8 @@ func (ec *executionContext) fieldContext_Query_HasSLSA(ctx context.Context, fiel
 			switch field.Name {
 			case "subject":
 				return ec.fieldContext_HasSLSA_subject(ctx, field)
-			case "builtFrom":
-				return ec.fieldContext_HasSLSA_builtFrom(ctx, field)
-			case "builtBy":
-				return ec.fieldContext_HasSLSA_builtBy(ctx, field)
-			case "buildType":
-				return ec.fieldContext_HasSLSA_buildType(ctx, field)
-			case "slsaPredicate":
-				return ec.fieldContext_HasSLSA_slsaPredicate(ctx, field)
-			case "slsaVersion":
-				return ec.fieldContext_HasSLSA_slsaVersion(ctx, field)
-			case "startedOn":
-				return ec.fieldContext_HasSLSA_startedOn(ctx, field)
-			case "finishedOn":
-				return ec.fieldContext_HasSLSA_finishedOn(ctx, field)
-			case "origin":
-				return ec.fieldContext_HasSLSA_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HasSLSA_collector(ctx, field)
+			case "slsa":
+				return ec.fieldContext_HasSLSA_slsa(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HasSLSA", field.Name)
 		},

--- a/pkg/assembler/graphql/generated/certifyBad.generated.go
+++ b/pkg/assembler/graphql/generated/certifyBad.generated.go
@@ -5,7 +5,6 @@ package generated
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -54,9 +53,9 @@ func (ec *executionContext) _CertifyBad_subject(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(model.PkgSrcArtObject)
+	res := resTmp.(model.PackageSourceOrArtifact)
 	fc.Result = res
-	return ec.marshalNPkgSrcArtObject2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObject(ctx, field.Selections, res)
+	return ec.marshalNPackageSourceOrArtifact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifact(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyBad_subject(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -66,7 +65,7 @@ func (ec *executionContext) fieldContext_CertifyBad_subject(ctx context.Context,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type PkgSrcArtObject does not have child fields")
+			return nil, errors.New("field of type PackageSourceOrArtifact does not have child fields")
 		},
 	}
 	return fc, nil
@@ -280,36 +279,6 @@ func (ec *executionContext) unmarshalInputCertifyBadSpec(ctx context.Context, ob
 
 // region    ************************** interface.gotpl ***************************
 
-func (ec *executionContext) _PkgSrcArtObject(ctx context.Context, sel ast.SelectionSet, obj model.PkgSrcArtObject) graphql.Marshaler {
-	switch obj := (obj).(type) {
-	case nil:
-		return graphql.Null
-	case model.Package:
-		return ec._Package(ctx, sel, &obj)
-	case *model.Package:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Package(ctx, sel, obj)
-	case model.Source:
-		return ec._Source(ctx, sel, &obj)
-	case *model.Source:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Source(ctx, sel, obj)
-	case model.Artifact:
-		return ec._Artifact(ctx, sel, &obj)
-	case *model.Artifact:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._Artifact(ctx, sel, obj)
-	default:
-		panic(fmt.Errorf("unexpected type %T", obj))
-	}
-}
-
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
@@ -419,60 +388,6 @@ func (ec *executionContext) marshalNCertifyBad2ᚖgithubᚗcomᚋguacsecᚋguac�
 		return graphql.Null
 	}
 	return ec._CertifyBad(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNPkgSrcArtObject2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObject(ctx context.Context, sel ast.SelectionSet, v model.PkgSrcArtObject) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._PkgSrcArtObject(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNPkgSrcArtObject2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObjectᚄ(ctx context.Context, sel ast.SelectionSet, v []model.PkgSrcArtObject) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNPkgSrcArtObject2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObject(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalOCertifyBadSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyBadSpec(ctx context.Context, v interface{}) (*model.CertifyBadSpec, error) {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -55,9 +55,9 @@ func (ec *executionContext) _HasSLSA_subject(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.(model.PkgSrcArtObject)
+	res := resTmp.(model.PackageSourceOrArtifact)
 	fc.Result = res
-	return ec.marshalNPkgSrcArtObject2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObject(ctx, field.Selections, res)
+	return ec.marshalNPackageSourceOrArtifact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifact(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSLSA_subject(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -67,7 +67,7 @@ func (ec *executionContext) fieldContext_HasSLSA_subject(ctx context.Context, fi
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type PkgSrcArtObject does not have child fields")
+			return nil, errors.New("field of type PackageSourceOrArtifact does not have child fields")
 		},
 	}
 	return fc, nil
@@ -99,9 +99,9 @@ func (ec *executionContext) _HasSLSA_builtFrom(ctx context.Context, field graphq
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]model.PkgSrcArtObject)
+	res := resTmp.([]model.PackageSourceOrArtifact)
 	fc.Result = res
-	return ec.marshalNPkgSrcArtObject2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSrcArtObjectᚄ(ctx, field.Selections, res)
+	return ec.marshalNPackageSourceOrArtifact2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSLSA_builtFrom(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -111,7 +111,7 @@ func (ec *executionContext) fieldContext_HasSLSA_builtFrom(ctx context.Context, 
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type PkgSrcArtObject does not have child fields")
+			return nil, errors.New("field of type PackageSourceOrArtifact does not have child fields")
 		},
 	}
 	return fc, nil
@@ -747,6 +747,36 @@ func (ec *executionContext) unmarshalInputSLSAPredicateSpec(ctx context.Context,
 
 // region    ************************** interface.gotpl ***************************
 
+func (ec *executionContext) _PackageSourceOrArtifact(ctx context.Context, sel ast.SelectionSet, obj model.PackageSourceOrArtifact) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case model.Package:
+		return ec._Package(ctx, sel, &obj)
+	case *model.Package:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Package(ctx, sel, obj)
+	case model.Source:
+		return ec._Source(ctx, sel, &obj)
+	case *model.Source:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Source(ctx, sel, obj)
+	case model.Artifact:
+		return ec._Artifact(ctx, sel, &obj)
+	case *model.Artifact:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Artifact(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
@@ -933,6 +963,60 @@ func (ec *executionContext) marshalNHasSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋp
 		return graphql.Null
 	}
 	return ec._HasSLSA(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPackageSourceOrArtifact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifact(ctx context.Context, sel ast.SelectionSet, v model.PackageSourceOrArtifact) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PackageSourceOrArtifact(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPackageSourceOrArtifact2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactᚄ(ctx context.Context, sel ast.SelectionSet, v []model.PackageSourceOrArtifact) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPackageSourceOrArtifact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifact(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNSLSAPredicate2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAPredicateᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SLSAPredicate) graphql.Marshaler {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -643,7 +643,7 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 		asMap["predicate"] = []interface{}{}
 	}
 
-	fieldsInOrder := [...]string{"package", "source", "artifact", "builtFromPackages", "builtFromSource", "builtFromArtifact", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
+	fieldsInOrder := [...]string{"package", "source", "artifact", "builtFrom", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -674,27 +674,11 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 			if err != nil {
 				return it, err
 			}
-		case "builtFromPackages":
+		case "builtFrom":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFromPackages"))
-			it.BuiltFromPackages, err = ec.unmarshalOPkgSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "builtFromSource":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFromSource"))
-			it.BuiltFromSource, err = ec.unmarshalOSourceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "builtFromArtifact":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFromArtifact"))
-			it.BuiltFromArtifact, err = ec.unmarshalOArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifactSpec(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFrom"))
+			it.BuiltFrom, err = ec.unmarshalOPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -759,6 +743,50 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("collector"))
 			it.Collector, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputPackageSourceOrArtifactInput(ctx context.Context, obj interface{}) (model.PackageSourceOrArtifactInput, error) {
+	var it model.PackageSourceOrArtifactInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"package", "source", "artifact"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "package":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("package"))
+			it.Package, err = ec.unmarshalOPkgSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "source":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+			it.Source, err = ec.unmarshalOSourceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "artifact":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("artifact"))
+			it.Artifact, err = ec.unmarshalOArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifactSpec(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1105,6 +1133,11 @@ func (ec *executionContext) marshalNPackageSourceOrArtifact2ᚕgithubᚗcomᚋgu
 	return ret
 }
 
+func (ec *executionContext) unmarshalNPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx context.Context, v interface{}) (*model.PackageSourceOrArtifactInput, error) {
+	res, err := ec.unmarshalInputPackageSourceOrArtifactInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNSLSAPredicate2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAPredicateᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SLSAPredicate) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -1170,6 +1203,26 @@ func (ec *executionContext) unmarshalOHasSLSASpec2ᚖgithubᚗcomᚋguacsecᚋgu
 	}
 	res, err := ec.unmarshalInputHasSLSASpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx context.Context, v interface{}) ([]*model.PackageSourceOrArtifactInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.PackageSourceOrArtifactInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) marshalOSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSlsa(ctx context.Context, sel ast.SelectionSet, v *model.Slsa) graphql.Marshaler {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -73,8 +73,69 @@ func (ec *executionContext) fieldContext_HasSLSA_subject(ctx context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_builtFrom(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_builtFrom(ctx, field)
+func (ec *executionContext) _HasSLSA_slsa(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSLSA_slsa(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Slsa, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Slsa)
+	fc.Result = res
+	return ec.marshalOSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSlsa(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSLSA_slsa(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSLSA",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "builtFrom":
+				return ec.fieldContext_SLSA_builtFrom(ctx, field)
+			case "builtBy":
+				return ec.fieldContext_SLSA_builtBy(ctx, field)
+			case "buildType":
+				return ec.fieldContext_SLSA_buildType(ctx, field)
+			case "slsaPredicate":
+				return ec.fieldContext_SLSA_slsaPredicate(ctx, field)
+			case "slsaVersion":
+				return ec.fieldContext_SLSA_slsaVersion(ctx, field)
+			case "startedOn":
+				return ec.fieldContext_SLSA_startedOn(ctx, field)
+			case "finishedOn":
+				return ec.fieldContext_SLSA_finishedOn(ctx, field)
+			case "origin":
+				return ec.fieldContext_SLSA_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_SLSA_collector(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SLSA", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SLSA_builtFrom(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_builtFrom(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -104,9 +165,9 @@ func (ec *executionContext) _HasSLSA_builtFrom(ctx context.Context, field graphq
 	return ec.marshalNPackageSourceOrArtifact2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_builtFrom(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_builtFrom(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -117,8 +178,8 @@ func (ec *executionContext) fieldContext_HasSLSA_builtFrom(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_builtBy(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_builtBy(ctx, field)
+func (ec *executionContext) _SLSA_builtBy(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_builtBy(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -148,9 +209,9 @@ func (ec *executionContext) _HasSLSA_builtBy(ctx context.Context, field graphql.
 	return ec.marshalNBuilder2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilder(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_builtBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_builtBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -165,8 +226,8 @@ func (ec *executionContext) fieldContext_HasSLSA_builtBy(ctx context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_buildType(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_buildType(ctx, field)
+func (ec *executionContext) _SLSA_buildType(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_buildType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -196,9 +257,9 @@ func (ec *executionContext) _HasSLSA_buildType(ctx context.Context, field graphq
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_buildType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_buildType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -209,8 +270,8 @@ func (ec *executionContext) fieldContext_HasSLSA_buildType(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_slsaPredicate(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_slsaPredicate(ctx, field)
+func (ec *executionContext) _SLSA_slsaPredicate(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_slsaPredicate(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -240,9 +301,9 @@ func (ec *executionContext) _HasSLSA_slsaPredicate(ctx context.Context, field gr
 	return ec.marshalNSLSAPredicate2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAPredicateᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_slsaPredicate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_slsaPredicate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -259,8 +320,8 @@ func (ec *executionContext) fieldContext_HasSLSA_slsaPredicate(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_slsaVersion(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_slsaVersion(ctx, field)
+func (ec *executionContext) _SLSA_slsaVersion(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_slsaVersion(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -290,9 +351,9 @@ func (ec *executionContext) _HasSLSA_slsaVersion(ctx context.Context, field grap
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_slsaVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_slsaVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -303,8 +364,8 @@ func (ec *executionContext) fieldContext_HasSLSA_slsaVersion(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_startedOn(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_startedOn(ctx, field)
+func (ec *executionContext) _SLSA_startedOn(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_startedOn(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -334,9 +395,9 @@ func (ec *executionContext) _HasSLSA_startedOn(ctx context.Context, field graphq
 	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_startedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_startedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -347,8 +408,8 @@ func (ec *executionContext) fieldContext_HasSLSA_startedOn(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_finishedOn(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_finishedOn(ctx, field)
+func (ec *executionContext) _SLSA_finishedOn(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_finishedOn(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -378,9 +439,9 @@ func (ec *executionContext) _HasSLSA_finishedOn(ctx context.Context, field graph
 	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_finishedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_finishedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -391,8 +452,8 @@ func (ec *executionContext) fieldContext_HasSLSA_finishedOn(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_origin(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_origin(ctx, field)
+func (ec *executionContext) _SLSA_origin(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_origin(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -422,9 +483,9 @@ func (ec *executionContext) _HasSLSA_origin(ctx context.Context, field graphql.C
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_origin(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_origin(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -435,8 +496,8 @@ func (ec *executionContext) fieldContext_HasSLSA_origin(ctx context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSLSA_collector(ctx context.Context, field graphql.CollectedField, obj *model.HasSlsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSLSA_collector(ctx, field)
+func (ec *executionContext) _SLSA_collector(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_collector(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -466,9 +527,9 @@ func (ec *executionContext) _HasSLSA_collector(ctx context.Context, field graphq
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSLSA_collector(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_SLSA_collector(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "HasSLSA",
+		Object:     "SLSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -798,65 +859,90 @@ func (ec *executionContext) _HasSLSA(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "slsa":
+
+			out.Values[i] = ec._HasSLSA_slsa(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var sLSAImplementors = []string{"SLSA"}
+
+func (ec *executionContext) _SLSA(ctx context.Context, sel ast.SelectionSet, obj *model.Slsa) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sLSAImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SLSA")
 		case "builtFrom":
 
-			out.Values[i] = ec._HasSLSA_builtFrom(ctx, field, obj)
+			out.Values[i] = ec._SLSA_builtFrom(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "builtBy":
 
-			out.Values[i] = ec._HasSLSA_builtBy(ctx, field, obj)
+			out.Values[i] = ec._SLSA_builtBy(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "buildType":
 
-			out.Values[i] = ec._HasSLSA_buildType(ctx, field, obj)
+			out.Values[i] = ec._SLSA_buildType(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "slsaPredicate":
 
-			out.Values[i] = ec._HasSLSA_slsaPredicate(ctx, field, obj)
+			out.Values[i] = ec._SLSA_slsaPredicate(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "slsaVersion":
 
-			out.Values[i] = ec._HasSLSA_slsaVersion(ctx, field, obj)
+			out.Values[i] = ec._SLSA_slsaVersion(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "startedOn":
 
-			out.Values[i] = ec._HasSLSA_startedOn(ctx, field, obj)
+			out.Values[i] = ec._SLSA_startedOn(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "finishedOn":
 
-			out.Values[i] = ec._HasSLSA_finishedOn(ctx, field, obj)
+			out.Values[i] = ec._SLSA_finishedOn(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "origin":
 
-			out.Values[i] = ec._HasSLSA_origin(ctx, field, obj)
+			out.Values[i] = ec._SLSA_origin(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "collector":
 
-			out.Values[i] = ec._HasSLSA_collector(ctx, field, obj)
+			out.Values[i] = ec._SLSA_collector(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -1084,6 +1170,13 @@ func (ec *executionContext) unmarshalOHasSLSASpec2ᚖgithubᚗcomᚋguacsecᚋgu
 	}
 	res, err := ec.unmarshalInputHasSLSASpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSlsa(ctx context.Context, sel ast.SelectionSet, v *model.Slsa) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._SLSA(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOSLSAPredicateSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAPredicateSpecᚄ(ctx context.Context, v interface{}) ([]*model.SLSAPredicateSpec, error) {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -643,34 +643,18 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 		asMap["predicate"] = []interface{}{}
 	}
 
-	fieldsInOrder := [...]string{"package", "source", "artifact", "builtFrom", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
+	fieldsInOrder := [...]string{"subject", "builtFrom", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "package":
+		case "subject":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("package"))
-			it.Package, err = ec.unmarshalOPkgSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "source":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
-			it.Source, err = ec.unmarshalOSourceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "artifact":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("artifact"))
-			it.Artifact, err = ec.unmarshalOArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifactSpec(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subject"))
+			it.Subject, err = ec.unmarshalOPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1223,6 +1207,14 @@ func (ec *executionContext) unmarshalOPackageSourceOrArtifactInput2ᚕᚖgithub�
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) unmarshalOPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx context.Context, v interface{}) (*model.PackageSourceOrArtifactInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputPackageSourceOrArtifactInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSlsa(ctx context.Context, sel ast.SelectionSet, v *model.Slsa) graphql.Marshaler {

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -786,7 +786,7 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 
 // region    **************************** object.gotpl ****************************
 
-var packageImplementors = []string{"Package", "PkgSrcArtObject", "PkgArtObject", "PkgSrcObject"}
+var packageImplementors = []string{"Package", "PkgArtObject", "PkgSrcObject", "PackageSourceOrArtifact"}
 
 func (ec *executionContext) _Package(ctx context.Context, sel ast.SelectionSet, obj *model.Package) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, packageImplementors)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1433,6 +1433,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputOsvCveOrGhsaSpec,
 		ec.unmarshalInputPackageQualifierInputSpec,
 		ec.unmarshalInputPackageQualifierSpec,
+		ec.unmarshalInputPackageSourceOrArtifactInput,
 		ec.unmarshalInputPkgInputSpec,
 		ec.unmarshalInputPkgNameSpec,
 		ec.unmarshalInputPkgSpec,
@@ -1810,9 +1811,7 @@ type ScorecardCheck {
   score: Int!
 }
 
-"""
-CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
-"""
+"CertifyScorecardSpec allows filtering the list of CertifyScorecard to return."
 input CertifyScorecardSpec {
   source: SourceSpec
   timeScanned: Time
@@ -1824,9 +1823,7 @@ input CertifyScorecardSpec {
   collector: String
 }
 
-"""
-ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input.
-"""
+"ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input."
 input ScorecardCheckSpec {
   check: String!
   score: Int!
@@ -2266,6 +2263,18 @@ extend type Query {
 "PackageSourceOrArtifact is a union of Package, Source, and Artifact."
 union PackageSourceOrArtifact = Package | Source | Artifact
 
+"""
+PackageSourceOrArtifactInput allows using PackageSourceOrArtifact union as
+input type.
+
+Exactly one of the value must be set to non-nil.
+"""
+input PackageSourceOrArtifactInput {
+  package: PkgSpec
+  source: SourceSpec
+  artifact: ArtifactSpec
+}
+
 "HasSLSA records that a subject node has a SLSA attestation."
 type HasSLSA {
   "The subject of SLSA attestation: package, source, or artifact."
@@ -2339,18 +2348,12 @@ type SLSAPredicate {
   value: String!
 }
 
-# TODO: clean from here down
-
-"""
-HasSLSASpec allows filtering the list of HasSLSA to return.
-"""
+"HasSLSASpec allows filtering the list of HasSLSA to return."
 input HasSLSASpec {
   package: PkgSpec
   source: SourceSpec
   artifact: ArtifactSpec
-  builtFromPackages: [PkgSpec]
-  builtFromSource: [SourceSpec]
-  builtFromArtifact: [ArtifactSpec]
+  builtFrom: [PackageSourceOrArtifactInput!]
   builtBy: BuilderSpec
   buildType: String
   predicate: [SLSAPredicateSpec!] = []
@@ -2362,8 +2365,7 @@ input HasSLSASpec {
 }
 
 """
-SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query
-input.
+SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query input.
 """
 input SLSAPredicateSpec {
   key: String!
@@ -2371,7 +2373,7 @@ input SLSAPredicateSpec {
 }
 
 extend type Query {
-  "Returns all HasSLSA"
+  "Returns all SLSA attestations matching the filter"
   HasSLSA(hasSLSASpec: HasSLSASpec): [HasSLSA!]!
 }
 `, BuiltIn: false},

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -1638,7 +1638,7 @@ collector (property) - the GUAC collector that collected the document that gener
 Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 """
 type CertifyBad {
-  subject: PkgSrcArtObject!
+  subject: PackageSourceOrArtifact!
   justification: String!
   origin: String!
   collector: String!
@@ -1658,11 +1658,6 @@ input CertifyBadSpec {
   origin: String
   collector: String
 }
-
-"""
-PkgSrcArtObject is a union of Package, Source and Artifact. Any of these objects can be specified
-"""
-union PkgSrcArtObject = Package | Source | Artifact
 
 extend type Query {
   "Returns all CertifyBad"
@@ -2255,7 +2250,14 @@ extend type Query {
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines a GraphQL schema for the HasSLSA. It contains the Subject which can be of type package, source or artifact,
+# Defines a GraphQL schema for specifiying SLSA provenance.
+
+"""
+PackageSourceOrArtifact is a union of Package, Source and Artifact.
+"""
+union PackageSourceOrArtifact = Package | Source | Artifact
+
+# the HasSLSA. It contains the Subject which can be of type package, source or artifact,
 # buliltFrom which can also be of type package, source or artifact, builtby (builder object), build type,  predicate (key value pair of
 # the predicate values), slsa version, started on, finished on, origin and collector.
 """
@@ -2273,8 +2275,8 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HasSLSA {
-  subject: PkgSrcArtObject!
-  builtFrom: [PkgSrcArtObject!]!
+  subject: PackageSourceOrArtifact!
+  builtFrom: [PackageSourceOrArtifact!]!
   builtBy: Builder!
   buildType: String!
   slsaPredicate: [SLSAPredicate!]!

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -106,16 +106,8 @@ type ComplexityRoot struct {
 	}
 
 	HasSLSA struct {
-		BuildType     func(childComplexity int) int
-		BuiltBy       func(childComplexity int) int
-		BuiltFrom     func(childComplexity int) int
-		Collector     func(childComplexity int) int
-		FinishedOn    func(childComplexity int) int
-		Origin        func(childComplexity int) int
-		SlsaPredicate func(childComplexity int) int
-		SlsaVersion   func(childComplexity int) int
-		StartedOn     func(childComplexity int) int
-		Subject       func(childComplexity int) int
+		Slsa    func(childComplexity int) int
+		Subject func(childComplexity int) int
 	}
 
 	HasSourceAt struct {
@@ -227,6 +219,18 @@ type ComplexityRoot struct {
 		Packages            func(childComplexity int, pkgSpec *model.PkgSpec) int
 		Scorecards          func(childComplexity int, scorecardSpec *model.CertifyScorecardSpec) int
 		Sources             func(childComplexity int, sourceSpec *model.SourceSpec) int
+	}
+
+	SLSA struct {
+		BuildType     func(childComplexity int) int
+		BuiltBy       func(childComplexity int) int
+		BuiltFrom     func(childComplexity int) int
+		Collector     func(childComplexity int) int
+		FinishedOn    func(childComplexity int) int
+		Origin        func(childComplexity int) int
+		SlsaPredicate func(childComplexity int) int
+		SlsaVersion   func(childComplexity int) int
+		StartedOn     func(childComplexity int) int
 	}
 
 	SLSAPredicate struct {
@@ -508,68 +512,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.HasSBOM.URI(childComplexity), true
 
-	case "HasSLSA.buildType":
-		if e.complexity.HasSLSA.BuildType == nil {
+	case "HasSLSA.slsa":
+		if e.complexity.HasSLSA.Slsa == nil {
 			break
 		}
 
-		return e.complexity.HasSLSA.BuildType(childComplexity), true
-
-	case "HasSLSA.builtBy":
-		if e.complexity.HasSLSA.BuiltBy == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.BuiltBy(childComplexity), true
-
-	case "HasSLSA.builtFrom":
-		if e.complexity.HasSLSA.BuiltFrom == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.BuiltFrom(childComplexity), true
-
-	case "HasSLSA.collector":
-		if e.complexity.HasSLSA.Collector == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.Collector(childComplexity), true
-
-	case "HasSLSA.finishedOn":
-		if e.complexity.HasSLSA.FinishedOn == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.FinishedOn(childComplexity), true
-
-	case "HasSLSA.origin":
-		if e.complexity.HasSLSA.Origin == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.Origin(childComplexity), true
-
-	case "HasSLSA.slsaPredicate":
-		if e.complexity.HasSLSA.SlsaPredicate == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.SlsaPredicate(childComplexity), true
-
-	case "HasSLSA.slsaVersion":
-		if e.complexity.HasSLSA.SlsaVersion == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.SlsaVersion(childComplexity), true
-
-	case "HasSLSA.startedOn":
-		if e.complexity.HasSLSA.StartedOn == nil {
-			break
-		}
-
-		return e.complexity.HasSLSA.StartedOn(childComplexity), true
+		return e.complexity.HasSLSA.Slsa(childComplexity), true
 
 	case "HasSLSA.subject":
 		if e.complexity.HasSLSA.Subject == nil {
@@ -1210,6 +1158,69 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Sources(childComplexity, args["sourceSpec"].(*model.SourceSpec)), true
+
+	case "SLSA.buildType":
+		if e.complexity.SLSA.BuildType == nil {
+			break
+		}
+
+		return e.complexity.SLSA.BuildType(childComplexity), true
+
+	case "SLSA.builtBy":
+		if e.complexity.SLSA.BuiltBy == nil {
+			break
+		}
+
+		return e.complexity.SLSA.BuiltBy(childComplexity), true
+
+	case "SLSA.builtFrom":
+		if e.complexity.SLSA.BuiltFrom == nil {
+			break
+		}
+
+		return e.complexity.SLSA.BuiltFrom(childComplexity), true
+
+	case "SLSA.collector":
+		if e.complexity.SLSA.Collector == nil {
+			break
+		}
+
+		return e.complexity.SLSA.Collector(childComplexity), true
+
+	case "SLSA.finishedOn":
+		if e.complexity.SLSA.FinishedOn == nil {
+			break
+		}
+
+		return e.complexity.SLSA.FinishedOn(childComplexity), true
+
+	case "SLSA.origin":
+		if e.complexity.SLSA.Origin == nil {
+			break
+		}
+
+		return e.complexity.SLSA.Origin(childComplexity), true
+
+	case "SLSA.slsaPredicate":
+		if e.complexity.SLSA.SlsaPredicate == nil {
+			break
+		}
+
+		return e.complexity.SLSA.SlsaPredicate(childComplexity), true
+
+	case "SLSA.slsaVersion":
+		if e.complexity.SLSA.SlsaVersion == nil {
+			break
+		}
+
+		return e.complexity.SLSA.SlsaVersion(childComplexity), true
+
+	case "SLSA.startedOn":
+		if e.complexity.SLSA.StartedOn == nil {
+			break
+		}
+
+		return e.complexity.SLSA.StartedOn(childComplexity), true
 
 	case "SLSAPredicate.key":
 		if e.complexity.SLSAPredicate.Key == nil {
@@ -2252,79 +2263,83 @@ extend type Query {
 
 # Defines a GraphQL schema for specifiying SLSA provenance.
 
-"""
-PackageSourceOrArtifact is a union of Package, Source and Artifact.
-"""
+"PackageSourceOrArtifact is a union of Package, Source, and Artifact."
 union PackageSourceOrArtifact = Package | Source | Artifact
 
-# the HasSLSA. It contains the Subject which can be of type package, source or artifact,
-# buliltFrom which can also be of type package, source or artifact, builtby (builder object), build type,  predicate (key value pair of
-# the predicate values), slsa version, started on, finished on, origin and collector.
-"""
-HasSLSA is an attestation represents that the subject has a SLSA attestation associated with it.
-
-subject - an union type that consists of package, source or artifact
-builtFrom (object) - list of union types that consists of the package, source or artifact that the subject was build from
-builtBy (object) - represents the builder that was used to build the subject
-buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
-slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
-slsaVersion (property) - version of the SLSA predicate
-startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
-finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
-origin (property) - where this attestation was generated from (based on which document)
-collector (property) - the GUAC collector that collected the document that generated this attestation
-"""
+"HasSLSA records that a subject node has a SLSA attestation."
 type HasSLSA {
+  "The subject of SLSA attestation: package, source, or artifact."
   subject: PackageSourceOrArtifact!
+  "The SLSA attestation."
+  slsa: SLSA
+}
+
+"""
+SLSA contains all of the fields present in a SLSA attestation.
+
+The materials and builders are objects of the HasSLSA predicate, everything
+else are properties extracted from the attestation.
+
+We also include fields to specify under what conditions the check was performed
+(time of scan, version of scanners, etc.) as well as how this information got
+included into GUAC (origin document and the collector for that document).
+"""
+type SLSA {
+  "Sources of the build resulting in subject (materials)"
   builtFrom: [PackageSourceOrArtifact!]!
+  "Builder performing the build"
   builtBy: Builder!
+  "Type of the builder"
   buildType: String!
+  "Individual predicates found in the attestation"
   slsaPredicate: [SLSAPredicate!]!
+  "Version of the SLSA predicate"
   slsaVersion: String!
+  "Timestamp (RFC3339Nano format) of build start time"
   startedOn: Time!
+  "Timestamp (RFC3339Nano format) of build end time"
   finishedOn: Time!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
 }
 
 """
 SLSAPredicate are the values from the SLSA predicate in key-value pair form.
-// Predicate:
-"predicateType": "https://slsa.dev/provenance/v1",
-"predicate": {
-    "buildDefinition": {
-        "buildType": string,
-        "externalParameters": object,
-        "systemParameters": object,
-        "resolvedDependencies": [ ...#ArtifactReference ],
-    },
-    "runDetails": {
-        "builder": {
-            "id": string,
-            "version": string,
-            "builderDependencies": [ ...#ArtifactReference ],
-        },
-        "metadata": {
-            "invocationId": string,
-            "startedOn": #Timestamp,
-            "finishedOn": #Timestamp,
-        },
-        "byproducts": [ ...#ArtifactReference ],
-    }
-}
-where
-"externalParameters": {
-    "repository": "https://github.com/octocat/hello-world",
-    "ref": "refs/heads/main"
-},
 
-For example: key = "buildDefinition.externalParameters.repository" value = "https://github.com/octocat/hello-world"
+For example, given the following predicate
+
+` + "`" + `` + "`" + `` + "`" + `
+"predicate": {
+  "buildDefinition": {
+    "externalParameters": {
+      "repository": "https://github.com/octocat/hello-world",
+      ...
+    },
+    ...
+  },
+  ...
+}
+` + "`" + `` + "`" + `` + "`" + `
+
+we have
+
+` + "`" + `` + "`" + `` + "`" + `
+key   = "buildDefinition.externalParameters.repository"
+value = "https://github.com/octocat/hello-world"
+` + "`" + `` + "`" + `` + "`" + `
+
 This node cannot be directly referred by other parts of GUAC.
+
+TODO(mihaimaruseac): Can we define these directly?
 """
 type SLSAPredicate {
   key: String!
   value: String!
 }
+
+# TODO: clean from here down
 
 """
 HasSLSASpec allows filtering the list of HasSLSA to return.

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2350,9 +2350,7 @@ type SLSAPredicate {
 
 "HasSLSASpec allows filtering the list of HasSLSA to return."
 input HasSLSASpec {
-  package: PkgSpec
-  source: SourceSpec
-  artifact: ArtifactSpec
+  subject: PackageSourceOrArtifactInput
   builtFrom: [PackageSourceOrArtifactInput!]
   builtBy: BuilderSpec
   buildType: String

--- a/pkg/assembler/graphql/generated/source.generated.go
+++ b/pkg/assembler/graphql/generated/source.generated.go
@@ -483,7 +483,7 @@ func (ec *executionContext) unmarshalInputSourceSpec(ctx context.Context, obj in
 
 // region    **************************** object.gotpl ****************************
 
-var sourceImplementors = []string{"Source", "PkgSrcArtObject", "PkgSrcObject"}
+var sourceImplementors = []string{"Source", "PkgSrcObject", "PackageSourceOrArtifact"}
 
 func (ec *executionContext) _Source(ctx context.Context, sel ast.SelectionSet, obj *model.Source) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, sourceImplementors)

--- a/pkg/assembler/graphql/generated/source.generated.go
+++ b/pkg/assembler/graphql/generated/source.generated.go
@@ -772,26 +772,6 @@ func (ec *executionContext) unmarshalOSourceInputSpec2ᚖgithubᚗcomᚋguacsec�
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOSourceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx context.Context, v interface{}) ([]*model.SourceSpec, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.SourceSpec, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOSourceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) unmarshalOSourceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceSpec(ctx context.Context, v interface{}) (*model.SourceSpec, error) {
 	if v == nil {
 		return nil, nil

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -314,9 +314,7 @@ type HasSlsa struct {
 
 // HasSLSASpec allows filtering the list of HasSLSA to return.
 type HasSLSASpec struct {
-	Package     *PkgSpec                        `json:"package"`
-	Source      *SourceSpec                     `json:"source"`
-	Artifact    *ArtifactSpec                   `json:"artifact"`
+	Subject     *PackageSourceOrArtifactInput   `json:"subject"`
 	BuiltFrom   []*PackageSourceOrArtifactInput `json:"builtFrom"`
 	BuiltBy     *BuilderSpec                    `json:"builtBy"`
 	BuildType   *string                         `json:"buildType"`

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -16,14 +16,14 @@ type OsvCveOrGhsa interface {
 	IsOsvCveOrGhsa()
 }
 
+// PackageSourceOrArtifact is a union of Package, Source and Artifact.
+type PackageSourceOrArtifact interface {
+	IsPackageSourceOrArtifact()
+}
+
 // PkgArtObject is a union of Package and Artifact. Any of these objects can be specified
 type PkgArtObject interface {
 	IsPkgArtObject()
-}
-
-// PkgSrcArtObject is a union of Package, Source and Artifact. Any of these objects can be specified
-type PkgSrcArtObject interface {
-	IsPkgSrcArtObject()
 }
 
 // PkgSrcObject is a union of Package and Source. Any of these objects can be specified
@@ -43,9 +43,9 @@ type Artifact struct {
 	Digest    string `json:"digest"`
 }
 
-func (Artifact) IsPkgSrcArtObject() {}
-
 func (Artifact) IsPkgArtObject() {}
+
+func (Artifact) IsPackageSourceOrArtifact() {}
 
 // ArtifactInputSpec is the same as Artifact, but used as mutation input.
 //
@@ -126,10 +126,10 @@ type CVESpec struct {
 //
 // Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 type CertifyBad struct {
-	Subject       PkgSrcArtObject `json:"subject"`
-	Justification string          `json:"justification"`
-	Origin        string          `json:"origin"`
-	Collector     string          `json:"collector"`
+	Subject       PackageSourceOrArtifact `json:"subject"`
+	Justification string                  `json:"justification"`
+	Origin        string                  `json:"origin"`
+	Collector     string                  `json:"collector"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad to return.
@@ -317,16 +317,16 @@ type HasSBOMSpec struct {
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type HasSlsa struct {
-	Subject       PkgSrcArtObject   `json:"subject"`
-	BuiltFrom     []PkgSrcArtObject `json:"builtFrom"`
-	BuiltBy       *Builder          `json:"builtBy"`
-	BuildType     string            `json:"buildType"`
-	SlsaPredicate []*SLSAPredicate  `json:"slsaPredicate"`
-	SlsaVersion   string            `json:"slsaVersion"`
-	StartedOn     time.Time         `json:"startedOn"`
-	FinishedOn    time.Time         `json:"finishedOn"`
-	Origin        string            `json:"origin"`
-	Collector     string            `json:"collector"`
+	Subject       PackageSourceOrArtifact   `json:"subject"`
+	BuiltFrom     []PackageSourceOrArtifact `json:"builtFrom"`
+	BuiltBy       *Builder                  `json:"builtBy"`
+	BuildType     string                    `json:"buildType"`
+	SlsaPredicate []*SLSAPredicate          `json:"slsaPredicate"`
+	SlsaVersion   string                    `json:"slsaVersion"`
+	StartedOn     time.Time                 `json:"startedOn"`
+	FinishedOn    time.Time                 `json:"finishedOn"`
+	Origin        string                    `json:"origin"`
+	Collector     string                    `json:"collector"`
 }
 
 // HasSLSASpec allows filtering the list of HasSLSA to return.
@@ -575,11 +575,11 @@ type Package struct {
 	Namespaces []*PackageNamespace `json:"namespaces"`
 }
 
-func (Package) IsPkgSrcArtObject() {}
-
 func (Package) IsPkgArtObject() {}
 
 func (Package) IsPkgSrcObject() {}
+
+func (Package) IsPackageSourceOrArtifact() {}
 
 // PackageName is a name for packages.
 //
@@ -846,9 +846,9 @@ type Source struct {
 	Namespaces []*SourceNamespace `json:"namespaces"`
 }
 
-func (Source) IsPkgSrcArtObject() {}
-
 func (Source) IsPkgSrcObject() {}
+
+func (Source) IsPackageSourceOrArtifact() {}
 
 // SourceInputSpec specifies a source for a mutation.
 //

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -16,7 +16,7 @@ type OsvCveOrGhsa interface {
 	IsOsvCveOrGhsa()
 }
 
-// PackageSourceOrArtifact is a union of Package, Source and Artifact.
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
 type PackageSourceOrArtifact interface {
 	IsPackageSourceOrArtifact()
 }
@@ -304,29 +304,12 @@ type HasSBOMSpec struct {
 	Collector *string     `json:"collector"`
 }
 
-// HasSLSA is an attestation represents that the subject has a SLSA attestation associated with it.
-//
-// subject - an union type that consists of package, source or artifact
-// builtFrom (object) - list of union types that consists of the package, source or artifact that the subject was build from
-// builtBy (object) - represents the builder that was used to build the subject
-// buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
-// slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
-// slsaVersion (property) - version of the SLSA predicate
-// startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
-// finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
-// origin (property) - where this attestation was generated from (based on which document)
-// collector (property) - the GUAC collector that collected the document that generated this attestation
+// HasSLSA records that a subject node has a SLSA attestation.
 type HasSlsa struct {
-	Subject       PackageSourceOrArtifact   `json:"subject"`
-	BuiltFrom     []PackageSourceOrArtifact `json:"builtFrom"`
-	BuiltBy       *Builder                  `json:"builtBy"`
-	BuildType     string                    `json:"buildType"`
-	SlsaPredicate []*SLSAPredicate          `json:"slsaPredicate"`
-	SlsaVersion   string                    `json:"slsaVersion"`
-	StartedOn     time.Time                 `json:"startedOn"`
-	FinishedOn    time.Time                 `json:"finishedOn"`
-	Origin        string                    `json:"origin"`
-	Collector     string                    `json:"collector"`
+	// The subject of SLSA attestation: package, source, or artifact.
+	Subject PackageSourceOrArtifact `json:"subject"`
+	// The SLSA attestation.
+	Slsa *Slsa `json:"slsa"`
 }
 
 // HasSLSASpec allows filtering the list of HasSLSA to return.
@@ -717,41 +700,64 @@ type PkgSpec struct {
 	Subpath                  *string                 `json:"subpath"`
 }
 
+// SLSA contains all of the fields present in a SLSA attestation.
+//
+// The materials and builders are objects of the HasSLSA predicate, everything
+// else are properties extracted from the attestation.
+//
+// We also include fields to specify under what conditions the check was performed
+// (time of scan, version of scanners, etc.) as well as how this information got
+// included into GUAC (origin document and the collector for that document).
+type Slsa struct {
+	// Sources of the build resulting in subject (materials)
+	BuiltFrom []PackageSourceOrArtifact `json:"builtFrom"`
+	// Builder performing the build
+	BuiltBy *Builder `json:"builtBy"`
+	// Type of the builder
+	BuildType string `json:"buildType"`
+	// Individual predicates found in the attestation
+	SlsaPredicate []*SLSAPredicate `json:"slsaPredicate"`
+	// Version of the SLSA predicate
+	SlsaVersion string `json:"slsaVersion"`
+	// Timestamp (RFC3339Nano format) of build start time
+	StartedOn time.Time `json:"startedOn"`
+	// Timestamp (RFC3339Nano format) of build end time
+	FinishedOn time.Time `json:"finishedOn"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
 // SLSAPredicate are the values from the SLSA predicate in key-value pair form.
-// // Predicate:
-// "predicateType": "https://slsa.dev/provenance/v1",
+//
+// # For example, given the following predicate
+//
+// ```
 //
 //	"predicate": {
-//	    "buildDefinition": {
-//	        "buildType": string,
-//	        "externalParameters": object,
-//	        "systemParameters": object,
-//	        "resolvedDependencies": [ ...#ArtifactReference ],
+//	  "buildDefinition": {
+//	    "externalParameters": {
+//	      "repository": "https://github.com/octocat/hello-world",
+//	      ...
 //	    },
-//	    "runDetails": {
-//	        "builder": {
-//	            "id": string,
-//	            "version": string,
-//	            "builderDependencies": [ ...#ArtifactReference ],
-//	        },
-//	        "metadata": {
-//	            "invocationId": string,
-//	            "startedOn": #Timestamp,
-//	            "finishedOn": #Timestamp,
-//	        },
-//	        "byproducts": [ ...#ArtifactReference ],
-//	    }
+//	    ...
+//	  },
+//	  ...
 //	}
 //
-// where
+// ```
 //
-//	"externalParameters": {
-//	    "repository": "https://github.com/octocat/hello-world",
-//	    "ref": "refs/heads/main"
-//	},
+// we have
 //
-// For example: key = "buildDefinition.externalParameters.repository" value = "https://github.com/octocat/hello-world"
+// ```
+// key   = "buildDefinition.externalParameters.repository"
+// value = "https://github.com/octocat/hello-world"
+// ```
+//
 // This node cannot be directly referred by other parts of GUAC.
+//
+// TODO(mihaimaruseac): Can we define these directly?
 type SLSAPredicate struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -314,20 +314,18 @@ type HasSlsa struct {
 
 // HasSLSASpec allows filtering the list of HasSLSA to return.
 type HasSLSASpec struct {
-	Package           *PkgSpec             `json:"package"`
-	Source            *SourceSpec          `json:"source"`
-	Artifact          *ArtifactSpec        `json:"artifact"`
-	BuiltFromPackages []*PkgSpec           `json:"builtFromPackages"`
-	BuiltFromSource   []*SourceSpec        `json:"builtFromSource"`
-	BuiltFromArtifact []*ArtifactSpec      `json:"builtFromArtifact"`
-	BuiltBy           *BuilderSpec         `json:"builtBy"`
-	BuildType         *string              `json:"buildType"`
-	Predicate         []*SLSAPredicateSpec `json:"predicate"`
-	SlsaVersion       *string              `json:"slsaVersion"`
-	StartedOn         *time.Time           `json:"startedOn"`
-	FinishedOn        *time.Time           `json:"finishedOn"`
-	Origin            *string              `json:"origin"`
-	Collector         *string              `json:"collector"`
+	Package     *PkgSpec                        `json:"package"`
+	Source      *SourceSpec                     `json:"source"`
+	Artifact    *ArtifactSpec                   `json:"artifact"`
+	BuiltFrom   []*PackageSourceOrArtifactInput `json:"builtFrom"`
+	BuiltBy     *BuilderSpec                    `json:"builtBy"`
+	BuildType   *string                         `json:"buildType"`
+	Predicate   []*SLSAPredicateSpec            `json:"predicate"`
+	SlsaVersion *string                         `json:"slsaVersion"`
+	StartedOn   *time.Time                      `json:"startedOn"`
+	FinishedOn  *time.Time                      `json:"finishedOn"`
+	Origin      *string                         `json:"origin"`
+	Collector   *string                         `json:"collector"`
 }
 
 // HasSourceAt is an attestation represents that a package object has a source object since a timestamp
@@ -633,6 +631,16 @@ type PackageQualifierSpec struct {
 	Value *string `json:"value"`
 }
 
+// PackageSourceOrArtifactInput allows using PackageSourceOrArtifact union as
+// input type.
+//
+// Exactly one of the value must be set to non-nil.
+type PackageSourceOrArtifactInput struct {
+	Package  *PkgSpec      `json:"package"`
+	Source   *SourceSpec   `json:"source"`
+	Artifact *ArtifactSpec `json:"artifact"`
+}
+
 // PackageVersion is a package version.
 //
 // In the pURL representation, each PackageName matches the
@@ -763,8 +771,7 @@ type SLSAPredicate struct {
 	Value string `json:"value"`
 }
 
-// SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query
-// input.
+// SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query input.
 type SLSAPredicateSpec struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -28,7 +28,7 @@ collector (property) - the GUAC collector that collected the document that gener
 Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 """
 type CertifyBad {
-  subject: PkgSrcArtObject!
+  subject: PackageSourceOrArtifact!
   justification: String!
   origin: String!
   collector: String!
@@ -48,11 +48,6 @@ input CertifyBadSpec {
   origin: String
   collector: String
 }
-
-"""
-PkgSrcArtObject is a union of Package, Source and Artifact. Any of these objects can be specified
-"""
-union PkgSrcArtObject = Package | Source | Artifact
 
 extend type Query {
   "Returns all CertifyBad"

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -82,9 +82,7 @@ type ScorecardCheck {
   score: Int!
 }
 
-"""
-CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
-"""
+"CertifyScorecardSpec allows filtering the list of CertifyScorecard to return."
 input CertifyScorecardSpec {
   source: SourceSpec
   timeScanned: Time
@@ -96,9 +94,7 @@ input CertifyScorecardSpec {
   collector: String
 }
 
-"""
-ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input.
-"""
+"ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input."
 input ScorecardCheckSpec {
   check: String!
   score: Int!

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -17,79 +17,83 @@
 
 # Defines a GraphQL schema for specifiying SLSA provenance.
 
-"""
-PackageSourceOrArtifact is a union of Package, Source and Artifact.
-"""
+"PackageSourceOrArtifact is a union of Package, Source, and Artifact."
 union PackageSourceOrArtifact = Package | Source | Artifact
 
-# the HasSLSA. It contains the Subject which can be of type package, source or artifact,
-# buliltFrom which can also be of type package, source or artifact, builtby (builder object), build type,  predicate (key value pair of
-# the predicate values), slsa version, started on, finished on, origin and collector.
-"""
-HasSLSA is an attestation represents that the subject has a SLSA attestation associated with it.
-
-subject - an union type that consists of package, source or artifact
-builtFrom (object) - list of union types that consists of the package, source or artifact that the subject was build from
-builtBy (object) - represents the builder that was used to build the subject
-buildType (property) - individual scorecard check scores (Branch-Protection, Code-Review...etc)
-slsaPredicate (property) - a list of key value pair that consist of the keys and values of the SLSA predicate
-slsaVersion (property) - version of the SLSA predicate
-startedOn (property) - timestamp when the SLSA predicate was recorded during the build time of the subject (in RFC 3339 format)
-finishedOn (property) - timestamp when the SLSA predicate was completed during the build time of the subject (in RFC 3339 format)
-origin (property) - where this attestation was generated from (based on which document)
-collector (property) - the GUAC collector that collected the document that generated this attestation
-"""
+"HasSLSA records that a subject node has a SLSA attestation."
 type HasSLSA {
+  "The subject of SLSA attestation: package, source, or artifact."
   subject: PackageSourceOrArtifact!
+  "The SLSA attestation."
+  slsa: SLSA
+}
+
+"""
+SLSA contains all of the fields present in a SLSA attestation.
+
+The materials and builders are objects of the HasSLSA predicate, everything
+else are properties extracted from the attestation.
+
+We also include fields to specify under what conditions the check was performed
+(time of scan, version of scanners, etc.) as well as how this information got
+included into GUAC (origin document and the collector for that document).
+"""
+type SLSA {
+  "Sources of the build resulting in subject (materials)"
   builtFrom: [PackageSourceOrArtifact!]!
+  "Builder performing the build"
   builtBy: Builder!
+  "Type of the builder"
   buildType: String!
+  "Individual predicates found in the attestation"
   slsaPredicate: [SLSAPredicate!]!
+  "Version of the SLSA predicate"
   slsaVersion: String!
+  "Timestamp (RFC3339Nano format) of build start time"
   startedOn: Time!
+  "Timestamp (RFC3339Nano format) of build end time"
   finishedOn: Time!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
 }
 
 """
 SLSAPredicate are the values from the SLSA predicate in key-value pair form.
-// Predicate:
-"predicateType": "https://slsa.dev/provenance/v1",
-"predicate": {
-    "buildDefinition": {
-        "buildType": string,
-        "externalParameters": object,
-        "systemParameters": object,
-        "resolvedDependencies": [ ...#ArtifactReference ],
-    },
-    "runDetails": {
-        "builder": {
-            "id": string,
-            "version": string,
-            "builderDependencies": [ ...#ArtifactReference ],
-        },
-        "metadata": {
-            "invocationId": string,
-            "startedOn": #Timestamp,
-            "finishedOn": #Timestamp,
-        },
-        "byproducts": [ ...#ArtifactReference ],
-    }
-}
-where
-"externalParameters": {
-    "repository": "https://github.com/octocat/hello-world",
-    "ref": "refs/heads/main"
-},
 
-For example: key = "buildDefinition.externalParameters.repository" value = "https://github.com/octocat/hello-world"
+For example, given the following predicate
+
+```
+"predicate": {
+  "buildDefinition": {
+    "externalParameters": {
+      "repository": "https://github.com/octocat/hello-world",
+      ...
+    },
+    ...
+  },
+  ...
+}
+```
+
+we have
+
+```
+key   = "buildDefinition.externalParameters.repository"
+value = "https://github.com/octocat/hello-world"
+```
+
 This node cannot be directly referred by other parts of GUAC.
+
+TODO(mihaimaruseac): Can we define these directly?
 """
 type SLSAPredicate {
   key: String!
   value: String!
 }
+
+# TODO: clean from here down
 
 """
 HasSLSASpec allows filtering the list of HasSLSA to return.

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -107,9 +107,7 @@ type SLSAPredicate {
 
 "HasSLSASpec allows filtering the list of HasSLSA to return."
 input HasSLSASpec {
-  package: PkgSpec
-  source: SourceSpec
-  artifact: ArtifactSpec
+  subject: PackageSourceOrArtifactInput
   builtFrom: [PackageSourceOrArtifactInput!]
   builtBy: BuilderSpec
   buildType: String

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -20,6 +20,18 @@
 "PackageSourceOrArtifact is a union of Package, Source, and Artifact."
 union PackageSourceOrArtifact = Package | Source | Artifact
 
+"""
+PackageSourceOrArtifactInput allows using PackageSourceOrArtifact union as
+input type.
+
+Exactly one of the value must be set to non-nil.
+"""
+input PackageSourceOrArtifactInput {
+  package: PkgSpec
+  source: SourceSpec
+  artifact: ArtifactSpec
+}
+
 "HasSLSA records that a subject node has a SLSA attestation."
 type HasSLSA {
   "The subject of SLSA attestation: package, source, or artifact."
@@ -93,18 +105,12 @@ type SLSAPredicate {
   value: String!
 }
 
-# TODO: clean from here down
-
-"""
-HasSLSASpec allows filtering the list of HasSLSA to return.
-"""
+"HasSLSASpec allows filtering the list of HasSLSA to return."
 input HasSLSASpec {
   package: PkgSpec
   source: SourceSpec
   artifact: ArtifactSpec
-  builtFromPackages: [PkgSpec]
-  builtFromSource: [SourceSpec]
-  builtFromArtifact: [ArtifactSpec]
+  builtFrom: [PackageSourceOrArtifactInput!]
   builtBy: BuilderSpec
   buildType: String
   predicate: [SLSAPredicateSpec!] = []
@@ -116,8 +122,7 @@ input HasSLSASpec {
 }
 
 """
-SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query
-input.
+SLSAPredicateSpec is the same as SLSAPredicateSpec, but usable as query input.
 """
 input SLSAPredicateSpec {
   key: String!
@@ -125,6 +130,6 @@ input SLSAPredicateSpec {
 }
 
 extend type Query {
-  "Returns all HasSLSA"
+  "Returns all SLSA attestations matching the filter"
   HasSLSA(hasSLSASpec: HasSLSASpec): [HasSLSA!]!
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -15,7 +15,14 @@
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines a GraphQL schema for the HasSLSA. It contains the Subject which can be of type package, source or artifact,
+# Defines a GraphQL schema for specifiying SLSA provenance.
+
+"""
+PackageSourceOrArtifact is a union of Package, Source and Artifact.
+"""
+union PackageSourceOrArtifact = Package | Source | Artifact
+
+# the HasSLSA. It contains the Subject which can be of type package, source or artifact,
 # buliltFrom which can also be of type package, source or artifact, builtby (builder object), build type,  predicate (key value pair of
 # the predicate values), slsa version, started on, finished on, origin and collector.
 """
@@ -33,8 +40,8 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HasSLSA {
-  subject: PkgSrcArtObject!
-  builtFrom: [PkgSrcArtObject!]!
+  subject: PackageSourceOrArtifact!
+  builtFrom: [PackageSourceOrArtifact!]!
   builtBy: Builder!
   buildType: String!
   slsaPredicate: [SLSAPredicate!]!


### PR DESCRIPTION
* Rename `PkgSrcArtObject` to `PackageSourceOrArtifact` for better readability
* Add comments to GraphQL structures
* Reformat the example GraphQL queries
* Split the `HasSLSA` node to contain the subject and the attestation as a separate node
* Allow mixed materials, propagate this to query filter too
* Simplify checking for valid query input