### PR TITLE
update guac purl uri

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -278,7 +278,7 @@ var (
 
 	// SPDX Testdata
 
-	topLevelPack, _       = asmhelpers.PurlToPkg("pkg:guac/oci/gcr.io/google-containers/alpine-latest")
+	topLevelPack, _       = asmhelpers.PurlToPkg("pkg:guac/spdx/gcr.io/google-containers/alpine-latest")
 	baselayoutPack, _     = asmhelpers.PurlToPkg("pkg:alpine/alpine-baselayout@3.2.0-r22?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.2")
 	keysPack, _           = asmhelpers.PurlToPkg("pkg:alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.2")
 	baselayoutdataPack, _ = asmhelpers.PurlToPkg("pkg:alpine/alpine-baselayout-data@3.2.0-r22?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.2")

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -71,14 +71,17 @@ func (s *spdxParser) Parse(ctx context.Context, doc *processor.Document) error {
 
 // creating top level package manually until https://github.com/anchore/syft/issues/1241 is resolved
 func (s *spdxParser) getTopLevelPackage() error {
-	// TODO: change this from OCI purls to GUAC purls
+	// TODO: Add CertifyPkg to make a connection from GUAC purl to OCI purl guessed
 	// oci purl: pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
 	splitImage := strings.Split(s.spdxDoc.DocumentName, "/")
+
+	// Currently create TopLevel package as well in some cases where we guess that the SPDX document
+	// may not encode it
 	var purl string
 	if len(splitImage) == 3 {
-		purl = "pkg:guac/oci/" + s.spdxDoc.DocumentName
+		purl = "pkg:guac/spdx/" + s.spdxDoc.DocumentName
 	} else if len(splitImage) == 2 {
-		purl = "pkg:guac/oci/" + s.spdxDoc.DocumentName
+		purl = "pkg:guac/spdx/" + s.spdxDoc.DocumentName
 	}
 
 	if purl != "" {


### PR DESCRIPTION
Update based on discussion in #543 , open question is whether we want to keep the top level links just for things that we think that the SPDX document doesn't encode the relationships properly? or do it for all (the later will end up having a lot of additional relationships).