### PR TITLE
Ingest SLSA via GraphQL (in-memory only)

### DIFF
--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -118,22 +118,22 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		},
 	}
 	slsa := model.SLSAInputSpec{
-		BuiltFrom: materials,
-		BuiltBy: builder,
-		BuildType: "Test:Source->Package",
+		BuiltFrom:     materials,
+		BuiltBy:       builder,
+		BuildType:     "Test:Source->Package",
 		SlsaPredicate: predicate,
-		SlsaVersion: "v1",
-		StartedOn: time.Now(),
-		FinishedOn: time.Now().Add(10 * time.Second),
-		Origin:           "Demo ingestion",
-		Collector:        "Demo ingestion",
+		SlsaVersion:   "v1",
+		StartedOn:     time.Now(),
+		FinishedOn:    time.Now().Add(10 * time.Second),
+		Origin:        "Demo ingestion",
+		Collector:     "Demo ingestion",
 	}
 	emptyNamespace := ""
 	pkg := model.PkgInputSpec{
 		Type:      "pypi",
 		Namespace: &emptyNamespace,
 		Name:      "tensorflow",
-		Version: &version,
+		Version:   &version,
 	}
 	_, err := model.SLSAForPackage(context.Background(), client, pkg, slsa)
 	if err != nil {
@@ -142,15 +142,15 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 
 	// from source to artifact
 	slsa = model.SLSAInputSpec{
-		BuiltFrom: materials,
-		BuiltBy: builder,
-		BuildType: "Test:Source->Artifact",
+		BuiltFrom:     materials,
+		BuiltBy:       builder,
+		BuildType:     "Test:Source->Artifact",
 		SlsaPredicate: predicate,
-		SlsaVersion: "v1",
-		StartedOn: time.Now(),
-		FinishedOn: time.Now().Add(10 * time.Second),
-		Origin:           "Demo ingestion",
-		Collector:        "Demo ingestion",
+		SlsaVersion:   "v1",
+		StartedOn:     time.Now(),
+		FinishedOn:    time.Now().Add(10 * time.Second),
+		Origin:        "Demo ingestion",
+		Collector:     "Demo ingestion",
 	}
 	artifact := model.ArtifactInputSpec{
 		Digest:    "5a787865sd676dacb0142afa0b83029cd7befd9",
@@ -166,15 +166,15 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Uri: "https://github.com/CreateFork/HubHostedActions@v1",
 	}
 	slsa = model.SLSAInputSpec{
-		BuiltFrom: materials,
-		BuiltBy: builder,
-		BuildType: "Test:Source->Source",
+		BuiltFrom:     materials,
+		BuiltBy:       builder,
+		BuildType:     "Test:Source->Source",
 		SlsaPredicate: predicate,
-		SlsaVersion: "v1",
-		StartedOn: time.Now(),
-		FinishedOn: time.Now().Add(10 * time.Second),
-		Origin:           "Demo ingestion",
-		Collector:        "Demo ingestion",
+		SlsaVersion:   "v1",
+		StartedOn:     time.Now(),
+		FinishedOn:    time.Now().Add(10 * time.Second),
+		Origin:        "Demo ingestion",
+		Collector:     "Demo ingestion",
 	}
 	finalSource := model.SourceInputSpec{
 		Type:      "git",
@@ -204,15 +204,15 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Uri: "https://github.com/MixedBuild/HubHostedActions@v1",
 	}
 	slsa = model.SLSAInputSpec{
-		BuiltFrom: materials,
-		BuiltBy: builder,
-		BuildType: "Test:Mixed-build",
+		BuiltFrom:     materials,
+		BuiltBy:       builder,
+		BuildType:     "Test:Mixed-build",
 		SlsaPredicate: predicate,
-		SlsaVersion: "v1",
-		StartedOn: time.Now(),
-		FinishedOn: time.Now().Add(10 * time.Second),
-		Origin:           "Demo ingestion",
-		Collector:        "Demo ingestion",
+		SlsaVersion:   "v1",
+		StartedOn:     time.Now(),
+		FinishedOn:    time.Now().Add(10 * time.Second),
+		Origin:        "Demo ingestion",
+		Collector:     "Demo ingestion",
 	}
 	artifact = model.ArtifactInputSpec{
 		Digest:    "0123456789abcdef0000000fedcba9876543210",

--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -41,6 +41,7 @@ func ingestData(port int) {
 	start := time.Now()
 	logger.Infof("Ingesting test data into backend server")
 	ingestScorecards(ctx, gqlclient)
+	ingestSLSA(ctx, gqlclient)
 	ingestDependency(ctx, gqlclient)
 	ingestOccurrence(ctx, gqlclient)
 	ingestVulnerability(ctx, gqlclient)
@@ -75,6 +76,149 @@ func ingestScorecards(ctx context.Context, client graphql.Client) {
 		Collector:        "Demo ingestion",
 	}
 	_, err := model.Scorecard(context.Background(), client, source, scorecard)
+	if err != nil {
+		logger.Errorf("Error in ingesting: %v\n", err)
+	}
+}
+
+func ingestSLSA(ctx context.Context, client graphql.Client) {
+	logger := logging.FromContext(ctx)
+
+	tag := "v2.12.0"
+	version := "2.12.0"
+	initialSource := model.SourceInputSpec{
+		Type:      "git",
+		Namespace: "github",
+		Name:      "github.com/tensorflow/tensorflow",
+		Tag:       &tag,
+	}
+	initialSourceAsMaterial := model.PackageSourceOrArtifactInput{
+		Source: &initialSource,
+	}
+
+	// from source to package
+	materials := []model.PackageSourceOrArtifactInput{
+		initialSourceAsMaterial,
+	}
+	builder := model.BuilderInputSpec{
+		Uri: "https://github.com/BuildPythonWheel/HubHostedActions@v1",
+	}
+	predicate := []model.SLSAPredicateInputSpec{
+		{
+			Key:   "buildDefinition.externalParameters.repository",
+			Value: "https://github.com/octocat/hello-world",
+		},
+		{
+			Key:   "buildDefinition.externalParameters.ref",
+			Value: "refs/heads/main",
+		},
+		{
+			Key:   "buildDefinition.resolvedDependencies.uri",
+			Value: "git+https://github.com/octocat/hello-world@refs/heads/main",
+		},
+	}
+	slsa := model.SLSAInputSpec{
+		BuiltFrom: materials,
+		BuiltBy: builder,
+		BuildType: "Test:Source->Package",
+		SlsaPredicate: predicate,
+		SlsaVersion: "v1",
+		StartedOn: time.Now(),
+		FinishedOn: time.Now().Add(10 * time.Second),
+		Origin:           "Demo ingestion",
+		Collector:        "Demo ingestion",
+	}
+	emptyNamespace := ""
+	pkg := model.PkgInputSpec{
+		Type:      "pypi",
+		Namespace: &emptyNamespace,
+		Name:      "tensorflow",
+		Version: &version,
+	}
+	_, err := model.SLSAForPackage(context.Background(), client, pkg, slsa)
+	if err != nil {
+		logger.Errorf("Error in ingesting: %v\n", err)
+	}
+
+	// from source to artifact
+	slsa = model.SLSAInputSpec{
+		BuiltFrom: materials,
+		BuiltBy: builder,
+		BuildType: "Test:Source->Artifact",
+		SlsaPredicate: predicate,
+		SlsaVersion: "v1",
+		StartedOn: time.Now(),
+		FinishedOn: time.Now().Add(10 * time.Second),
+		Origin:           "Demo ingestion",
+		Collector:        "Demo ingestion",
+	}
+	artifact := model.ArtifactInputSpec{
+		Digest:    "5a787865sd676dacb0142afa0b83029cd7befd9",
+		Algorithm: "sha1",
+	}
+	_, err = model.SLSAForArtifact(context.Background(), client, artifact, slsa)
+	if err != nil {
+		logger.Errorf("Error in ingesting: %v\n", err)
+	}
+
+	// from source to source
+	builder = model.BuilderInputSpec{
+		Uri: "https://github.com/CreateFork/HubHostedActions@v1",
+	}
+	slsa = model.SLSAInputSpec{
+		BuiltFrom: materials,
+		BuiltBy: builder,
+		BuildType: "Test:Source->Source",
+		SlsaPredicate: predicate,
+		SlsaVersion: "v1",
+		StartedOn: time.Now(),
+		FinishedOn: time.Now().Add(10 * time.Second),
+		Origin:           "Demo ingestion",
+		Collector:        "Demo ingestion",
+	}
+	finalSource := model.SourceInputSpec{
+		Type:      "git",
+		Namespace: "github",
+		Name:      "github.com/forked/tensorflow",
+		Tag:       &tag,
+	}
+	_, err = model.SLSAForSource(context.Background(), client, finalSource, slsa)
+	if err != nil {
+		logger.Errorf("Error in ingesting: %v\n", err)
+	}
+
+	// multiple, mixed materials
+	pkgAsMaterial := model.PackageSourceOrArtifactInput{
+		Package: &pkg,
+	}
+	artifactAsMaterial := model.PackageSourceOrArtifactInput{
+		Artifact: &artifact,
+	}
+	finalSourceAsMaterial := model.PackageSourceOrArtifactInput{
+		Source: &finalSource,
+	}
+	materials = []model.PackageSourceOrArtifactInput{
+		pkgAsMaterial, artifactAsMaterial, finalSourceAsMaterial,
+	}
+	builder = model.BuilderInputSpec{
+		Uri: "https://github.com/MixedBuild/HubHostedActions@v1",
+	}
+	slsa = model.SLSAInputSpec{
+		BuiltFrom: materials,
+		BuiltBy: builder,
+		BuildType: "Test:Mixed-build",
+		SlsaPredicate: predicate,
+		SlsaVersion: "v1",
+		StartedOn: time.Now(),
+		FinishedOn: time.Now().Add(10 * time.Second),
+		Origin:           "Demo ingestion",
+		Collector:        "Demo ingestion",
+	}
+	artifact = model.ArtifactInputSpec{
+		Digest:    "0123456789abcdef0000000fedcba9876543210",
+		Algorithm: "sha1",
+	}
+	_, err = model.SLSAForArtifact(context.Background(), client, artifact, slsa)
 	if err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -25,6 +25,14 @@ func (v *ArtifactInputSpec) GetAlgorithm() string { return v.Algorithm }
 // GetDigest returns ArtifactInputSpec.Digest, and is useful for accessing the field via an interface.
 func (v *ArtifactInputSpec) GetDigest() string { return v.Digest }
 
+// BuilderInputSpec is the same as Builder, but used for mutation ingestion.
+type BuilderInputSpec struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns BuilderInputSpec.Uri, and is useful for accessing the field via an interface.
+func (v *BuilderInputSpec) GetUri() string { return v.Uri }
+
 // CVEInputSpec is the same as CVESpec, but used for mutation ingestion.
 type CVEInputSpec struct {
 	Year  string `json:"year"`
@@ -1797,15 +1805,15 @@ func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) __premarshalJSON() (*__pre
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
 type IsOccurrenceSrcIngestSource struct {
-	allSrcTree `json:"-"`
+	allSourceTree `json:"-"`
 }
 
 // GetType returns IsOccurrenceSrcIngestSource.Type, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestSource) GetType() string { return v.allSrcTree.Type }
+func (v *IsOccurrenceSrcIngestSource) GetType() string { return v.allSourceTree.Type }
 
 // GetNamespaces returns IsOccurrenceSrcIngestSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestSource) GetNamespaces() []allSrcTreeNamespacesSourceNamespace {
-	return v.allSrcTree.Namespaces
+func (v *IsOccurrenceSrcIngestSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
 }
 
 func (v *IsOccurrenceSrcIngestSource) UnmarshalJSON(b []byte) error {
@@ -1826,7 +1834,7 @@ func (v *IsOccurrenceSrcIngestSource) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSrcTree)
+		b, &v.allSourceTree)
 	if err != nil {
 		return err
 	}
@@ -1836,7 +1844,7 @@ func (v *IsOccurrenceSrcIngestSource) UnmarshalJSON(b []byte) error {
 type __premarshalIsOccurrenceSrcIngestSource struct {
 	Type string `json:"type"`
 
-	Namespaces []allSrcTreeNamespacesSourceNamespace `json:"namespaces"`
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
 }
 
 func (v *IsOccurrenceSrcIngestSource) MarshalJSON() ([]byte, error) {
@@ -1850,8 +1858,8 @@ func (v *IsOccurrenceSrcIngestSource) MarshalJSON() ([]byte, error) {
 func (v *IsOccurrenceSrcIngestSource) __premarshalJSON() (*__premarshalIsOccurrenceSrcIngestSource, error) {
 	var retval __premarshalIsOccurrenceSrcIngestSource
 
-	retval.Type = v.allSrcTree.Type
-	retval.Namespaces = v.allSrcTree.Namespaces
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
 	return &retval, nil
 }
 
@@ -1907,6 +1915,25 @@ func (v *PackageQualifierInputSpec) GetKey() string { return v.Key }
 // GetValue returns PackageQualifierInputSpec.Value, and is useful for accessing the field via an interface.
 func (v *PackageQualifierInputSpec) GetValue() string { return v.Value }
 
+// PackageSourceOrArtifactInput allows using PackageSourceOrArtifact union as
+// input type to be used in mutations.
+//
+// Exactly one of the value must be set to non-nil.
+type PackageSourceOrArtifactInput struct {
+	Package  *PkgInputSpec      `json:"package"`
+	Source   *SourceInputSpec   `json:"source"`
+	Artifact *ArtifactInputSpec `json:"artifact"`
+}
+
+// GetPackage returns PackageSourceOrArtifactInput.Package, and is useful for accessing the field via an interface.
+func (v *PackageSourceOrArtifactInput) GetPackage() *PkgInputSpec { return v.Package }
+
+// GetSource returns PackageSourceOrArtifactInput.Source, and is useful for accessing the field via an interface.
+func (v *PackageSourceOrArtifactInput) GetSource() *SourceInputSpec { return v.Source }
+
+// GetArtifact returns PackageSourceOrArtifactInput.Artifact, and is useful for accessing the field via an interface.
+func (v *PackageSourceOrArtifactInput) GetArtifact() *ArtifactInputSpec { return v.Artifact }
+
 // PkgInputSpec specifies a package for a mutation.
 //
 // This is different than PkgSpec because we want to encode mandatory fields:
@@ -1937,6 +1964,543 @@ func (v *PkgInputSpec) GetQualifiers() []PackageQualifierInputSpec { return v.Qu
 
 // GetSubpath returns PkgInputSpec.Subpath, and is useful for accessing the field via an interface.
 func (v *PkgInputSpec) GetSubpath() *string { return v.Subpath }
+
+// SLSAForArtifactIngestArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type SLSAForArtifactIngestArtifact struct {
+	allArtifactTree `json:"-"`
+}
+
+// GetAlgorithm returns SLSAForArtifactIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
+
+// GetDigest returns SLSAForArtifactIngestArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *SLSAForArtifactIngestArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactIngestArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactIngestArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactIngestArtifact struct {
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *SLSAForArtifactIngestArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactIngestArtifact) __premarshalJSON() (*__premarshalSLSAForArtifactIngestArtifact, error) {
+	var retval __premarshalSLSAForArtifactIngestArtifact
+
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// SLSAForArtifactIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
+// The GraphQL type's documentation follows.
+//
+// HasSLSA records that a subject node has a SLSA attestation.
+type SLSAForArtifactIngestSLSAHasSLSA struct {
+	allSLSATree `json:"-"`
+}
+
+// GetSubject returns SLSAForArtifactIngestSLSAHasSLSA.Subject, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSubject() allSLSATreeSubjectPackageSourceOrArtifact {
+	return v.allSLSATree.Subject
+}
+
+// GetSlsa returns SLSAForArtifactIngestSLSAHasSLSA.Slsa, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSlsa() *allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+
+func (v *SLSAForArtifactIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactIngestSLSAHasSLSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactIngestSLSAHasSLSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSLSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactIngestSLSAHasSLSA struct {
+	Subject json.RawMessage `json:"subject"`
+
+	Slsa *allSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+func (v *SLSAForArtifactIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAForArtifactIngestSLSAHasSLSA, error) {
+	var retval __premarshalSLSAForArtifactIngestSLSAHasSLSA
+
+	{
+
+		dst := &retval.Subject
+		src := v.allSLSATree.Subject
+		var err error
+		*dst, err = __marshalallSLSATreeSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SLSAForArtifactIngestSLSAHasSLSA.allSLSATree.Subject: %w", err)
+		}
+	}
+	retval.Slsa = v.allSLSATree.Slsa
+	return &retval, nil
+}
+
+// SLSAForArtifactResponse is returned by SLSAForArtifact on success.
+type SLSAForArtifactResponse struct {
+	// Ingest a new artifact. Returns the ingested artifact
+	IngestArtifact SLSAForArtifactIngestArtifact `json:"ingestArtifact"`
+	// Ingests a SLSA attestation
+	IngestSLSA SLSAForArtifactIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+// GetIngestArtifact returns SLSAForArtifactResponse.IngestArtifact, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactResponse) GetIngestArtifact() SLSAForArtifactIngestArtifact {
+	return v.IngestArtifact
+}
+
+// GetIngestSLSA returns SLSAForArtifactResponse.IngestSLSA, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactResponse) GetIngestSLSA() SLSAForArtifactIngestSLSAHasSLSA {
+	return v.IngestSLSA
+}
+
+// SLSAForPackageIngestPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type SLSAForPackageIngestPackage struct {
+	allPkgTree `json:"-"`
+}
+
+// GetType returns SLSAForPackageIngestPackage.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns SLSAForPackageIngestPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *SLSAForPackageIngestPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageIngestPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageIngestPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageIngestPackage struct {
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForPackageIngestPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageIngestPackage) __premarshalJSON() (*__premarshalSLSAForPackageIngestPackage, error) {
+	var retval __premarshalSLSAForPackageIngestPackage
+
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// SLSAForPackageIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
+// The GraphQL type's documentation follows.
+//
+// HasSLSA records that a subject node has a SLSA attestation.
+type SLSAForPackageIngestSLSAHasSLSA struct {
+	allSLSATree `json:"-"`
+}
+
+// GetSubject returns SLSAForPackageIngestSLSAHasSLSA.Subject, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestSLSAHasSLSA) GetSubject() allSLSATreeSubjectPackageSourceOrArtifact {
+	return v.allSLSATree.Subject
+}
+
+// GetSlsa returns SLSAForPackageIngestSLSAHasSLSA.Slsa, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestSLSAHasSLSA) GetSlsa() *allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+
+func (v *SLSAForPackageIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageIngestSLSAHasSLSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageIngestSLSAHasSLSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSLSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageIngestSLSAHasSLSA struct {
+	Subject json.RawMessage `json:"subject"`
+
+	Slsa *allSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+func (v *SLSAForPackageIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAForPackageIngestSLSAHasSLSA, error) {
+	var retval __premarshalSLSAForPackageIngestSLSAHasSLSA
+
+	{
+
+		dst := &retval.Subject
+		src := v.allSLSATree.Subject
+		var err error
+		*dst, err = __marshalallSLSATreeSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SLSAForPackageIngestSLSAHasSLSA.allSLSATree.Subject: %w", err)
+		}
+	}
+	retval.Slsa = v.allSLSATree.Slsa
+	return &retval, nil
+}
+
+// SLSAForPackageResponse is returned by SLSAForPackage on success.
+type SLSAForPackageResponse struct {
+	// Ingest a new package. Returns the ingested package trie
+	IngestPackage SLSAForPackageIngestPackage `json:"ingestPackage"`
+	// Ingests a SLSA attestation
+	IngestSLSA SLSAForPackageIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+// GetIngestPackage returns SLSAForPackageResponse.IngestPackage, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageResponse) GetIngestPackage() SLSAForPackageIngestPackage {
+	return v.IngestPackage
+}
+
+// GetIngestSLSA returns SLSAForPackageResponse.IngestSLSA, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageResponse) GetIngestSLSA() SLSAForPackageIngestSLSAHasSLSA { return v.IngestSLSA }
+
+// SLSAForSourceIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
+// The GraphQL type's documentation follows.
+//
+// HasSLSA records that a subject node has a SLSA attestation.
+type SLSAForSourceIngestSLSAHasSLSA struct {
+	allSLSATree `json:"-"`
+}
+
+// GetSubject returns SLSAForSourceIngestSLSAHasSLSA.Subject, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestSLSAHasSLSA) GetSubject() allSLSATreeSubjectPackageSourceOrArtifact {
+	return v.allSLSATree.Subject
+}
+
+// GetSlsa returns SLSAForSourceIngestSLSAHasSLSA.Slsa, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestSLSAHasSLSA) GetSlsa() *allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+
+func (v *SLSAForSourceIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceIngestSLSAHasSLSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceIngestSLSAHasSLSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSLSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceIngestSLSAHasSLSA struct {
+	Subject json.RawMessage `json:"subject"`
+
+	Slsa *allSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+func (v *SLSAForSourceIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAForSourceIngestSLSAHasSLSA, error) {
+	var retval __premarshalSLSAForSourceIngestSLSAHasSLSA
+
+	{
+
+		dst := &retval.Subject
+		src := v.allSLSATree.Subject
+		var err error
+		*dst, err = __marshalallSLSATreeSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SLSAForSourceIngestSLSAHasSLSA.allSLSATree.Subject: %w", err)
+		}
+	}
+	retval.Slsa = v.allSLSATree.Slsa
+	return &retval, nil
+}
+
+// SLSAForSourceIngestSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type SLSAForSourceIngestSource struct {
+	allSourceTree `json:"-"`
+}
+
+// GetType returns SLSAForSourceIngestSource.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestSource) GetType() string { return v.allSourceTree.Type }
+
+// GetNamespaces returns SLSAForSourceIngestSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *SLSAForSourceIngestSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceIngestSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceIngestSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceIngestSource struct {
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForSourceIngestSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceIngestSource) __premarshalJSON() (*__premarshalSLSAForSourceIngestSource, error) {
+	var retval __premarshalSLSAForSourceIngestSource
+
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
+
+// SLSAForSourceResponse is returned by SLSAForSource on success.
+type SLSAForSourceResponse struct {
+	// Ingest a new source. Returns the ingested source trie
+	IngestSource SLSAForSourceIngestSource `json:"ingestSource"`
+	// Ingests a SLSA attestation
+	IngestSLSA SLSAForSourceIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+// GetIngestSource returns SLSAForSourceResponse.IngestSource, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceResponse) GetIngestSource() SLSAForSourceIngestSource { return v.IngestSource }
+
+// GetIngestSLSA returns SLSAForSourceResponse.IngestSLSA, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceResponse) GetIngestSLSA() SLSAForSourceIngestSLSAHasSLSA { return v.IngestSLSA }
+
+// SLSAInputSpec is the same as SLSA but for mutation input.
+//
+// All fields are required.
+type SLSAInputSpec struct {
+	BuiltFrom     []PackageSourceOrArtifactInput `json:"builtFrom"`
+	BuiltBy       BuilderInputSpec               `json:"builtBy"`
+	BuildType     string                         `json:"buildType"`
+	SlsaPredicate []SLSAPredicateInputSpec       `json:"slsaPredicate"`
+	SlsaVersion   string                         `json:"slsaVersion"`
+	StartedOn     time.Time                      `json:"startedOn"`
+	FinishedOn    time.Time                      `json:"finishedOn"`
+	Origin        string                         `json:"origin"`
+	Collector     string                         `json:"collector"`
+}
+
+// GetBuiltFrom returns SLSAInputSpec.BuiltFrom, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetBuiltFrom() []PackageSourceOrArtifactInput { return v.BuiltFrom }
+
+// GetBuiltBy returns SLSAInputSpec.BuiltBy, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetBuiltBy() BuilderInputSpec { return v.BuiltBy }
+
+// GetBuildType returns SLSAInputSpec.BuildType, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetBuildType() string { return v.BuildType }
+
+// GetSlsaPredicate returns SLSAInputSpec.SlsaPredicate, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetSlsaPredicate() []SLSAPredicateInputSpec { return v.SlsaPredicate }
+
+// GetSlsaVersion returns SLSAInputSpec.SlsaVersion, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetSlsaVersion() string { return v.SlsaVersion }
+
+// GetStartedOn returns SLSAInputSpec.StartedOn, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetStartedOn() time.Time { return v.StartedOn }
+
+// GetFinishedOn returns SLSAInputSpec.FinishedOn, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetFinishedOn() time.Time { return v.FinishedOn }
+
+// GetOrigin returns SLSAInputSpec.Origin, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetOrigin() string { return v.Origin }
+
+// GetCollector returns SLSAInputSpec.Collector, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetCollector() string { return v.Collector }
+
+// SLSAPredicateInputSpec is the same as SLSAPredicateSpec, but for mutation
+// input.
+type SLSAPredicateInputSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns SLSAPredicateInputSpec.Key, and is useful for accessing the field via an interface.
+func (v *SLSAPredicateInputSpec) GetKey() string { return v.Key }
+
+// GetValue returns SLSAPredicateInputSpec.Value, and is useful for accessing the field via an interface.
+func (v *SLSAPredicateInputSpec) GetValue() string { return v.Value }
 
 // ScorecardCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
 // The GraphQL type's documentation follows.
@@ -2029,15 +2593,15 @@ func (v *ScorecardCheckInputSpec) GetScore() int { return v.Score }
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
 type ScorecardIngestSource struct {
-	allSrcTree `json:"-"`
+	allSourceTree `json:"-"`
 }
 
 // GetType returns ScorecardIngestSource.Type, and is useful for accessing the field via an interface.
-func (v *ScorecardIngestSource) GetType() string { return v.allSrcTree.Type }
+func (v *ScorecardIngestSource) GetType() string { return v.allSourceTree.Type }
 
 // GetNamespaces returns ScorecardIngestSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *ScorecardIngestSource) GetNamespaces() []allSrcTreeNamespacesSourceNamespace {
-	return v.allSrcTree.Namespaces
+func (v *ScorecardIngestSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
 }
 
 func (v *ScorecardIngestSource) UnmarshalJSON(b []byte) error {
@@ -2058,7 +2622,7 @@ func (v *ScorecardIngestSource) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSrcTree)
+		b, &v.allSourceTree)
 	if err != nil {
 		return err
 	}
@@ -2068,7 +2632,7 @@ func (v *ScorecardIngestSource) UnmarshalJSON(b []byte) error {
 type __premarshalScorecardIngestSource struct {
 	Type string `json:"type"`
 
-	Namespaces []allSrcTreeNamespacesSourceNamespace `json:"namespaces"`
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
 }
 
 func (v *ScorecardIngestSource) MarshalJSON() ([]byte, error) {
@@ -2082,8 +2646,8 @@ func (v *ScorecardIngestSource) MarshalJSON() ([]byte, error) {
 func (v *ScorecardIngestSource) __premarshalJSON() (*__premarshalScorecardIngestSource, error) {
 	var retval __premarshalScorecardIngestSource
 
-	retval.Type = v.allSrcTree.Type
-	retval.Namespaces = v.allSrcTree.Namespaces
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
 	return &retval, nil
 }
 
@@ -2313,6 +2877,42 @@ func (v *__IsOccurrenceSrcInput) GetArtifact() ArtifactInputSpec { return v.Arti
 
 // GetOccurrence returns __IsOccurrenceSrcInput.Occurrence, and is useful for accessing the field via an interface.
 func (v *__IsOccurrenceSrcInput) GetOccurrence() IsOccurrenceInputSpec { return v.Occurrence }
+
+// __SLSAForArtifactInput is used internally by genqlient
+type __SLSAForArtifactInput struct {
+	Artifact ArtifactInputSpec `json:"artifact"`
+	Slsa     SLSAInputSpec     `json:"slsa"`
+}
+
+// GetArtifact returns __SLSAForArtifactInput.Artifact, and is useful for accessing the field via an interface.
+func (v *__SLSAForArtifactInput) GetArtifact() ArtifactInputSpec { return v.Artifact }
+
+// GetSlsa returns __SLSAForArtifactInput.Slsa, and is useful for accessing the field via an interface.
+func (v *__SLSAForArtifactInput) GetSlsa() SLSAInputSpec { return v.Slsa }
+
+// __SLSAForPackageInput is used internally by genqlient
+type __SLSAForPackageInput struct {
+	Pkg  PkgInputSpec  `json:"pkg"`
+	Slsa SLSAInputSpec `json:"slsa"`
+}
+
+// GetPkg returns __SLSAForPackageInput.Pkg, and is useful for accessing the field via an interface.
+func (v *__SLSAForPackageInput) GetPkg() PkgInputSpec { return v.Pkg }
+
+// GetSlsa returns __SLSAForPackageInput.Slsa, and is useful for accessing the field via an interface.
+func (v *__SLSAForPackageInput) GetSlsa() SLSAInputSpec { return v.Slsa }
+
+// __SLSAForSourceInput is used internally by genqlient
+type __SLSAForSourceInput struct {
+	Source SourceInputSpec `json:"source"`
+	Slsa   SLSAInputSpec   `json:"slsa"`
+}
+
+// GetSource returns __SLSAForSourceInput.Source, and is useful for accessing the field via an interface.
+func (v *__SLSAForSourceInput) GetSource() SourceInputSpec { return v.Source }
+
+// GetSlsa returns __SLSAForSourceInput.Slsa, and is useful for accessing the field via an interface.
+func (v *__SLSAForSourceInput) GetSlsa() SLSAInputSpec { return v.Slsa }
 
 // __ScorecardInput is used internally by genqlient
 type __ScorecardInput struct {
@@ -2556,15 +3156,15 @@ func (v *allCertifyScorecardScorecardChecksScorecardCheck) GetScore() int { retu
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
 type allCertifyScorecardSource struct {
-	allSrcTree `json:"-"`
+	allSourceTree `json:"-"`
 }
 
 // GetType returns allCertifyScorecardSource.Type, and is useful for accessing the field via an interface.
-func (v *allCertifyScorecardSource) GetType() string { return v.allSrcTree.Type }
+func (v *allCertifyScorecardSource) GetType() string { return v.allSourceTree.Type }
 
 // GetNamespaces returns allCertifyScorecardSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allCertifyScorecardSource) GetNamespaces() []allSrcTreeNamespacesSourceNamespace {
-	return v.allSrcTree.Namespaces
+func (v *allCertifyScorecardSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
 }
 
 func (v *allCertifyScorecardSource) UnmarshalJSON(b []byte) error {
@@ -2585,7 +3185,7 @@ func (v *allCertifyScorecardSource) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSrcTree)
+		b, &v.allSourceTree)
 	if err != nil {
 		return err
 	}
@@ -2595,7 +3195,7 @@ func (v *allCertifyScorecardSource) UnmarshalJSON(b []byte) error {
 type __premarshalallCertifyScorecardSource struct {
 	Type string `json:"type"`
 
-	Namespaces []allSrcTreeNamespacesSourceNamespace `json:"namespaces"`
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
 }
 
 func (v *allCertifyScorecardSource) MarshalJSON() ([]byte, error) {
@@ -2609,8 +3209,8 @@ func (v *allCertifyScorecardSource) MarshalJSON() ([]byte, error) {
 func (v *allCertifyScorecardSource) __premarshalJSON() (*__premarshalallCertifyScorecardSource, error) {
 	var retval __premarshalallCertifyScorecardSource
 
-	retval.Type = v.allSrcTree.Type
-	retval.Namespaces = v.allSrcTree.Namespaces
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
 	return &retval, nil
 }
 
@@ -3708,19 +4308,19 @@ func __marshalallIsOccurrencesTreeSubjectPackageOrSource(v *allIsOccurrencesTree
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
 type allIsOccurrencesTreeSubjectSource struct {
-	Typename   *string `json:"__typename"`
-	allSrcTree `json:"-"`
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
 }
 
 // GetTypename returns allIsOccurrencesTreeSubjectSource.Typename, and is useful for accessing the field via an interface.
 func (v *allIsOccurrencesTreeSubjectSource) GetTypename() *string { return v.Typename }
 
 // GetType returns allIsOccurrencesTreeSubjectSource.Type, and is useful for accessing the field via an interface.
-func (v *allIsOccurrencesTreeSubjectSource) GetType() string { return v.allSrcTree.Type }
+func (v *allIsOccurrencesTreeSubjectSource) GetType() string { return v.allSourceTree.Type }
 
 // GetNamespaces returns allIsOccurrencesTreeSubjectSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allIsOccurrencesTreeSubjectSource) GetNamespaces() []allSrcTreeNamespacesSourceNamespace {
-	return v.allSrcTree.Namespaces
+func (v *allIsOccurrencesTreeSubjectSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
 }
 
 func (v *allIsOccurrencesTreeSubjectSource) UnmarshalJSON(b []byte) error {
@@ -3741,7 +4341,7 @@ func (v *allIsOccurrencesTreeSubjectSource) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSrcTree)
+		b, &v.allSourceTree)
 	if err != nil {
 		return err
 	}
@@ -3753,7 +4353,7 @@ type __premarshalallIsOccurrencesTreeSubjectSource struct {
 
 	Type string `json:"type"`
 
-	Namespaces []allSrcTreeNamespacesSourceNamespace `json:"namespaces"`
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
 }
 
 func (v *allIsOccurrencesTreeSubjectSource) MarshalJSON() ([]byte, error) {
@@ -3768,8 +4368,8 @@ func (v *allIsOccurrencesTreeSubjectSource) __premarshalJSON() (*__premarshalall
 	var retval __premarshalallIsOccurrencesTreeSubjectSource
 
 	retval.Typename = v.Typename
-	retval.Type = v.allSrcTree.Type
-	retval.Namespaces = v.allSrcTree.Namespaces
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
 	return &retval, nil
 }
 
@@ -3946,7 +4546,524 @@ func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVers
 	return v.Value
 }
 
-// allSrcTree includes the GraphQL fields of Source requested by the fragment allSrcTree.
+// allSLSATree includes the GraphQL fields of HasSLSA requested by the fragment allSLSATree.
+// The GraphQL type's documentation follows.
+//
+// HasSLSA records that a subject node has a SLSA attestation.
+type allSLSATree struct {
+	// The subject of SLSA attestation: package, source, or artifact.
+	Subject allSLSATreeSubjectPackageSourceOrArtifact `json:"-"`
+	// The SLSA attestation.
+	Slsa *allSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+// GetSubject returns allSLSATree.Subject, and is useful for accessing the field via an interface.
+func (v *allSLSATree) GetSubject() allSLSATreeSubjectPackageSourceOrArtifact { return v.Subject }
+
+// GetSlsa returns allSLSATree.Slsa, and is useful for accessing the field via an interface.
+func (v *allSLSATree) GetSlsa() *allSLSATreeSlsaSLSA { return v.Slsa }
+
+func (v *allSLSATree) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATree
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATree = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalallSLSATreeSubjectPackageSourceOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal allSLSATree.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalallSLSATree struct {
+	Subject json.RawMessage `json:"subject"`
+
+	Slsa *allSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+func (v *allSLSATree) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATree) __premarshalJSON() (*__premarshalallSLSATree, error) {
+	var retval __premarshalallSLSATree
+
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalallSLSATreeSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal allSLSATree.Subject: %w", err)
+		}
+	}
+	retval.Slsa = v.Slsa
+	return &retval, nil
+}
+
+// allSLSATreeSlsaSLSA includes the requested fields of the GraphQL type SLSA.
+// The GraphQL type's documentation follows.
+//
+// SLSA contains all of the fields present in a SLSA attestation.
+//
+// The materials and builders are objects of the HasSLSA predicate, everything
+// else are properties extracted from the attestation.
+//
+// We also include fields to specify under what conditions the check was performed
+// (time of scan, version of scanners, etc.) as well as how this information got
+// included into GUAC (origin document and the collector for that document).
+type allSLSATreeSlsaSLSA struct {
+	// Sources of the build resulting in subject (materials)
+	BuiltFrom []allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact `json:"-"`
+	// Builder performing the build
+	BuiltBy allSLSATreeSlsaSLSABuiltByBuilder `json:"builtBy"`
+	// Type of the builder
+	BuildType string `json:"buildType"`
+	// Individual predicates found in the attestation
+	SlsaPredicate []allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate `json:"slsaPredicate"`
+	// Version of the SLSA predicate
+	SlsaVersion string `json:"slsaVersion"`
+	// Timestamp (RFC3339Nano format) of build start time
+	StartedOn time.Time `json:"startedOn"`
+	// Timestamp (RFC3339Nano format) of build end time
+	FinishedOn time.Time `json:"finishedOn"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetBuiltFrom returns allSLSATreeSlsaSLSA.BuiltFrom, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetBuiltFrom() []allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact {
+	return v.BuiltFrom
+}
+
+// GetBuiltBy returns allSLSATreeSlsaSLSA.BuiltBy, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetBuiltBy() allSLSATreeSlsaSLSABuiltByBuilder { return v.BuiltBy }
+
+// GetBuildType returns allSLSATreeSlsaSLSA.BuildType, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetBuildType() string { return v.BuildType }
+
+// GetSlsaPredicate returns allSLSATreeSlsaSLSA.SlsaPredicate, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetSlsaPredicate() []allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate {
+	return v.SlsaPredicate
+}
+
+// GetSlsaVersion returns allSLSATreeSlsaSLSA.SlsaVersion, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetSlsaVersion() string { return v.SlsaVersion }
+
+// GetStartedOn returns allSLSATreeSlsaSLSA.StartedOn, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetStartedOn() time.Time { return v.StartedOn }
+
+// GetFinishedOn returns allSLSATreeSlsaSLSA.FinishedOn, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetFinishedOn() time.Time { return v.FinishedOn }
+
+// GetOrigin returns allSLSATreeSlsaSLSA.Origin, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetOrigin() string { return v.Origin }
+
+// GetCollector returns allSLSATreeSlsaSLSA.Collector, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSA) GetCollector() string { return v.Collector }
+
+func (v *allSLSATreeSlsaSLSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSlsaSLSA
+		BuiltFrom []json.RawMessage `json:"builtFrom"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSlsaSLSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.BuiltFrom
+		src := firstPass.BuiltFrom
+		*dst = make(
+			[]allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"Unable to unmarshal allSLSATreeSlsaSLSA.BuiltFrom: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSlsaSLSA struct {
+	BuiltFrom []json.RawMessage `json:"builtFrom"`
+
+	BuiltBy allSLSATreeSlsaSLSABuiltByBuilder `json:"builtBy"`
+
+	BuildType string `json:"buildType"`
+
+	SlsaPredicate []allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate `json:"slsaPredicate"`
+
+	SlsaVersion string `json:"slsaVersion"`
+
+	StartedOn time.Time `json:"startedOn"`
+
+	FinishedOn time.Time `json:"finishedOn"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *allSLSATreeSlsaSLSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSlsaSLSA) __premarshalJSON() (*__premarshalallSLSATreeSlsaSLSA, error) {
+	var retval __premarshalallSLSATreeSlsaSLSA
+
+	{
+
+		dst := &retval.BuiltFrom
+		src := v.BuiltFrom
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal allSLSATreeSlsaSLSA.BuiltFrom: %w", err)
+			}
+		}
+	}
+	retval.BuiltBy = v.BuiltBy
+	retval.BuildType = v.BuildType
+	retval.SlsaPredicate = v.SlsaPredicate
+	retval.SlsaVersion = v.SlsaVersion
+	retval.StartedOn = v.StartedOn
+	retval.FinishedOn = v.FinishedOn
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// allSLSATreeSlsaSLSABuiltByBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder such as (FRSCA or github actions).
+//
+// Currently builders are identified by the `uri` field, which is mandatory.
+type allSLSATreeSlsaSLSABuiltByBuilder struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns allSLSATreeSlsaSLSABuiltByBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltByBuilder) GetUri() string { return v.Uri }
+
+// allSLSATreeSlsaSLSABuiltFromArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type allSLSATreeSlsaSLSABuiltFromArtifact struct {
+	Typename        *string `json:"__typename"`
+	allArtifactTree `json:"-"`
+}
+
+// GetTypename returns allSLSATreeSlsaSLSABuiltFromArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetTypename() *string { return v.Typename }
+
+// GetAlgorithm returns allSLSATreeSlsaSLSABuiltFromArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetAlgorithm() string {
+	return v.allArtifactTree.Algorithm
+}
+
+// GetDigest returns allSLSATreeSlsaSLSABuiltFromArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSlsaSLSABuiltFromArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSlsaSLSABuiltFromArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSlsaSLSABuiltFromArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) __premarshalJSON() (*__premarshalallSLSATreeSlsaSLSABuiltFromArtifact, error) {
+	var retval __premarshalallSLSATreeSlsaSLSABuiltFromArtifact
+
+	retval.Typename = v.Typename
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// allSLSATreeSlsaSLSABuiltFromPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type allSLSATreeSlsaSLSABuiltFromPackage struct {
+	Typename   *string `json:"__typename"`
+	allPkgTree `json:"-"`
+}
+
+// GetTypename returns allSLSATreeSlsaSLSABuiltFromPackage.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) GetTypename() *string { return v.Typename }
+
+// GetType returns allSLSATreeSlsaSLSABuiltFromPackage.Type, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns allSLSATreeSlsaSLSABuiltFromPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSlsaSLSABuiltFromPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSlsaSLSABuiltFromPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSlsaSLSABuiltFromPackage struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) __premarshalJSON() (*__premarshalallSLSATreeSlsaSLSABuiltFromPackage, error) {
+	var retval __premarshalallSLSATreeSlsaSLSABuiltFromPackage
+
+	retval.Typename = v.Typename
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact is implemented by the following types:
+// allSLSATreeSlsaSLSABuiltFromPackage
+// allSLSATreeSlsaSLSABuiltFromSource
+// allSLSATreeSlsaSLSABuiltFromArtifact
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromPackage) implementsGraphQLInterfaceallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact() {
+}
+func (v *allSLSATreeSlsaSLSABuiltFromSource) implementsGraphQLInterfaceallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact() {
+}
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) implementsGraphQLInterfaceallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact() {
+}
+
+func __unmarshalallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact(b []byte, v *allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Package":
+		*v = new(allSLSATreeSlsaSLSABuiltFromPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(allSLSATreeSlsaSLSABuiltFromSource)
+		return json.Unmarshal(b, *v)
+	case "Artifact":
+		*v = new(allSLSATreeSlsaSLSABuiltFromArtifact)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalallSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact(v *allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *allSLSATreeSlsaSLSABuiltFromPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSlsaSLSABuiltFromPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *allSLSATreeSlsaSLSABuiltFromSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSlsaSLSABuiltFromSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *allSLSATreeSlsaSLSABuiltFromArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSlsaSLSABuiltFromArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for allSLSATreeSlsaSLSABuiltFromPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// allSLSATreeSlsaSLSABuiltFromSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
 //
 // Source represents a source.
@@ -3958,18 +5075,472 @@ func (v *allPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVers
 //
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
-type allSrcTree struct {
-	Type       string                                `json:"type"`
-	Namespaces []allSrcTreeNamespacesSourceNamespace `json:"namespaces"`
+type allSLSATreeSlsaSLSABuiltFromSource struct {
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
 }
 
-// GetType returns allSrcTree.Type, and is useful for accessing the field via an interface.
-func (v *allSrcTree) GetType() string { return v.Type }
+// GetTypename returns allSLSATreeSlsaSLSABuiltFromSource.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromSource) GetTypename() *string { return v.Typename }
 
-// GetNamespaces returns allSrcTree.Namespaces, and is useful for accessing the field via an interface.
-func (v *allSrcTree) GetNamespaces() []allSrcTreeNamespacesSourceNamespace { return v.Namespaces }
+// GetType returns allSLSATreeSlsaSLSABuiltFromSource.Type, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromSource) GetType() string { return v.allSourceTree.Type }
 
-// allSrcTreeNamespacesSourceNamespace includes the requested fields of the GraphQL type SourceNamespace.
+// GetNamespaces returns allSLSATreeSlsaSLSABuiltFromSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSlsaSLSABuiltFromSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSlsaSLSABuiltFromSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSlsaSLSABuiltFromSource struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSlsaSLSABuiltFromSource) __premarshalJSON() (*__premarshalallSLSATreeSlsaSLSABuiltFromSource, error) {
+	var retval __premarshalallSLSATreeSlsaSLSABuiltFromSource
+
+	retval.Typename = v.Typename
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
+
+// allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate includes the requested fields of the GraphQL type SLSAPredicate.
+// The GraphQL type's documentation follows.
+//
+// SLSAPredicate are the values from the SLSA predicate in key-value pair form.
+//
+// # For example, given the following predicate
+//
+// ```
+// "predicate": {
+// "buildDefinition": {
+// "externalParameters": {
+// "repository": "https://github.com/octocat/hello-world",
+// ...
+// },
+// ...
+// },
+// ...
+// }
+// ```
+//
+// we have
+//
+// ```
+// key   = "buildDefinition.externalParameters.repository"
+// value = "https://github.com/octocat/hello-world"
+// ```
+//
+// This node cannot be directly referred by other parts of GUAC.
+//
+// TODO(mihaimaruseac): Can we define these directly?
+type allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Key, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetKey() string { return v.Key }
+
+// GetValue returns allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Value, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetValue() string { return v.Value }
+
+// allSLSATreeSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type allSLSATreeSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	allArtifactTree `json:"-"`
+}
+
+// GetTypename returns allSLSATreeSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetAlgorithm returns allSLSATreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
+
+// GetDigest returns allSLSATreeSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *allSLSATreeSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *allSLSATreeSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSubjectArtifact) __premarshalJSON() (*__premarshalallSLSATreeSubjectArtifact, error) {
+	var retval __premarshalallSLSATreeSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// allSLSATreeSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type allSLSATreeSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	allPkgTree `json:"-"`
+}
+
+// GetTypename returns allSLSATreeSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetType returns allSLSATreeSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns allSLSATreeSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *allSLSATreeSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *allSLSATreeSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSubjectPackage) __premarshalJSON() (*__premarshalallSLSATreeSubjectPackage, error) {
+	var retval __premarshalallSLSATreeSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// allSLSATreeSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// allSLSATreeSubjectPackageSourceOrArtifact is implemented by the following types:
+// allSLSATreeSubjectPackage
+// allSLSATreeSubjectSource
+// allSLSATreeSubjectArtifact
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type allSLSATreeSubjectPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceallSLSATreeSubjectPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *allSLSATreeSubjectPackage) implementsGraphQLInterfaceallSLSATreeSubjectPackageSourceOrArtifact() {
+}
+func (v *allSLSATreeSubjectSource) implementsGraphQLInterfaceallSLSATreeSubjectPackageSourceOrArtifact() {
+}
+func (v *allSLSATreeSubjectArtifact) implementsGraphQLInterfaceallSLSATreeSubjectPackageSourceOrArtifact() {
+}
+
+func __unmarshalallSLSATreeSubjectPackageSourceOrArtifact(b []byte, v *allSLSATreeSubjectPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Package":
+		*v = new(allSLSATreeSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(allSLSATreeSubjectSource)
+		return json.Unmarshal(b, *v)
+	case "Artifact":
+		*v = new(allSLSATreeSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for allSLSATreeSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalallSLSATreeSubjectPackageSourceOrArtifact(v *allSLSATreeSubjectPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *allSLSATreeSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *allSLSATreeSubjectSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSubjectSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *allSLSATreeSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalallSLSATreeSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for allSLSATreeSubjectPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// allSLSATreeSubjectSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type allSLSATreeSubjectSource struct {
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
+}
+
+// GetTypename returns allSLSATreeSubjectSource.Typename, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectSource) GetTypename() *string { return v.Typename }
+
+// GetType returns allSLSATreeSubjectSource.Type, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectSource) GetType() string { return v.allSourceTree.Type }
+
+// GetNamespaces returns allSLSATreeSubjectSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *allSLSATreeSubjectSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*allSLSATreeSubjectSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.allSLSATreeSubjectSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalallSLSATreeSubjectSource struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *allSLSATreeSubjectSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *allSLSATreeSubjectSource) __premarshalJSON() (*__premarshalallSLSATreeSubjectSource, error) {
+	var retval __premarshalallSLSATreeSubjectSource
+
+	retval.Typename = v.Typename
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
+
+// allSourceTree includes the GraphQL fields of Source requested by the fragment allSourceTree.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type allSourceTree struct {
+	Type       string                                   `json:"type"`
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+// GetType returns allSourceTree.Type, and is useful for accessing the field via an interface.
+func (v *allSourceTree) GetType() string { return v.Type }
+
+// GetNamespaces returns allSourceTree.Namespaces, and is useful for accessing the field via an interface.
+func (v *allSourceTree) GetNamespaces() []allSourceTreeNamespacesSourceNamespace { return v.Namespaces }
+
+// allSourceTreeNamespacesSourceNamespace includes the requested fields of the GraphQL type SourceNamespace.
 // The GraphQL type's documentation follows.
 //
 // SourceNamespace is a namespace for sources.
@@ -3977,20 +5548,20 @@ func (v *allSrcTree) GetNamespaces() []allSrcTreeNamespacesSourceNamespace { ret
 // This is the location of the repository (such as github/gitlab/bitbucket).
 //
 // The `namespace` field is mandatory.
-type allSrcTreeNamespacesSourceNamespace struct {
-	Namespace string                                               `json:"namespace"`
-	Names     []allSrcTreeNamespacesSourceNamespaceNamesSourceName `json:"names"`
+type allSourceTreeNamespacesSourceNamespace struct {
+	Namespace string                                                  `json:"namespace"`
+	Names     []allSourceTreeNamespacesSourceNamespaceNamesSourceName `json:"names"`
 }
 
-// GetNamespace returns allSrcTreeNamespacesSourceNamespace.Namespace, and is useful for accessing the field via an interface.
-func (v *allSrcTreeNamespacesSourceNamespace) GetNamespace() string { return v.Namespace }
+// GetNamespace returns allSourceTreeNamespacesSourceNamespace.Namespace, and is useful for accessing the field via an interface.
+func (v *allSourceTreeNamespacesSourceNamespace) GetNamespace() string { return v.Namespace }
 
-// GetNames returns allSrcTreeNamespacesSourceNamespace.Names, and is useful for accessing the field via an interface.
-func (v *allSrcTreeNamespacesSourceNamespace) GetNames() []allSrcTreeNamespacesSourceNamespaceNamesSourceName {
+// GetNames returns allSourceTreeNamespacesSourceNamespace.Names, and is useful for accessing the field via an interface.
+func (v *allSourceTreeNamespacesSourceNamespace) GetNames() []allSourceTreeNamespacesSourceNamespaceNamesSourceName {
 	return v.Names
 }
 
-// allSrcTreeNamespacesSourceNamespaceNamesSourceName includes the requested fields of the GraphQL type SourceName.
+// allSourceTreeNamespacesSourceNamespaceNamesSourceName includes the requested fields of the GraphQL type SourceName.
 // The GraphQL type's documentation follows.
 //
 // SourceName is a url of the repository and its tag or commit.
@@ -4000,20 +5571,20 @@ func (v *allSrcTreeNamespacesSourceNamespace) GetNames() []allSrcTreeNamespacesS
 //
 // This is the only source trie node that can be referenced by other parts of
 // GUAC.
-type allSrcTreeNamespacesSourceNamespaceNamesSourceName struct {
+type allSourceTreeNamespacesSourceNamespaceNamesSourceName struct {
 	Name   string  `json:"name"`
 	Tag    *string `json:"tag"`
 	Commit *string `json:"commit"`
 }
 
-// GetName returns allSrcTreeNamespacesSourceNamespaceNamesSourceName.Name, and is useful for accessing the field via an interface.
-func (v *allSrcTreeNamespacesSourceNamespaceNamesSourceName) GetName() string { return v.Name }
+// GetName returns allSourceTreeNamespacesSourceNamespaceNamesSourceName.Name, and is useful for accessing the field via an interface.
+func (v *allSourceTreeNamespacesSourceNamespaceNamesSourceName) GetName() string { return v.Name }
 
-// GetTag returns allSrcTreeNamespacesSourceNamespaceNamesSourceName.Tag, and is useful for accessing the field via an interface.
-func (v *allSrcTreeNamespacesSourceNamespaceNamesSourceName) GetTag() *string { return v.Tag }
+// GetTag returns allSourceTreeNamespacesSourceNamespaceNamesSourceName.Tag, and is useful for accessing the field via an interface.
+func (v *allSourceTreeNamespacesSourceNamespaceNamesSourceName) GetTag() *string { return v.Tag }
 
-// GetCommit returns allSrcTreeNamespacesSourceNamespaceNamesSourceName.Commit, and is useful for accessing the field via an interface.
-func (v *allSrcTreeNamespacesSourceNamespaceNamesSourceName) GetCommit() *string { return v.Commit }
+// GetCommit returns allSourceTreeNamespacesSourceNamespaceNamesSourceName.Commit, and is useful for accessing the field via an interface.
+func (v *allSourceTreeNamespacesSourceNamespaceNamesSourceName) GetCommit() *string { return v.Commit }
 
 func CertifyCVE(
 	ctx context.Context,
@@ -4536,7 +6107,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
 			... allPkgTree
 		}
 		... on Source {
-			... allSrcTree
+			... allSourceTree
 		}
 	}
 	artifact {
@@ -4546,7 +6117,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
 	origin
 	collector
 }
-fragment allSrcTree on Source {
+fragment allSourceTree on Source {
 	type
 	namespaces {
 		namespace
@@ -4590,7 +6161,7 @@ func IsOccurrenceSrc(
 		Query: `
 mutation IsOccurrenceSrc ($source: SourceInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
 	ingestSource(source: $source) {
-		... allSrcTree
+		... allSourceTree
 	}
 	ingestArtifact(artifact: $artifact) {
 		... allArtifactTree
@@ -4599,7 +6170,7 @@ mutation IsOccurrenceSrc ($source: SourceInputSpec!, $artifact: ArtifactInputSpe
 		... allIsOccurrencesTree
 	}
 }
-fragment allSrcTree on Source {
+fragment allSourceTree on Source {
 	type
 	namespaces {
 		namespace
@@ -4621,7 +6192,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
 			... allPkgTree
 		}
 		... on Source {
-			... allSrcTree
+			... allSourceTree
 		}
 	}
 	artifact {
@@ -4669,6 +6240,336 @@ fragment allPkgTree on Package {
 	return &data, err
 }
 
+func SLSAForArtifact(
+	ctx context.Context,
+	client graphql.Client,
+	artifact ArtifactInputSpec,
+	slsa SLSAInputSpec,
+) (*SLSAForArtifactResponse, error) {
+	req := &graphql.Request{
+		OpName: "SLSAForArtifact",
+		Query: `
+mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $slsa: SLSAInputSpec!) {
+	ingestArtifact(artifact: $artifact) {
+		... allArtifactTree
+	}
+	ingestSLSA(subject: {artifact:$artifact}, slsa: $slsa) {
+		... allSLSATree
+	}
+}
+fragment allArtifactTree on Artifact {
+	algorithm
+	digest
+}
+fragment allSLSATree on HasSLSA {
+	subject {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	slsa {
+		builtFrom {
+			__typename
+			... on Package {
+				... allPkgTree
+			}
+			... on Source {
+				... allSourceTree
+			}
+			... on Artifact {
+				... allArtifactTree
+			}
+		}
+		builtBy {
+			uri
+		}
+		buildType
+		slsaPredicate {
+			key
+			value
+		}
+		slsaVersion
+		startedOn
+		finishedOn
+		origin
+		collector
+	}
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
+}
+`,
+		Variables: &__SLSAForArtifactInput{
+			Artifact: artifact,
+			Slsa:     slsa,
+		},
+	}
+	var err error
+
+	var data SLSAForArtifactResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+func SLSAForPackage(
+	ctx context.Context,
+	client graphql.Client,
+	pkg PkgInputSpec,
+	slsa SLSAInputSpec,
+) (*SLSAForPackageResponse, error) {
+	req := &graphql.Request{
+		OpName: "SLSAForPackage",
+		Query: `
+mutation SLSAForPackage ($pkg: PkgInputSpec!, $slsa: SLSAInputSpec!) {
+	ingestPackage(pkg: $pkg) {
+		... allPkgTree
+	}
+	ingestSLSA(subject: {package:$pkg}, slsa: $slsa) {
+		... allSLSATree
+	}
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allSLSATree on HasSLSA {
+	subject {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	slsa {
+		builtFrom {
+			__typename
+			... on Package {
+				... allPkgTree
+			}
+			... on Source {
+				... allSourceTree
+			}
+			... on Artifact {
+				... allArtifactTree
+			}
+		}
+		builtBy {
+			uri
+		}
+		buildType
+		slsaPredicate {
+			key
+			value
+		}
+		slsaVersion
+		startedOn
+		finishedOn
+		origin
+		collector
+	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
+}
+fragment allArtifactTree on Artifact {
+	algorithm
+	digest
+}
+`,
+		Variables: &__SLSAForPackageInput{
+			Pkg:  pkg,
+			Slsa: slsa,
+		},
+	}
+	var err error
+
+	var data SLSAForPackageResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+func SLSAForSource(
+	ctx context.Context,
+	client graphql.Client,
+	source SourceInputSpec,
+	slsa SLSAInputSpec,
+) (*SLSAForSourceResponse, error) {
+	req := &graphql.Request{
+		OpName: "SLSAForSource",
+		Query: `
+mutation SLSAForSource ($source: SourceInputSpec!, $slsa: SLSAInputSpec!) {
+	ingestSource(source: $source) {
+		... allSourceTree
+	}
+	ingestSLSA(subject: {source:$source}, slsa: $slsa) {
+		... allSLSATree
+	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
+}
+fragment allSLSATree on HasSLSA {
+	subject {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	slsa {
+		builtFrom {
+			__typename
+			... on Package {
+				... allPkgTree
+			}
+			... on Source {
+				... allSourceTree
+			}
+			... on Artifact {
+				... allArtifactTree
+			}
+		}
+		builtBy {
+			uri
+		}
+		buildType
+		slsaPredicate {
+			key
+			value
+		}
+		slsaVersion
+		startedOn
+		finishedOn
+		origin
+		collector
+	}
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allArtifactTree on Artifact {
+	algorithm
+	digest
+}
+`,
+		Variables: &__SLSAForSourceInput{
+			Source: source,
+			Slsa:   slsa,
+		},
+	}
+	var err error
+
+	var data SLSAForSourceResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 func Scorecard(
 	ctx context.Context,
 	client graphql.Client,
@@ -4680,13 +6581,13 @@ func Scorecard(
 		Query: `
 mutation Scorecard ($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
 	ingestSource(source: $source) {
-		... allSrcTree
+		... allSourceTree
 	}
 	certifyScorecard(source: $source, scorecard: $scorecard) {
 		... allCertifyScorecard
 	}
 }
-fragment allSrcTree on Source {
+fragment allSourceTree on Source {
 	type
 	namespaces {
 		namespace
@@ -4699,7 +6600,7 @@ fragment allSrcTree on Source {
 }
 fragment allCertifyScorecard on CertifyScorecard {
 	source {
-		... allSrcTree
+		... allSourceTree
 	}
 	scorecard {
 		timeScanned

--- a/pkg/assembler/clients/operations/certifyScorecard.graphql
+++ b/pkg/assembler/clients/operations/certifyScorecard.graphql
@@ -17,38 +17,6 @@
 
 # Defines the GraphQL operations to ingest a Scorecard certification into GUAC
 
-# TODO(mihaimaruseac): Clean this up: do we want all of these to be returned?
-
-fragment allSrcTree on Source {
-  type
-    namespaces {
-      namespace
-        names {
-          name
-            tag
-            commit
-        }
-    }
-}
-
-fragment allCertifyScorecard on CertifyScorecard {
-  source {
-    ...allSrcTree
-  }
-  scorecard {
-    timeScanned
-      aggregateScore
-      checks {
-        check
-          score
-      }
-    scorecardVersion
-      scorecardCommit
-      origin
-      collector
-  }
-}
-
 mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
   ingestSource(source: $source) {
     ...allSrcTree

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -15,13 +15,31 @@
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines the GraphQL operations to ingest a Scorecard certification into GUAC
+# Defines the GraphQL operations to ingest SLSA attestations into GUAC
 
-mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
+mutation SLSAForPackage($pkg: PkgInputSpec!, $slsa: SLSAInputSpec!) {
+  ingestPackage(pkg: $pkg) {
+    ...allPkgTree
+  }
+  ingestSLSA(subject: {package: $pkg}, slsa: $slsa) {
+    ...allSLSATree
+  }
+}
+
+mutation SLSAForSource($source: SourceInputSpec!, $slsa: SLSAInputSpec!) {
   ingestSource(source: $source) {
     ...allSourceTree
   }
-  certifyScorecard(source: $source, scorecard: $scorecard) {
-    ...allCertifyScorecard
+  ingestSLSA(subject: {source: $source}, slsa: $slsa) {
+    ...allSLSATree
+  }
+}
+
+mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $slsa: SLSAInputSpec!) {
+  ingestArtifact(artifact: $artifact) {
+    ...allArtifactTree
+  }
+  ingestSLSA(subject: {artifact: $artifact}, slsa: $slsa) {
+    ...allSLSATree
   }
 }

--- a/pkg/assembler/clients/operations/isDependency.graphql
+++ b/pkg/assembler/clients/operations/isDependency.graphql
@@ -15,38 +15,7 @@
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines the GraphQL operations to ingest a IsDependency into GUAC
-
-fragment allPkgTree on Package {
-  type
-  namespaces {
-    namespace
-    names {
-      name
-      versions {
-        version
-        qualifiers {
-          key
-          value
-        }
-        subpath
-      }
-    }
-  }
-}
-
-fragment allIsDependencyTree on IsDependency {
-  justification
-  package {
-    ...allPkgTree
-  }
-  dependentPackage {
-    ...allPkgTree
-  }
-  versionRange
-  origin
-  collector
-}
+# Defines the GraphQL operations to ingest dependency information into GUAC
 
 mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: IsDependencyInputSpec!) {
   pkg: ingestPackage(pkg: $pkg) {

--- a/pkg/assembler/clients/operations/isOccurrence.graphql
+++ b/pkg/assembler/clients/operations/isOccurrence.graphql
@@ -31,7 +31,7 @@ mutation IsOccurrencePkg($pkg: PkgInputSpec!, $artifact: ArtifactInputSpec!, $oc
 
 mutation IsOccurrenceSrc($source: SourceInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
   ingestSource(source: $source) {
-    ...allSrcTree
+    ...allSourceTree
   }
   ingestArtifact(artifact: $artifact) {
     ...allArtifactTree

--- a/pkg/assembler/clients/operations/isOccurrence.graphql
+++ b/pkg/assembler/clients/operations/isOccurrence.graphql
@@ -15,30 +15,7 @@
 
 # NOTE: This is experimental and might change in the future!
 
-# Defines the GraphQL operations to ingest a IsOccurrence into GUAC
-
-fragment allArtifactTree on Artifact {
-  algorithm
-  digest
-}
-
-fragment allIsOccurrencesTree on IsOccurrence {
-  subject {
-    __typename 
-    ... on Package {
-      ...allPkgTree
-    }
-   ...on Source {
-      ...allSrcTree
-    }
-  }
-  artifact {
-    ...allArtifactTree
-  }
-  justification
-  origin
-  collector
-}
+# Defines the GraphQL operations to ingest occurence information into GUAC
 
 mutation IsOccurrencePkg($pkg: PkgInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
   ingestPackage(pkg: $pkg) {

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -1,0 +1,104 @@
+#
+# Copyright 2023 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This is experimental and might change in the future!
+
+# Defines GraphQL fragments used in the operations
+
+# TODO(mihaimaruseac): Clean this up: do we want all of these to be returned?
+
+fragment allPkgTree on Package {
+  type
+  namespaces {
+    namespace
+    names {
+      name
+      versions {
+        version
+        qualifiers {
+          key
+          value
+        }
+        subpath
+      }
+    }
+  }
+}
+
+fragment allSrcTree on Source {
+  type
+    namespaces {
+      namespace
+        names {
+          name
+            tag
+            commit
+        }
+    }
+}
+
+fragment allArtifactTree on Artifact {
+  algorithm
+  digest
+}
+
+fragment allCertifyScorecard on CertifyScorecard {
+  source {
+    ...allSrcTree
+  }
+  scorecard {
+    timeScanned
+      aggregateScore
+      checks {
+        check
+          score
+      }
+    scorecardVersion
+      scorecardCommit
+      origin
+      collector
+  }
+}
+
+fragment allIsOccurrencesTree on IsOccurrence {
+  subject {
+    __typename
+    ...on Package {
+      ...allPkgTree
+    }
+   ...on Source {
+      ...allSrcTree
+    }
+  }
+  occurrenceArtifact {
+    ...allArtifactTree
+  }
+  justification
+  origin
+  collector
+}
+
+fragment allIsDependencyTree on IsDependency {
+  justification
+  package {
+    ...allPkgTree
+  }
+  dependentPackage {
+    ...allPkgTree
+  }
+  versionRange
+  origin
+  collector
+}

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -82,7 +82,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
       ...allSourceTree
     }
   }
-  occurrenceArtifact {
+  artifact {
     ...allArtifactTree
   }
   justification

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -37,7 +37,7 @@ fragment allPkgTree on Package {
   }
 }
 
-fragment allSrcTree on Source {
+fragment allSourceTree on Source {
   type
     namespaces {
       namespace
@@ -56,7 +56,7 @@ fragment allArtifactTree on Artifact {
 
 fragment allCertifyScorecard on CertifyScorecard {
   source {
-    ...allSrcTree
+    ...allSourceTree
   }
   scorecard {
     timeScanned
@@ -79,7 +79,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
       ...allPkgTree
     }
    ...on Source {
-      ...allSrcTree
+      ...allSourceTree
     }
   }
   occurrenceArtifact {
@@ -101,4 +101,46 @@ fragment allIsDependencyTree on IsDependency {
   versionRange
   origin
   collector
+}
+
+fragment allSLSATree on HasSLSA {
+  subject {
+    __typename
+    ... on Package {
+      ...allPkgTree
+    }
+    ... on Source {
+      ...allSourceTree
+    }
+    ... on Artifact {
+      ...allArtifactTree
+    }
+  }
+  slsa {
+    builtFrom {
+      __typename
+      ... on Package {
+        ...allPkgTree
+      }
+      ... on Source {
+        ...allSourceTree
+      }
+      ... on Artifact {
+        ...allArtifactTree
+      }
+    }
+    builtBy {
+      uri
+    }
+    buildType
+    slsaPredicate {
+      key
+      value
+    }
+    slsaVersion
+    startedOn
+    finishedOn
+    origin
+    collector
+  }
 }


### PR DESCRIPTION
While here, move fragment trees to separate file, since they cannot be duplicated.