### PR TITLE
Split materials and builder from SLSA input

### DIFF
--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -120,8 +120,6 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		},
 	}
 	slsa := model.SLSAInputSpec{
-		BuiltFrom:     materials,
-		BuiltBy:       builder,
 		BuildType:     "Test:Source->Package",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
@@ -137,15 +135,13 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Name:      "tensorflow",
 		Version:   &version,
 	}
-	_, err := model.SLSAForPackage(context.Background(), client, pkg, slsa)
+	_, err := model.SLSAForPackage(context.Background(), client, pkg, materials, builder, slsa)
 	if err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}
 
 	// from source to artifact
 	slsa = model.SLSAInputSpec{
-		BuiltFrom:     materials,
-		BuiltBy:       builder,
 		BuildType:     "Test:Source->Artifact",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
@@ -158,7 +154,7 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Digest:    "5a787865sd676dacb0142afa0b83029cd7befd9",
 		Algorithm: "sha1",
 	}
-	_, err = model.SLSAForArtifact(context.Background(), client, artifact, slsa)
+	_, err = model.SLSAForArtifact(context.Background(), client, artifact, materials, builder, slsa)
 	if err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}
@@ -168,8 +164,6 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Uri: "https://github.com/CreateFork/HubHostedActions@v1",
 	}
 	slsa = model.SLSAInputSpec{
-		BuiltFrom:     materials,
-		BuiltBy:       builder,
 		BuildType:     "Test:Source->Source",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
@@ -184,7 +178,7 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Name:      "github.com/forked/tensorflow",
 		Tag:       &tag,
 	}
-	_, err = model.SLSAForSource(context.Background(), client, finalSource, slsa)
+	_, err = model.SLSAForSource(context.Background(), client, finalSource, materials, builder, slsa)
 	if err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}
@@ -206,8 +200,6 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Uri: "https://github.com/MixedBuild/HubHostedActions@v1",
 	}
 	slsa = model.SLSAInputSpec{
-		BuiltFrom:     materials,
-		BuiltBy:       builder,
 		BuildType:     "Test:Mixed-build",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
@@ -220,7 +212,7 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		Digest:    "0123456789abcdef0000000fedcba9876543210",
 		Algorithm: "sha1",
 	}
-	_, err = model.SLSAForArtifact(context.Background(), client, artifact, slsa)
+	_, err = model.SLSAForArtifact(context.Background(), client, artifact, materials, builder, slsa)
 	if err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -52,6 +52,7 @@ type Backend interface {
 	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
 	IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error)
 	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error)
+	IngestMaterials(ctx context.Context, materials []*model.PackageSourceOrArtifactInput) ([]model.PackageSourceOrArtifact, error)
 	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error)
 	IngestCve(ctx context.Context, cve *model.CVEInputSpec) (*model.Cve, error)
 	IngestGhsa(ctx context.Context, ghsa *model.GHSAInputSpec) (*model.Ghsa, error)
@@ -59,7 +60,7 @@ type Backend interface {
 
 	// Mutations for evidence trees (read-write queries, assume software trees ingested)
 	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
-	IngestSLSA(ctx context.Context, subject model.PackageSourceOrArtifactInput, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
+	IngestSLSA(ctx context.Context, subject model.PackageSourceOrArtifactInput, builtFrom []*model.PackageSourceOrArtifactInput, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
 	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)
 	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error)
 	IngestVulnerability(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.OsvCveOrGhsaInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error)

--- a/pkg/assembler/backends/helper/inputCheker.go
+++ b/pkg/assembler/backends/helper/inputCheker.go
@@ -76,23 +76,6 @@ func CheckOccurrenceIngestionInput(subject model.PackageOrSourceInput) error {
 	return nil
 }
 
-func CheckCertifyBadIngestionInput(subject model.PackageSourceOrArtifactInput) error {
-	subjectDefined := 0
-	if subject.Package != nil {
-		subjectDefined = subjectDefined + 1
-	}
-	if subject.Source != nil {
-		subjectDefined = subjectDefined + 1
-	}
-	if subject.Artifact != nil {
-		subjectDefined = subjectDefined + 1
-	}
-	if subjectDefined != 1 {
-		return gqlerror.Errorf("must specify at most one subject (package, source, or artifact)")
-	}
-	return nil
-}
-
 func CheckCertifyBadQueryInput(subject *model.PackageSourceOrArtifactSpec) (bool, error) {
 	if subject == nil {
 		return true, nil
@@ -112,4 +95,22 @@ func CheckCertifyBadQueryInput(subject *model.PackageSourceOrArtifactSpec) (bool
 		}
 	}
 	return false, nil
+}
+
+func ValidatePackageSourceOrArtifactInput(item *model.PackageSourceOrArtifactInput, path string) error {
+	valuesDefined := 0
+	if item.Package != nil {
+		valuesDefined = valuesDefined + 1
+	}
+	if item.Source != nil {
+		valuesDefined = valuesDefined + 1
+	}
+	if item.Artifact != nil {
+		valuesDefined = valuesDefined + 1
+	}
+	if valuesDefined != 1 {
+		return gqlerror.Errorf("Must specify at most one package, source, or artifact for %v", path)
+	}
+
+	return nil
 }

--- a/pkg/assembler/backends/neo4j/certifyBad.go
+++ b/pkg/assembler/backends/neo4j/certifyBad.go
@@ -264,7 +264,7 @@ func generateModelCertifyBad(subject model.PackageSourceOrArtifact, justificatio
 
 func (c *neo4jClient) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error) {
 
-	err := helper.CheckCertifyBadIngestionInput(subject)
+	err := helper.ValidatePackageSourceOrArtifactInput(&subject, "bad subject")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -600,6 +600,10 @@ func generateModelHasSLSA(subject model.PackageSourceOrArtifact,
 	return &hasSLSA
 }
 
-func (c *neo4jClient) IngestSLSA(ctx context.Context, subject model.PackageSourceOrArtifactInput, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
+func (c *neo4jClient) IngestSLSA(ctx context.Context, subject model.PackageSourceOrArtifactInput, builtFrom []*model.PackageSourceOrArtifactInput, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
+	panic(fmt.Errorf("not implemented: IngestSlsa - ingestSLSA"))
+}
+
+func (c *neo4jClient) IngestMaterials(ctx context.Context, materials []*model.PackageSourceOrArtifactInput) ([]model.PackageSourceOrArtifact, error) {
 	panic(fmt.Errorf("not implemented: IngestSlsa - ingestSLSA"))
 }

--- a/pkg/assembler/backends/testing/certifyBad.go
+++ b/pkg/assembler/backends/testing/certifyBad.go
@@ -113,7 +113,7 @@ func (c *demoClient) registerCertifyBad(selectedPackage *model.Package, selected
 
 func (c *demoClient) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error) {
 
-	err := helper.CheckCertifyBadIngestionInput(subject)
+	err := helper.ValidatePackageSourceOrArtifactInput(&subject, "bad subject")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -2829,6 +2829,356 @@ func (v *SLSAForArtifactIngestArtifact) __premarshalJSON() (*__premarshalSLSAFor
 	return &retval, nil
 }
 
+// SLSAForArtifactIngestBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder such as (FRSCA or github actions).
+//
+// Currently builders are identified by the `uri` field, which is mandatory.
+type SLSAForArtifactIngestBuilder struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns SLSAForArtifactIngestBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestBuilder) GetUri() string { return v.Uri }
+
+// SLSAForArtifactIngestMaterialsArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type SLSAForArtifactIngestMaterialsArtifact struct {
+	Typename        *string `json:"__typename"`
+	allArtifactTree `json:"-"`
+}
+
+// GetTypename returns SLSAForArtifactIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
+
+// GetAlgorithm returns SLSAForArtifactIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsArtifact) GetAlgorithm() string {
+	return v.allArtifactTree.Algorithm
+}
+
+// GetDigest returns SLSAForArtifactIngestMaterialsArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *SLSAForArtifactIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactIngestMaterialsArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactIngestMaterialsArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactIngestMaterialsArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *SLSAForArtifactIngestMaterialsArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactIngestMaterialsArtifact) __premarshalJSON() (*__premarshalSLSAForArtifactIngestMaterialsArtifact, error) {
+	var retval __premarshalSLSAForArtifactIngestMaterialsArtifact
+
+	retval.Typename = v.Typename
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// SLSAForArtifactIngestMaterialsPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type SLSAForArtifactIngestMaterialsPackage struct {
+	Typename   *string `json:"__typename"`
+	allPkgTree `json:"-"`
+}
+
+// GetTypename returns SLSAForArtifactIngestMaterialsPackage.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsPackage) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForArtifactIngestMaterialsPackage.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns SLSAForArtifactIngestMaterialsPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *SLSAForArtifactIngestMaterialsPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactIngestMaterialsPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactIngestMaterialsPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactIngestMaterialsPackage struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForArtifactIngestMaterialsPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactIngestMaterialsPackage) __premarshalJSON() (*__premarshalSLSAForArtifactIngestMaterialsPackage, error) {
+	var retval __premarshalSLSAForArtifactIngestMaterialsPackage
+
+	retval.Typename = v.Typename
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// SLSAForArtifactIngestMaterialsPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// SLSAForArtifactIngestMaterialsPackageSourceOrArtifact is implemented by the following types:
+// SLSAForArtifactIngestMaterialsPackage
+// SLSAForArtifactIngestMaterialsSource
+// SLSAForArtifactIngestMaterialsArtifact
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type SLSAForArtifactIngestMaterialsPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceSLSAForArtifactIngestMaterialsPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *SLSAForArtifactIngestMaterialsPackage) implementsGraphQLInterfaceSLSAForArtifactIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForArtifactIngestMaterialsSource) implementsGraphQLInterfaceSLSAForArtifactIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForArtifactIngestMaterialsArtifact) implementsGraphQLInterfaceSLSAForArtifactIngestMaterialsPackageSourceOrArtifact() {
+}
+
+func __unmarshalSLSAForArtifactIngestMaterialsPackageSourceOrArtifact(b []byte, v *SLSAForArtifactIngestMaterialsPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Package":
+		*v = new(SLSAForArtifactIngestMaterialsPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(SLSAForArtifactIngestMaterialsSource)
+		return json.Unmarshal(b, *v)
+	case "Artifact":
+		*v = new(SLSAForArtifactIngestMaterialsArtifact)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for SLSAForArtifactIngestMaterialsPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalSLSAForArtifactIngestMaterialsPackageSourceOrArtifact(v *SLSAForArtifactIngestMaterialsPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SLSAForArtifactIngestMaterialsPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForArtifactIngestMaterialsPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForArtifactIngestMaterialsSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForArtifactIngestMaterialsSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForArtifactIngestMaterialsArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForArtifactIngestMaterialsArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for SLSAForArtifactIngestMaterialsPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// SLSAForArtifactIngestMaterialsSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type SLSAForArtifactIngestMaterialsSource struct {
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
+}
+
+// GetTypename returns SLSAForArtifactIngestMaterialsSource.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsSource) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForArtifactIngestMaterialsSource.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsSource) GetType() string { return v.allSourceTree.Type }
+
+// GetNamespaces returns SLSAForArtifactIngestMaterialsSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *SLSAForArtifactIngestMaterialsSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactIngestMaterialsSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactIngestMaterialsSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactIngestMaterialsSource struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForArtifactIngestMaterialsSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactIngestMaterialsSource) __premarshalJSON() (*__premarshalSLSAForArtifactIngestMaterialsSource, error) {
+	var retval __premarshalSLSAForArtifactIngestMaterialsSource
+
+	retval.Typename = v.Typename
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
+
 // SLSAForArtifactIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
 // The GraphQL type's documentation follows.
 //
@@ -2907,7 +3257,19 @@ func (v *SLSAForArtifactIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSA
 type SLSAForArtifactResponse struct {
 	// Ingest a new artifact. Returns the ingested artifact
 	IngestArtifact SLSAForArtifactIngestArtifact `json:"ingestArtifact"`
-	// Ingests a SLSA attestation
+	// Ingests a set of packages, sources, and artifacts.
+	//
+	// This is a helper mutation for ingesting SLSA nodes. It should be more
+	// efficient to call this method to ingest a set materials instead of ingesting
+	// them one by one.
+	IngestMaterials []SLSAForArtifactIngestMaterialsPackageSourceOrArtifact `json:"-"`
+	// Ingest a new builder. Returns the ingested builder
+	IngestBuilder SLSAForArtifactIngestBuilder `json:"ingestBuilder"`
+	// Ingests a SLSA attestation.
+	//
+	// Note that materials and builder are extracted as separate arguments. This is
+	// because this ingestion method assumes that the subject and the materials are
+	// already ingested and only creates the SLSA node.
 	IngestSLSA SLSAForArtifactIngestSLSAHasSLSA `json:"ingestSLSA"`
 }
 
@@ -2916,9 +3278,453 @@ func (v *SLSAForArtifactResponse) GetIngestArtifact() SLSAForArtifactIngestArtif
 	return v.IngestArtifact
 }
 
+// GetIngestMaterials returns SLSAForArtifactResponse.IngestMaterials, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactResponse) GetIngestMaterials() []SLSAForArtifactIngestMaterialsPackageSourceOrArtifact {
+	return v.IngestMaterials
+}
+
+// GetIngestBuilder returns SLSAForArtifactResponse.IngestBuilder, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactResponse) GetIngestBuilder() SLSAForArtifactIngestBuilder {
+	return v.IngestBuilder
+}
+
 // GetIngestSLSA returns SLSAForArtifactResponse.IngestSLSA, and is useful for accessing the field via an interface.
 func (v *SLSAForArtifactResponse) GetIngestSLSA() SLSAForArtifactIngestSLSAHasSLSA {
 	return v.IngestSLSA
+}
+
+func (v *SLSAForArtifactResponse) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForArtifactResponse
+		IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForArtifactResponse = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.IngestMaterials
+		src := firstPass.IngestMaterials
+		*dst = make(
+			[]SLSAForArtifactIngestMaterialsPackageSourceOrArtifact,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalSLSAForArtifactIngestMaterialsPackageSourceOrArtifact(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"Unable to unmarshal SLSAForArtifactResponse.IngestMaterials: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalSLSAForArtifactResponse struct {
+	IngestArtifact SLSAForArtifactIngestArtifact `json:"ingestArtifact"`
+
+	IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+
+	IngestBuilder SLSAForArtifactIngestBuilder `json:"ingestBuilder"`
+
+	IngestSLSA SLSAForArtifactIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+func (v *SLSAForArtifactResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForArtifactResponse) __premarshalJSON() (*__premarshalSLSAForArtifactResponse, error) {
+	var retval __premarshalSLSAForArtifactResponse
+
+	retval.IngestArtifact = v.IngestArtifact
+	{
+
+		dst := &retval.IngestMaterials
+		src := v.IngestMaterials
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalSLSAForArtifactIngestMaterialsPackageSourceOrArtifact(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal SLSAForArtifactResponse.IngestMaterials: %w", err)
+			}
+		}
+	}
+	retval.IngestBuilder = v.IngestBuilder
+	retval.IngestSLSA = v.IngestSLSA
+	return &retval, nil
+}
+
+// SLSAForPackageIngestBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder such as (FRSCA or github actions).
+//
+// Currently builders are identified by the `uri` field, which is mandatory.
+type SLSAForPackageIngestBuilder struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns SLSAForPackageIngestBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestBuilder) GetUri() string { return v.Uri }
+
+// SLSAForPackageIngestMaterialsArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type SLSAForPackageIngestMaterialsArtifact struct {
+	Typename        *string `json:"__typename"`
+	allArtifactTree `json:"-"`
+}
+
+// GetTypename returns SLSAForPackageIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
+
+// GetAlgorithm returns SLSAForPackageIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsArtifact) GetAlgorithm() string {
+	return v.allArtifactTree.Algorithm
+}
+
+// GetDigest returns SLSAForPackageIngestMaterialsArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *SLSAForPackageIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageIngestMaterialsArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageIngestMaterialsArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageIngestMaterialsArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *SLSAForPackageIngestMaterialsArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageIngestMaterialsArtifact) __premarshalJSON() (*__premarshalSLSAForPackageIngestMaterialsArtifact, error) {
+	var retval __premarshalSLSAForPackageIngestMaterialsArtifact
+
+	retval.Typename = v.Typename
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// SLSAForPackageIngestMaterialsPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type SLSAForPackageIngestMaterialsPackage struct {
+	Typename   *string `json:"__typename"`
+	allPkgTree `json:"-"`
+}
+
+// GetTypename returns SLSAForPackageIngestMaterialsPackage.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsPackage) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForPackageIngestMaterialsPackage.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns SLSAForPackageIngestMaterialsPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *SLSAForPackageIngestMaterialsPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageIngestMaterialsPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageIngestMaterialsPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageIngestMaterialsPackage struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForPackageIngestMaterialsPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageIngestMaterialsPackage) __premarshalJSON() (*__premarshalSLSAForPackageIngestMaterialsPackage, error) {
+	var retval __premarshalSLSAForPackageIngestMaterialsPackage
+
+	retval.Typename = v.Typename
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// SLSAForPackageIngestMaterialsPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// SLSAForPackageIngestMaterialsPackageSourceOrArtifact is implemented by the following types:
+// SLSAForPackageIngestMaterialsPackage
+// SLSAForPackageIngestMaterialsSource
+// SLSAForPackageIngestMaterialsArtifact
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type SLSAForPackageIngestMaterialsPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceSLSAForPackageIngestMaterialsPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *SLSAForPackageIngestMaterialsPackage) implementsGraphQLInterfaceSLSAForPackageIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForPackageIngestMaterialsSource) implementsGraphQLInterfaceSLSAForPackageIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForPackageIngestMaterialsArtifact) implementsGraphQLInterfaceSLSAForPackageIngestMaterialsPackageSourceOrArtifact() {
+}
+
+func __unmarshalSLSAForPackageIngestMaterialsPackageSourceOrArtifact(b []byte, v *SLSAForPackageIngestMaterialsPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Package":
+		*v = new(SLSAForPackageIngestMaterialsPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(SLSAForPackageIngestMaterialsSource)
+		return json.Unmarshal(b, *v)
+	case "Artifact":
+		*v = new(SLSAForPackageIngestMaterialsArtifact)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for SLSAForPackageIngestMaterialsPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalSLSAForPackageIngestMaterialsPackageSourceOrArtifact(v *SLSAForPackageIngestMaterialsPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SLSAForPackageIngestMaterialsPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForPackageIngestMaterialsPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForPackageIngestMaterialsSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForPackageIngestMaterialsSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForPackageIngestMaterialsArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForPackageIngestMaterialsArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for SLSAForPackageIngestMaterialsPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// SLSAForPackageIngestMaterialsSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type SLSAForPackageIngestMaterialsSource struct {
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
+}
+
+// GetTypename returns SLSAForPackageIngestMaterialsSource.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsSource) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForPackageIngestMaterialsSource.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsSource) GetType() string { return v.allSourceTree.Type }
+
+// GetNamespaces returns SLSAForPackageIngestMaterialsSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *SLSAForPackageIngestMaterialsSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageIngestMaterialsSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageIngestMaterialsSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageIngestMaterialsSource struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForPackageIngestMaterialsSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageIngestMaterialsSource) __premarshalJSON() (*__premarshalSLSAForPackageIngestMaterialsSource, error) {
+	var retval __premarshalSLSAForPackageIngestMaterialsSource
+
+	retval.Typename = v.Typename
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
 }
 
 // SLSAForPackageIngestPackage includes the requested fields of the GraphQL type Package.
@@ -3073,7 +3879,19 @@ func (v *SLSAForPackageIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAF
 type SLSAForPackageResponse struct {
 	// Ingest a new package. Returns the ingested package trie
 	IngestPackage SLSAForPackageIngestPackage `json:"ingestPackage"`
-	// Ingests a SLSA attestation
+	// Ingests a set of packages, sources, and artifacts.
+	//
+	// This is a helper mutation for ingesting SLSA nodes. It should be more
+	// efficient to call this method to ingest a set materials instead of ingesting
+	// them one by one.
+	IngestMaterials []SLSAForPackageIngestMaterialsPackageSourceOrArtifact `json:"-"`
+	// Ingest a new builder. Returns the ingested builder
+	IngestBuilder SLSAForPackageIngestBuilder `json:"ingestBuilder"`
+	// Ingests a SLSA attestation.
+	//
+	// Note that materials and builder are extracted as separate arguments. This is
+	// because this ingestion method assumes that the subject and the materials are
+	// already ingested and only creates the SLSA node.
 	IngestSLSA SLSAForPackageIngestSLSAHasSLSA `json:"ingestSLSA"`
 }
 
@@ -3082,8 +3900,452 @@ func (v *SLSAForPackageResponse) GetIngestPackage() SLSAForPackageIngestPackage 
 	return v.IngestPackage
 }
 
+// GetIngestMaterials returns SLSAForPackageResponse.IngestMaterials, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageResponse) GetIngestMaterials() []SLSAForPackageIngestMaterialsPackageSourceOrArtifact {
+	return v.IngestMaterials
+}
+
+// GetIngestBuilder returns SLSAForPackageResponse.IngestBuilder, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageResponse) GetIngestBuilder() SLSAForPackageIngestBuilder {
+	return v.IngestBuilder
+}
+
 // GetIngestSLSA returns SLSAForPackageResponse.IngestSLSA, and is useful for accessing the field via an interface.
 func (v *SLSAForPackageResponse) GetIngestSLSA() SLSAForPackageIngestSLSAHasSLSA { return v.IngestSLSA }
+
+func (v *SLSAForPackageResponse) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForPackageResponse
+		IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForPackageResponse = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.IngestMaterials
+		src := firstPass.IngestMaterials
+		*dst = make(
+			[]SLSAForPackageIngestMaterialsPackageSourceOrArtifact,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalSLSAForPackageIngestMaterialsPackageSourceOrArtifact(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"Unable to unmarshal SLSAForPackageResponse.IngestMaterials: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalSLSAForPackageResponse struct {
+	IngestPackage SLSAForPackageIngestPackage `json:"ingestPackage"`
+
+	IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+
+	IngestBuilder SLSAForPackageIngestBuilder `json:"ingestBuilder"`
+
+	IngestSLSA SLSAForPackageIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+func (v *SLSAForPackageResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForPackageResponse) __premarshalJSON() (*__premarshalSLSAForPackageResponse, error) {
+	var retval __premarshalSLSAForPackageResponse
+
+	retval.IngestPackage = v.IngestPackage
+	{
+
+		dst := &retval.IngestMaterials
+		src := v.IngestMaterials
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalSLSAForPackageIngestMaterialsPackageSourceOrArtifact(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal SLSAForPackageResponse.IngestMaterials: %w", err)
+			}
+		}
+	}
+	retval.IngestBuilder = v.IngestBuilder
+	retval.IngestSLSA = v.IngestSLSA
+	return &retval, nil
+}
+
+// SLSAForSourceIngestBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder such as (FRSCA or github actions).
+//
+// Currently builders are identified by the `uri` field, which is mandatory.
+type SLSAForSourceIngestBuilder struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns SLSAForSourceIngestBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestBuilder) GetUri() string { return v.Uri }
+
+// SLSAForSourceIngestMaterialsArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// # Artifact represents the artifact and contains a digest field
+//
+// Both field are mandatory and canonicalized to be lowercase.
+//
+// If having a `checksum` Go object, `algorithm` can be
+// `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
+// `checksum.Value`.
+type SLSAForSourceIngestMaterialsArtifact struct {
+	Typename        *string `json:"__typename"`
+	allArtifactTree `json:"-"`
+}
+
+// GetTypename returns SLSAForSourceIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
+
+// GetAlgorithm returns SLSAForSourceIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsArtifact) GetAlgorithm() string {
+	return v.allArtifactTree.Algorithm
+}
+
+// GetDigest returns SLSAForSourceIngestMaterialsArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsArtifact) GetDigest() string { return v.allArtifactTree.Digest }
+
+func (v *SLSAForSourceIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceIngestMaterialsArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceIngestMaterialsArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceIngestMaterialsArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *SLSAForSourceIngestMaterialsArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceIngestMaterialsArtifact) __premarshalJSON() (*__premarshalSLSAForSourceIngestMaterialsArtifact, error) {
+	var retval __premarshalSLSAForSourceIngestMaterialsArtifact
+
+	retval.Typename = v.Typename
+	retval.Algorithm = v.allArtifactTree.Algorithm
+	retval.Digest = v.allArtifactTree.Digest
+	return &retval, nil
+}
+
+// SLSAForSourceIngestMaterialsPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents a package.
+//
+// In the pURL representation, each Package matches a `pkg:<type>` partial pURL.
+// The `type` field matches the pURL types but we might also use `"guac"` for the
+// cases where the pURL representation is not complete or when we have custom
+// rules.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Package`, not `PackageType`. This is only to make
+// queries more readable.
+type SLSAForSourceIngestMaterialsPackage struct {
+	Typename   *string `json:"__typename"`
+	allPkgTree `json:"-"`
+}
+
+// GetTypename returns SLSAForSourceIngestMaterialsPackage.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsPackage) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForSourceIngestMaterialsPackage.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsPackage) GetType() string { return v.allPkgTree.Type }
+
+// GetNamespaces returns SLSAForSourceIngestMaterialsPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsPackage) GetNamespaces() []allPkgTreeNamespacesPackageNamespace {
+	return v.allPkgTree.Namespaces
+}
+
+func (v *SLSAForSourceIngestMaterialsPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceIngestMaterialsPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceIngestMaterialsPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceIngestMaterialsPackage struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForSourceIngestMaterialsPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceIngestMaterialsPackage) __premarshalJSON() (*__premarshalSLSAForSourceIngestMaterialsPackage, error) {
+	var retval __premarshalSLSAForSourceIngestMaterialsPackage
+
+	retval.Typename = v.Typename
+	retval.Type = v.allPkgTree.Type
+	retval.Namespaces = v.allPkgTree.Namespaces
+	return &retval, nil
+}
+
+// SLSAForSourceIngestMaterialsPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// SLSAForSourceIngestMaterialsPackageSourceOrArtifact is implemented by the following types:
+// SLSAForSourceIngestMaterialsPackage
+// SLSAForSourceIngestMaterialsSource
+// SLSAForSourceIngestMaterialsArtifact
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type SLSAForSourceIngestMaterialsPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceSLSAForSourceIngestMaterialsPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *SLSAForSourceIngestMaterialsPackage) implementsGraphQLInterfaceSLSAForSourceIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForSourceIngestMaterialsSource) implementsGraphQLInterfaceSLSAForSourceIngestMaterialsPackageSourceOrArtifact() {
+}
+func (v *SLSAForSourceIngestMaterialsArtifact) implementsGraphQLInterfaceSLSAForSourceIngestMaterialsPackageSourceOrArtifact() {
+}
+
+func __unmarshalSLSAForSourceIngestMaterialsPackageSourceOrArtifact(b []byte, v *SLSAForSourceIngestMaterialsPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Package":
+		*v = new(SLSAForSourceIngestMaterialsPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(SLSAForSourceIngestMaterialsSource)
+		return json.Unmarshal(b, *v)
+	case "Artifact":
+		*v = new(SLSAForSourceIngestMaterialsArtifact)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for SLSAForSourceIngestMaterialsPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalSLSAForSourceIngestMaterialsPackageSourceOrArtifact(v *SLSAForSourceIngestMaterialsPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SLSAForSourceIngestMaterialsPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForSourceIngestMaterialsPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForSourceIngestMaterialsSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForSourceIngestMaterialsSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SLSAForSourceIngestMaterialsArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSLSAForSourceIngestMaterialsArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for SLSAForSourceIngestMaterialsPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// SLSAForSourceIngestMaterialsSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type SLSAForSourceIngestMaterialsSource struct {
+	Typename      *string `json:"__typename"`
+	allSourceTree `json:"-"`
+}
+
+// GetTypename returns SLSAForSourceIngestMaterialsSource.Typename, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsSource) GetTypename() *string { return v.Typename }
+
+// GetType returns SLSAForSourceIngestMaterialsSource.Type, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsSource) GetType() string { return v.allSourceTree.Type }
+
+// GetNamespaces returns SLSAForSourceIngestMaterialsSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *SLSAForSourceIngestMaterialsSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceIngestMaterialsSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceIngestMaterialsSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceIngestMaterialsSource struct {
+	Typename *string `json:"__typename"`
+
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SLSAForSourceIngestMaterialsSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceIngestMaterialsSource) __premarshalJSON() (*__premarshalSLSAForSourceIngestMaterialsSource, error) {
+	var retval __premarshalSLSAForSourceIngestMaterialsSource
+
+	retval.Typename = v.Typename
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
 
 // SLSAForSourceIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
 // The GraphQL type's documentation follows.
@@ -3234,36 +4496,132 @@ func (v *SLSAForSourceIngestSource) __premarshalJSON() (*__premarshalSLSAForSour
 type SLSAForSourceResponse struct {
 	// Ingest a new source. Returns the ingested source trie
 	IngestSource SLSAForSourceIngestSource `json:"ingestSource"`
-	// Ingests a SLSA attestation
+	// Ingests a set of packages, sources, and artifacts.
+	//
+	// This is a helper mutation for ingesting SLSA nodes. It should be more
+	// efficient to call this method to ingest a set materials instead of ingesting
+	// them one by one.
+	IngestMaterials []SLSAForSourceIngestMaterialsPackageSourceOrArtifact `json:"-"`
+	// Ingest a new builder. Returns the ingested builder
+	IngestBuilder SLSAForSourceIngestBuilder `json:"ingestBuilder"`
+	// Ingests a SLSA attestation.
+	//
+	// Note that materials and builder are extracted as separate arguments. This is
+	// because this ingestion method assumes that the subject and the materials are
+	// already ingested and only creates the SLSA node.
 	IngestSLSA SLSAForSourceIngestSLSAHasSLSA `json:"ingestSLSA"`
 }
 
 // GetIngestSource returns SLSAForSourceResponse.IngestSource, and is useful for accessing the field via an interface.
 func (v *SLSAForSourceResponse) GetIngestSource() SLSAForSourceIngestSource { return v.IngestSource }
 
+// GetIngestMaterials returns SLSAForSourceResponse.IngestMaterials, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceResponse) GetIngestMaterials() []SLSAForSourceIngestMaterialsPackageSourceOrArtifact {
+	return v.IngestMaterials
+}
+
+// GetIngestBuilder returns SLSAForSourceResponse.IngestBuilder, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceResponse) GetIngestBuilder() SLSAForSourceIngestBuilder { return v.IngestBuilder }
+
 // GetIngestSLSA returns SLSAForSourceResponse.IngestSLSA, and is useful for accessing the field via an interface.
 func (v *SLSAForSourceResponse) GetIngestSLSA() SLSAForSourceIngestSLSAHasSLSA { return v.IngestSLSA }
+
+func (v *SLSAForSourceResponse) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SLSAForSourceResponse
+		IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SLSAForSourceResponse = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.IngestMaterials
+		src := firstPass.IngestMaterials
+		*dst = make(
+			[]SLSAForSourceIngestMaterialsPackageSourceOrArtifact,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalSLSAForSourceIngestMaterialsPackageSourceOrArtifact(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"Unable to unmarshal SLSAForSourceResponse.IngestMaterials: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalSLSAForSourceResponse struct {
+	IngestSource SLSAForSourceIngestSource `json:"ingestSource"`
+
+	IngestMaterials []json.RawMessage `json:"ingestMaterials"`
+
+	IngestBuilder SLSAForSourceIngestBuilder `json:"ingestBuilder"`
+
+	IngestSLSA SLSAForSourceIngestSLSAHasSLSA `json:"ingestSLSA"`
+}
+
+func (v *SLSAForSourceResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SLSAForSourceResponse) __premarshalJSON() (*__premarshalSLSAForSourceResponse, error) {
+	var retval __premarshalSLSAForSourceResponse
+
+	retval.IngestSource = v.IngestSource
+	{
+
+		dst := &retval.IngestMaterials
+		src := v.IngestMaterials
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalSLSAForSourceIngestMaterialsPackageSourceOrArtifact(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal SLSAForSourceResponse.IngestMaterials: %w", err)
+			}
+		}
+	}
+	retval.IngestBuilder = v.IngestBuilder
+	retval.IngestSLSA = v.IngestSLSA
+	return &retval, nil
+}
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
 //
 // All fields are required.
 type SLSAInputSpec struct {
-	BuiltFrom     []PackageSourceOrArtifactInput `json:"builtFrom"`
-	BuiltBy       BuilderInputSpec               `json:"builtBy"`
-	BuildType     string                         `json:"buildType"`
-	SlsaPredicate []SLSAPredicateInputSpec       `json:"slsaPredicate"`
-	SlsaVersion   string                         `json:"slsaVersion"`
-	StartedOn     time.Time                      `json:"startedOn"`
-	FinishedOn    time.Time                      `json:"finishedOn"`
-	Origin        string                         `json:"origin"`
-	Collector     string                         `json:"collector"`
+	BuildType     string                   `json:"buildType"`
+	SlsaPredicate []SLSAPredicateInputSpec `json:"slsaPredicate"`
+	SlsaVersion   string                   `json:"slsaVersion"`
+	StartedOn     time.Time                `json:"startedOn"`
+	FinishedOn    time.Time                `json:"finishedOn"`
+	Origin        string                   `json:"origin"`
+	Collector     string                   `json:"collector"`
 }
-
-// GetBuiltFrom returns SLSAInputSpec.BuiltFrom, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetBuiltFrom() []PackageSourceOrArtifactInput { return v.BuiltFrom }
-
-// GetBuiltBy returns SLSAInputSpec.BuiltBy, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetBuiltBy() BuilderInputSpec { return v.BuiltBy }
 
 // GetBuildType returns SLSAInputSpec.BuildType, and is useful for accessing the field via an interface.
 func (v *SLSAInputSpec) GetBuildType() string { return v.BuildType }
@@ -3733,36 +5091,60 @@ func (v *__IsOccurrenceSrcInput) GetOccurrence() IsOccurrenceInputSpec { return 
 
 // __SLSAForArtifactInput is used internally by genqlient
 type __SLSAForArtifactInput struct {
-	Artifact ArtifactInputSpec `json:"artifact"`
-	Slsa     SLSAInputSpec     `json:"slsa"`
+	Artifact  ArtifactInputSpec              `json:"artifact"`
+	Materials []PackageSourceOrArtifactInput `json:"materials"`
+	Builder   BuilderInputSpec               `json:"builder"`
+	Slsa      SLSAInputSpec                  `json:"slsa"`
 }
 
 // GetArtifact returns __SLSAForArtifactInput.Artifact, and is useful for accessing the field via an interface.
 func (v *__SLSAForArtifactInput) GetArtifact() ArtifactInputSpec { return v.Artifact }
+
+// GetMaterials returns __SLSAForArtifactInput.Materials, and is useful for accessing the field via an interface.
+func (v *__SLSAForArtifactInput) GetMaterials() []PackageSourceOrArtifactInput { return v.Materials }
+
+// GetBuilder returns __SLSAForArtifactInput.Builder, and is useful for accessing the field via an interface.
+func (v *__SLSAForArtifactInput) GetBuilder() BuilderInputSpec { return v.Builder }
 
 // GetSlsa returns __SLSAForArtifactInput.Slsa, and is useful for accessing the field via an interface.
 func (v *__SLSAForArtifactInput) GetSlsa() SLSAInputSpec { return v.Slsa }
 
 // __SLSAForPackageInput is used internally by genqlient
 type __SLSAForPackageInput struct {
-	Pkg  PkgInputSpec  `json:"pkg"`
-	Slsa SLSAInputSpec `json:"slsa"`
+	Pkg       PkgInputSpec                   `json:"pkg"`
+	Materials []PackageSourceOrArtifactInput `json:"materials"`
+	Builder   BuilderInputSpec               `json:"builder"`
+	Slsa      SLSAInputSpec                  `json:"slsa"`
 }
 
 // GetPkg returns __SLSAForPackageInput.Pkg, and is useful for accessing the field via an interface.
 func (v *__SLSAForPackageInput) GetPkg() PkgInputSpec { return v.Pkg }
+
+// GetMaterials returns __SLSAForPackageInput.Materials, and is useful for accessing the field via an interface.
+func (v *__SLSAForPackageInput) GetMaterials() []PackageSourceOrArtifactInput { return v.Materials }
+
+// GetBuilder returns __SLSAForPackageInput.Builder, and is useful for accessing the field via an interface.
+func (v *__SLSAForPackageInput) GetBuilder() BuilderInputSpec { return v.Builder }
 
 // GetSlsa returns __SLSAForPackageInput.Slsa, and is useful for accessing the field via an interface.
 func (v *__SLSAForPackageInput) GetSlsa() SLSAInputSpec { return v.Slsa }
 
 // __SLSAForSourceInput is used internally by genqlient
 type __SLSAForSourceInput struct {
-	Source SourceInputSpec `json:"source"`
-	Slsa   SLSAInputSpec   `json:"slsa"`
+	Source    SourceInputSpec                `json:"source"`
+	Materials []PackageSourceOrArtifactInput `json:"materials"`
+	Builder   BuilderInputSpec               `json:"builder"`
+	Slsa      SLSAInputSpec                  `json:"slsa"`
 }
 
 // GetSource returns __SLSAForSourceInput.Source, and is useful for accessing the field via an interface.
 func (v *__SLSAForSourceInput) GetSource() SourceInputSpec { return v.Source }
+
+// GetMaterials returns __SLSAForSourceInput.Materials, and is useful for accessing the field via an interface.
+func (v *__SLSAForSourceInput) GetMaterials() []PackageSourceOrArtifactInput { return v.Materials }
+
+// GetBuilder returns __SLSAForSourceInput.Builder, and is useful for accessing the field via an interface.
+func (v *__SLSAForSourceInput) GetBuilder() BuilderInputSpec { return v.Builder }
 
 // GetSlsa returns __SLSAForSourceInput.Slsa, and is useful for accessing the field via an interface.
 func (v *__SLSAForSourceInput) GetSlsa() SLSAInputSpec { return v.Slsa }
@@ -7878,22 +9260,67 @@ func SLSAForArtifact(
 	ctx context.Context,
 	client graphql.Client,
 	artifact ArtifactInputSpec,
+	materials []PackageSourceOrArtifactInput,
+	builder BuilderInputSpec,
 	slsa SLSAInputSpec,
 ) (*SLSAForArtifactResponse, error) {
 	req := &graphql.Request{
 		OpName: "SLSAForArtifact",
 		Query: `
-mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
 	ingestArtifact(artifact: $artifact) {
 		... allArtifactTree
 	}
-	ingestSLSA(subject: {artifact:$artifact}, slsa: $slsa) {
+	ingestMaterials(materials: $materials) {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	ingestBuilder(builder: $builder) {
+		uri
+	}
+	ingestSLSA(subject: {artifact:$artifact}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
 		... allSLSATree
 	}
 }
 fragment allArtifactTree on Artifact {
 	algorithm
 	digest
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
 }
 fragment allSLSATree on HasSLSA {
 	subject {
@@ -7936,38 +9363,12 @@ fragment allSLSATree on HasSLSA {
 		collector
 	}
 }
-fragment allPkgTree on Package {
-	type
-	namespaces {
-		namespace
-		names {
-			name
-			versions {
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment allSourceTree on Source {
-	type
-	namespaces {
-		namespace
-		names {
-			name
-			tag
-			commit
-		}
-	}
-}
 `,
 		Variables: &__SLSAForArtifactInput{
-			Artifact: artifact,
-			Slsa:     slsa,
+			Artifact:  artifact,
+			Materials: materials,
+			Builder:   builder,
+			Slsa:      slsa,
 		},
 	}
 	var err error
@@ -7988,16 +9389,33 @@ func SLSAForPackage(
 	ctx context.Context,
 	client graphql.Client,
 	pkg PkgInputSpec,
+	materials []PackageSourceOrArtifactInput,
+	builder BuilderInputSpec,
 	slsa SLSAInputSpec,
 ) (*SLSAForPackageResponse, error) {
 	req := &graphql.Request{
 		OpName: "SLSAForPackage",
 		Query: `
-mutation SLSAForPackage ($pkg: PkgInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForPackage ($pkg: PkgInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
 	ingestPackage(pkg: $pkg) {
 		... allPkgTree
 	}
-	ingestSLSA(subject: {package:$pkg}, slsa: $slsa) {
+	ingestMaterials(materials: $materials) {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	ingestBuilder(builder: $builder) {
+		uri
+	}
+	ingestSLSA(subject: {package:$pkg}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
 		... allSLSATree
 	}
 }
@@ -8017,6 +9435,21 @@ fragment allPkgTree on Package {
 			}
 		}
 	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
+}
+fragment allArtifactTree on Artifact {
+	algorithm
+	digest
 }
 fragment allSLSATree on HasSLSA {
 	subject {
@@ -8059,25 +9492,12 @@ fragment allSLSATree on HasSLSA {
 		collector
 	}
 }
-fragment allSourceTree on Source {
-	type
-	namespaces {
-		namespace
-		names {
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment allArtifactTree on Artifact {
-	algorithm
-	digest
-}
 `,
 		Variables: &__SLSAForPackageInput{
-			Pkg:  pkg,
-			Slsa: slsa,
+			Pkg:       pkg,
+			Materials: materials,
+			Builder:   builder,
+			Slsa:      slsa,
 		},
 	}
 	var err error
@@ -8098,16 +9518,33 @@ func SLSAForSource(
 	ctx context.Context,
 	client graphql.Client,
 	source SourceInputSpec,
+	materials []PackageSourceOrArtifactInput,
+	builder BuilderInputSpec,
 	slsa SLSAInputSpec,
 ) (*SLSAForSourceResponse, error) {
 	req := &graphql.Request{
 		OpName: "SLSAForSource",
 		Query: `
-mutation SLSAForSource ($source: SourceInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForSource ($source: SourceInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
 	ingestSource(source: $source) {
 		... allSourceTree
 	}
-	ingestSLSA(subject: {source:$source}, slsa: $slsa) {
+	ingestMaterials(materials: $materials) {
+		__typename
+		... on Package {
+			... allPkgTree
+		}
+		... on Source {
+			... allSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	ingestBuilder(builder: $builder) {
+		uri
+	}
+	ingestSLSA(subject: {source:$source}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
 		... allSLSATree
 	}
 }
@@ -8121,6 +9558,27 @@ fragment allSourceTree on Source {
 			commit
 		}
 	}
+}
+fragment allPkgTree on Package {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			versions {
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment allArtifactTree on Artifact {
+	algorithm
+	digest
 }
 fragment allSLSATree on HasSLSA {
 	subject {
@@ -8163,31 +9621,12 @@ fragment allSLSATree on HasSLSA {
 		collector
 	}
 }
-fragment allPkgTree on Package {
-	type
-	namespaces {
-		namespace
-		names {
-			name
-			versions {
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment allArtifactTree on Artifact {
-	algorithm
-	digest
-}
 `,
 		Variables: &__SLSAForSourceInput{
-			Source: source,
-			Slsa:   slsa,
+			Source:    source,
+			Materials: materials,
+			Builder:   builder,
+			Slsa:      slsa,
 		},
 	}
 	var err error

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -17,29 +17,74 @@
 
 # Defines the GraphQL operations to ingest SLSA attestations into GUAC
 
-mutation SLSAForPackage($pkg: PkgInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForPackage($pkg: PkgInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
   ingestPackage(pkg: $pkg) {
     ...allPkgTree
   }
-  ingestSLSA(subject: {package: $pkg}, slsa: $slsa) {
+  ingestMaterials(materials: $materials) {
+    __typename
+    ... on Package {
+      ...allPkgTree
+    }
+    ... on Source {
+      ...allSourceTree
+    }
+    ... on Artifact {
+      ...allArtifactTree
+    }
+  }
+  ingestBuilder(builder: $builder) {
+    uri
+  }
+  ingestSLSA(subject: {package: $pkg}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
     ...allSLSATree
   }
 }
 
-mutation SLSAForSource($source: SourceInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForSource($source: SourceInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
   ingestSource(source: $source) {
     ...allSourceTree
   }
-  ingestSLSA(subject: {source: $source}, slsa: $slsa) {
+  ingestMaterials(materials: $materials) {
+    __typename
+    ... on Package {
+      ...allPkgTree
+    }
+    ... on Source {
+      ...allSourceTree
+    }
+    ... on Artifact {
+      ...allArtifactTree
+    }
+  }
+  ingestBuilder(builder: $builder) {
+    uri
+  }
+  ingestSLSA(subject: {source: $source}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
     ...allSLSATree
   }
 }
 
-mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $slsa: SLSAInputSpec!) {
+mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $materials: [PackageSourceOrArtifactInput!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
   ingestArtifact(artifact: $artifact) {
     ...allArtifactTree
   }
-  ingestSLSA(subject: {artifact: $artifact}, slsa: $slsa) {
+  ingestMaterials(materials: $materials) {
+    __typename
+    ... on Package {
+      ...allPkgTree
+    }
+    ... on Source {
+      ...allSourceTree
+    }
+    ... on Artifact {
+      ...allArtifactTree
+    }
+  }
+  ingestBuilder(builder: $builder) {
+    uri
+  }
+  ingestSLSA(subject: {artifact: $artifact}, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
     ...allSLSATree
   }
 }

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -39,14 +39,14 @@ fragment allPkgTree on Package {
 
 fragment allSourceTree on Source {
   type
-    namespaces {
-      namespace
-        names {
-          name
-            tag
-            commit
-        }
+  namespaces {
+    namespace
+    names {
+      name
+      tag
+      commit
     }
+  }
 }
 
 fragment allArtifactTree on Artifact {
@@ -60,15 +60,15 @@ fragment allCertifyScorecard on CertifyScorecard {
   }
   scorecard {
     timeScanned
-      aggregateScore
-      checks {
-        check
-          score
-      }
+    aggregateScore
+    checks {
+      check
+      score
+    }
     scorecardVersion
-      scorecardCommit
-      origin
-      collector
+    scorecardCommit
+    origin
+    collector
   }
 }
 

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -26,7 +26,8 @@ type MutationResolver interface {
 	IngestVulnerability(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.OsvCveOrGhsaInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error)
 	IngestCve(ctx context.Context, cve *model.CVEInputSpec) (*model.Cve, error)
 	IngestGhsa(ctx context.Context, ghsa *model.GHSAInputSpec) (*model.Ghsa, error)
-	IngestSlsa(ctx context.Context, subject model.PackageSourceOrArtifactInput, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
+	IngestSlsa(ctx context.Context, subject model.PackageSourceOrArtifactInput, builtFrom []*model.PackageSourceOrArtifactInput, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
+	IngestMaterials(ctx context.Context, materials []*model.PackageSourceOrArtifactInput) ([]model.PackageSourceOrArtifact, error)
 	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error)
 	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)
 	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error)
@@ -276,6 +277,21 @@ func (ec *executionContext) field_Mutation_ingestHashEqual_args(ctx context.Cont
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_ingestMaterials_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.PackageSourceOrArtifactInput
+	if tmp, ok := rawArgs["materials"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("materials"))
+		arg0, err = ec.unmarshalNPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["materials"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_ingestOSV_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -351,15 +367,33 @@ func (ec *executionContext) field_Mutation_ingestSLSA_args(ctx context.Context, 
 		}
 	}
 	args["subject"] = arg0
-	var arg1 model.SLSAInputSpec
-	if tmp, ok := rawArgs["slsa"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slsa"))
-		arg1, err = ec.unmarshalNSLSAInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAInputSpec(ctx, tmp)
+	var arg1 []*model.PackageSourceOrArtifactInput
+	if tmp, ok := rawArgs["builtFrom"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFrom"))
+		arg1, err = ec.unmarshalNPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["slsa"] = arg1
+	args["builtFrom"] = arg1
+	var arg2 model.BuilderInputSpec
+	if tmp, ok := rawArgs["builtBy"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtBy"))
+		arg2, err = ec.unmarshalNBuilderInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["builtBy"] = arg2
+	var arg3 model.SLSAInputSpec
+	if tmp, ok := rawArgs["slsa"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slsa"))
+		arg3, err = ec.unmarshalNSLSAInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSLSAInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["slsa"] = arg3
 	return args, nil
 }
 
@@ -1307,7 +1341,7 @@ func (ec *executionContext) _Mutation_ingestSLSA(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().IngestSlsa(rctx, fc.Args["subject"].(model.PackageSourceOrArtifactInput), fc.Args["slsa"].(model.SLSAInputSpec))
+		return ec.resolvers.Mutation().IngestSlsa(rctx, fc.Args["subject"].(model.PackageSourceOrArtifactInput), fc.Args["builtFrom"].([]*model.PackageSourceOrArtifactInput), fc.Args["builtBy"].(model.BuilderInputSpec), fc.Args["slsa"].(model.SLSAInputSpec))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -1347,6 +1381,60 @@ func (ec *executionContext) fieldContext_Mutation_ingestSLSA(ctx context.Context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestSLSA_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestMaterials(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestMaterials(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestMaterials(rctx, fc.Args["materials"].([]*model.PackageSourceOrArtifactInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model.PackageSourceOrArtifact)
+	fc.Result = res
+	return ec.marshalNPackageSourceOrArtifact2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestMaterials(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type PackageSourceOrArtifact does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestMaterials_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -3233,6 +3321,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestSLSA(ctx, field)
+			})
+
+		case "ingestMaterials":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestMaterials(ctx, field)
 			})
 
 		case "ingestHashEqual":

--- a/pkg/assembler/graphql/generated/builder.generated.go
+++ b/pkg/assembler/graphql/generated/builder.generated.go
@@ -229,9 +229,9 @@ func (ec *executionContext) marshalNBuilder2ᚖgithubᚗcomᚋguacsecᚋguacᚋp
 	return ec._Builder(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx context.Context, v interface{}) (*model.BuilderInputSpec, error) {
+func (ec *executionContext) unmarshalNBuilderInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx context.Context, v interface{}) (model.BuilderInputSpec, error) {
 	res, err := ec.unmarshalInputBuilderInputSpec(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx context.Context, v interface{}) (*model.BuilderInputSpec, error) {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -831,29 +831,13 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"builtFrom", "builtBy", "buildType", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
+	fieldsInOrder := [...]string{"buildType", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "builtFrom":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtFrom"))
-			it.BuiltFrom, err = ec.unmarshalOPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "builtBy":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builtBy"))
-			it.BuiltBy, err = ec.unmarshalNBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "buildType":
 			var err error
 
@@ -1298,6 +1282,23 @@ func (ec *executionContext) unmarshalNPackageSourceOrArtifactInput2githubᚗcom�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx context.Context, v interface{}) ([]*model.PackageSourceOrArtifactInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.PackageSourceOrArtifactInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) unmarshalNPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx context.Context, v interface{}) (*model.PackageSourceOrArtifactInput, error) {
 	res, err := ec.unmarshalInputPackageSourceOrArtifactInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
@@ -1400,26 +1401,6 @@ func (ec *executionContext) unmarshalOHasSLSASpec2ᚖgithubᚗcomᚋguacsecᚋgu
 	}
 	res, err := ec.unmarshalInputHasSLSASpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalOPackageSourceOrArtifactInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputᚄ(ctx context.Context, v interface{}) ([]*model.PackageSourceOrArtifactInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.PackageSourceOrArtifactInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNPackageSourceOrArtifactInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
 }
 
 func (ec *executionContext) unmarshalOPackageSourceOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactSpecᚄ(ctx context.Context, v interface{}) ([]*model.PackageSourceOrArtifactSpec, error) {

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -791,15 +791,13 @@ type Slsa struct {
 //
 // All fields are required.
 type SLSAInputSpec struct {
-	BuiltFrom     []*PackageSourceOrArtifactInput `json:"builtFrom"`
-	BuiltBy       *BuilderInputSpec               `json:"builtBy"`
-	BuildType     string                          `json:"buildType"`
-	SlsaPredicate []*SLSAPredicateInputSpec       `json:"slsaPredicate"`
-	SlsaVersion   string                          `json:"slsaVersion"`
-	StartedOn     time.Time                       `json:"startedOn"`
-	FinishedOn    time.Time                       `json:"finishedOn"`
-	Origin        string                          `json:"origin"`
-	Collector     string                          `json:"collector"`
+	BuildType     string                    `json:"buildType"`
+	SlsaPredicate []*SLSAPredicateInputSpec `json:"slsaPredicate"`
+	SlsaVersion   string                    `json:"slsaVersion"`
+	StartedOn     time.Time                 `json:"startedOn"`
+	FinishedOn    time.Time                 `json:"finishedOn"`
+	Origin        string                    `json:"origin"`
+	Collector     string                    `json:"collector"`
 }
 
 // SLSAPredicate are the values from the SLSA predicate in key-value pair form.

--- a/pkg/assembler/graphql/resolvers/hasSLSA.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSLSA.resolvers.go
@@ -11,8 +11,13 @@ import (
 )
 
 // IngestSlsa is the resolver for the ingestSLSA field.
-func (r *mutationResolver) IngestSlsa(ctx context.Context, subject model.PackageSourceOrArtifactInput, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
-	return r.Backend.IngestSLSA(ctx, subject, slsa)
+func (r *mutationResolver) IngestSlsa(ctx context.Context, subject model.PackageSourceOrArtifactInput, builtFrom []*model.PackageSourceOrArtifactInput, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
+	return r.Backend.IngestSLSA(ctx, subject, builtFrom, builtBy, slsa)
+}
+
+// IngestMaterials is the resolver for the ingestMaterials field.
+func (r *mutationResolver) IngestMaterials(ctx context.Context, materials []*model.PackageSourceOrArtifactInput) ([]model.PackageSourceOrArtifact, error) {
+	return r.Backend.IngestMaterials(ctx, materials)
 }
 
 // HasSlsa is the resolver for the HasSLSA field.

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -143,8 +143,6 @@ SLSAInputSpec is the same as SLSA but for mutation input.
 All fields are required.
 """
 input SLSAInputSpec {
-  builtFrom: [PackageSourceOrArtifactInput!]
-  builtBy: BuilderInputSpec!
   buildType: String!
   slsaPredicate: [SLSAPredicateInputSpec!]!
   slsaVersion: String!
@@ -169,6 +167,21 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a SLSA attestation"
-  ingestSLSA(subject: PackageSourceOrArtifactInput!, slsa: SLSAInputSpec!): HasSLSA!
+  """
+  Ingests a SLSA attestation.
+
+  Note that materials and builder are extracted as separate arguments. This is
+  because this ingestion method assumes that the subject and the materials are
+  already ingested and only creates the SLSA node.
+  """
+  ingestSLSA(subject: PackageSourceOrArtifactInput!, builtFrom: [PackageSourceOrArtifactInput!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): HasSLSA!
+
+  """
+  Ingests a set of packages, sources, and artifacts.
+
+  This is a helper mutation for ingesting SLSA nodes. It should be more
+  efficient to call this method to ingest a set materials instead of ingesting
+  them one by one.
+  """
+  ingestMaterials(materials: [PackageSourceOrArtifactInput!]!): [PackageSourceOrArtifact!]!
 }


### PR DESCRIPTION
We expect source trees to already exist when performing the ingestion of the evidence tree.

The fact that we only need this when trying to ingest SLSA for the Neo4J backend signals that we have a significant bug in the in-memory backend.