### PR TITLE
plumb dsse parser to graphql (without trust)

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -32,6 +32,7 @@ import (
 	asmhelpers "github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
@@ -264,6 +265,24 @@ var (
 			},
 		},
 	}
+
+	// TODO: needs to be resolved by https://github.com/guacsec/guac/issues/75
+	Ident = []common.TrustInformation{}
+	// Ident = assembler.IdentityNode{
+	// 	ID:        "test",
+	// 	Digest:    keyHash,
+	// 	Key:       base64.StdEncoding.EncodeToString(pemBytes),
+	// 	KeyType:   "ecdsa",
+	// 	KeyScheme: "ecdsa",
+	// 	NodeData: *assembler.NewObjectMetadata(
+	// 		processor.SourceInformation{
+	// 			Collector: "TestCollector",
+	// 			Source:    "TestSource",
+	// 		},
+	// 	),
+	// }
+
+	DssePredicates = &assembler.IngestPredicates{}
 
 	// SPDX Testdata
 

--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -60,7 +60,7 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("MarshalPublicKeyToPEM returned error: %w", err)
 			}
-			// TODO(bulldozer): change this to new TrustInformation struct
+			// TODO: change this to new TrustInformation struct by resolving https://github.com/guacsec/guac/issues/75
 			// d.identities = append(d.identities, common.TrustInformation{
 			// 	ID: i.ID, Digest: i.Key.Hash, Key: base64.StdEncoding.EncodeToString(pemBytes),
 			// 	KeyType: string(i.Key.Type), KeyScheme: string(i.Key.Scheme), NodeData: *assembler.NewObjectMetadata(d.doc.SourceInformation)})
@@ -73,32 +73,19 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 	return nil
 }
 
-// TODO(bulldozer): implement GetIdentities
+// TODO: Needs to be handled as part of https://github.com/guacsec/guac/issues/75
 // GetIdentities gets the identity node from the document if they exist
 func (d *dsseParser) GetIdentities(ctx context.Context) []common.TrustInformation {
 	return []common.TrustInformation{}
 	//return d.identities
 }
 
-// TODO(bulldozer): replace with GetPredicates
-// // CreateNodes creates the GuacNode for the graph inputs
-// func (d *dsseParser) CreateNodes(_ context.Context) []assembler.GuacNode {
-// 	nodes := []assembler.GuacNode{}
-// 	for _, i := range d.identities {
-// 		nodes = append(nodes, i)
-// 	}
-// 	return nodes
-// }
-//
-// // CreateEdges creates the GuacEdges that form the relationship for the graph inputs
-// func (d *dsseParser) CreateEdges(_ context.Context, _ []common.TrustInformation) []assembler.GuacEdge {
-// 	return []assembler.GuacEdge{}
-// }
-
 func (d *dsseParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	return nil, fmt.Errorf("not yet implemented")
 }
 
+// TODO: Right now, trust information isn't encapsulated yet as nodes as edges
+// see https://github.com/guacsec/guac/issues/75
 func (d *dsseParser) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
-	return nil
+	return &assembler.IngestPredicates{}
 }

--- a/pkg/ingestor/parser/dsse/parser_dsse_test.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse_test.go
@@ -16,16 +16,16 @@
 package dsse
 
 // TODO(bulldozer): freeze tests
-/*
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/mockverifier"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/guacsec/guac/pkg/logging"
 )
@@ -37,19 +37,17 @@ func Test_DsseParser(t *testing.T) {
 		t.Errorf("verifier.RegisterVerifier() failed with error: %v", err)
 	}
 	tests := []struct {
-		name         string
-		doc          *processor.Document
-		wantNodes    []assembler.GuacNode
-		wantEdges    []assembler.GuacEdge
-		wantIdentity assembler.IdentityNode
-		wantErr      bool
+		name           string
+		doc            *processor.Document
+		wantPredicates *assembler.IngestPredicates
+		wantIdentities []common.TrustInformation
+		wantErr        bool
 	}{{
-		name:         "testing",
-		doc:          &testdata.Ite6DSSEDoc,
-		wantNodes:    testdata.DsseNodes,
-		wantEdges:    testdata.DsseEdges,
-		wantIdentity: testdata.Ident,
-		wantErr:      false,
+		name:           "testing",
+		doc:            &testdata.Ite6DSSEDoc,
+		wantPredicates: testdata.DssePredicates,
+		wantIdentities: testdata.Ident,
+		wantErr:        false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -62,16 +60,16 @@ func Test_DsseParser(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if nodes := d.CreateNodes(ctx); !reflect.DeepEqual(nodes, tt.wantNodes) {
-				t.Errorf("slsa.CreateNodes() = %v, want %v", nodes, tt.wantNodes)
+
+			preds := d.GetPredicates(ctx)
+			if d := cmp.Diff(tt.wantPredicates, preds, testdata.IngestPredicatesCmpOpts...); len(d) != 0 {
+				t.Errorf("dsse.GetPredicate mismatch values (+got, -expected): %s", d)
 			}
-			if edges := d.CreateEdges(ctx, []assembler.IdentityNode{tt.wantIdentity}); !reflect.DeepEqual(edges, tt.wantEdges) {
-				t.Errorf("slsa.CreateEdges() = %v, want %v", edges, tt.wantEdges)
-			}
-			if identity := d.GetIdentities(ctx); !reflect.DeepEqual(identity, []assembler.IdentityNode{tt.wantIdentity}) {
-				t.Errorf("slsa.GetIdentities() = %v, want %v", identity, []assembler.IdentityNode{tt.wantIdentity})
+
+			identities := d.GetIdentities(ctx)
+			if d := cmp.Diff(tt.wantIdentities, identities, testdata.IngestPredicatesCmpOpts...); len(d) != 0 {
+				t.Errorf("dsse.GetIdentities mismatch values (+got, -expected): %s", d)
 			}
 		})
 	}
 }
-*/


### PR DESCRIPTION
Updates DSSE to use new interfaces, right now it doesn't do much since a lot of it is dependent on the implementation of #75 post beta. FYI @SantiagoTorres @abuishgair