### PR TITLE
update scorecard certifier to use graphQL query

### DIFF
--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
-	sc "github.com/guacsec/guac/pkg/certifier/components/source_artifact"
+	sc "github.com/guacsec/guac/pkg/certifier/components/source"
 
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/scorecard"

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -18,15 +18,16 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/Khan/genqlient/graphql"
 	sc "github.com/guacsec/guac/pkg/certifier/components/source_artifact"
 
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/scorecard"
 
-	"github.com/guacsec/guac/pkg/assembler/graphdb"
 	"github.com/guacsec/guac/pkg/certifier/certify"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
@@ -46,6 +47,7 @@ var scorecardCmd = &cobra.Command{
 			viper.GetString("gdbpass"),
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
+			viper.GetString("gql-endpoint"),
 		)
 
 		if err != nil {
@@ -61,12 +63,9 @@ var scorecardCmd = &cobra.Command{
 			_ = cmd.Help()
 			os.Exit(1)
 		}
-		authToken := graphdb.CreateAuthTokenWithUsernameAndPassword(opts.user, opts.pass, opts.realm)
-		client, err := graphdb.NewGraphClient(opts.dbAddr, authToken)
-		if err != nil {
-			logger.Errorf("error: %v", err)
-			os.Exit(1)
-		}
+
+		httpClient := http.Client{}
+		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		// running and getting the scorecard checks
 		scorecardCertifier, err := scorecard.NewScorecardCertifier(scorecardRunner)
@@ -77,8 +76,8 @@ var scorecardCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// scorecard certifier is the certifier that gets the scorecard data from the graph
-		query, err := sc.NewCertifier(client)
+		// scorecard certifier is the certifier that gets the scorecard data graphQL
+		query, err := sc.NewCertifier(gqlclient)
 
 		if err != nil {
 			fmt.Printf("unable to create scorecard certifier: %v\n", err)
@@ -160,12 +159,13 @@ var scorecardCmd = &cobra.Command{
 	},
 }
 
-func validateScorecardFlags(user string, pass string, dbAddr string, realm string) (options, error) {
+func validateScorecardFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint string) (options, error) {
 	var opts options
 	opts.user = user
 	opts.pass = pass
 	opts.dbAddr = dbAddr
 	opts.realm = realm
+	opts.graphqlEndpoint = graphqlEndpoint
 
 	return opts, nil
 }

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -71,6 +71,9 @@ type Backend interface {
 	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error)
 	IngestIsVulnerability(ctx context.Context, osv model.OSVInputSpec, vulnerability model.CveOrGhsaInput, isVulnerability model.IsVulnerabilityInputSpec) (*model.IsVulnerability, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.CveOrGhsaInput, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
+
+	// Certifier queries
+	SourcesRequiringScorecard(ctx context.Context, scorecardSpec *model.CertifyScorecardSpec) ([]*model.Source, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/neo4j/src.go
+++ b/pkg/assembler/backends/neo4j/src.go
@@ -17,6 +17,7 @@ package neo4jBackend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler"
@@ -409,6 +410,11 @@ func (c *neo4jClient) sourcesNamespace(ctx context.Context, sourceSpec *model.So
 	}
 
 	return result.([]*model.Source), nil
+}
+
+// TODO: implement for neo4j
+func (c *neo4jClient) SourcesRequiringScorecard(ctx context.Context, scorecardSpec *model.CertifyScorecardSpec) ([]*model.Source, error) {
+	panic(fmt.Errorf("not implemented: IngestCertifyBad - IngestCertifyBad"))
 }
 
 func (c *neo4jClient) IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error) {

--- a/pkg/assembler/backends/testing/src.go
+++ b/pkg/assembler/backends/testing/src.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -129,6 +130,12 @@ func (c *demoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec) 
 		}
 	}
 	return sources, nil
+}
+
+// TODO (pxp928): implement once the back edges are integrated. Get all source that do not have scorecard associated with it or that have been
+// scanned after a time period
+func (c *demoClient) SourcesRequiringScorecard(ctx context.Context, scorecardSpec *model.CertifyScorecardSpec) ([]*model.Source, error) {
+	panic(fmt.Errorf("not implemented: IngestCertifyBad - IngestCertifyBad"))
 }
 
 func filterSourceNamespace(src *model.Source, sourceSpec *model.SourceSpec) (*model.Source, error) {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1559,6 +1559,42 @@ func (v *CertifyPkgResponse) GetIngestCertifyPkg() CertifyPkgIngestCertifyPkg {
 	return v.IngestCertifyPkg
 }
 
+// CertifyScorecardSpec allows filtering the list of CertifyScorecard to return.
+type CertifyScorecardSpec struct {
+	Source           *SourceSpec          `json:"source"`
+	TimeScanned      *time.Time           `json:"timeScanned"`
+	AggregateScore   *float64             `json:"aggregateScore"`
+	Checks           []ScorecardCheckSpec `json:"checks"`
+	ScorecardVersion *string              `json:"scorecardVersion"`
+	ScorecardCommit  *string              `json:"scorecardCommit"`
+	Origin           *string              `json:"origin"`
+	Collector        *string              `json:"collector"`
+}
+
+// GetSource returns CertifyScorecardSpec.Source, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetSource() *SourceSpec { return v.Source }
+
+// GetTimeScanned returns CertifyScorecardSpec.TimeScanned, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetTimeScanned() *time.Time { return v.TimeScanned }
+
+// GetAggregateScore returns CertifyScorecardSpec.AggregateScore, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetAggregateScore() *float64 { return v.AggregateScore }
+
+// GetChecks returns CertifyScorecardSpec.Checks, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetChecks() []ScorecardCheckSpec { return v.Checks }
+
+// GetScorecardVersion returns CertifyScorecardSpec.ScorecardVersion, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetScorecardVersion() *string { return v.ScorecardVersion }
+
+// GetScorecardCommit returns CertifyScorecardSpec.ScorecardCommit, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetScorecardCommit() *string { return v.ScorecardCommit }
+
+// GetOrigin returns CertifyScorecardSpec.Origin, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetOrigin() *string { return v.Origin }
+
+// GetCollector returns CertifyScorecardSpec.Collector, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetCollector() *string { return v.Collector }
+
 // GHSAInputSpec is the same as GHSASpec, but used for mutation ingestion.
 type GHSAInputSpec struct {
 	GhsaId string `json:"ghsaId"`
@@ -5912,6 +5948,18 @@ func (v *ScorecardCheckInputSpec) GetCheck() string { return v.Check }
 // GetScore returns ScorecardCheckInputSpec.Score, and is useful for accessing the field via an interface.
 func (v *ScorecardCheckInputSpec) GetScore() int { return v.Score }
 
+// ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input.
+type ScorecardCheckSpec struct {
+	Check string `json:"check"`
+	Score int    `json:"score"`
+}
+
+// GetCheck returns ScorecardCheckSpec.Check, and is useful for accessing the field via an interface.
+func (v *ScorecardCheckSpec) GetCheck() string { return v.Check }
+
+// GetScore returns ScorecardCheckSpec.Score, and is useful for accessing the field via an interface.
+func (v *ScorecardCheckSpec) GetScore() int { return v.Score }
+
 // ScorecardIngestSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
 //
@@ -6063,6 +6111,121 @@ func (v *SourceInputSpec) GetTag() *string { return v.Tag }
 
 // GetCommit returns SourceInputSpec.Commit, and is useful for accessing the field via an interface.
 func (v *SourceInputSpec) GetCommit() *string { return v.Commit }
+
+// SourceSpec allows filtering the list of sources to return.
+//
+// Empty string at a field means matching with the empty string. Missing field
+// means retrieving all possible matches.
+//
+// It is an error to specify both `tag` and `commit` fields, except it both are
+// set as empty string (in which case the returned sources are only those for
+// which there is no tag/commit information).
+type SourceSpec struct {
+	Type      *string `json:"type"`
+	Namespace *string `json:"namespace"`
+	Name      *string `json:"name"`
+	Tag       *string `json:"tag"`
+	Commit    *string `json:"commit"`
+}
+
+// GetType returns SourceSpec.Type, and is useful for accessing the field via an interface.
+func (v *SourceSpec) GetType() *string { return v.Type }
+
+// GetNamespace returns SourceSpec.Namespace, and is useful for accessing the field via an interface.
+func (v *SourceSpec) GetNamespace() *string { return v.Namespace }
+
+// GetName returns SourceSpec.Name, and is useful for accessing the field via an interface.
+func (v *SourceSpec) GetName() *string { return v.Name }
+
+// GetTag returns SourceSpec.Tag, and is useful for accessing the field via an interface.
+func (v *SourceSpec) GetTag() *string { return v.Tag }
+
+// GetCommit returns SourceSpec.Commit, and is useful for accessing the field via an interface.
+func (v *SourceSpec) GetCommit() *string { return v.Commit }
+
+// SourcesRequiringScorecardResponse is returned by SourcesRequiringScorecard on success.
+type SourcesRequiringScorecardResponse struct {
+	// query for all sources that do not contain a scorecard or need to be updated after a certain threshold of time
+	SourcesRequiringScorecard []SourcesRequiringScorecardSourcesRequiringScorecardSource `json:"sourcesRequiringScorecard"`
+}
+
+// GetSourcesRequiringScorecard returns SourcesRequiringScorecardResponse.SourcesRequiringScorecard, and is useful for accessing the field via an interface.
+func (v *SourcesRequiringScorecardResponse) GetSourcesRequiringScorecard() []SourcesRequiringScorecardSourcesRequiringScorecardSource {
+	return v.SourcesRequiringScorecard
+}
+
+// SourcesRequiringScorecardSourcesRequiringScorecardSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents a source.
+//
+// This can be the version control system that is being used.
+//
+// This node is a singleton: backends guarantee that there is exactly one node
+// with the same `type` value.
+//
+// Also note that this is named `Source`, not `SourceType`. This is only to make
+// queries more readable.
+type SourcesRequiringScorecardSourcesRequiringScorecardSource struct {
+	allSourceTree `json:"-"`
+}
+
+// GetType returns SourcesRequiringScorecardSourcesRequiringScorecardSource.Type, and is useful for accessing the field via an interface.
+func (v *SourcesRequiringScorecardSourcesRequiringScorecardSource) GetType() string {
+	return v.allSourceTree.Type
+}
+
+// GetNamespaces returns SourcesRequiringScorecardSourcesRequiringScorecardSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SourcesRequiringScorecardSourcesRequiringScorecardSource) GetNamespaces() []allSourceTreeNamespacesSourceNamespace {
+	return v.allSourceTree.Namespaces
+}
+
+func (v *SourcesRequiringScorecardSourcesRequiringScorecardSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SourcesRequiringScorecardSourcesRequiringScorecardSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SourcesRequiringScorecardSourcesRequiringScorecardSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSourcesRequiringScorecardSourcesRequiringScorecardSource struct {
+	Type string `json:"type"`
+
+	Namespaces []allSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SourcesRequiringScorecardSourcesRequiringScorecardSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SourcesRequiringScorecardSourcesRequiringScorecardSource) __premarshalJSON() (*__premarshalSourcesRequiringScorecardSourcesRequiringScorecardSource, error) {
+	var retval __premarshalSourcesRequiringScorecardSourcesRequiringScorecardSource
+
+	retval.Type = v.allSourceTree.Type
+	retval.Namespaces = v.allSourceTree.Namespaces
+	return &retval, nil
+}
 
 // VEXPackageAndGhsaIngestGHSA includes the requested fields of the GraphQL type GHSA.
 // The GraphQL type's documentation follows.
@@ -7571,6 +7734,14 @@ func (v *__ScorecardInput) GetSource() SourceInputSpec { return v.Source }
 
 // GetScorecard returns __ScorecardInput.Scorecard, and is useful for accessing the field via an interface.
 func (v *__ScorecardInput) GetScorecard() ScorecardInputSpec { return v.Scorecard }
+
+// __SourcesRequiringScorecardInput is used internally by genqlient
+type __SourcesRequiringScorecardInput struct {
+	Scorecard *CertifyScorecardSpec `json:"scorecard"`
+}
+
+// GetScorecard returns __SourcesRequiringScorecardInput.Scorecard, and is useful for accessing the field via an interface.
+func (v *__SourcesRequiringScorecardInput) GetScorecard() *CertifyScorecardSpec { return v.Scorecard }
 
 // __VEXPackageAndGhsaInput is used internally by genqlient
 type __VEXPackageAndGhsaInput struct {
@@ -14142,6 +14313,49 @@ fragment allCertifyScorecard on CertifyScorecard {
 	var err error
 
 	var data ScorecardResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+func SourcesRequiringScorecard(
+	ctx context.Context,
+	client graphql.Client,
+	scorecard *CertifyScorecardSpec,
+) (*SourcesRequiringScorecardResponse, error) {
+	req := &graphql.Request{
+		OpName: "SourcesRequiringScorecard",
+		Query: `
+query SourcesRequiringScorecard ($scorecard: CertifyScorecardSpec) {
+	sourcesRequiringScorecard(scorecard: $scorecard) {
+		... allSourceTree
+	}
+}
+fragment allSourceTree on Source {
+	type
+	namespaces {
+		namespace
+		names {
+			name
+			tag
+			commit
+		}
+	}
+}
+`,
+		Variables: &__SourcesRequiringScorecardInput{
+			Scorecard: scorecard,
+		},
+	}
+	var err error
+
+	var data SourcesRequiringScorecardResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/operations/sources.graphql
+++ b/pkg/assembler/clients/operations/sources.graphql
@@ -1,0 +1,24 @@
+#
+# Copyright 2023 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This is experimental and might change in the future!
+
+# Defines the GraphQL operations to query for all sources that do not contain a scorecard or need to be updated after a certain threshold of time
+
+query SourcesRequiringScorecard($scorecard: CertifyScorecardSpec) {
+   sourcesRequiringScorecard(scorecard: $scorecard) {
+    ...allSourceTree
+  }
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -60,6 +60,7 @@ type QueryResolver interface {
 	Osv(ctx context.Context, osvSpec *model.OSVSpec) ([]*model.Osv, error)
 	Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error)
 	Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error)
+	SourcesRequiringScorecard(ctx context.Context, scorecard *model.CertifyScorecardSpec) ([]*model.Source, error)
 }
 
 // endregion ************************** generated!.gotpl **************************
@@ -864,6 +865,21 @@ func (ec *executionContext) field_Query_scorecards_args(ctx context.Context, raw
 		}
 	}
 	args["scorecardSpec"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_sourcesRequiringScorecard_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.CertifyScorecardSpec
+	if tmp, ok := rawArgs["scorecard"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scorecard"))
+		arg0, err = ec.unmarshalOCertifyScorecardSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecardSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["scorecard"] = arg0
 	return args, nil
 }
 
@@ -3447,6 +3463,67 @@ func (ec *executionContext) fieldContext_Query_sources(ctx context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_sourcesRequiringScorecard(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_sourcesRequiringScorecard(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SourcesRequiringScorecard(rctx, fc.Args["scorecard"].(*model.CertifyScorecardSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Source)
+	fc.Result = res
+	return ec.marshalNSource2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_sourcesRequiringScorecard(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "type":
+				return ec.fieldContext_Source_type(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_Source_namespaces(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Source", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_sourcesRequiringScorecard_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -4348,6 +4425,29 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_sources(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "sourcesRequiringScorecard":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_sourcesRequiringScorecard(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -209,25 +209,26 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Artifacts           func(childComplexity int, artifactSpec *model.ArtifactSpec) int
-		Builders            func(childComplexity int, builderSpec *model.BuilderSpec) int
-		CertifyBad          func(childComplexity int, certifyBadSpec *model.CertifyBadSpec) int
-		CertifyPkg          func(childComplexity int, certifyPkgSpec *model.CertifyPkgSpec) int
-		CertifyVEXStatement func(childComplexity int, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) int
-		CertifyVuln         func(childComplexity int, certifyVulnSpec *model.CertifyVulnSpec) int
-		Cve                 func(childComplexity int, cveSpec *model.CVESpec) int
-		Ghsa                func(childComplexity int, ghsaSpec *model.GHSASpec) int
-		HasSbom             func(childComplexity int, hasSBOMSpec *model.HasSBOMSpec) int
-		HasSlsa             func(childComplexity int, hasSLSASpec *model.HasSLSASpec) int
-		HasSourceAt         func(childComplexity int, hasSourceAtSpec *model.HasSourceAtSpec) int
-		HashEqual           func(childComplexity int, hashEqualSpec *model.HashEqualSpec) int
-		IsDependency        func(childComplexity int, isDependencySpec *model.IsDependencySpec) int
-		IsOccurrence        func(childComplexity int, isOccurrenceSpec *model.IsOccurrenceSpec) int
-		IsVulnerability     func(childComplexity int, isVulnerabilitySpec *model.IsVulnerabilitySpec) int
-		Osv                 func(childComplexity int, osvSpec *model.OSVSpec) int
-		Packages            func(childComplexity int, pkgSpec *model.PkgSpec) int
-		Scorecards          func(childComplexity int, scorecardSpec *model.CertifyScorecardSpec) int
-		Sources             func(childComplexity int, sourceSpec *model.SourceSpec) int
+		Artifacts                 func(childComplexity int, artifactSpec *model.ArtifactSpec) int
+		Builders                  func(childComplexity int, builderSpec *model.BuilderSpec) int
+		CertifyBad                func(childComplexity int, certifyBadSpec *model.CertifyBadSpec) int
+		CertifyPkg                func(childComplexity int, certifyPkgSpec *model.CertifyPkgSpec) int
+		CertifyVEXStatement       func(childComplexity int, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) int
+		CertifyVuln               func(childComplexity int, certifyVulnSpec *model.CertifyVulnSpec) int
+		Cve                       func(childComplexity int, cveSpec *model.CVESpec) int
+		Ghsa                      func(childComplexity int, ghsaSpec *model.GHSASpec) int
+		HasSbom                   func(childComplexity int, hasSBOMSpec *model.HasSBOMSpec) int
+		HasSlsa                   func(childComplexity int, hasSLSASpec *model.HasSLSASpec) int
+		HasSourceAt               func(childComplexity int, hasSourceAtSpec *model.HasSourceAtSpec) int
+		HashEqual                 func(childComplexity int, hashEqualSpec *model.HashEqualSpec) int
+		IsDependency              func(childComplexity int, isDependencySpec *model.IsDependencySpec) int
+		IsOccurrence              func(childComplexity int, isOccurrenceSpec *model.IsOccurrenceSpec) int
+		IsVulnerability           func(childComplexity int, isVulnerabilitySpec *model.IsVulnerabilitySpec) int
+		Osv                       func(childComplexity int, osvSpec *model.OSVSpec) int
+		Packages                  func(childComplexity int, pkgSpec *model.PkgSpec) int
+		Scorecards                func(childComplexity int, scorecardSpec *model.CertifyScorecardSpec) int
+		Sources                   func(childComplexity int, sourceSpec *model.SourceSpec) int
+		SourcesRequiringScorecard func(childComplexity int, scorecard *model.CertifyScorecardSpec) int
 	}
 
 	SLSA struct {
@@ -1275,6 +1276,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Sources(childComplexity, args["sourceSpec"].(*model.SourceSpec)), true
+
+	case "Query.sourcesRequiringScorecard":
+		if e.complexity.Query.SourcesRequiringScorecard == nil {
+			break
+		}
+
+		args, err := ec.field_Query_sourcesRequiringScorecard_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SourcesRequiringScorecard(childComplexity, args["scorecard"].(*model.CertifyScorecardSpec)), true
 
 	case "SLSA.buildType":
 		if e.complexity.SLSA.BuildType == nil {
@@ -3443,6 +3456,8 @@ input SourceInputSpec {
 extend type Query {
   "Returns all sources"
   sources(sourceSpec: SourceSpec): [Source!]!
+  "query for all sources that do not contain a scorecard or need to be updated after a certain threshold of time"
+  sourcesRequiringScorecard(scorecard: CertifyScorecardSpec): [Source!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -19,3 +19,8 @@ func (r *mutationResolver) IngestSource(ctx context.Context, source *model.Sourc
 func (r *queryResolver) Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error) {
 	return r.Backend.Sources(ctx, sourceSpec)
 }
+
+// SourcesRequiringScorecard is the resolver for the sourcesRequiringScorecard field.
+func (r *queryResolver) SourcesRequiringScorecard(ctx context.Context, scorecard *model.CertifyScorecardSpec) ([]*model.Source, error) {
+	return r.Backend.SourcesRequiringScorecard(ctx, scorecard)
+}

--- a/pkg/assembler/graphql/schema/source.graphql
+++ b/pkg/assembler/graphql/schema/source.graphql
@@ -101,6 +101,8 @@ input SourceInputSpec {
 extend type Query {
   "Returns all sources"
   sources(sourceSpec: SourceSpec): [Source!]!
+  "query for all sources that do not contain a scorecard or need to be updated after a certain threshold of time"
+  sourcesRequiringScorecard(scorecard: CertifyScorecardSpec): [Source!]!
 }
 
 extend type Mutation {

--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package source_artifact
+package source
 
 import (
 	"context"

--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -22,8 +22,7 @@ import (
 	"os"
 
 	"github.com/guacsec/guac/pkg/certifier"
-	"github.com/guacsec/guac/pkg/certifier/components/source_artifact"
-
+	"github.com/guacsec/guac/pkg/certifier/components/source"
 	"github.com/ossf/scorecard/v4/docs/checks"
 	"github.com/ossf/scorecard/v4/log"
 
@@ -47,9 +46,9 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 		return fmt.Errorf("rootComponent cannot be nil")
 	}
 
-	var sourceNode *source_artifact.SourceNode
+	var sourceNode *source.SourceNode
 
-	if component, ok := rootComponent.(*source_artifact.SourceNode); ok {
+	if component, ok := rootComponent.(*source.SourceNode); ok {
 		sourceNode = component
 	} else {
 		return ErrArtifactNodeTypeMismatch

--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/components/source_artifact"
 
 	"github.com/ossf/scorecard/v4/docs/checks"
 	"github.com/ossf/scorecard/v4/log"
 
-	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
@@ -48,27 +47,24 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 		return fmt.Errorf("rootComponent cannot be nil")
 	}
 
-	var artifactNode *assembler.ArtifactNode
+	var sourceNode *source_artifact.SourceNode
 
-	if component, ok := rootComponent.(*assembler.ArtifactNode); ok {
-		artifactNode = component
+	if component, ok := rootComponent.(*source_artifact.SourceNode); ok {
+		sourceNode = component
 	} else {
 		return ErrArtifactNodeTypeMismatch
 	}
 
-	// Remove the git+ prefix from the artifact name
-	repoName := strings.TrimLeft(artifactNode.Name, "git+")
-
 	// s.artifact.Digest is the commit SHA
-	if artifactNode.Digest == "" {
-		return fmt.Errorf("artifact digest cannot be empty")
+	if sourceNode.Commit == "" {
+		return fmt.Errorf("source commit cannot be empty")
 	}
 
-	if repoName == "" {
-		return fmt.Errorf("artifact name cannot be empty")
+	if sourceNode.Repo == "" {
+		return fmt.Errorf("source repo cannot be empty")
 	}
 
-	score, err := s.scorecard.GetScore(repoName, artifactNode.Digest)
+	score, err := s.scorecard.GetScore(sourceNode.Repo, sourceNode.Commit)
 	if err != nil {
 		return fmt.Errorf("error getting scorecard result: %w", err)
 	}
@@ -89,7 +85,7 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 		Type:   processor.DocumentScorecard,
 		SourceInformation: processor.SourceInformation{
 			Collector: "scorecard",
-			Source:    artifactNode.Name + "@" + artifactNode.Digest,
+			Source:    sourceNode.Repo + "@" + sourceNode.Commit,
 		},
 	}
 


### PR DESCRIPTION
Currently in draft until the ID/back edge work has been completed on the in-memory backend. 

Addresses issue #571 to update `source_artifact` in components  and fixes #573 