### PR TITLE
add IDs for pacakge, source and hasSourceAt. Add back edges for hasSourceAt

### DIFF
--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -49,8 +49,8 @@ type Backend interface {
 	HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error)
 
 	// Mutations for software trees (read-write queries)
-	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
-	IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error)
+	IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error)
+	IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error)
 	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error)
 	IngestMaterials(ctx context.Context, materials []*model.PackageSourceOrArtifactInput) ([]model.PackageSourceOrArtifact, error)
 	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error)

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -575,7 +575,7 @@ func removeInvalidCharFromProperty(key string) string {
 	return strings.ReplaceAll(key, ".", "_")
 }
 
-func (c *neo4jClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+func (c *neo4jClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error) {
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 

--- a/pkg/assembler/backends/neo4j/src.go
+++ b/pkg/assembler/backends/neo4j/src.go
@@ -411,7 +411,7 @@ func (c *neo4jClient) sourcesNamespace(ctx context.Context, sourceSpec *model.So
 	return result.([]*model.Source), nil
 }
 
-func (c *neo4jClient) IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error) {
+func (c *neo4jClient) IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error) {
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 

--- a/pkg/assembler/backends/testing/hasSLSA.go
+++ b/pkg/assembler/backends/testing/hasSLSA.go
@@ -136,13 +136,13 @@ func (c *demoClient) IngestMaterials(
 		}
 
 		if material.Package != nil {
-			pkg, err := c.IngestPackage(ctx, material.Package)
+			pkg, err := c.IngestPackage(ctx, *material.Package)
 			if err != nil {
 				return nil, err
 			}
 			output = append(output, pkg)
 		} else if material.Source != nil {
-			source, err := c.IngestSource(ctx, material.Source)
+			source, err := c.IngestSource(ctx, *material.Source)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/assembler/backends/testing/hasSourceAt.go
+++ b/pkg/assembler/backends/testing/hasSourceAt.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
@@ -87,7 +86,129 @@ func registerAllHasSourceAt(client *demoClient) error {
 	return nil
 }
 
+// Internal data: link between sources and packages (HasSourceAt)
+type srcMaps []*srcMapLink
+type srcMapLink struct {
+	id            nodeID
+	sourceID      nodeID
+	packageID     nodeID
+	knownSince    time.Time
+	justification string
+	origin        string
+	collector     string
+}
+
+func (n *srcMapLink) getID() nodeID { return n.id }
+
 // Ingest HasSourceAt
+func (c *demoClient) IngestHasSourceAt(ctx context.Context, packageArg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
+	// Note: This assumes that the package and source have already been
+	// ingested (and should error otherwise).
+
+	srcNamespace, srcHasNamespace := sources[source.Type]
+	if !srcHasNamespace {
+		return nil, gqlerror.Errorf("Source type \"%s\" not found", source.Type)
+	}
+	srcName, srcHasName := srcNamespace.namespaces[source.Namespace]
+	if !srcHasName {
+		return nil, gqlerror.Errorf("Source namespace \"%s\" not found", source.Namespace)
+	}
+	found := false
+	var sourceID nodeID
+	for _, src := range srcName.names {
+		if src.name != source.Name {
+			continue
+		}
+		if noMatchInput(source.Tag, src.tag) {
+			continue
+		}
+		if noMatchInput(source.Commit, src.commit) {
+			continue
+		}
+		if found {
+			return nil, gqlerror.Errorf("More than one source matches input")
+		}
+		sourceID = src.id
+		found = true
+	}
+	if !found {
+		return nil, gqlerror.Errorf("No source matches input")
+	}
+
+	pkgNamespace, pkgHasNamespace := packages[packageArg.Type]
+	if !pkgHasNamespace {
+		return nil, gqlerror.Errorf("Package type \"%s\" not found", packageArg.Type)
+	}
+	pkgName, pkgHasName := pkgNamespace.namespaces[nilToEmpty(packageArg.Namespace)]
+	if !pkgHasName {
+		return nil, gqlerror.Errorf("Package namespace \"%s\" not found", nilToEmpty(packageArg.Namespace))
+	}
+	pkgVersion, pkgHasVersion := pkgName.names[packageArg.Name]
+	if !pkgHasVersion {
+		return nil, gqlerror.Errorf("Package name \"%s\" not found", packageArg.Name)
+	}
+	var packageID nodeID
+	if pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
+		packageID = pkgVersion.id
+	} else {
+		found = false
+		for _, version := range pkgVersion.versions {
+			if noMatchInput(packageArg.Version, version.version) {
+				continue
+			}
+			if noMatchInput(packageArg.Subpath, version.subpath) {
+				continue
+			}
+			if !reflect.DeepEqual(version.qualifiers, getQualifiers(packageArg.Qualifiers)) {
+				continue
+			}
+			if found {
+				return nil, gqlerror.Errorf("More than one package matches input")
+			}
+			packageID = version.id
+			found = true
+		}
+		if !found {
+			return nil, gqlerror.Errorf("No package matches input")
+		}
+	}
+
+	// store the link
+	newSrcMapLink := &srcMapLink{
+		id:            c.getNextID(),
+		sourceID:      sourceID,
+		packageID:     packageID,
+		knownSince:    hasSourceAt.KnownSince.UTC(),
+		justification: hasSourceAt.Justification,
+		origin:        hasSourceAt.Origin,
+		collector:     hasSourceAt.Collector,
+	}
+	index[newSrcMapLink.id] = newSrcMapLink
+	sourceMaps = append(sourceMaps, newSrcMapLink)
+	// set the backlinks
+	index[packageID].(pkgNameOrVersion).setSrcMapLink(newSrcMapLink.id)
+	index[sourceID].(*srcNameNode).srcMapLink = newSrcMapLink.id
+
+	// build return GraphQL type
+	p, err := buildPackageResponse(packageID, nil)
+	if err != nil {
+		return nil, err
+	}
+	s, err := buildSourceResponse(sourceID, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := model.HasSourceAt{
+		Package:       p,
+		Source:        s,
+		KnownSince:    hasSourceAt.KnownSince.UTC(),
+		Justification: hasSourceAt.Justification,
+		Origin:        hasSourceAt.Origin,
+		Collector:     hasSourceAt.Collector,
+	}
+
+	return &out, nil
+}
 
 func (c *demoClient) registerHasSourceAt(selectedPackage *model.Package, selectedSource *model.Source, since time.Time, justification, origin, collector string) (*model.HasSourceAt, error) {
 
@@ -112,92 +233,46 @@ func (c *demoClient) registerHasSourceAt(selectedPackage *model.Package, selecte
 	return newHasSourceAt, nil
 }
 
-func (c *demoClient) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
-
-	var selectedPkgSpec *model.PkgSpec
-	if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
-		selectedPkgSpec = helper.ConvertPkgInputSpecToPkgSpec(&pkg)
-
-	} else {
-		selectedPkgSpec = &model.PkgSpec{
-			Type:      &pkg.Type,
-			Namespace: pkg.Namespace,
-			Name:      &pkg.Name,
-		}
-	}
-	collectedPkg, err := c.Packages(ctx, selectedPkgSpec)
-	if err != nil {
-		return nil, err
-	}
-	if len(collectedPkg) != 1 {
-		return nil, gqlerror.Errorf(
-			"IngestCertifyBad :: multiple packages found")
-	}
-
-	sourceSpec := helper.ConvertSrcInputSpecToSrcSpec(&source)
-
-	sources, err := c.Sources(ctx, sourceSpec)
-	if err != nil {
-		return nil, err
-	}
-	if len(sources) != 1 {
-		return nil, gqlerror.Errorf(
-			"IngestOccurrence :: source argument must match one"+
-				" single source repository, found %d",
-			len(sources))
-	}
-	return c.registerHasSourceAt(
-		collectedPkg[0],
-		sources[0],
-		hasSourceAt.KnownSince,
-		hasSourceAt.Justification,
-		hasSourceAt.Origin,
-		hasSourceAt.Collector)
-}
-
 // Query HasSourceAt
 
-func (c *demoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
+func (c *demoClient) HasSourceAt(ctx context.Context, filter *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
+	out := []*model.HasSourceAt{}
 
-	var collectedHasSourceAt []*model.HasSourceAt
-
-	for _, h := range c.hasSourceAt {
-		matchOrSkip := true
-
-		if hasSourceAtSpec.Justification != nil && h.Justification != *hasSourceAtSpec.Justification {
-			matchOrSkip = false
+	for _, mapLink := range sourceMaps {
+		if noMatch(filter.Justification, mapLink.justification) || noMatch(filter.Origin, mapLink.origin) || noMatch(filter.Collector, mapLink.collector) {
+			continue
 		}
-		if hasSourceAtSpec.Collector != nil && h.Collector != *hasSourceAtSpec.Collector {
-			matchOrSkip = false
+		// Note: Here we may call the selection resolvers since we
+		// build GraphQL structs based on what's on the backend. But
+		// this will result in then having to build a cartesian product
+		// between packages (of count, say, P) and sources (of count,
+		// say, C), for a total of P*C nodes than then need to be
+		// compared with the, say, M sourceMaps that we select so far.
+		// In general M << {P, C}, so this is wasteful.
+		p, err := buildPackageResponse(mapLink.packageID, filter.Package)
+		if err != nil {
+			return nil, err
 		}
-		if hasSourceAtSpec.Origin != nil && h.Origin != *hasSourceAtSpec.Origin {
-			matchOrSkip = false
+		if p == nil {
+			continue
 		}
-
-		if hasSourceAtSpec.Package != nil && h.Package != nil {
-			if hasSourceAtSpec.Package.Type == nil || h.Package.Type == *hasSourceAtSpec.Package.Type {
-				newPkg := filterPackageNamespace(h.Package, hasSourceAtSpec.Package)
-				if newPkg == nil {
-					matchOrSkip = false
-				}
-			}
+		s, err := buildSourceResponse(mapLink.sourceID, filter.Source)
+		if err != nil {
+			return nil, err
 		}
-
-		if hasSourceAtSpec.Source != nil && h.Source != nil {
-			if hasSourceAtSpec.Source.Type == nil || h.Source.Type == *hasSourceAtSpec.Source.Type {
-				newSource, err := filterSourceNamespace(h.Source, hasSourceAtSpec.Source)
-				if err != nil {
-					return nil, err
-				}
-				if newSource == nil {
-					matchOrSkip = false
-				}
-			}
+		if s == nil {
+			continue
 		}
-
-		if matchOrSkip {
-			collectedHasSourceAt = append(collectedHasSourceAt, h)
+		newHSA := model.HasSourceAt{
+			Package:       p,
+			Source:        s,
+			KnownSince:    mapLink.knownSince,
+			Justification: mapLink.justification,
+			Origin:        mapLink.origin,
+			Collector:     mapLink.collector,
 		}
+		out = append(out, &newHSA)
 	}
-	return collectedHasSourceAt, nil
+
+	return out, nil
 }

--- a/pkg/assembler/backends/testing/isDependency.go
+++ b/pkg/assembler/backends/testing/isDependency.go
@@ -79,7 +79,7 @@ func registerAllIsDependency(client *demoClient) error {
 
 	// Dependent Package:
 	// pkg:apk/alpine/curl@7.83.0-r0?arch=x86
-	client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "", "arch", "x86")
+	//client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "", "arch", "x86")
 
 	depType = "apk"
 	depdNameSpace = "alpine"

--- a/pkg/assembler/backends/testing/pkg.go
+++ b/pkg/assembler/backends/testing/pkg.go
@@ -17,205 +17,404 @@ package testing
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"strconv"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func registerAllPackages(client *demoClient) {
-	// TODO: add util to convert from pURL to package fields
-	// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
-	client.registerPackage("apk", "alpine", "apk", "2.12.9-r3", "", "arch", "x86")
-	// pkg:apk/alpine/curl@7.83.0-r0?arch=x86
-	client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "", "arch", "x86")
-	// pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&shared=True&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c
-	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "arch", "x86_64", "build_type", "Debug", "compiler", "Visual%20Studio", "compiler.runtime", "MDd", "compiler.version", "16", "os", "Windows", "shared", "True", "rrev", "93a82349c31917d2d674d22065c7a9ef9f380c8e", "prev", "b429db8a0e324114c25ec387bfd8281f330d7c5c")
-	// pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
-	client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "user", "bincrafters", "channel", "stable")
-	// pkg:conan/openssl@3.0.3
-	client.registerPackage("conan", "", "openssl", "3.0.3", "")
-	// pkg:deb/debian/attr@1:2.4.47-2?arch=amd64
-	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch", "amd64")
-	// pkg:deb/debian/attr@1:2.4.47-2?arch=source
-	client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch", "source")
-	// pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
-	client.registerPackage("deb", "debian", "curl", "7.50.3-1", "", "arch", "i386", "distro", "jessie")
-	// pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch
-	client.registerPackage("deb", "debian", "dpkg", "1.19.0.4", "", "arch", "amd64", "distro", "stretch")
-	// pkg:deb/ubuntu/dpkg@1.19.0.4?arch=amd64
-	client.registerPackage("deb", "ubuntu", "dpkg", "1.19.0.4", "", "arch", "amd64")
-	// pkg:docker/cassandra@latest
-	client.registerPackage("docker", "", "cassandra", "latest", "")
-	// pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c
-	client.registerPackage("docker", "", "cassandra", "sha256:244fd47e07d1004f0aed9c", "")
-	// pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io
-	client.registerPackage("docker", "customer", "dockerimage", "sha256:244fd47e07d1004f0aed9c", "", "repository_url", "gcr.io")
-	// pkg:docker/smartentry/debian@dc437cc87d10
-	client.registerPackage("docker", "smartentry", "debian", "dc437cc87d10", "")
-	// pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32
-	client.registerPackage("generic", "", "bitwarderl", "", "", "vcs_url", "git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32")
-	// pkg:generic/openssl@1.1.10g
-	client.registerPackage("generic", "", "openssl", "1.1.10g", "")
-	// pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da
-	client.registerPackage("generic", "", "openssl", "1.1.10g", "", "download_url", "https://openssl.org/source/openssl-1.1.0g.tar.gz", "checksum", "sha256:de4d501267da")
-	// pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
-	client.registerPackage("oci", "", "debian", "sha256:244fd47e07d10", "", "repository_url", "ghcr.io/debian", "tag", "bullseye")
-	// pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1
-	client.registerPackage("oci", "", "hello-wasm", "sha256:244fd47e07d10", "", "tag", "v1")
-	// pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest
-	client.registerPackage("oci", "", "static", "sha256:244fd47e07d10", "", "repository_url", "gcr.io/distroless/static", "tag", "latest")
-	// pkg:pypi/django-allauth@12.23
-	client.registerPackage("pypi", "", "django-allauth", "12.23", "")
-	// pkg:pypi/django@1.11.1
-	client.registerPackage("pypi", "", "django", "1.11.1", "")
-	// pkg:pypi/django@1.11.1#subpath
-	client.registerPackage("pypi", "", "django", "1.11.1", "subpath")
-	// pkg:pypi/kubetest@0.9.5
-	client.registerPackage("pypi", "", "kubetest", "0.9.5", "")
+	ctx := context.Background()
+
+	v11 := "2.11.1"
+	v12 := "2.12.0"
+	subpath1 := "saved_model_cli.py"
+	subpath2 := "__init__.py"
+	opensslNamespace := "openssl.org"
+	opensslVersion := "3.0.3"
+
+	inputs := []model.PkgInputSpec{{
+		Type: "pypi",
+		Name: "tensorflow",
+	}, {
+		Type:    "pypi",
+		Name:    "tensorflow",
+		Version: &v11,
+	}, {
+		Type:    "pypi",
+		Name:    "tensorflow",
+		Version: &v12,
+	}, {
+		Type:    "pypi",
+		Name:    "tensorflow",
+		Version: &v12,
+		Subpath: &subpath1,
+	}, {
+		Type:    "pypi",
+		Name:    "tensorflow",
+		Version: &v12,
+		Subpath: &subpath2,
+	}, {
+		Type:      "conan",
+		Namespace: &opensslNamespace,
+		Name:      "openssl",
+		Version:   &opensslVersion,
+	}}
+
+	for _, input := range inputs {
+		_, err := client.IngestPackage(ctx, input)
+		if err != nil {
+			log.Printf("Error in ingesting: %v\n", err)
+		}
+	}
+	// // TODO: add util to convert from pURL to package fields
+	// // pkg:apk/alpine/apk@2.12.9-r3?arch=x86
+	// client.registerPackage("apk", "alpine", "apk", "2.12.9-r3", "", "arch", "x86")
+	// // pkg:apk/alpine/curl@7.83.0-r0?arch=x86
+	// client.registerPackage("apk", "alpine", "curl", "7.83.0-r0", "", "arch", "x86")
+	// // pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&shared=True&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c
+	// client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "arch", "x86_64", "build_type", "Debug", "compiler", "Visual%20Studio", "compiler.runtime", "MDd", "compiler.version", "16", "os", "Windows", "shared", "True", "rrev", "93a82349c31917d2d674d22065c7a9ef9f380c8e", "prev", "b429db8a0e324114c25ec387bfd8281f330d7c5c")
+	// // pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
+	// client.registerPackage("conan", "openssl.org", "openssl", "3.0.3", "", "user", "bincrafters", "channel", "stable")
+	// // pkg:conan/openssl@3.0.3
+	// client.registerPackage("conan", "", "openssl", "3.0.3", "")
+	// // pkg:deb/debian/attr@1:2.4.47-2?arch=amd64
+	// client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch", "amd64")
+	// // pkg:deb/debian/attr@1:2.4.47-2?arch=source
+	// client.registerPackage("deb", "debian", "attr", "1:2.4.47-2", "", "arch", "source")
+	// // pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
+	// client.registerPackage("deb", "debian", "curl", "7.50.3-1", "", "arch", "i386", "distro", "jessie")
+	// // pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch
+	// client.registerPackage("deb", "debian", "dpkg", "1.19.0.4", "", "arch", "amd64", "distro", "stretch")
+	// // pkg:deb/ubuntu/dpkg@1.19.0.4?arch=amd64
+	// client.registerPackage("deb", "ubuntu", "dpkg", "1.19.0.4", "", "arch", "amd64")
+	// // pkg:docker/cassandra@latest
+	// client.registerPackage("docker", "", "cassandra", "latest", "")
+	// // pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c
+	// client.registerPackage("docker", "", "cassandra", "sha256:244fd47e07d1004f0aed9c", "")
+	// // pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io
+	// client.registerPackage("docker", "customer", "dockerimage", "sha256:244fd47e07d1004f0aed9c", "", "repository_url", "gcr.io")
+	// // pkg:docker/smartentry/debian@dc437cc87d10
+	// client.registerPackage("docker", "smartentry", "debian", "dc437cc87d10", "")
+	// // pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32
+	// client.registerPackage("generic", "", "bitwarderl", "", "", "vcs_url", "git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32")
+	// // pkg:generic/openssl@1.1.10g
+	// client.registerPackage("generic", "", "openssl", "1.1.10g", "")
+	// // pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da
+	// client.registerPackage("generic", "", "openssl", "1.1.10g", "", "download_url", "https://openssl.org/source/openssl-1.1.0g.tar.gz", "checksum", "sha256:de4d501267da")
+	// // pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
+	// client.registerPackage("oci", "", "debian", "sha256:244fd47e07d10", "", "repository_url", "ghcr.io/debian", "tag", "bullseye")
+	// // pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1
+	// client.registerPackage("oci", "", "hello-wasm", "sha256:244fd47e07d10", "", "tag", "v1")
+	// // pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest
+	// client.registerPackage("oci", "", "static", "sha256:244fd47e07d10", "", "repository_url", "gcr.io/distroless/static", "tag", "latest")
+	// // pkg:pypi/django-allauth@12.23
+	// client.registerPackage("pypi", "", "django-allauth", "12.23", "")
+	// // pkg:pypi/django@1.11.1
+	// client.registerPackage("pypi", "", "django", "1.11.1", "")
+	// // pkg:pypi/django@1.11.1#subpath
+	// client.registerPackage("pypi", "", "django", "1.11.1", "subpath")
+	// // pkg:pypi/kubetest@0.9.5
+	// client.registerPackage("pypi", "", "kubetest", "0.9.5", "")
 }
+
+// Internal data: Packages
+type pkgTypeMap map[string]*pkgNamespaceStruct
+type pkgNamespaceStruct struct {
+	id         nodeID
+	typeKey    string
+	namespaces pkgNamespaceMap
+}
+type pkgNamespaceMap map[string]*pkgNameStruct
+type pkgNameStruct struct {
+	id        nodeID
+	parent    nodeID
+	namespace string
+	names     pkgNameMap
+}
+type pkgNameMap map[string]*pkgVersionStruct
+type pkgVersionStruct struct {
+	id         nodeID
+	parent     nodeID
+	name       string
+	versions   pkgVersionList
+	srcMapLink nodeID
+}
+type pkgVersionList []*pkgVersionNode
+type pkgVersionNode struct {
+	id         nodeID
+	parent     nodeID
+	version    string
+	subpath    string
+	qualifiers map[string]string
+	srcMapLink nodeID
+}
+
+// Be type safe, don't use any / interface{}
+type pkgNameOrVersion interface {
+	implementsPkgNameOrVersion()
+	setSrcMapLink(id nodeID)
+	getSrcMapLink() nodeID
+}
+
+func (n *pkgNamespaceStruct) getID() nodeID { return n.id }
+func (n *pkgNameStruct) getID() nodeID      { return n.id }
+func (n *pkgVersionStruct) getID() nodeID   { return n.id }
+func (n *pkgVersionNode) getID() nodeID     { return n.id }
+
+func (p *pkgVersionStruct) implementsPkgNameOrVersion() {}
+func (p *pkgVersionNode) implementsPkgNameOrVersion()   {}
+func (p *pkgVersionStruct) setSrcMapLink(id nodeID)     { p.srcMapLink = id }
+func (p *pkgVersionNode) setSrcMapLink(id nodeID)       { p.srcMapLink = id }
+func (p *pkgVersionStruct) getSrcMapLink() nodeID       { return p.srcMapLink }
+func (p *pkgVersionNode) getSrcMapLink() nodeID         { return p.srcMapLink }
 
 // Ingest Package
 
-func (c *demoClient) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
-	pkgType := pkg.Type
-	name := pkg.Name
-
-	namespace := ""
-	if pkg.Namespace != nil {
-		namespace = *pkg.Namespace
+func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec) (*model.Package, error) {
+	namespacesStruct, hasNamespace := packages[input.Type]
+	if !hasNamespace {
+		namespacesStruct = &pkgNamespaceStruct{
+			id:         c.getNextID(),
+			typeKey:    input.Type,
+			namespaces: pkgNamespaceMap{},
+		}
+		index[namespacesStruct.id] = namespacesStruct
 	}
+	namespaces := namespacesStruct.namespaces
 
-	version := ""
-	if pkg.Version != nil {
-		version = *pkg.Version
+	namesStruct, hasName := namespaces[nilToEmpty(input.Namespace)]
+	if !hasName {
+		namesStruct = &pkgNameStruct{
+			id:        c.getNextID(),
+			parent:    namespacesStruct.id,
+			namespace: nilToEmpty(input.Namespace),
+			names:     pkgNameMap{},
+		}
+		index[namesStruct.id] = namesStruct
 	}
+	names := namesStruct.names
 
-	subpath := ""
-	if pkg.Subpath != nil {
-		subpath = *pkg.Subpath
+	versionStruct, hasVersions := names[input.Name]
+	if !hasVersions {
+		versionStruct = &pkgVersionStruct{
+			id:       c.getNextID(),
+			parent:   namesStruct.id,
+			name:     input.Name,
+			versions: pkgVersionList{},
+		}
+		index[versionStruct.id] = versionStruct
 	}
+	versions := versionStruct.versions
 
-	var qualifiers []string
-	for _, qualifier := range pkg.Qualifiers {
-		qualifiers = append(qualifiers, qualifier.Key, qualifier.Value)
+	newVersion := pkgVersionNode{
+		id:         c.getNextID(),
+		parent:     versionStruct.id,
+		version:    nilToEmpty(input.Version),
+		subpath:    nilToEmpty(input.Subpath),
+		qualifiers: getQualifiers(input.Qualifiers),
 	}
+	index[newVersion.id] = &newVersion
 
-	newPkg := c.registerPackage(pkgType, namespace, name, version, subpath, qualifiers...)
-
-	return newPkg, nil
-}
-
-func (c *demoClient) registerPackage(pkgType, namespace, name, version, subpath string, qualifiers ...string) *model.Package {
-	for i, p := range c.packages {
-		if p.Type == pkgType {
-			c.packages[i] = registerNamespace(p, namespace, name, version, subpath, qualifiers...)
-			return c.packages[i]
+	// Don't insert duplicates
+	duplicate := false
+	for _, v := range versions {
+		if v.version == newVersion.version && v.subpath == newVersion.subpath && reflect.DeepEqual(v.qualifiers, newVersion.qualifiers) {
+			duplicate = true
+			break
 		}
 	}
-
-	newPkg := &model.Package{Type: pkgType}
-	newPkg = registerNamespace(newPkg, namespace, name, version, subpath, qualifiers...)
-	c.packages = append(c.packages, newPkg)
-
-	return newPkg
-}
-
-func registerNamespace(p *model.Package, namespace, name, version, subpath string, qualifiers ...string) *model.Package {
-	for i, ns := range p.Namespaces {
-		if ns.Namespace == namespace {
-			p.Namespaces[i] = registerName(ns, name, version, subpath, qualifiers...)
-			return p
-		}
+	if !duplicate {
+		// Need to append to version and replace field in versionStruct
+		versionStruct.versions = append(versions, &newVersion)
+		// All others are refs to maps, so no need to update struct
+		names[input.Name] = versionStruct
+		namespaces[nilToEmpty(input.Namespace)] = namesStruct
+		packages[input.Type] = namespacesStruct
 	}
 
-	newNs := &model.PackageNamespace{Namespace: namespace}
-	newNs = registerName(newNs, name, version, subpath, qualifiers...)
-	p.Namespaces = append(p.Namespaces, newNs)
-	return p
+	// build return GraphQL type
+	return buildPackageResponse(newVersion.id, nil)
 }
 
-func registerName(ns *model.PackageNamespace, name, version, subpath string, qualifiers ...string) *model.PackageNamespace {
-	for i, n := range ns.Names {
-		if n.Name == name {
-			ns.Names[i] = registerVersion(n, version, subpath, qualifiers...)
-			return ns
+func (c *demoClient) Packages(ctx context.Context, filter *model.PkgSpec) ([]*model.Package, error) {
+	if filter.ID != nil {
+		id, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
 		}
+		p, err := buildPackageResponse(nodeID(id), filter)
+		if err != nil {
+			return nil, err
+		}
+		return []*model.Package{p}, nil
 	}
-
-	newN := &model.PackageName{Name: name}
-	newN = registerVersion(newN, version, subpath, qualifiers...)
-	ns.Names = append(ns.Names, newN)
-	return ns
-}
-
-func registerVersion(n *model.PackageName, version, subpath string, qualifiers ...string) *model.PackageName {
-	inputQualifiers := buildQualifierSet(qualifiers...)
-
-	for _, v := range n.Versions {
-		if v.Version != version {
+	out := []*model.Package{}
+	for dbType, namespaces := range packages {
+		if filter != nil && noMatch(filter.Type, dbType) {
 			continue
 		}
-		if v.Subpath != subpath {
-			continue
-		}
-		// TODO(mihaimaruseac): This is O(n*m) instead of O(n+m)
-		allFound := true
-		for _, qualifier := range v.Qualifiers {
-			dbKey := qualifier.Key
-			dbValue := qualifier.Value
-			found := false
-			for _, inputQualifier := range inputQualifiers {
-				if inputQualifier.Key == dbKey &&
-					inputQualifier.Value == dbValue {
-					found = true
-					break
+		pNamespaces := []*model.PackageNamespace{}
+		for namespace, names := range namespaces.namespaces {
+			if filter != nil && noMatch(filter.Namespace, namespace) {
+				continue
+			}
+			pns := []*model.PackageName{}
+			for name, versions := range names.names {
+				if filter != nil && noMatch(filter.Name, name) {
+					continue
+				}
+				pvs := []*model.PackageVersion{}
+				for _, v := range versions.versions {
+					if filter != nil && noMatch(filter.Version, v.version) {
+						continue
+					}
+					if filter != nil && noMatch(filter.Subpath, v.subpath) {
+						continue
+					}
+					if filter != nil && noMatchQualifiers(filter, v.qualifiers) {
+						continue
+					}
+					pv := model.PackageVersion{
+						// IDs are generated as string even though we ask for integers
+						// See https://github.com/99designs/gqlgen/issues/2561
+						ID:         fmt.Sprintf("%d", v.id),
+						Version:    v.version,
+						Subpath:    v.subpath,
+						Qualifiers: getCollectedPackageQualifiers(v.qualifiers),
+					}
+					pvs = append(pvs, &pv)
+				}
+				if len(pvs) > 0 {
+					pn := model.PackageName{
+						// IDs are generated as string even though we ask for integers
+						// See https://github.com/99designs/gqlgen/issues/2561
+						ID:       fmt.Sprintf("%d", versions.id),
+						Name:     name,
+						Versions: pvs,
+					}
+					pns = append(pns, &pn)
 				}
 			}
-			if !found {
-				allFound = false
-				break
+			if len(pns) > 0 {
+				pn := model.PackageNamespace{
+					// IDs are generated as string even though we ask for integers
+					// See https://github.com/99designs/gqlgen/issues/2561
+					ID:        fmt.Sprintf("%d", names.id),
+					Namespace: namespace,
+					Names:     pns,
+				}
+				pNamespaces = append(pNamespaces, &pn)
 			}
 		}
-		if allFound {
-			return n
+		if len(pNamespaces) > 0 {
+			p := model.Package{
+				// IDs are generated as string even though we ask for integers
+				// See https://github.com/99designs/gqlgen/issues/2561
+				ID:         fmt.Sprintf("%d", namespaces.id),
+				Type:       dbType,
+				Namespaces: pNamespaces,
+			}
+			out = append(out, &p)
 		}
 	}
-
-	newV := &model.PackageVersion{
-		Version:    version,
-		Subpath:    subpath,
-		Qualifiers: inputQualifiers,
-	}
-	n.Versions = append(n.Versions, newV)
-	return n
+	return out, nil
 }
 
-func buildQualifierSet(qualifiers ...string) []*model.PackageQualifier {
-	var qs []*model.PackageQualifier
-	for i, _ := range qualifiers {
-		if i%2 == 0 {
-			qs = append(qs, &model.PackageQualifier{
-				Key:   qualifiers[i],
-				Value: qualifiers[i+1],
-			})
+// Builds a model.Package to send as GraphQL response, starting from id.
+// The optional filter allows restricting output (on selection operations).
+func buildPackageResponse(id nodeID, filter *model.PkgSpec) (*model.Package, error) {
+	if filter != nil && filter.ID != nil {
+		filteredID, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
+		}
+		if nodeID(filteredID) != id {
+			return nil, nil
 		}
 	}
-	return qs
+
+	node, ok := index[id]
+	if !ok {
+		return nil, gqlerror.Errorf("ID does not match existing node")
+	}
+
+	pvl := []*model.PackageVersion{}
+	if versionNode, ok := node.(*pkgVersionNode); ok {
+		pv := model.PackageVersion{
+			// IDs are generated as string even though we ask for integers
+			// See https://github.com/99designs/gqlgen/issues/2561
+			ID:         fmt.Sprintf("%d", versionNode.id),
+			Version:    versionNode.version,
+			Subpath:    versionNode.subpath,
+			Qualifiers: getCollectedPackageQualifiers(versionNode.qualifiers),
+		}
+		if filter != nil && noMatch(filter.Version, pv.Version) {
+			return nil, nil
+		}
+		if filter != nil && noMatch(filter.Subpath, pv.Subpath) {
+			return nil, nil
+		}
+		if filter != nil && noMatchQualifiers(filter, versionNode.qualifiers) {
+			return nil, nil
+		}
+		pvl = append(pvl, &pv)
+		node = index[versionNode.parent]
+	}
+
+	pnl := []*model.PackageName{}
+	if versionStruct, ok := node.(*pkgVersionStruct); ok {
+		pn := model.PackageName{
+			// IDs are generated as string even though we ask for integers
+			// See https://github.com/99designs/gqlgen/issues/2561
+			ID:       fmt.Sprintf("%d", versionStruct.id),
+			Name:     versionStruct.name,
+			Versions: pvl,
+		}
+		if filter != nil && noMatch(filter.Name, pn.Name) {
+			return nil, nil
+		}
+		pnl = append(pnl, &pn)
+		node = index[versionStruct.parent]
+	}
+
+	pnsl := []*model.PackageNamespace{}
+	if nameStruct, ok := node.(*pkgNameStruct); ok {
+		pns := model.PackageNamespace{
+			// IDs are generated as string even though we ask for integers
+			// See https://github.com/99designs/gqlgen/issues/2561
+			ID:        fmt.Sprintf("%d", nameStruct.id),
+			Namespace: nameStruct.namespace,
+			Names:     pnl,
+		}
+		if filter != nil && noMatch(filter.Namespace, pns.Namespace) {
+			return nil, nil
+		}
+		pnsl = append(pnsl, &pns)
+		node = index[nameStruct.parent]
+	}
+
+	namespaceStruct, ok := node.(*pkgNamespaceStruct)
+	if !ok {
+		return nil, gqlerror.Errorf("ID does not match expected node type")
+	}
+	p := model.Package{
+		// IDs are generated as string even though we ask for integers
+		// See https://github.com/99designs/gqlgen/issues/2561
+		ID:         fmt.Sprintf("%d", namespaceStruct.id),
+		Type:       namespaceStruct.typeKey,
+		Namespaces: pnsl,
+	}
+	if filter != nil && noMatch(filter.Type, p.Type) {
+		return nil, nil
+	}
+	return &p, nil
 }
 
 // Query Package
-
-func (c *demoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
-	var packages []*model.Package
-	for _, p := range c.packages {
-		if pkgSpec.Type == nil || p.Type == *pkgSpec.Type {
-			newPkg := filterPackageNamespace(p, pkgSpec)
-			if newPkg != nil {
-				packages = append(packages, newPkg)
-			}
-		}
-	}
-	return packages, nil
-}
 
 func filterPackageNamespace(pkg *model.Package, pkgSpec *model.PkgSpec) *model.Package {
 	var namespaces []*model.PackageNamespace
@@ -272,6 +471,55 @@ func filterPackageVersion(n *model.PackageName, pkgSpec *model.PkgSpec) *model.P
 		Name:     n.Name,
 		Versions: versions,
 	}
+}
+
+func getCollectedPackageQualifiers(qualifieMap map[string]string) []*model.PackageQualifier {
+	qualifiers := []*model.PackageQualifier{}
+	for key, val := range qualifieMap {
+		qualifier := &model.PackageQualifier{
+			Key:   key,
+			Value: val,
+		}
+		qualifiers = append(qualifiers, qualifier)
+
+	}
+	return qualifiers
+}
+
+func getQualifiers(qualifiersSpec []*model.PackageQualifierInputSpec) map[string]string {
+	qualifiersMap := map[string]string{}
+	if qualifiersSpec == nil {
+		return qualifiersMap
+	}
+	for _, kv := range qualifiersSpec {
+		qualifiersMap[kv.Key] = kv.Value
+	}
+	return qualifiersMap
+}
+
+func getQualifiersFromFilter(qualifiersSpec []*model.PackageQualifierSpec) map[string]string {
+	qualifiersMap := map[string]string{}
+	if qualifiersSpec == nil {
+		return qualifiersMap
+	}
+	for _, kv := range qualifiersSpec {
+		qualifiersMap[kv.Key] = *kv.Value
+	}
+	return qualifiersMap
+}
+
+func noMatchQualifiers(filter *model.PkgSpec, v map[string]string) bool {
+	// Allow matching on nodes with no qualifiers
+	if filter.MatchOnlyEmptyQualifiers != nil {
+		if *filter.MatchOnlyEmptyQualifiers && len(v) != 0 {
+			return true
+		}
+	}
+	if filter.Qualifiers != nil {
+		filterQualifiers := getQualifiersFromFilter(filter.Qualifiers)
+		return !reflect.DeepEqual(v, filterQualifiers)
+	}
+	return false
 }
 
 func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec) *model.PackageVersion {

--- a/pkg/assembler/backends/testing/src.go
+++ b/pkg/assembler/backends/testing/src.go
@@ -17,119 +17,284 @@ package testing
 
 import (
 	"context"
-	"strings"
+	"fmt"
+	"log"
+	"strconv"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func registerAllSources(client *demoClient) {
-	// with tag
-	client.registerSource("git", "github", "github.com/guacsec/guac", "tag=v0.0.1")
-	// with commit
-	client.registerSource("git", "github", "github.com/guacsec/guac", "commit=fcba958b73e27cad8b5c8655d46439984d27853b")
-	// with no tag or commit
-	client.registerSource("git", "github", "github.com/guacsec/guac", "")
-	// gitlab namespace
-	client.registerSource("git", "gitlab", "github.com/guacsec/guacdata", "tag=v0.0.1")
-	// differnt type
-	client.registerSource("svn", "gitlab", "github.com/guacsec/guac", "")
-	// "git", "github", "https://github.com/django/django", "tag=1.11.1"
-	client.registerSource("git", "github", "https://github.com/django/django", "tag=1.11.1")
-	// "git", "github", "https://github.com/vapor-ware/kubetest", "tag=0.9.5"
-	client.registerSource("git", "github", "https://github.com/vapor-ware/kubetest", "tag=0.9.5")
+	ctx := context.Background()
+	v12 := "v2.12.0"
+	commit := "abcdef"
+
+	inputs := []model.SourceInputSpec{{
+		Type:      "git",
+		Namespace: "github.com/tensorflow",
+		Name:      "tensorflow",
+	}, {
+		Type:      "git",
+		Namespace: "github.com/tensorflow",
+		Name:      "build",
+	}, {
+		Type:      "git",
+		Namespace: "github.com/tensorflow",
+		Name:      "tensorflow",
+		Tag:       &v12,
+	}, {
+		Type:      "git",
+		Namespace: "github.com/tensorflow",
+		Name:      "tensorflow",
+		Commit:    &commit,
+	}}
+
+	for _, input := range inputs {
+		_, err := client.IngestSource(ctx, input)
+		if err != nil {
+			log.Printf("Error in ingesting: %v\n", err)
+		}
+	}
 }
+
+// Internal data: Sources
+type srcTypeMap map[string]*srcNamespaceStruct
+type srcNamespaceStruct struct {
+	id         nodeID
+	typeKey    string
+	namespaces srcNamespaceMap
+}
+type srcNamespaceMap map[string]*srcNameStruct
+type srcNameStruct struct {
+	id        nodeID
+	parent    nodeID
+	namespace string
+	names     srcNameList
+}
+type srcNameList []*srcNameNode
+type srcNameNode struct {
+	id         nodeID
+	parent     nodeID
+	name       string
+	tag        string
+	commit     string
+	srcMapLink nodeID
+}
+
+func (n *srcNamespaceStruct) getID() nodeID { return n.id }
+func (n *srcNameStruct) getID() nodeID      { return n.id }
+func (n *srcNameNode) getID() nodeID        { return n.id }
 
 // Ingest Source
 
-func (c *demoClient) registerSource(srcType, namespace, name, qualifier string) *model.Source {
-	for i, s := range c.sources {
-		if s.Type == srcType {
-			c.sources[i] = registerSourceNamespace(s, namespace, name, qualifier)
-			return c.sources[i]
+func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSpec) (*model.Source, error) {
+	namespacesStruct, hasNamespace := sources[input.Type]
+	if !hasNamespace {
+		namespacesStruct = &srcNamespaceStruct{
+			id:         c.getNextID(),
+			typeKey:    input.Type,
+			namespaces: srcNamespaceMap{},
 		}
+		index[namespacesStruct.id] = namespacesStruct
+	}
+	namespaces := namespacesStruct.namespaces
+
+	namesStruct, hasName := namespaces[input.Namespace]
+	if !hasName {
+		namesStruct = &srcNameStruct{
+			id:        c.getNextID(),
+			parent:    namespacesStruct.id,
+			namespace: input.Namespace,
+			names:     srcNameList{},
+		}
+		index[namesStruct.id] = namesStruct
+	}
+	names := namesStruct.names
+
+	newSource := srcNameNode{
+		id:     c.getNextID(),
+		parent: namesStruct.id,
+		name:   input.Name,
+	}
+	index[newSource.id] = &newSource
+	if input.Tag != nil {
+		newSource.tag = nilToEmpty(input.Tag)
+	}
+	if input.Commit != nil {
+		newSource.commit = nilToEmpty(input.Commit)
 	}
 
-	newSrc := &model.Source{Type: srcType}
-	newSrc = registerSourceNamespace(newSrc, namespace, name, qualifier)
-	c.sources = append(c.sources, newSrc)
-
-	return newSrc
-}
-
-func registerSourceNamespace(s *model.Source, namespace, name, qualifier string) *model.Source {
-	for i, ns := range s.Namespaces {
-		if ns.Namespace == namespace {
-			s.Namespaces[i] = registerSourceName(ns, name, qualifier)
-			return s
+	// Don't insert duplicates
+	duplicate := false
+	for _, src := range names {
+		if src.name != input.Name {
+			continue
 		}
+		if noMatch(input.Tag, src.tag) {
+			continue
+		}
+		if noMatch(input.Commit, src.commit) {
+			continue
+		}
+		duplicate = true
+		break
+	}
+	if !duplicate {
+		namesStruct.names = append(names, &newSource)
+		namespaces[input.Namespace] = namesStruct
+		sources[input.Type] = namespacesStruct
 	}
 
-	newNs := &model.SourceNamespace{Namespace: namespace}
-	newNs = registerSourceName(newNs, name, qualifier)
-	s.Namespaces = append(s.Namespaces, newNs)
-	return s
+	// build return GraphQL type
+	return buildSourceResponse(newSource.id, nil)
 }
 
-func registerSourceName(ns *model.SourceNamespace, name, qualifier string) *model.SourceNamespace {
-	for _, n := range ns.Names {
-		if n.Name == name {
-			if checkQualifier(n, qualifier) {
-				return ns
+func (c *demoClient) Sources(ctx context.Context, filter *model.SourceSpec) ([]*model.Source, error) {
+	if filter.ID != nil {
+		id, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
+		}
+		s, err := buildSourceResponse(nodeID(id), filter)
+		if err != nil {
+			return nil, err
+		}
+		return []*model.Source{s}, nil
+	}
+	out := []*model.Source{}
+	for dbType, namespaces := range sources {
+		if noMatch(filter.Type, dbType) {
+			continue
+		}
+		sNamespaces := []*model.SourceNamespace{}
+		for namespace, names := range namespaces.namespaces {
+			if noMatch(filter.Namespace, namespace) {
+				continue
+			}
+			sns := []*model.SourceName{}
+			for _, s := range names.names {
+				if noMatch(filter.Name, s.name) {
+					continue
+				}
+				if noMatch(filter.Tag, s.tag) {
+					continue
+				}
+				if noMatch(filter.Commit, s.commit) {
+					continue
+				}
+				newSrc := model.SourceName{
+					// IDs are generated as string even though we ask for integers
+					// See https://github.com/99designs/gqlgen/issues/2561
+					ID:     fmt.Sprintf("%d", s.id),
+					Name:   s.name,
+					Tag:    &s.tag,
+					Commit: &s.commit,
+				}
+				sns = append(sns, &newSrc)
+			}
+			if len(sns) > 0 {
+				sn := model.SourceNamespace{
+					// IDs are generated as string even though we ask for integers
+					// See https://github.com/99designs/gqlgen/issues/2561
+					ID:        fmt.Sprintf("%d", names.id),
+					Namespace: namespace,
+					Names:     sns,
+				}
+				sNamespaces = append(sNamespaces, &sn)
 			}
 		}
-	}
-	newN := &model.SourceName{Name: name}
-	newN = sortQualifier(newN, qualifier)
-	ns.Names = append(ns.Names, newN)
-	return ns
-}
-
-func sortQualifier(n *model.SourceName, qualifier string) *model.SourceName {
-	if qualifier != "" {
-		pair := strings.Split(qualifier, "=")
-		if pair[0] == "tag" {
-			n.Tag = &pair[1]
-		} else {
-			n.Commit = &pair[1]
+		if len(sNamespaces) > 0 {
+			s := model.Source{
+				// IDs are generated as string even though we ask for integers
+				// See https://github.com/99designs/gqlgen/issues/2561
+				ID:         fmt.Sprintf("%d", namespaces.id),
+				Type:       dbType,
+				Namespaces: sNamespaces,
+			}
+			out = append(out, &s)
 		}
 	}
-	return n
+	return out, nil
 }
 
-func checkQualifier(n *model.SourceName, qualifier string) bool {
-	if qualifier != "" {
-		pair := strings.Split(qualifier, "=")
-		if pair[0] == "tag" {
-			if n.Tag != nil {
-				return *n.Tag == pair[1]
-			}
-		} else {
-			if n.Commit != nil {
-				return *n.Commit == pair[1]
-			}
+// Builds a model.Source to send as GraphQL response, starting from id.
+// The optional filter allows restricting output (on selection operations).
+func buildSourceResponse(id nodeID, filter *model.SourceSpec) (*model.Source, error) {
+	if filter != nil && filter.ID != nil {
+		filteredID, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
+		}
+		if nodeID(filteredID) != id {
+			return nil, nil
 		}
 	}
-	return false
+
+	node, ok := index[id]
+	if !ok {
+		return nil, gqlerror.Errorf("ID does not match existing node")
+	}
+
+	snl := []*model.SourceName{}
+	if nameNode, ok := node.(*srcNameNode); ok {
+		sn := model.SourceName{
+			// IDs are generated as string even though we ask for integers
+			// See https://github.com/99designs/gqlgen/issues/2561
+			ID:   fmt.Sprintf("%d", nameNode.id),
+			Name: nameNode.name,
+		}
+		sn.Tag = &nameNode.tag
+
+		sn.Commit = &nameNode.commit
+
+		if filter != nil && noMatch(filter.Name, sn.Name) {
+			return nil, nil
+		}
+		if filter != nil && noMatchPtr(filter.Tag, sn.Tag) {
+			return nil, nil
+		}
+		if filter != nil && noMatchPtr(filter.Commit, sn.Commit) {
+			return nil, nil
+		}
+		snl = append(snl, &sn)
+		node = index[nameNode.parent]
+	}
+
+	snsl := []*model.SourceNamespace{}
+	if nameStruct, ok := node.(*srcNameStruct); ok {
+		sns := model.SourceNamespace{
+			// IDs are generated as string even though we ask for integers
+			// See https://github.com/99designs/gqlgen/issues/2561
+			ID:        fmt.Sprintf("%d", nameStruct.id),
+			Namespace: nameStruct.namespace,
+			Names:     snl,
+		}
+		if filter != nil && noMatch(filter.Namespace, sns.Namespace) {
+			return nil, nil
+		}
+		snsl = append(snsl, &sns)
+		node = index[nameStruct.parent]
+	}
+
+	namespaceStruct, ok := node.(*srcNamespaceStruct)
+	if !ok {
+		return nil, gqlerror.Errorf("ID does not match expected node type")
+	}
+	s := model.Source{
+		// IDs are generated as string even though we ask for integers
+		// See https://github.com/99designs/gqlgen/issues/2561
+		ID:         fmt.Sprintf("%d", namespaceStruct.id),
+		Type:       namespaceStruct.typeKey,
+		Namespaces: snsl,
+	}
+	if filter != nil && noMatch(filter.Type, s.Type) {
+		return nil, nil
+	}
+	return &s, nil
 }
 
 // Query Source
-
-func (c *demoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error) {
-	var sources []*model.Source
-	for _, s := range c.sources {
-		if sourceSpec.Type == nil || s.Type == *sourceSpec.Type {
-			newSource, err := filterSourceNamespace(s, sourceSpec)
-			if err != nil {
-				return nil, err
-			}
-			if newSource != nil {
-				sources = append(sources, newSource)
-			}
-		}
-	}
-	return sources, nil
-}
 
 func filterSourceNamespace(src *model.Source, sourceSpec *model.SourceSpec) (*model.Source, error) {
 	var namespaces []*model.SourceNamespace
@@ -210,30 +375,4 @@ func matchInputSpecWithDBField(spec *string, dbField *string) bool {
 	}
 
 	return (dbField != nil && *dbField == *spec)
-}
-
-func (c *demoClient) IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error) {
-	sourceType := source.Type
-	namespace := source.Namespace
-	name := source.Name
-
-	// TODO(mihaimaruseac): Separate in two fields, no need for `tag=`/`commit=`
-	tagOrCommit := ""
-	if source.Commit != nil && source.Tag != nil {
-		if *source.Commit != "" && *source.Tag != "" {
-			return nil, gqlerror.Errorf("Passing both commit and tag selectors is an error")
-		} else if *source.Commit != "" {
-			tagOrCommit = "commit=" + *source.Commit
-		} else if *source.Tag != "" {
-			tagOrCommit = "tag=" + *source.Tag
-		}
-	} else if source.Commit != nil {
-		tagOrCommit = "commit=" + *source.Commit
-	} else if source.Tag != nil {
-		tagOrCommit = "tag=" + *source.Tag
-	}
-
-	newSrc := c.registerSource(sourceType, namespace, name, tagOrCommit)
-
-	return newSrc, nil
 }

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -41,7 +41,7 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 			}
 
 			logger.Infof("assembling IsOccurence: %v", len(p.IsOccurence))
-			if err := ingestIsOccurence(ctx, gqlclient, p.IsOccurence); err != nil {
+			if err := ingestIsOccurrence(ctx, gqlclient, p.IsOccurence); err != nil {
 				return err
 			}
 
@@ -75,7 +75,7 @@ func ingestIsDependency(ctx context.Context, client graphql.Client, vs []assembl
 	return nil
 }
 
-func ingestIsOccurence(ctx context.Context, client graphql.Client, vs []assembler.IsOccurenceIngest) error {
+func ingestIsOccurrence(ctx context.Context, client graphql.Client, vs []assembler.IsOccurenceIngest) error {
 	for _, v := range vs {
 		if v.Pkg != nil && v.Src != nil {
 			return fmt.Errorf("unable to create IsOccurence with both Src and Pkg subject specified")

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -37,8 +37,8 @@ type MutationResolver interface {
 	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error)
 	IngestIsVulnerability(ctx context.Context, osv model.OSVInputSpec, vulnerability model.CveOrGhsaInput, isVulnerability model.IsVulnerabilityInputSpec) (*model.IsVulnerability, error)
 	IngestOsv(ctx context.Context, osv *model.OSVInputSpec) (*model.Osv, error)
-	IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error)
-	IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error)
+	IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error)
+	IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error)
 }
 type QueryResolver interface {
 	Artifacts(ctx context.Context, artifactSpec *model.ArtifactSpec) ([]*model.Artifact, error)
@@ -447,10 +447,10 @@ func (ec *executionContext) field_Mutation_ingestOccurrence_args(ctx context.Con
 func (ec *executionContext) field_Mutation_ingestPackage_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *model.PkgInputSpec
+	var arg0 model.PkgInputSpec
 	if tmp, ok := rawArgs["pkg"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkg"))
-		arg0, err = ec.unmarshalOPkgInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx, tmp)
+		arg0, err = ec.unmarshalNPkgInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpec(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -504,10 +504,10 @@ func (ec *executionContext) field_Mutation_ingestSLSA_args(ctx context.Context, 
 func (ec *executionContext) field_Mutation_ingestSource_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *model.SourceInputSpec
+	var arg0 model.SourceInputSpec
 	if tmp, ok := rawArgs["source"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
-		arg0, err = ec.unmarshalOSourceInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpec(ctx, tmp)
+		arg0, err = ec.unmarshalNSourceInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpec(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -1761,6 +1761,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSourceAt(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_HasSourceAt_id(ctx, field)
 			case "package":
 				return ec.fieldContext_HasSourceAt_package(ctx, field)
 			case "source":
@@ -2132,7 +2134,7 @@ func (ec *executionContext) _Mutation_ingestPackage(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().IngestPackage(rctx, fc.Args["pkg"].(*model.PkgInputSpec))
+		return ec.resolvers.Mutation().IngestPackage(rctx, fc.Args["pkg"].(model.PkgInputSpec))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2157,6 +2159,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestPackage(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":
@@ -2193,7 +2197,7 @@ func (ec *executionContext) _Mutation_ingestSource(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().IngestSource(rctx, fc.Args["source"].(*model.SourceInputSpec))
+		return ec.resolvers.Mutation().IngestSource(rctx, fc.Args["source"].(model.SourceInputSpec))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2218,6 +2222,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestSource(ctx context.Conte
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Source_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Source_type(ctx, field)
 			case "namespaces":
@@ -2968,6 +2974,8 @@ func (ec *executionContext) fieldContext_Query_HasSourceAt(ctx context.Context, 
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_HasSourceAt_id(ctx, field)
 			case "package":
 				return ec.fieldContext_HasSourceAt_package(ctx, field)
 			case "source":
@@ -3364,6 +3372,8 @@ func (ec *executionContext) fieldContext_Query_packages(ctx context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":
@@ -3425,6 +3435,8 @@ func (ec *executionContext) fieldContext_Query_sources(ctx context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Source_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Source_type(ctx, field)
 			case "namespaces":

--- a/pkg/assembler/graphql/generated/certifyPkg.generated.go
+++ b/pkg/assembler/graphql/generated/certifyPkg.generated.go
@@ -67,6 +67,8 @@ func (ec *executionContext) fieldContext_CertifyPkg_packages(ctx context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -68,6 +68,8 @@ func (ec *executionContext) fieldContext_CertifyScorecard_source(ctx context.Con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Source_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Source_type(ctx, field)
 			case "namespaces":

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -68,6 +68,8 @@ func (ec *executionContext) fieldContext_CertifyVuln_package(ctx context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -29,6 +29,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _HasSourceAt_id(ctx context.Context, field graphql.CollectedField, obj *model.HasSourceAt) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSourceAt_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSourceAt_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSourceAt",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HasSourceAt_package(ctx context.Context, field graphql.CollectedField, obj *model.HasSourceAt) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HasSourceAt_package(ctx, field)
 	if err != nil {
@@ -68,6 +112,8 @@ func (ec *executionContext) fieldContext_HasSourceAt_package(ctx context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":
@@ -118,6 +164,8 @@ func (ec *executionContext) fieldContext_HasSourceAt_source(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Source_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Source_type(ctx, field)
 			case "namespaces":
@@ -368,13 +416,21 @@ func (ec *executionContext) unmarshalInputHasSourceAtSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"package", "source", "knownSince", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "package", "source", "knownSince", "justification", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "package":
 			var err error
 
@@ -447,6 +503,13 @@ func (ec *executionContext) _HasSourceAt(ctx context.Context, sel ast.SelectionS
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("HasSourceAt")
+		case "id":
+
+			out.Values[i] = ec._HasSourceAt_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "package":
 
 			out.Values[i] = ec._HasSourceAt_package(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -67,6 +67,8 @@ func (ec *executionContext) fieldContext_IsDependency_package(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":
@@ -117,6 +119,8 @@ func (ec *executionContext) fieldContext_IsDependency_dependentPackage(ctx conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Package_id(ctx, field)
 			case "type":
 				return ec.fieldContext_Package_type(ctx, field)
 			case "namespaces":

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -28,6 +28,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _Package_id(ctx context.Context, field graphql.CollectedField, obj *model.Package) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Package_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Package_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Package",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Package_type(ctx context.Context, field graphql.CollectedField, obj *model.Package) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Package_type(ctx, field)
 	if err != nil {
@@ -111,12 +155,58 @@ func (ec *executionContext) fieldContext_Package_namespaces(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_PackageNamespace_id(ctx, field)
 			case "namespace":
 				return ec.fieldContext_PackageNamespace_namespace(ctx, field)
 			case "names":
 				return ec.fieldContext_PackageNamespace_names(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PackageNamespace", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackageName_id(ctx context.Context, field graphql.CollectedField, obj *model.PackageName) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackageName_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackageName_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackageName",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -205,6 +295,8 @@ func (ec *executionContext) fieldContext_PackageName_versions(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_PackageVersion_id(ctx, field)
 			case "version":
 				return ec.fieldContext_PackageVersion_version(ctx, field)
 			case "qualifiers":
@@ -213,6 +305,50 @@ func (ec *executionContext) fieldContext_PackageName_versions(ctx context.Contex
 				return ec.fieldContext_PackageVersion_subpath(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PackageVersion", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackageNamespace_id(ctx context.Context, field graphql.CollectedField, obj *model.PackageNamespace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackageNamespace_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackageNamespace_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackageNamespace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -301,6 +437,8 @@ func (ec *executionContext) fieldContext_PackageNamespace_names(ctx context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_PackageName_id(ctx, field)
 			case "name":
 				return ec.fieldContext_PackageName_name(ctx, field)
 			case "versions":
@@ -395,6 +533,50 @@ func (ec *executionContext) fieldContext_PackageQualifier_value(ctx context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackageVersion_id(ctx context.Context, field graphql.CollectedField, obj *model.PackageVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackageVersion_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackageVersion_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackageVersion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -709,13 +891,21 @@ func (ec *executionContext) unmarshalInputPkgSpec(ctx context.Context, obj inter
 		asMap["matchOnlyEmptyQualifiers"] = false
 	}
 
-	fieldsInOrder := [...]string{"type", "namespace", "name", "version", "qualifiers", "matchOnlyEmptyQualifiers", "subpath"}
+	fieldsInOrder := [...]string{"id", "type", "namespace", "name", "version", "qualifiers", "matchOnlyEmptyQualifiers", "subpath"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "type":
 			var err error
 
@@ -796,6 +986,13 @@ func (ec *executionContext) _Package(ctx context.Context, sel ast.SelectionSet, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Package")
+		case "id":
+
+			out.Values[i] = ec._Package_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "type":
 
 			out.Values[i] = ec._Package_type(ctx, field, obj)
@@ -831,6 +1028,13 @@ func (ec *executionContext) _PackageName(ctx context.Context, sel ast.SelectionS
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PackageName")
+		case "id":
+
+			out.Values[i] = ec._PackageName_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "name":
 
 			out.Values[i] = ec._PackageName_name(ctx, field, obj)
@@ -866,6 +1070,13 @@ func (ec *executionContext) _PackageNamespace(ctx context.Context, sel ast.Selec
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PackageNamespace")
+		case "id":
+
+			out.Values[i] = ec._PackageNamespace_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "namespace":
 
 			out.Values[i] = ec._PackageNamespace_namespace(ctx, field, obj)
@@ -936,6 +1147,13 @@ func (ec *executionContext) _PackageVersion(ctx context.Context, sel ast.Selecti
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PackageVersion")
+		case "id":
+
+			out.Values[i] = ec._PackageVersion_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "version":
 
 			out.Values[i] = ec._PackageVersion_version(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/prelude.generated.go
+++ b/pkg/assembler/graphql/generated/prelude.generated.go
@@ -2187,6 +2187,21 @@ func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.S
 	return graphql.WrapContextMarshaler(ctx, res)
 }
 
+func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
+	res, err := graphql.UnmarshalID(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	res := graphql.MarshalID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {
 	res, err := graphql.UnmarshalInt(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -2510,6 +2525,22 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalID(*v)
+	return res
 }
 
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v interface{}) (*string, error) {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -112,6 +112,7 @@ type ComplexityRoot struct {
 
 	HasSourceAt struct {
 		Collector     func(childComplexity int) int
+		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		KnownSince    func(childComplexity int) int
 		Origin        func(childComplexity int) int
@@ -167,9 +168,9 @@ type ComplexityRoot struct {
 		IngestMaterials       func(childComplexity int, materials []*model.PackageSourceOrArtifactInput) int
 		IngestOccurrence      func(childComplexity int, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) int
 		IngestOsv             func(childComplexity int, osv *model.OSVInputSpec) int
-		IngestPackage         func(childComplexity int, pkg *model.PkgInputSpec) int
+		IngestPackage         func(childComplexity int, pkg model.PkgInputSpec) int
 		IngestSlsa            func(childComplexity int, subject model.PackageSourceOrArtifactInput, builtFrom []*model.PackageSourceOrArtifactInput, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) int
-		IngestSource          func(childComplexity int, source *model.SourceInputSpec) int
+		IngestSource          func(childComplexity int, source model.SourceInputSpec) int
 		IngestVEXStatement    func(childComplexity int, subject model.PackageOrArtifactInput, vulnerability model.CveOrGhsaInput, vexStatement model.VexStatementInputSpec) int
 		IngestVulnerability   func(childComplexity int, pkg model.PkgInputSpec, vulnerability model.OsvCveOrGhsaInput, certifyVuln model.VulnerabilityMetaDataInput) int
 	}
@@ -183,16 +184,19 @@ type ComplexityRoot struct {
 	}
 
 	Package struct {
+		ID         func(childComplexity int) int
 		Namespaces func(childComplexity int) int
 		Type       func(childComplexity int) int
 	}
 
 	PackageName struct {
+		ID       func(childComplexity int) int
 		Name     func(childComplexity int) int
 		Versions func(childComplexity int) int
 	}
 
 	PackageNamespace struct {
+		ID        func(childComplexity int) int
 		Names     func(childComplexity int) int
 		Namespace func(childComplexity int) int
 	}
@@ -203,6 +207,7 @@ type ComplexityRoot struct {
 	}
 
 	PackageVersion struct {
+		ID         func(childComplexity int) int
 		Qualifiers func(childComplexity int) int
 		Subpath    func(childComplexity int) int
 		Version    func(childComplexity int) int
@@ -263,17 +268,20 @@ type ComplexityRoot struct {
 	}
 
 	Source struct {
+		ID         func(childComplexity int) int
 		Namespaces func(childComplexity int) int
 		Type       func(childComplexity int) int
 	}
 
 	SourceName struct {
 		Commit func(childComplexity int) int
+		ID     func(childComplexity int) int
 		Name   func(childComplexity int) int
 		Tag    func(childComplexity int) int
 	}
 
 	SourceNamespace struct {
+		ID        func(childComplexity int) int
 		Names     func(childComplexity int) int
 		Namespace func(childComplexity int) int
 	}
@@ -541,6 +549,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.HasSourceAt.Collector(childComplexity), true
+
+	case "HasSourceAt.id":
+		if e.complexity.HasSourceAt.ID == nil {
+			break
+		}
+
+		return e.complexity.HasSourceAt.ID(childComplexity), true
 
 	case "HasSourceAt.justification":
 		if e.complexity.HasSourceAt.Justification == nil {
@@ -907,7 +922,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.IngestPackage(childComplexity, args["pkg"].(*model.PkgInputSpec)), true
+		return e.complexity.Mutation.IngestPackage(childComplexity, args["pkg"].(model.PkgInputSpec)), true
 
 	case "Mutation.ingestSLSA":
 		if e.complexity.Mutation.IngestSlsa == nil {
@@ -931,7 +946,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.IngestSource(childComplexity, args["source"].(*model.SourceInputSpec)), true
+		return e.complexity.Mutation.IngestSource(childComplexity, args["source"].(model.SourceInputSpec)), true
 
 	case "Mutation.ingestVEXStatement":
 		if e.complexity.Mutation.IngestVEXStatement == nil {
@@ -971,6 +986,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OSVId.ID(childComplexity), true
 
+	case "Package.id":
+		if e.complexity.Package.ID == nil {
+			break
+		}
+
+		return e.complexity.Package.ID(childComplexity), true
+
 	case "Package.namespaces":
 		if e.complexity.Package.Namespaces == nil {
 			break
@@ -985,6 +1007,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Package.Type(childComplexity), true
 
+	case "PackageName.id":
+		if e.complexity.PackageName.ID == nil {
+			break
+		}
+
+		return e.complexity.PackageName.ID(childComplexity), true
+
 	case "PackageName.name":
 		if e.complexity.PackageName.Name == nil {
 			break
@@ -998,6 +1027,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PackageName.Versions(childComplexity), true
+
+	case "PackageNamespace.id":
+		if e.complexity.PackageNamespace.ID == nil {
+			break
+		}
+
+		return e.complexity.PackageNamespace.ID(childComplexity), true
 
 	case "PackageNamespace.names":
 		if e.complexity.PackageNamespace.Names == nil {
@@ -1026,6 +1062,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PackageQualifier.Value(childComplexity), true
+
+	case "PackageVersion.id":
+		if e.complexity.PackageVersion.ID == nil {
+			break
+		}
+
+		return e.complexity.PackageVersion.ID(childComplexity), true
 
 	case "PackageVersion.qualifiers":
 		if e.complexity.PackageVersion.Qualifiers == nil {
@@ -1416,6 +1459,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ScorecardCheck.Score(childComplexity), true
 
+	case "Source.id":
+		if e.complexity.Source.ID == nil {
+			break
+		}
+
+		return e.complexity.Source.ID(childComplexity), true
+
 	case "Source.namespaces":
 		if e.complexity.Source.Namespaces == nil {
 			break
@@ -1437,6 +1487,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SourceName.Commit(childComplexity), true
 
+	case "SourceName.id":
+		if e.complexity.SourceName.ID == nil {
+			break
+		}
+
+		return e.complexity.SourceName.ID(childComplexity), true
+
 	case "SourceName.name":
 		if e.complexity.SourceName.Name == nil {
 			break
@@ -1450,6 +1507,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SourceName.Tag(childComplexity), true
+
+	case "SourceNamespace.id":
+		if e.complexity.SourceNamespace.ID == nil {
+			break
+		}
+
+		return e.complexity.SourceNamespace.ID(childComplexity), true
 
 	case "SourceNamespace.names":
 		if e.complexity.SourceNamespace.Names == nil {
@@ -2684,6 +2748,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HasSourceAt {
+  id: ID!
   package: Package!
   source: Source!
   knownSince: Time!
@@ -2696,6 +2761,7 @@ type HasSourceAt {
 HasSourceAtSpec allows filtering the list of HasSourceAt to return.
 """
 input HasSourceAtSpec {
+  id: ID
   package: PkgSpec
   source: SourceSpec
   knownSince: Time
@@ -3183,6 +3249,7 @@ Also note that this is named ` + "`" + `Package` + "`" + `, not ` + "`" + `Packa
 queries more readable.
 """
 type Package {
+  id: ID!
   type: String!
   namespaces: [PackageNamespace!]!
 }
@@ -3197,6 +3264,7 @@ Namespaces are optional and type specific. Because they are optional, we use
 empty string to denote missing namespaces.
 """
 type PackageNamespace {
+  id: ID!
   namespace: String!
   names: [PackageName!]!
 }
@@ -3213,6 +3281,7 @@ This is the first node in the trie that can be referred to by other parts of
 GUAC.
 """
 type PackageName {
+  id: ID!
   name: String!
   versions: [PackageVersion!]!
 }
@@ -3237,6 +3306,7 @@ a subset of the qualifier of the other also mean two different packages in the
 trie.
 """
 type PackageVersion {
+  id: ID!
   version: String!
   qualifiers: [PackageQualifier!]!
   subpath: String!
@@ -3273,6 +3343,7 @@ on nodes that don't contain any qualifier, set ` + "`" + `matchOnlyEmptyQualifie
 true. If this field is true, then the qualifiers argument is ignored.
 """
 input PkgSpec {
+  id: ID
   type: String
   namespace: String
   name: String
@@ -3337,7 +3408,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a new package. Returns the ingested package trie"
-  ingestPackage(pkg: PkgInputSpec): Package!
+  ingestPackage(pkg: PkgInputSpec!): Package!
 }
 `, BuiltIn: false},
 	{Name: "../schema/source.graphql", Input: `#
@@ -3373,6 +3444,7 @@ Also note that this is named ` + "`" + `Source` + "`" + `, not ` + "`" + `Source
 queries more readable.
 """
 type Source {
+  id: ID!
   type: String!
   namespaces: [SourceNamespace!]!
 }
@@ -3385,6 +3457,7 @@ This is the location of the repository (such as github/gitlab/bitbucket).
 The ` + "`" + `namespace` + "`" + ` field is mandatory.
 """
 type SourceNamespace {
+  id: ID!
   namespace: String!
   names: [SourceName!]!
 }
@@ -3399,6 +3472,7 @@ This is the only source trie node that can be referenced by other parts of
 GUAC.
 """
 type SourceName {
+  id: ID!
   name: String!
   tag: String
   commit: String
@@ -3415,6 +3489,7 @@ set as empty string (in which case the returned sources are only those for
 which there is no tag/commit information).
 """
 input SourceSpec {
+  id: ID
   type: String
   namespace: String
   name: String
@@ -3447,7 +3522,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a new source. Returns the ingested source trie"
-  ingestSource(source: SourceInputSpec): Source!
+  ingestSource(source: SourceInputSpec!): Source!
 }
 `, BuiltIn: false},
 }

--- a/pkg/assembler/graphql/generated/source.generated.go
+++ b/pkg/assembler/graphql/generated/source.generated.go
@@ -28,6 +28,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _Source_id(ctx context.Context, field graphql.CollectedField, obj *model.Source) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Source_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Source_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Source",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Source_type(ctx context.Context, field graphql.CollectedField, obj *model.Source) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Source_type(ctx, field)
 	if err != nil {
@@ -111,12 +155,58 @@ func (ec *executionContext) fieldContext_Source_namespaces(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_SourceNamespace_id(ctx, field)
 			case "namespace":
 				return ec.fieldContext_SourceNamespace_namespace(ctx, field)
 			case "names":
 				return ec.fieldContext_SourceNamespace_names(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SourceNamespace", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceName_id(ctx context.Context, field graphql.CollectedField, obj *model.SourceName) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceName_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceName_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceName",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -248,6 +338,50 @@ func (ec *executionContext) fieldContext_SourceName_commit(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _SourceNamespace_id(ctx context.Context, field graphql.CollectedField, obj *model.SourceNamespace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceNamespace_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceNamespace_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceNamespace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SourceNamespace_namespace(ctx context.Context, field graphql.CollectedField, obj *model.SourceNamespace) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SourceNamespace_namespace(ctx, field)
 	if err != nil {
@@ -331,6 +465,8 @@ func (ec *executionContext) fieldContext_SourceNamespace_names(ctx context.Conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_SourceName_id(ctx, field)
 			case "name":
 				return ec.fieldContext_SourceName_name(ctx, field)
 			case "tag":
@@ -422,13 +558,21 @@ func (ec *executionContext) unmarshalInputSourceSpec(ctx context.Context, obj in
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "namespace", "name", "tag", "commit"}
+	fieldsInOrder := [...]string{"id", "type", "namespace", "name", "tag", "commit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "type":
 			var err error
 
@@ -493,6 +637,13 @@ func (ec *executionContext) _Source(ctx context.Context, sel ast.SelectionSet, o
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Source")
+		case "id":
+
+			out.Values[i] = ec._Source_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "type":
 
 			out.Values[i] = ec._Source_type(ctx, field, obj)
@@ -528,6 +679,13 @@ func (ec *executionContext) _SourceName(ctx context.Context, sel ast.SelectionSe
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SourceName")
+		case "id":
+
+			out.Values[i] = ec._SourceName_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "name":
 
 			out.Values[i] = ec._SourceName_name(ctx, field, obj)
@@ -564,6 +722,13 @@ func (ec *executionContext) _SourceNamespace(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("SourceNamespace")
+		case "id":
+
+			out.Values[i] = ec._SourceNamespace_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "namespace":
 
 			out.Values[i] = ec._SourceNamespace_namespace(ctx, field, obj)

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -376,6 +376,7 @@ type HasSLSASpec struct {
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type HasSourceAt struct {
+	ID            string    `json:"id"`
 	Package       *Package  `json:"package"`
 	Source        *Source   `json:"source"`
 	KnownSince    time.Time `json:"knownSince"`
@@ -396,6 +397,7 @@ type HasSourceAtInputSpec struct {
 
 // HasSourceAtSpec allows filtering the list of HasSourceAt to return.
 type HasSourceAtSpec struct {
+	ID            *string     `json:"id"`
 	Package       *PkgSpec    `json:"package"`
 	Source        *SourceSpec `json:"source"`
 	KnownSince    *time.Time  `json:"knownSince"`
@@ -616,6 +618,7 @@ type OsvCveOrGhsaSpec struct {
 // Also note that this is named `Package`, not `PackageType`. This is only to make
 // queries more readable.
 type Package struct {
+	ID         string              `json:"id"`
 	Type       string              `json:"type"`
 	Namespaces []*PackageNamespace `json:"namespaces"`
 }
@@ -636,6 +639,7 @@ func (Package) IsPackageOrSource() {}
 // This is the first node in the trie that can be referred to by other parts of
 // GUAC.
 type PackageName struct {
+	ID       string            `json:"id"`
 	Name     string            `json:"name"`
 	Versions []*PackageVersion `json:"versions"`
 }
@@ -648,6 +652,7 @@ type PackageName struct {
 // Namespaces are optional and type specific. Because they are optional, we use
 // empty string to denote missing namespaces.
 type PackageNamespace struct {
+	ID        string         `json:"id"`
 	Namespace string         `json:"namespace"`
 	Names     []*PackageName `json:"names"`
 }
@@ -765,6 +770,7 @@ type PackageSourceOrArtifactSpec struct {
 // a subset of the qualifier of the other also mean two different packages in the
 // trie.
 type PackageVersion struct {
+	ID         string              `json:"id"`
 	Version    string              `json:"version"`
 	Qualifiers []*PackageQualifier `json:"qualifiers"`
 	Subpath    string              `json:"subpath"`
@@ -805,6 +811,7 @@ type PkgNameSpec struct {
 // on nodes that don't contain any qualifier, set `matchOnlyEmptyQualifiers` to
 // true. If this field is true, then the qualifiers argument is ignored.
 type PkgSpec struct {
+	ID                       *string                 `json:"id"`
 	Type                     *string                 `json:"type"`
 	Namespace                *string                 `json:"namespace"`
 	Name                     *string                 `json:"name"`
@@ -981,6 +988,7 @@ type ScorecardInputSpec struct {
 // Also note that this is named `Source`, not `SourceType`. This is only to make
 // queries more readable.
 type Source struct {
+	ID         string             `json:"id"`
 	Type       string             `json:"type"`
 	Namespaces []*SourceNamespace `json:"namespaces"`
 }
@@ -1013,6 +1021,7 @@ type SourceInputSpec struct {
 // This is the only source trie node that can be referenced by other parts of
 // GUAC.
 type SourceName struct {
+	ID     string  `json:"id"`
 	Name   string  `json:"name"`
 	Tag    *string `json:"tag"`
 	Commit *string `json:"commit"`
@@ -1024,6 +1033,7 @@ type SourceName struct {
 //
 // The `namespace` field is mandatory.
 type SourceNamespace struct {
+	ID        string        `json:"id"`
 	Namespace string        `json:"namespace"`
 	Names     []*SourceName `json:"names"`
 }
@@ -1037,6 +1047,7 @@ type SourceNamespace struct {
 // set as empty string (in which case the returned sources are only those for
 // which there is no tag/commit information).
 type SourceSpec struct {
+	ID        *string `json:"id"`
 	Type      *string `json:"type"`
 	Namespace *string `json:"namespace"`
 	Name      *string `json:"name"`

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // IngestPackage is the resolver for the ingestPackage field.
-func (r *mutationResolver) IngestPackage(ctx context.Context, pkg *model.PkgInputSpec) (*model.Package, error) {
+func (r *mutationResolver) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error) {
 	return r.Backend.IngestPackage(ctx, pkg)
 }
 

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // IngestSource is the resolver for the ingestSource field.
-func (r *mutationResolver) IngestSource(ctx context.Context, source *model.SourceInputSpec) (*model.Source, error) {
+func (r *mutationResolver) IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error) {
 	return r.Backend.IngestSource(ctx, source)
 }
 

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -27,6 +27,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HasSourceAt {
+  id: ID!
   package: Package!
   source: Source!
   knownSince: Time!
@@ -39,6 +40,7 @@ type HasSourceAt {
 HasSourceAtSpec allows filtering the list of HasSourceAt to return.
 """
 input HasSourceAtSpec {
+  id: ID
   package: PkgSpec
   source: SourceSpec
   knownSince: Time

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -36,6 +36,7 @@ Also note that this is named `Package`, not `PackageType`. This is only to make
 queries more readable.
 """
 type Package {
+  id: ID!
   type: String!
   namespaces: [PackageNamespace!]!
 }
@@ -50,6 +51,7 @@ Namespaces are optional and type specific. Because they are optional, we use
 empty string to denote missing namespaces.
 """
 type PackageNamespace {
+  id: ID!
   namespace: String!
   names: [PackageName!]!
 }
@@ -66,6 +68,7 @@ This is the first node in the trie that can be referred to by other parts of
 GUAC.
 """
 type PackageName {
+  id: ID!
   name: String!
   versions: [PackageVersion!]!
 }
@@ -90,6 +93,7 @@ a subset of the qualifier of the other also mean two different packages in the
 trie.
 """
 type PackageVersion {
+  id: ID!
   version: String!
   qualifiers: [PackageQualifier!]!
   subpath: String!
@@ -126,6 +130,7 @@ on nodes that don't contain any qualifier, set `matchOnlyEmptyQualifiers` to
 true. If this field is true, then the qualifiers argument is ignored.
 """
 input PkgSpec {
+  id: ID
   type: String
   namespace: String
   name: String
@@ -190,5 +195,5 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a new package. Returns the ingested package trie"
-  ingestPackage(pkg: PkgInputSpec): Package!
+  ingestPackage(pkg: PkgInputSpec!): Package!
 }

--- a/pkg/assembler/graphql/schema/source.graphql
+++ b/pkg/assembler/graphql/schema/source.graphql
@@ -31,6 +31,7 @@ Also note that this is named `Source`, not `SourceType`. This is only to make
 queries more readable.
 """
 type Source {
+  id: ID!
   type: String!
   namespaces: [SourceNamespace!]!
 }
@@ -43,6 +44,7 @@ This is the location of the repository (such as github/gitlab/bitbucket).
 The `namespace` field is mandatory.
 """
 type SourceNamespace {
+  id: ID!
   namespace: String!
   names: [SourceName!]!
 }
@@ -57,6 +59,7 @@ This is the only source trie node that can be referenced by other parts of
 GUAC.
 """
 type SourceName {
+  id: ID!
   name: String!
   tag: String
   commit: String
@@ -73,6 +76,7 @@ set as empty string (in which case the returned sources are only those for
 which there is no tag/commit information).
 """
 input SourceSpec {
+  id: ID
   type: String
   namespace: String
   name: String
@@ -105,5 +109,5 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a new source. Returns the ingested source trie"
-  ingestSource(source: SourceInputSpec): Source!
+  ingestSource(source: SourceInputSpec!): Source!
 }


### PR DESCRIPTION
Building on the work done by @mihaimaruseac on [his repo](https://github.com/mihaimaruseac/guac/blob/9d9c9be4c18a1f2645353867386d81ca26e20970/server/backends/memory/trees.go)
- Add IDs for package, source, and `hasSourceAt`
- add back edge for `hasSourceAt`
- update register package and source tests
- fix issues in querying