### PR TITLE
Update artifacts, hashEquals, and isOccurrance with internal structs and ids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,5 +172,6 @@ require (
 	github.com/spdx/tools-golang v0.4.0
 	github.com/spf13/viper v1.15.0
 	github.com/vektah/gqlparser/v2 v2.5.1
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -909,6 +909,7 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -39,6 +39,12 @@ type artStruct struct {
 
 func (n *artStruct) getID() uint32 { return n.id }
 
+func (n *artStruct) getHashEquals() []uint32 { return n.hashEquals }
+func (n *artStruct) setHashEquals(id uint32) { n.hashEquals = append(n.hashEquals, id) }
+
+func (n *artStruct) getOccurrences() []uint32 { return n.occurrences }
+func (n *artStruct) setOccurrences(id uint32) { n.occurrences = append(n.occurrences, id) }
+
 // TODO convert to unit tests
 // func registerAllArtifacts(c *demoClient) {
 // 	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{

--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -17,67 +17,154 @@ package testing
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-func registerAllArtifacts(client *demoClient) {
-	// strings.ToLower(string(checksum.Algorithm)) + ":" + checksum.Value
-	client.registerArtifact("sha256", "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf")
-	client.registerArtifact("sha1", "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9")
-	client.registerArtifact("sha512", "374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7")
+// Internal data: Artifacts
+type artMap map[string]*artStruct
+type artStruct struct {
+	id          uint32
+	algorithm   string
+	digest      string
+	hashEquals  []uint32
+	occurrences []uint32
+}
+
+func (n *artStruct) getID() uint32 { return n.id }
+
+func registerAllArtifacts(c *demoClient) {
+	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+		Algorithm: "sha256",
+		Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+	})
+	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+		Algorithm: "sha1",
+		Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+	})
+	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+		Algorithm: "sha512",
+		Digest:    "374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7",
+	})
 }
 
 // Ingest Artifacts
 
-func (c *demoClient) registerArtifact(algorithm, digest string) *model.Artifact {
-	// enforce lowercase for both the algorithm and digest when ingesting
-	lowerCaseDigest := strings.ToLower(digest)
-	lowerCaseAlgorithm := strings.ToLower(algorithm)
+func (c *demoClient) IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error) {
+	algorithm := strings.ToLower(artifact.Algorithm)
+	digest := strings.ToLower(artifact.Digest)
+	a, err := c.artifactByKey(algorithm, digest)
 
-	for _, a := range c.artifacts {
-		if a.Digest == lowerCaseDigest && a.Algorithm == lowerCaseAlgorithm {
-			return a
+	if err != nil {
+		a = &artStruct{
+			id:        c.getNextID(),
+			algorithm: algorithm,
+			digest:    digest,
+		}
+		c.index[a.id] = a
+		c.artifacts[strings.Join([]string{algorithm, digest}, ":")] = a
+	}
+
+	return convArtifact(a), nil
+}
+
+func (c *demoClient) artifactByID(id uint32) (*artStruct, error) {
+	o, ok := c.index[id]
+	if !ok {
+		return nil, errors.New("could not find artifact")
+	}
+	a, ok := o.(*artStruct)
+	if !ok {
+		return nil, errors.New("not an artifact")
+	}
+	return a, nil
+}
+
+func (c *demoClient) artifactByKey(alg, dig string) (*artStruct, error) {
+	algorithm := strings.ToLower(alg)
+	digest := strings.ToLower(dig)
+	if a, ok := c.artifacts[strings.Join([]string{algorithm, digest}, ":")]; ok {
+		return a, nil
+	}
+	return nil, errors.New("artifact not found")
+}
+
+func (c *demoClient) artifactExact(artifactSpec *model.ArtifactSpec) (*artStruct, error) {
+	algorithm := strings.ToLower(nilToEmpty(artifactSpec.Algorithm))
+	digest := strings.ToLower(nilToEmpty(artifactSpec.Digest))
+
+	// If ID is provided, try to look up, then check if algo and digest match.
+	if artifactSpec.ID != nil {
+		id64, err := strconv.ParseUint(*artifactSpec.ID, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse id %w", err)
+		}
+		id := uint32(id64)
+		a, err := c.artifactByID(id)
+		if err != nil {
+			// Not found
+			return nil, nil
+		}
+		if algorithm != "" && algorithm != a.algorithm {
+			return nil, nil
+		}
+		if digest != "" && digest != a.digest {
+			return nil, nil
+		}
+		return a, nil
+	}
+
+	// If algo and digest are provided, try to lookup
+	if algorithm != "" && digest != "" {
+		if a, err := c.artifactByKey(algorithm, digest); err != nil {
+			return a, nil
 		}
 	}
-	newArtifact := &model.Artifact{
-		Digest:    lowerCaseDigest,
-		Algorithm: lowerCaseAlgorithm,
-	}
-	c.artifacts = append(c.artifacts, newArtifact)
-
-	return newArtifact
+	return nil, nil
 }
 
 // Query Artifacts
 
 func (c *demoClient) Artifacts(ctx context.Context, artifactSpec *model.ArtifactSpec) ([]*model.Artifact, error) {
-	var artifacts []*model.Artifact
+	a, err := c.artifactExact(artifactSpec)
+	if err != nil {
+		return nil, gqlerror.Errorf("Artifacts :: invalid spec %s", err)
+	}
+	if a != nil {
+		return []*model.Artifact{convArtifact(a)}, nil
+	}
 
-	// enforce lowercase for both the algorithm and digest when querying
+	algorithm := strings.ToLower(nilToEmpty(artifactSpec.Algorithm))
+	digest := strings.ToLower(nilToEmpty(artifactSpec.Digest))
+	var rv []*model.Artifact
 	for _, a := range c.artifacts {
-		matchDigest := false
-		if artifactSpec.Digest == nil {
-			matchDigest = true
-		} else if a.Digest == strings.ToLower(*artifactSpec.Digest) {
-			matchDigest = true
+		matchAlgorithm := false
+		if algorithm == "" || algorithm == a.algorithm {
+			matchAlgorithm = true
 		}
 
-		matchAlgorithm := false
-		if artifactSpec.Algorithm == nil {
-			matchAlgorithm = true
-		} else if a.Algorithm == strings.ToLower(*artifactSpec.Algorithm) {
-			matchAlgorithm = true
+		matchDigest := false
+		if digest == "" || digest == a.digest {
+			matchDigest = true
 		}
 
 		if matchDigest && matchAlgorithm {
-			artifacts = append(artifacts, a)
+			rv = append(rv, convArtifact(a))
 		}
 	}
-	return artifacts, nil
+	return rv, nil
 }
 
-func (c *demoClient) IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error) {
-	return c.registerArtifact(artifact.Algorithm, artifact.Digest), nil
+func convArtifact(a *artStruct) *model.Artifact {
+	return &model.Artifact{
+		ID:        fmt.Sprint(a.id),
+		Digest:    a.digest,
+		Algorithm: a.algorithm,
+	}
 }

--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -39,20 +39,21 @@ type artStruct struct {
 
 func (n *artStruct) getID() uint32 { return n.id }
 
-func registerAllArtifacts(c *demoClient) {
-	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
-		Algorithm: "sha256",
-		Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
-	})
-	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
-		Algorithm: "sha1",
-		Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
-	})
-	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
-		Algorithm: "sha512",
-		Digest:    "374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7",
-	})
-}
+// TODO convert to unit tests
+// func registerAllArtifacts(c *demoClient) {
+// 	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+// 		Algorithm: "sha256",
+// 		Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+// 	})
+// 	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+// 		Algorithm: "sha1",
+// 		Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+// 	})
+// 	c.IngestArtifact(context.Background(), &model.ArtifactInputSpec{
+// 		Algorithm: "sha512",
+// 		Digest:    "374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7",
+// 	})
+// }
 
 // Ingest Artifacts
 
@@ -111,12 +112,7 @@ func (c *demoClient) artifactExact(artifactSpec *model.ArtifactSpec) (*artStruct
 			// Not found
 			return nil, nil
 		}
-		if algorithm != "" && algorithm != a.algorithm {
-			return nil, nil
-		}
-		if digest != "" && digest != a.digest {
-			return nil, nil
-		}
+		// If found by id, ignore rest of fields in spec and return as a match
 		return a, nil
 	}
 

--- a/pkg/assembler/backends/testing/artifact.go
+++ b/pkg/assembler/backends/testing/artifact.go
@@ -165,7 +165,7 @@ func (c *demoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifact
 
 func convArtifact(a *artStruct) *model.Artifact {
 	return &model.Artifact{
-		ID:        fmt.Sprint(a.id),
+		ID:        nodeID(a.id),
 		Digest:    a.digest,
 		Algorithm: a.algorithm,
 	}

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -44,10 +44,7 @@ func (c *demoClient) getNextID() uint32 {
 }
 
 type demoClient struct {
-	artifacts           []*model.Artifact
 	builders            []*model.Builder
-	hashEquals          []*model.HashEqual
-	isOccurrence        []*model.IsOccurrence
 	hasSBOM             []*model.HasSbom
 	certifyPkg          []*model.CertifyPkg
 	certifyVuln         []*model.CertifyVuln
@@ -66,14 +63,14 @@ type demoClient struct {
 	hasSources          hasSrcList
 	isDependencies      isDependencyList
 	scorecards          scorecardList
+	artifacts           artMap
+	hashEquals          hashEqualList
+	occurrences         isOccurrenceList
 }
 
 func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 	client := &demoClient{
-		artifacts:           []*model.Artifact{},
 		builders:            []*model.Builder{},
-		hashEquals:          []*model.HashEqual{},
-		isOccurrence:        []*model.IsOccurrence{},
 		hasSBOM:             []*model.HasSbom{},
 		certifyPkg:          []*model.CertifyPkg{},
 		certifyVuln:         []*model.CertifyVuln{},
@@ -91,6 +88,9 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 		hasSources:          hasSrcList{},
 		isDependencies:      isDependencyList{},
 		scorecards:          scorecardList{},
+		artifacts:           artMap{},
+		hashEquals:          hashEqualList{},
+		occurrences:         isOccurrenceList{},
 	}
 	registerAllPackages(client)
 	registerAllSources(client)
@@ -98,6 +98,7 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 	registerAllGHSA(client)
 	registerAllOSV(client)
 	registerAllArtifacts(client)
+	registerAllHashEqual(client)
 	registerAllBuilders(client)
 
 	return client, nil
@@ -105,10 +106,7 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 
 func GetEmptyBackend(args backends.BackendArgs) (backends.Backend, error) {
 	client := &demoClient{
-		artifacts:           []*model.Artifact{},
 		builders:            []*model.Builder{},
-		hashEquals:          []*model.HashEqual{},
-		isOccurrence:        []*model.IsOccurrence{},
 		hasSBOM:             []*model.HasSbom{},
 		certifyPkg:          []*model.CertifyPkg{},
 		certifyVuln:         []*model.CertifyVuln{},
@@ -126,6 +124,9 @@ func GetEmptyBackend(args backends.BackendArgs) (backends.Backend, error) {
 		hasSources:          hasSrcList{},
 		isDependencies:      isDependencyList{},
 		scorecards:          scorecardList{},
+		artifacts:           artMap{},
+		hashEquals:          hashEqualList{},
+		occurrences:         isOccurrenceList{},
 	}
 	return client, nil
 }

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -97,8 +97,6 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 	registerAllCVE(client)
 	registerAllGHSA(client)
 	registerAllOSV(client)
-	registerAllArtifacts(client)
-	registerAllHashEqual(client)
 	registerAllBuilders(client)
 
 	return client, nil

--- a/pkg/assembler/backends/testing/hashEqual.go
+++ b/pkg/assembler/backends/testing/hashEqual.go
@@ -90,8 +90,8 @@ func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.Artifac
 	sort.Slice(artIDs, func(i, j int) bool { return artIDs[i] < artIDs[j] })
 
 	// Search backedges for existing.
-	searchHEs := slices.Clone(aInt1.hashEquals)
-	searchHEs = append(searchHEs, aInt2.hashEquals...)
+	searchHEs := slices.Clone(aInt1.getHashEquals())
+	searchHEs = append(searchHEs, aInt2.getHashEquals()...)
 
 	for _, he := range searchHEs {
 		h, err := c.hashEqualByID(he)
@@ -116,8 +116,8 @@ func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.Artifac
 	}
 	c.index[he.id] = he
 	c.hashEquals = append(c.hashEquals, he)
-	aInt1.hashEquals = append(aInt1.hashEquals, he.id)
-	aInt2.hashEquals = append(aInt2.hashEquals, he.id)
+	aInt1.setHashEquals(he.id)
+	aInt2.setHashEquals(he.id)
 
 	return c.convHashEqual(he), nil
 }

--- a/pkg/assembler/backends/testing/hashEqual.go
+++ b/pkg/assembler/backends/testing/hashEqual.go
@@ -18,7 +18,6 @@ package testing
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -208,7 +207,7 @@ func (c *demoClient) convHashEqual(h *hashEqualStruct) *model.HashEqual {
 		artifacts = append(artifacts, convArtifact(a))
 	}
 	return &model.HashEqual{
-		ID:            fmt.Sprint(h.id),
+		ID:            nodeID(h.id),
 		Justification: h.justification,
 		Artifacts:     artifacts,
 		Origin:        h.origin,

--- a/pkg/assembler/backends/testing/hashEqual.go
+++ b/pkg/assembler/backends/testing/hashEqual.go
@@ -42,25 +42,26 @@ type hashEqualStruct struct {
 
 func (n *hashEqualStruct) getID() uint32 { return n.id }
 
-func registerAllHashEqual(client *demoClient) {
-	// strings.ToLower(string(checksum.Algorithm)) + ":" + checksum.Value
-	//-client.registerHashEqual([]*model.Artifact{client.artifacts[0], client.artifacts[1], client.artifacts[2]}, "different algorithm for the same artifact", "testing backend", "testing backend")
-	client.IngestHashEqual(
-		context.Background(),
-		model.ArtifactInputSpec{
-			Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
-			Algorithm: "sha1",
-		},
-		model.ArtifactInputSpec{
-			Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
-			Algorithm: "sha256",
-		},
-		model.HashEqualInputSpec{
-			Justification: "these two are the same",
-			Origin:        "testing backend",
-			Collector:     "testing backend",
-		})
-}
+// TODO convert to unit tests
+// func registerAllHashEqual(client *demoClient) {
+// 	strings.ToLower(string(checksum.Algorithm)) + ":" + checksum.Value
+// 	-client.registerHashEqual([]*model.Artifact{client.artifacts[0], client.artifacts[1], client.artifacts[2]}, "different algorithm for the same artifact", "testing backend", "testing backend")
+// 	client.IngestHashEqual(
+// 		context.Background(),
+// 		model.ArtifactInputSpec{
+// 			Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+// 			Algorithm: "sha1",
+// 		},
+// 		model.ArtifactInputSpec{
+// 			Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+// 			Algorithm: "sha256",
+// 		},
+// 		model.HashEqualInputSpec{
+// 			Justification: "these two are the same",
+// 			Origin:        "testing backend",
+// 			Collector:     "testing backend",
+// 		})
+// }
 
 func (c *demoClient) hashEqualByID(id uint32) (*hashEqualStruct, error) {
 	o, ok := c.index[id]
@@ -180,17 +181,12 @@ func (c *demoClient) HashEqual(ctx context.Context, hSpec *model.HashEqualSpec) 
 			// Not found
 			return nil, nil
 		}
-		if noMatch(hSpec.Justification, h.justification) ||
-			noMatch(hSpec.Origin, h.origin) ||
-			noMatch(hSpec.Collector, h.collector) ||
-			!c.matchArtifacts(hSpec.Artifacts, h.artifacts) {
-			return nil, nil
-		}
+		// If found by id, ignore rest of fields in spec and return as a match
 		return []*model.HashEqual{c.convHashEqual(h)}, nil
 	}
 
 	var hashEquals []*model.HashEqual
-	//FIXME if any artifacts are exact matches only search those backedges
+	// TODO if any artifacts are exact matches only search those backedges
 	for _, h := range c.hashEquals {
 		if noMatch(hSpec.Justification, h.justification) ||
 			noMatch(hSpec.Origin, h.origin) ||
@@ -208,7 +204,7 @@ func (c *demoClient) convHashEqual(h *hashEqualStruct) *model.HashEqual {
 	var artifacts []*model.Artifact
 	for _, id := range h.artifacts {
 		a, _ := c.artifactByID(id)
-		//FIXME this will panic, if not found, but it should always be?
+		// TODO propagate error back
 		artifacts = append(artifacts, convArtifact(a))
 	}
 	return &model.HashEqual{

--- a/pkg/assembler/backends/testing/isDependency.go
+++ b/pkg/assembler/backends/testing/isDependency.go
@@ -76,8 +76,8 @@ func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgI
 		c.index[collectedIsDependencyLink.id] = &collectedIsDependencyLink
 		c.isDependencies = append(c.isDependencies, &collectedIsDependencyLink)
 		// set the backlinks
-		c.index[*packageID].(pkgNameOrVersion).setIsDependencyLink(collectedIsDependencyLink.id)
-		c.index[*depPackageID].(pkgNameOrVersion).setIsDependencyLink(collectedIsDependencyLink.id)
+		c.index[*packageID].(*pkgVersionNode).setIsDependencyLink(collectedIsDependencyLink.id)
+		c.index[*depPackageID].(*pkgVersionNode).setIsDependencyLink(collectedIsDependencyLink.id)
 	}
 
 	// build return GraphQL type

--- a/pkg/assembler/backends/testing/isOccurrence.go
+++ b/pkg/assembler/backends/testing/isOccurrence.go
@@ -18,7 +18,6 @@ package testing
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -164,7 +163,7 @@ func (c *demoClient) occurrenceByID(id uint32) (*isOccurrenceStruct, error) {
 func (c *demoClient) convOccurrence(in *isOccurrenceStruct) *model.IsOccurrence {
 	a, _ := c.artifactByID(in.artifact)
 	o := &model.IsOccurrence{
-		ID:            fmt.Sprint(in.id),
+		ID:            nodeID(in.id),
 		Artifact:      convArtifact(a),
 		Justification: in.justification,
 		Origin:        in.origin,

--- a/pkg/assembler/backends/testing/isOccurrence.go
+++ b/pkg/assembler/backends/testing/isOccurrence.go
@@ -97,11 +97,7 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 	packageID := maxUint32
 	if subject.Package != nil {
 		var pmt model.MatchFlags
-		if subject.Package.Version == nil {
-			pmt.Pkg = model.PkgMatchTypeAllVersions
-		} else {
-			pmt.Pkg = model.PkgMatchTypeSpecificVersion
-		}
+		pmt.Pkg = model.PkgMatchTypeSpecificVersion
 		pid, err := getPackageIDFromInput(c, *subject.Package, pmt)
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestOccurrence :: %v", err)
@@ -140,13 +136,13 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 		collector:     occurrence.Collector,
 	}
 	c.index[o.id] = o
-	a.occurrences = append(a.occurrences, o.id)
+	a.setOccurrences(o.id)
 	if packageID != maxUint32 {
-		p, _ := c.pkgByID(packageID)
+		p, _ := c.pkgVersionByID(packageID)
 		p.setOccurrenceLink(o.id)
 	} else {
 		s, _ := c.sourceByID(sourceID)
-		s.occurrences = append(s.occurrences, o.id)
+		s.setOccurrences(o.id)
 	}
 	c.occurrences = append(c.occurrences, o)
 

--- a/pkg/assembler/backends/testing/isOccurrence.go
+++ b/pkg/assembler/backends/testing/isOccurrence.go
@@ -45,43 +45,42 @@ type isOccurrenceStruct struct {
 
 func (n *isOccurrenceStruct) getID() uint32 { return n.id }
 
-func registerAllIsOccurrence(client *demoClient) error {
-	// TODO convert these
-	// // pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
-	// // "conan", "openssl.org", "openssl", "3.0.3", "", "user=bincrafters", "channel=stable"
-	// selectedType := "conan"
-	// selectedNameSpace := "openssl.org"
-	// selectedName := "openssl"
-	// selectedVersion := "3.0.3"
-	// qualifierA := "bincrafters"
-	// qualifierB := "stable"
-	// selectedQualifiers := []*model.PackageQualifierSpec{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
-	// selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Qualifiers: selectedQualifiers}
-	// selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
-	// if err != nil {
-	// 	return err
-	// }
-	// _, err = client.registerIsOccurrence(selectedPackage[0], nil, &model.Artifact{Digest: "5a787865sd676dacb0142afa0b83029cd7befd9", Algorithm: "sha1"}, "this artifact is an occurrence of this package", "testing backend", "testing backend")
-	// if err != nil {
-	// 	return err
-	// }
-	// // "git", "github", "github.com/guacsec/guac", "tag=v0.0.1"
-	// selectedSourceType := "git"
-	// selectedSourceNameSpace := "github"
-	// selectedSourceName := "github.com/guacsec/guac"
-	// selectedTag := "v0.0.1"
-	// selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
-	// //selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
-	// _, err = client.Sources(context.TODO(), selectedSourceSpec)
-	// if err != nil {
-	// 	return err
-	// }
-	// //_, err = client.registerIsOccurrence(nil, selectedSource[0], client.artifacts[0], "this artifact is an occurrence of this source", "testing backend", "testing backend")
-	// if err != nil {
-	// 	return err
-	// }
-	return nil
-}
+// TODO convert to unit tests
+// func registerAllIsOccurrence(client *demoClient) error {
+// 	// pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
+// 	// "conan", "openssl.org", "openssl", "3.0.3", "", "user=bincrafters", "channel=stable"
+// 	selectedType := "conan"
+// 	selectedNameSpace := "openssl.org"
+// 	selectedName := "openssl"
+// 	selectedVersion := "3.0.3"
+// 	qualifierA := "bincrafters"
+// 	qualifierB := "stable"
+// 	selectedQualifiers := []*model.PackageQualifierSpec{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
+// 	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Qualifiers: selectedQualifiers}
+// 	selectedPackage, err := client.Packages(context.TODO(), selectedPkgSpec)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	_, err = client.registerIsOccurrence(selectedPackage[0], nil, &model.Artifact{Digest: "5a787865sd676dacb0142afa0b83029cd7befd9", Algorithm: "sha1"}, "this artifact is an occurrence of this package", "testing backend", "testing backend")
+// 	if err != nil {
+// 		return err
+// 	}
+// 	// "git", "github", "github.com/guacsec/guac", "tag=v0.0.1"
+// 	selectedSourceType := "git"
+// 	selectedSourceNameSpace := "github"
+// 	selectedSourceName := "github.com/guacsec/guac"
+// 	selectedTag := "v0.0.1"
+// 	selectedSourceSpec := &model.SourceSpec{Type: &selectedSourceType, Namespace: &selectedSourceNameSpace, Name: &selectedSourceName, Tag: &selectedTag}
+// 	//selectedSource, err := client.Sources(context.TODO(), selectedSourceSpec)
+// 	_, err = client.Sources(context.TODO(), selectedSourceSpec)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	//_, err = client.registerIsOccurrence(nil, selectedSource[0], client.artifacts[0], "this artifact is an occurrence of this source", "testing backend", "testing backend")
+// 	if err != nil {
+// 		return err
+// 	}
+// }
 
 // Ingest IsOccurrence
 func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error) {
@@ -210,7 +209,7 @@ func (c *demoClient) IsOccurrence(ctx context.Context, ioSpec *model.IsOccurrenc
 	if err != nil {
 		return nil, err
 	}
-	// FIXME some code duplication here
+
 	if ioSpec.ID != nil {
 		id64, err := strconv.ParseUint(*ioSpec.ID, 10, 32)
 		if err != nil {
@@ -222,46 +221,12 @@ func (c *demoClient) IsOccurrence(ctx context.Context, ioSpec *model.IsOccurrenc
 			// Not found
 			return nil, nil
 		}
-		if noMatch(ioSpec.Justification, o.justification) ||
-			noMatch(ioSpec.Origin, o.origin) ||
-			noMatch(ioSpec.Collector, o.collector) {
-			// also check that subject and artifact match if provided
-			return nil, nil
-		}
-		if ioSpec.Artifact != nil && !c.artifactMatch(o.artifact, ioSpec.Artifact) {
-			return nil, nil
-		}
-		if ioSpec.Subject != nil {
-			if ioSpec.Subject.Package != nil {
-				if o.pkg == maxUint32 {
-					return nil, nil
-				}
-				p, err := c.buildPackageResponse(o.pkg, ioSpec.Subject.Package)
-				if err != nil {
-					return nil, err
-				}
-				if p == nil {
-					return nil, nil
-				}
-			} else if ioSpec.Subject.Source != nil {
-				if o.source == maxUint32 {
-					return nil, nil
-				}
-				s, err := c.buildSourceResponse(o.source, ioSpec.Subject.Source)
-				if err != nil {
-					return nil, err
-				}
-				if s == nil {
-					return nil, nil
-				}
-			}
-		}
-
+		// If found by id, ignore rest of fields in spec and return as a match
 		return []*model.IsOccurrence{c.convOccurrence(o)}, nil
 	}
 
 	var rv []*model.IsOccurrence
-	// FIXME if any of the pkg/src/artifact are specified, ony search those backedges
+	// TODO if any of the pkg/src/artifact are specified, ony search those backedges
 	for _, o := range c.occurrences {
 		if noMatch(ioSpec.Justification, o.justification) ||
 			noMatch(ioSpec.Origin, o.origin) ||

--- a/pkg/assembler/backends/testing/pkg.go
+++ b/pkg/assembler/backends/testing/pkg.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"log"
 	"reflect"
 	"strconv"
@@ -99,6 +100,7 @@ type pkgVersionStruct struct {
 	versions         pkgVersionList
 	srcMapLink       []uint32
 	isDependencyLink []uint32
+	occurrences      []uint32
 }
 type pkgVersionList []*pkgVersionNode
 type pkgVersionNode struct {
@@ -109,6 +111,7 @@ type pkgVersionNode struct {
 	qualifiers       map[string]string
 	srcMapLink       []uint32
 	isDependencyLink []uint32
+	occurrences      []uint32
 }
 
 // Be type safe, don't use any / interface{}
@@ -608,4 +611,18 @@ func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec)
 		}
 	}
 	return v
+}
+
+func (c *demoClient) pkgByID(id uint32) (*pkgVersionStruct, *pkgVersionNode, error) {
+	o, ok := c.index[id]
+	if !ok {
+		return nil, nil, errors.New("could not find source")
+	}
+	if a, ok := o.(*pkgVersionStruct); ok {
+		return a, nil, nil
+	}
+	if a, ok := o.(*pkgVersionNode); ok {
+		return nil, a, nil
+	}
+	return nil, nil, errors.New("not a source")
 }

--- a/pkg/assembler/backends/testing/pkg.go
+++ b/pkg/assembler/backends/testing/pkg.go
@@ -121,6 +121,8 @@ type pkgNameOrVersion interface {
 	getSrcMapLink() []uint32
 	setIsDependencyLink(id uint32)
 	getIsDependencyLink() []uint32
+	setOccurrenceLink(id uint32)
+	getOccurrenceLink() []uint32
 }
 
 func (n *pkgNamespaceStruct) getID() uint32 { return n.id }
@@ -146,6 +148,11 @@ func (p *pkgVersionNode) setIsDependencyLink(id uint32) {
 }
 func (p *pkgVersionStruct) getIsDependencyLink() []uint32 { return p.isDependencyLink }
 func (p *pkgVersionNode) getIsDependencyLink() []uint32   { return p.isDependencyLink }
+
+func (p *pkgVersionStruct) setOccurrenceLink(id uint32) { p.occurrences = append(p.occurrences, id) }
+func (p *pkgVersionNode) setOccurrenceLink(id uint32)   { p.occurrences = append(p.occurrences, id) }
+func (p *pkgVersionStruct) getOccurrenceLink() []uint32 { return p.occurrences }
+func (p *pkgVersionNode) getOccurrenceLink() []uint32   { return p.occurrences }
 
 // Ingest Package
 func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec) (*model.Package, error) {
@@ -613,16 +620,16 @@ func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec)
 	return v
 }
 
-func (c *demoClient) pkgByID(id uint32) (*pkgVersionStruct, *pkgVersionNode, error) {
+func (c *demoClient) pkgByID(id uint32) (pkgNameOrVersion, error) {
 	o, ok := c.index[id]
 	if !ok {
-		return nil, nil, errors.New("could not find source")
+		return nil, errors.New("could not find pkg")
 	}
 	if a, ok := o.(*pkgVersionStruct); ok {
-		return a, nil, nil
+		return a, nil
 	}
 	if a, ok := o.(*pkgVersionNode); ok {
-		return nil, a, nil
+		return a, nil
 	}
-	return nil, nil, errors.New("not a source")
+	return nil, errors.New("not a pkg")
 }

--- a/pkg/assembler/backends/testing/pkg.go
+++ b/pkg/assembler/backends/testing/pkg.go
@@ -94,13 +94,11 @@ type pkgNameStruct struct {
 }
 type pkgNameMap map[string]*pkgVersionStruct
 type pkgVersionStruct struct {
-	id               uint32
-	parent           uint32
-	name             string
-	versions         pkgVersionList
-	srcMapLink       []uint32
-	isDependencyLink []uint32
-	occurrences      []uint32
+	id         uint32
+	parent     uint32
+	name       string
+	versions   pkgVersionList
+	srcMapLink []uint32
 }
 type pkgVersionList []*pkgVersionNode
 type pkgVersionNode struct {
@@ -119,10 +117,6 @@ type pkgNameOrVersion interface {
 	implementsPkgNameOrVersion()
 	setSrcMapLink(id uint32)
 	getSrcMapLink() []uint32
-	setIsDependencyLink(id uint32)
-	getIsDependencyLink() []uint32
-	setOccurrenceLink(id uint32)
-	getOccurrenceLink() []uint32
 }
 
 func (n *pkgNamespaceStruct) getID() uint32 { return n.id }
@@ -140,19 +134,13 @@ func (p *pkgVersionStruct) getSrcMapLink() []uint32 { return p.srcMapLink }
 func (p *pkgVersionNode) getSrcMapLink() []uint32   { return p.srcMapLink }
 
 // isDependency back edges
-func (p *pkgVersionStruct) setIsDependencyLink(id uint32) {
-	p.isDependencyLink = append(p.isDependencyLink, id)
-}
 func (p *pkgVersionNode) setIsDependencyLink(id uint32) {
 	p.isDependencyLink = append(p.isDependencyLink, id)
 }
-func (p *pkgVersionStruct) getIsDependencyLink() []uint32 { return p.isDependencyLink }
-func (p *pkgVersionNode) getIsDependencyLink() []uint32   { return p.isDependencyLink }
+func (p *pkgVersionNode) getIsDependencyLink() []uint32 { return p.isDependencyLink }
 
-func (p *pkgVersionStruct) setOccurrenceLink(id uint32) { p.occurrences = append(p.occurrences, id) }
-func (p *pkgVersionNode) setOccurrenceLink(id uint32)   { p.occurrences = append(p.occurrences, id) }
-func (p *pkgVersionStruct) getOccurrenceLink() []uint32 { return p.occurrences }
-func (p *pkgVersionNode) getOccurrenceLink() []uint32   { return p.occurrences }
+func (p *pkgVersionNode) setOccurrenceLink(id uint32) { p.occurrences = append(p.occurrences, id) }
+func (p *pkgVersionNode) getOccurrenceLink() []uint32 { return p.occurrences }
 
 // Ingest Package
 func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec) (*model.Package, error) {
@@ -182,12 +170,11 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 	versionStruct, hasVersions := names[input.Name]
 	if !hasVersions {
 		versionStruct = &pkgVersionStruct{
-			id:               c.getNextID(),
-			parent:           namesStruct.id,
-			name:             input.Name,
-			versions:         pkgVersionList{},
-			srcMapLink:       []uint32{},
-			isDependencyLink: []uint32{},
+			id:         c.getNextID(),
+			parent:     namesStruct.id,
+			name:       input.Name,
+			versions:   pkgVersionList{},
+			srcMapLink: []uint32{},
 		}
 		c.index[versionStruct.id] = versionStruct
 	}
@@ -620,13 +607,10 @@ func filterQualifiersAndSubpath(v *model.PackageVersion, pkgSpec *model.PkgSpec)
 	return v
 }
 
-func (c *demoClient) pkgByID(id uint32) (pkgNameOrVersion, error) {
+func (c *demoClient) pkgVersionByID(id uint32) (*pkgVersionNode, error) {
 	o, ok := c.index[id]
 	if !ok {
 		return nil, errors.New("could not find pkg")
-	}
-	if a, ok := o.(*pkgVersionStruct); ok {
-		return a, nil
 	}
 	if a, ok := o.(*pkgVersionNode); ok {
 		return a, nil

--- a/pkg/assembler/backends/testing/src.go
+++ b/pkg/assembler/backends/testing/src.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strconv"
 
@@ -81,6 +82,7 @@ type srcNameNode struct {
 	commit        string
 	srcMapLink    []uint32
 	scorecardLink []uint32
+	occurrences   []uint32
 }
 
 func (n *srcNamespaceStruct) getID() uint32 { return n.id }
@@ -438,4 +440,16 @@ func matchInputSpecWithDBField(spec *string, dbField *string) bool {
 	}
 
 	return (dbField != nil && *dbField == *spec)
+}
+
+func (c *demoClient) sourceByID(id uint32) (*srcNameNode, error) {
+	o, ok := c.index[id]
+	if !ok {
+		return nil, errors.New("could not find source")
+	}
+	a, ok := o.(*srcNameNode)
+	if !ok {
+		return nil, errors.New("not a source")
+	}
+	return a, nil
 }

--- a/pkg/assembler/backends/testing/src.go
+++ b/pkg/assembler/backends/testing/src.go
@@ -97,6 +97,9 @@ func (p *srcNameNode) getSrcMapLink() []uint32 { return p.srcMapLink }
 func (p *srcNameNode) setScorecardLink(id uint32) { p.scorecardLink = append(p.scorecardLink, id) }
 func (p *srcNameNode) getScorecardLink() []uint32 { return p.scorecardLink }
 
+func (p *srcNameNode) setOccurrences(id uint32) { p.occurrences = append(p.occurrences, id) }
+func (p *srcNameNode) getOccurrences() []uint32 { return p.occurrences }
+
 // Ingest Source
 func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSpec) (*model.Source, error) {
 	namespacesStruct, hasNamespace := c.sources[input.Type]

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -59,6 +59,9 @@ type CertifyBadArtifactIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns CertifyBadArtifactIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *CertifyBadArtifactIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns CertifyBadArtifactIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *CertifyBadArtifactIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -91,6 +94,8 @@ func (v *CertifyBadArtifactIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalCertifyBadArtifactIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -107,6 +112,7 @@ func (v *CertifyBadArtifactIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *CertifyBadArtifactIngestArtifact) __premarshalJSON() (*__premarshalCertifyBadArtifactIngestArtifact, error) {
 	var retval __premarshalCertifyBadArtifactIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -2334,6 +2340,9 @@ type HashEqualArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns HashEqualArtifact.Id, and is useful for accessing the field via an interface.
+func (v *HashEqualArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns HashEqualArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *HashEqualArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -2366,6 +2375,8 @@ func (v *HashEqualArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalHashEqualArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -2382,6 +2393,7 @@ func (v *HashEqualArtifact) MarshalJSON() ([]byte, error) {
 func (v *HashEqualArtifact) __premarshalJSON() (*__premarshalHashEqualArtifact, error) {
 	var retval __premarshalHashEqualArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -2400,6 +2412,9 @@ func (v *HashEqualArtifact) __premarshalJSON() (*__premarshalHashEqualArtifact, 
 type HashEqualEqualArtifact struct {
 	allArtifactTree `json:"-"`
 }
+
+// GetId returns HashEqualEqualArtifact.Id, and is useful for accessing the field via an interface.
+func (v *HashEqualEqualArtifact) GetId() string { return v.allArtifactTree.Id }
 
 // GetAlgorithm returns HashEqualEqualArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *HashEqualEqualArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
@@ -2433,6 +2448,8 @@ func (v *HashEqualEqualArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalHashEqualEqualArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -2449,6 +2466,7 @@ func (v *HashEqualEqualArtifact) MarshalJSON() ([]byte, error) {
 func (v *HashEqualEqualArtifact) __premarshalJSON() (*__premarshalHashEqualEqualArtifact, error) {
 	var retval __premarshalHashEqualEqualArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -2466,6 +2484,9 @@ func (v *HashEqualEqualArtifact) __premarshalJSON() (*__premarshalHashEqualEqual
 type HashEqualIngestHashEqual struct {
 	allHashEqualTree `json:"-"`
 }
+
+// GetId returns HashEqualIngestHashEqual.Id, and is useful for accessing the field via an interface.
+func (v *HashEqualIngestHashEqual) GetId() string { return v.allHashEqualTree.Id }
 
 // GetJustification returns HashEqualIngestHashEqual.Justification, and is useful for accessing the field via an interface.
 func (v *HashEqualIngestHashEqual) GetJustification() string { return v.allHashEqualTree.Justification }
@@ -2507,6 +2528,8 @@ func (v *HashEqualIngestHashEqual) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalHashEqualIngestHashEqual struct {
+	Id string `json:"id"`
+
 	Justification string `json:"justification"`
 
 	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
@@ -2527,6 +2550,7 @@ func (v *HashEqualIngestHashEqual) MarshalJSON() ([]byte, error) {
 func (v *HashEqualIngestHashEqual) __premarshalJSON() (*__premarshalHashEqualIngestHashEqual, error) {
 	var retval __premarshalHashEqualIngestHashEqual
 
+	retval.Id = v.allHashEqualTree.Id
 	retval.Justification = v.allHashEqualTree.Justification
 	retval.Artifacts = v.allHashEqualTree.Artifacts
 	retval.Origin = v.allHashEqualTree.Origin
@@ -2918,6 +2942,9 @@ type IsOccurrencePkgIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns IsOccurrencePkgIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *IsOccurrencePkgIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns IsOccurrencePkgIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *IsOccurrencePkgIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -2950,6 +2977,8 @@ func (v *IsOccurrencePkgIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalIsOccurrencePkgIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -2966,6 +2995,7 @@ func (v *IsOccurrencePkgIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *IsOccurrencePkgIngestArtifact) __premarshalJSON() (*__premarshalIsOccurrencePkgIngestArtifact, error) {
 	var retval __premarshalIsOccurrencePkgIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -2980,6 +3010,11 @@ func (v *IsOccurrencePkgIngestArtifact) __premarshalJSON() (*__premarshalIsOccur
 // Attestation must occur at the PackageVersion or at the SourceName.
 type IsOccurrencePkgIngestOccurrenceIsOccurrence struct {
 	allIsOccurrencesTree `json:"-"`
+}
+
+// GetId returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Id, and is useful for accessing the field via an interface.
+func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetId() string {
+	return v.allIsOccurrencesTree.Id
 }
 
 // GetSubject returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Subject, and is useful for accessing the field via an interface.
@@ -3033,6 +3068,8 @@ func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) UnmarshalJSON(b []byte) er
 }
 
 type __premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence struct {
+	Id string `json:"id"`
+
 	Subject json.RawMessage `json:"subject"`
 
 	Artifact allIsOccurrencesTreeArtifact `json:"artifact"`
@@ -3055,6 +3092,7 @@ func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) MarshalJSON() ([]byte, err
 func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence, error) {
 	var retval __premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence
 
+	retval.Id = v.allIsOccurrencesTree.Id
 	{
 
 		dst := &retval.Subject
@@ -3193,6 +3231,9 @@ type IsOccurrenceSrcIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns IsOccurrenceSrcIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSrcIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns IsOccurrenceSrcIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *IsOccurrenceSrcIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -3225,6 +3266,8 @@ func (v *IsOccurrenceSrcIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalIsOccurrenceSrcIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -3241,6 +3284,7 @@ func (v *IsOccurrenceSrcIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *IsOccurrenceSrcIngestArtifact) __premarshalJSON() (*__premarshalIsOccurrenceSrcIngestArtifact, error) {
 	var retval __premarshalIsOccurrenceSrcIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -3255,6 +3299,11 @@ func (v *IsOccurrenceSrcIngestArtifact) __premarshalJSON() (*__premarshalIsOccur
 // Attestation must occur at the PackageVersion or at the SourceName.
 type IsOccurrenceSrcIngestOccurrenceIsOccurrence struct {
 	allIsOccurrencesTree `json:"-"`
+}
+
+// GetId returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Id, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetId() string {
+	return v.allIsOccurrencesTree.Id
 }
 
 // GetSubject returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Subject, and is useful for accessing the field via an interface.
@@ -3308,6 +3357,8 @@ func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) UnmarshalJSON(b []byte) er
 }
 
 type __premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence struct {
+	Id string `json:"id"`
+
 	Subject json.RawMessage `json:"subject"`
 
 	Artifact allIsOccurrencesTreeArtifact `json:"artifact"`
@@ -3330,6 +3381,7 @@ func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) MarshalJSON() ([]byte, err
 func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence, error) {
 	var retval __premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence
 
+	retval.Id = v.allIsOccurrencesTree.Id
 	{
 
 		dst := &retval.Subject
@@ -4099,6 +4151,9 @@ type SLSAForArtifactIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns SLSAForArtifactIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns SLSAForArtifactIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *SLSAForArtifactIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -4131,6 +4186,8 @@ func (v *SLSAForArtifactIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalSLSAForArtifactIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -4147,6 +4204,7 @@ func (v *SLSAForArtifactIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *SLSAForArtifactIngestArtifact) __premarshalJSON() (*__premarshalSLSAForArtifactIngestArtifact, error) {
 	var retval __premarshalSLSAForArtifactIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -4182,6 +4240,9 @@ type SLSAForArtifactIngestMaterialsArtifact struct {
 
 // GetTypename returns SLSAForArtifactIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *SLSAForArtifactIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns SLSAForArtifactIngestMaterialsArtifact.Id, and is useful for accessing the field via an interface.
+func (v *SLSAForArtifactIngestMaterialsArtifact) GetId() string { return v.allArtifactTree.Id }
 
 // GetAlgorithm returns SLSAForArtifactIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *SLSAForArtifactIngestMaterialsArtifact) GetAlgorithm() string {
@@ -4219,6 +4280,8 @@ func (v *SLSAForArtifactIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalSLSAForArtifactIngestMaterialsArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -4236,6 +4299,7 @@ func (v *SLSAForArtifactIngestMaterialsArtifact) __premarshalJSON() (*__premarsh
 	var retval __premarshalSLSAForArtifactIngestMaterialsArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -4743,6 +4807,9 @@ type SLSAForPackageIngestMaterialsArtifact struct {
 // GetTypename returns SLSAForPackageIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *SLSAForPackageIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns SLSAForPackageIngestMaterialsArtifact.Id, and is useful for accessing the field via an interface.
+func (v *SLSAForPackageIngestMaterialsArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns SLSAForPackageIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *SLSAForPackageIngestMaterialsArtifact) GetAlgorithm() string {
 	return v.allArtifactTree.Algorithm
@@ -4779,6 +4846,8 @@ func (v *SLSAForPackageIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalSLSAForPackageIngestMaterialsArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -4796,6 +4865,7 @@ func (v *SLSAForPackageIngestMaterialsArtifact) __premarshalJSON() (*__premarsha
 	var retval __premarshalSLSAForPackageIngestMaterialsArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -5381,6 +5451,9 @@ type SLSAForSourceIngestMaterialsArtifact struct {
 // GetTypename returns SLSAForSourceIngestMaterialsArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *SLSAForSourceIngestMaterialsArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns SLSAForSourceIngestMaterialsArtifact.Id, and is useful for accessing the field via an interface.
+func (v *SLSAForSourceIngestMaterialsArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns SLSAForSourceIngestMaterialsArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *SLSAForSourceIngestMaterialsArtifact) GetAlgorithm() string {
 	return v.allArtifactTree.Algorithm
@@ -5417,6 +5490,8 @@ func (v *SLSAForSourceIngestMaterialsArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalSLSAForSourceIngestMaterialsArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -5434,6 +5509,7 @@ func (v *SLSAForSourceIngestMaterialsArtifact) __premarshalJSON() (*__premarshal
 	var retval __premarshalSLSAForSourceIngestMaterialsArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -6578,6 +6654,9 @@ type VexArtifactAndCveIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns VexArtifactAndCveIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *VexArtifactAndCveIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns VexArtifactAndCveIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -6610,6 +6689,8 @@ func (v *VexArtifactAndCveIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalVexArtifactAndCveIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -6626,6 +6707,7 @@ func (v *VexArtifactAndCveIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *VexArtifactAndCveIngestArtifact) __premarshalJSON() (*__premarshalVexArtifactAndCveIngestArtifact, error) {
 	var retval __premarshalVexArtifactAndCveIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -6867,6 +6949,9 @@ type VexArtifactAndGhsaIngestArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns VexArtifactAndGhsaIngestArtifact.Id, and is useful for accessing the field via an interface.
+func (v *VexArtifactAndGhsaIngestArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns VexArtifactAndGhsaIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -6899,6 +6984,8 @@ func (v *VexArtifactAndGhsaIngestArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalVexArtifactAndGhsaIngestArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -6915,6 +7002,7 @@ func (v *VexArtifactAndGhsaIngestArtifact) MarshalJSON() ([]byte, error) {
 func (v *VexArtifactAndGhsaIngestArtifact) __premarshalJSON() (*__premarshalVexArtifactAndGhsaIngestArtifact, error) {
 	var retval __premarshalVexArtifactAndGhsaIngestArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -7889,9 +7977,13 @@ func (v *__VexPackageAndCveInput) GetVexStatement() VexStatementInputSpec { retu
 // `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
 // `checksum.Value`.
 type allArtifactTree struct {
+	Id        string `json:"id"`
 	Algorithm string `json:"algorithm"`
 	Digest    string `json:"digest"`
 }
+
+// GetId returns allArtifactTree.Id, and is useful for accessing the field via an interface.
+func (v *allArtifactTree) GetId() string { return v.Id }
 
 // GetAlgorithm returns allArtifactTree.Algorithm, and is useful for accessing the field via an interface.
 func (v *allArtifactTree) GetAlgorithm() string { return v.Algorithm }
@@ -8005,6 +8097,9 @@ type allCertifyBadSubjectArtifact struct {
 // GetTypename returns allCertifyBadSubjectArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *allCertifyBadSubjectArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns allCertifyBadSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allCertifyBadSubjectArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns allCertifyBadSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allCertifyBadSubjectArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -8039,6 +8134,8 @@ func (v *allCertifyBadSubjectArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalallCertifyBadSubjectArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -8056,6 +8153,7 @@ func (v *allCertifyBadSubjectArtifact) __premarshalJSON() (*__premarshalallCerti
 	var retval __premarshalallCertifyBadSubjectArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -8780,6 +8878,9 @@ type allCertifyVEXStatementSubjectArtifact struct {
 // GetTypename returns allCertifyVEXStatementSubjectArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *allCertifyVEXStatementSubjectArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns allCertifyVEXStatementSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allCertifyVEXStatementSubjectArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns allCertifyVEXStatementSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allCertifyVEXStatementSubjectArtifact) GetAlgorithm() string {
 	return v.allArtifactTree.Algorithm
@@ -8816,6 +8917,8 @@ func (v *allCertifyVEXStatementSubjectArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalallCertifyVEXStatementSubjectArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -8833,6 +8936,7 @@ func (v *allCertifyVEXStatementSubjectArtifact) __premarshalJSON() (*__premarsha
 	var retval __premarshalallCertifyVEXStatementSubjectArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -10437,11 +10541,15 @@ func (v *allHasSourceAtSource) __premarshalJSON() (*__premarshalallHasSourceAtSo
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type allHashEqualTree struct {
+	Id            string                              `json:"id"`
 	Justification string                              `json:"justification"`
 	Artifacts     []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
 	Origin        string                              `json:"origin"`
 	Collector     string                              `json:"collector"`
 }
+
+// GetId returns allHashEqualTree.Id, and is useful for accessing the field via an interface.
+func (v *allHashEqualTree) GetId() string { return v.Id }
 
 // GetJustification returns allHashEqualTree.Justification, and is useful for accessing the field via an interface.
 func (v *allHashEqualTree) GetJustification() string { return v.Justification }
@@ -10468,6 +10576,9 @@ func (v *allHashEqualTree) GetCollector() string { return v.Collector }
 type allHashEqualTreeArtifactsArtifact struct {
 	allArtifactTree `json:"-"`
 }
+
+// GetId returns allHashEqualTreeArtifactsArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allHashEqualTreeArtifactsArtifact) GetId() string { return v.allArtifactTree.Id }
 
 // GetAlgorithm returns allHashEqualTreeArtifactsArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allHashEqualTreeArtifactsArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
@@ -10501,6 +10612,8 @@ func (v *allHashEqualTreeArtifactsArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalallHashEqualTreeArtifactsArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -10517,6 +10630,7 @@ func (v *allHashEqualTreeArtifactsArtifact) MarshalJSON() ([]byte, error) {
 func (v *allHashEqualTreeArtifactsArtifact) __premarshalJSON() (*__premarshalallHashEqualTreeArtifactsArtifact, error) {
 	var retval __premarshalallHashEqualTreeArtifactsArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -10734,6 +10848,7 @@ func (v *allIsDependencyTreePackage) __premarshalJSON() (*__premarshalallIsDepen
 // Note: Package or Source must be specified but not both at the same time.
 // Attestation must occur at the PackageVersion or at the SourceName.
 type allIsOccurrencesTree struct {
+	Id string `json:"id"`
 	// subject - union type that can be either a package or source object type
 	Subject allIsOccurrencesTreeSubjectPackageOrSource `json:"-"`
 	// artifact (object) - artifact that represent the the package or source
@@ -10745,6 +10860,9 @@ type allIsOccurrencesTree struct {
 	// collector (property) - the GUAC collector that collected the document that generated this attestation
 	Collector string `json:"collector"`
 }
+
+// GetId returns allIsOccurrencesTree.Id, and is useful for accessing the field via an interface.
+func (v *allIsOccurrencesTree) GetId() string { return v.Id }
 
 // GetSubject returns allIsOccurrencesTree.Subject, and is useful for accessing the field via an interface.
 func (v *allIsOccurrencesTree) GetSubject() allIsOccurrencesTreeSubjectPackageOrSource {
@@ -10797,6 +10915,8 @@ func (v *allIsOccurrencesTree) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalallIsOccurrencesTree struct {
+	Id string `json:"id"`
+
 	Subject json.RawMessage `json:"subject"`
 
 	Artifact allIsOccurrencesTreeArtifact `json:"artifact"`
@@ -10819,6 +10939,7 @@ func (v *allIsOccurrencesTree) MarshalJSON() ([]byte, error) {
 func (v *allIsOccurrencesTree) __premarshalJSON() (*__premarshalallIsOccurrencesTree, error) {
 	var retval __premarshalallIsOccurrencesTree
 
+	retval.Id = v.Id
 	{
 
 		dst := &retval.Subject
@@ -10852,6 +10973,9 @@ type allIsOccurrencesTreeArtifact struct {
 	allArtifactTree `json:"-"`
 }
 
+// GetId returns allIsOccurrencesTreeArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allIsOccurrencesTreeArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns allIsOccurrencesTreeArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allIsOccurrencesTreeArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -10884,6 +11008,8 @@ func (v *allIsOccurrencesTreeArtifact) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalallIsOccurrencesTreeArtifact struct {
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -10900,6 +11026,7 @@ func (v *allIsOccurrencesTreeArtifact) MarshalJSON() ([]byte, error) {
 func (v *allIsOccurrencesTreeArtifact) __premarshalJSON() (*__premarshalallIsOccurrencesTreeArtifact, error) {
 	var retval __premarshalallIsOccurrencesTreeArtifact
 
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -12046,6 +12173,9 @@ type allSLSATreeSlsaSLSABuiltFromArtifact struct {
 // GetTypename returns allSLSATreeSlsaSLSABuiltFromArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns allSLSATreeSlsaSLSABuiltFromArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns allSLSATreeSlsaSLSABuiltFromArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetAlgorithm() string {
 	return v.allArtifactTree.Algorithm
@@ -12082,6 +12212,8 @@ func (v *allSLSATreeSlsaSLSABuiltFromArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalallSLSATreeSlsaSLSABuiltFromArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -12099,6 +12231,7 @@ func (v *allSLSATreeSlsaSLSABuiltFromArtifact) __premarshalJSON() (*__premarshal
 	var retval __premarshalallSLSATreeSlsaSLSABuiltFromArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -12436,6 +12569,9 @@ type allSLSATreeSubjectArtifact struct {
 // GetTypename returns allSLSATreeSubjectArtifact.Typename, and is useful for accessing the field via an interface.
 func (v *allSLSATreeSubjectArtifact) GetTypename() *string { return v.Typename }
 
+// GetId returns allSLSATreeSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *allSLSATreeSubjectArtifact) GetId() string { return v.allArtifactTree.Id }
+
 // GetAlgorithm returns allSLSATreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
 func (v *allSLSATreeSubjectArtifact) GetAlgorithm() string { return v.allArtifactTree.Algorithm }
 
@@ -12470,6 +12606,8 @@ func (v *allSLSATreeSubjectArtifact) UnmarshalJSON(b []byte) error {
 type __premarshalallSLSATreeSubjectArtifact struct {
 	Typename *string `json:"__typename"`
 
+	Id string `json:"id"`
+
 	Algorithm string `json:"algorithm"`
 
 	Digest string `json:"digest"`
@@ -12487,6 +12625,7 @@ func (v *allSLSATreeSubjectArtifact) __premarshalJSON() (*__premarshalallSLSATre
 	var retval __premarshalallSLSATreeSubjectArtifact
 
 	retval.Typename = v.Typename
+	retval.Id = v.allArtifactTree.Id
 	retval.Algorithm = v.allArtifactTree.Algorithm
 	retval.Digest = v.allArtifactTree.Digest
 	return &retval, nil
@@ -12864,6 +13003,7 @@ mutation CertifyBadArtifact ($artifact: ArtifactInputSpec!, $certifyBad: Certify
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -13006,6 +13146,7 @@ fragment allSourceTree on Source {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -13098,6 +13239,7 @@ fragment allPkgTree on Package {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -13811,10 +13953,12 @@ mutation HashEqual ($artifact: ArtifactInputSpec!, $equalArtifact: ArtifactInput
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
 fragment allHashEqualTree on HashEqual {
+	id
 	justification
 	artifacts {
 		... allArtifactTree
@@ -13962,10 +14106,12 @@ fragment allPkgTree on Package {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
 fragment allIsOccurrencesTree on IsOccurrence {
+	id
 	subject {
 		__typename
 		... on Package {
@@ -14053,10 +14199,12 @@ fragment allSourceTree on Source {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
 fragment allIsOccurrencesTree on IsOccurrence {
+	id
 	subject {
 		__typename
 		... on Package {
@@ -14312,6 +14460,7 @@ mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $materials: [PackageSou
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -14483,6 +14632,7 @@ fragment allSourceTree on Source {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -14619,6 +14769,7 @@ fragment allPkgTree on Package {
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -14828,6 +14979,7 @@ fragment allCertifyVEXStatement on CertifyVEXStatement {
 	collector
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -14882,6 +15034,7 @@ mutation VexArtifactAndCve ($artifact: ArtifactInputSpec!, $cve: CVEInputSpec!, 
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -14988,6 +15141,7 @@ mutation VexArtifactAndGhsa ($artifact: ArtifactInputSpec!, $ghsa: GHSAInputSpec
 	}
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }
@@ -15147,6 +15301,7 @@ fragment allCertifyVEXStatement on CertifyVEXStatement {
 	collector
 }
 fragment allArtifactTree on Artifact {
+	id
 	algorithm
 	digest
 }

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -57,6 +57,7 @@ fragment allSourceTree on Source {
 }
 
 fragment allArtifactTree on Artifact {
+  id
   algorithm
   digest
 }
@@ -106,6 +107,7 @@ fragment allCertifyScorecard on CertifyScorecard {
 }
 
 fragment allIsOccurrencesTree on IsOccurrence {
+  id
   subject {
     __typename
     ...on Package {
@@ -196,6 +198,7 @@ fragment allCertifyBad on CertifyBad {
 }
 
 fragment allHashEqualTree on HashEqual {
+  id
   justification
   artifacts {
     ...allArtifactTree

--- a/pkg/assembler/graphql/examples/artifact_builder.gql
+++ b/pkg/assembler/graphql/examples/artifact_builder.gql
@@ -1,4 +1,5 @@
 fragment allArtifactTree on Artifact {
+  id
   algorithm
   digest
 }

--- a/pkg/assembler/graphql/examples/hash_equal.gql
+++ b/pkg/assembler/graphql/examples/hash_equal.gql
@@ -1,6 +1,8 @@
 fragment allHashEqualTree on HashEqual {
+  id
   justification
   artifacts {
+    id
     algorithm
     digest
   }

--- a/pkg/assembler/graphql/examples/is_occurence.gql
+++ b/pkg/assembler/graphql/examples/is_occurence.gql
@@ -1,13 +1,18 @@
 fragment allIsOccurrencesTree on IsOccurrence {
+  id
   subject {
     __typename
     ... on Package {
+      id
       type
       namespaces {
+        id
         namespace
         names {
+          id
           name
           versions {
+            id
             version
             qualifiers {
               key
@@ -19,10 +24,13 @@ fragment allIsOccurrencesTree on IsOccurrence {
       }
     }
    ...on Source {
+      id
       type
       namespaces {
+        id
         namespace
         names {
+          id
           name
           tag
           commit
@@ -31,6 +39,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
     }
   }
   artifact {
+    id
     algorithm
     digest
   }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -890,6 +890,50 @@ func (ec *executionContext) field_Query_sources_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _Artifact_id(ctx context.Context, field graphql.CollectedField, obj *model.Artifact) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Artifact_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Artifact_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Artifact",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Artifact_algorithm(ctx context.Context, field graphql.CollectedField, obj *model.Artifact) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Artifact_algorithm(ctx, field)
 	if err != nil {
@@ -1017,6 +1061,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestArtifact(ctx context.Con
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Artifact_id(ctx, field)
 			case "algorithm":
 				return ec.fieldContext_Artifact_algorithm(ctx, field)
 			case "digest":
@@ -1838,6 +1884,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestHashEqual(ctx context.Co
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_HashEqual_id(ctx, field)
 			case "artifacts":
 				return ec.fieldContext_HashEqual_artifacts(ctx, field)
 			case "justification":
@@ -1974,6 +2022,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestOccurrence(ctx context.C
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsOccurrence_id(ctx, field)
 			case "subject":
 				return ec.fieldContext_IsOccurrence_subject(ctx, field)
 			case "artifact":
@@ -2295,6 +2345,8 @@ func (ec *executionContext) fieldContext_Query_artifacts(ctx context.Context, fi
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Artifact_id(ctx, field)
 			case "algorithm":
 				return ec.fieldContext_Artifact_algorithm(ctx, field)
 			case "digest":
@@ -3061,6 +3113,8 @@ func (ec *executionContext) fieldContext_Query_HashEqual(ctx context.Context, fi
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_HashEqual_id(ctx, field)
 			case "artifacts":
 				return ec.fieldContext_HashEqual_artifacts(ctx, field)
 			case "justification":
@@ -3197,6 +3251,8 @@ func (ec *executionContext) fieldContext_Query_IsOccurrence(ctx context.Context,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsOccurrence_id(ctx, field)
 			case "subject":
 				return ec.fieldContext_IsOccurrence_subject(ctx, field)
 			case "artifact":
@@ -3655,13 +3711,21 @@ func (ec *executionContext) unmarshalInputArtifactSpec(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"algorithm", "digest"}
+	fieldsInOrder := [...]string{"id", "algorithm", "digest"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "algorithm":
 			var err error
 
@@ -3702,6 +3766,13 @@ func (ec *executionContext) _Artifact(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Artifact")
+		case "id":
+
+			out.Values[i] = ec._Artifact_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "algorithm":
 
 			out.Values[i] = ec._Artifact_algorithm(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/hashEqual.generated.go
+++ b/pkg/assembler/graphql/generated/hashEqual.generated.go
@@ -28,6 +28,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _HashEqual_id(ctx context.Context, field graphql.CollectedField, obj *model.HashEqual) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HashEqual_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HashEqual_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HashEqual",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HashEqual_artifacts(ctx context.Context, field graphql.CollectedField, obj *model.HashEqual) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HashEqual_artifacts(ctx, field)
 	if err != nil {
@@ -67,6 +111,8 @@ func (ec *executionContext) fieldContext_HashEqual_artifacts(ctx context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Artifact_id(ctx, field)
 			case "algorithm":
 				return ec.fieldContext_Artifact_algorithm(ctx, field)
 			case "digest":
@@ -265,13 +311,21 @@ func (ec *executionContext) unmarshalInputHashEqualSpec(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"artifacts", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "artifacts", "justification", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "artifacts":
 			var err error
 
@@ -328,6 +382,13 @@ func (ec *executionContext) _HashEqual(ctx context.Context, sel ast.SelectionSet
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("HashEqual")
+		case "id":
+
+			out.Values[i] = ec._HashEqual_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "artifacts":
 
 			out.Values[i] = ec._HashEqual_artifacts(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -28,6 +28,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _IsOccurrence_id(ctx context.Context, field graphql.CollectedField, obj *model.IsOccurrence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IsOccurrence_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IsOccurrence_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IsOccurrence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _IsOccurrence_subject(ctx context.Context, field graphql.CollectedField, obj *model.IsOccurrence) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_IsOccurrence_subject(ctx, field)
 	if err != nil {
@@ -111,6 +155,8 @@ func (ec *executionContext) fieldContext_IsOccurrence_artifact(ctx context.Conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_Artifact_id(ctx, field)
 			case "algorithm":
 				return ec.fieldContext_Artifact_algorithm(ctx, field)
 			case "digest":
@@ -309,13 +355,21 @@ func (ec *executionContext) unmarshalInputIsOccurrenceSpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"subject", "artifact", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "artifact", "justification", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "subject":
 			var err error
 
@@ -475,6 +529,13 @@ func (ec *executionContext) _IsOccurrence(ctx context.Context, sel ast.Selection
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IsOccurrence")
+		case "id":
+
+			out.Values[i] = ec._IsOccurrence_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "subject":
 
 			out.Values[i] = ec._IsOccurrence_subject(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -41,6 +41,7 @@ type ComplexityRoot struct {
 	Artifact struct {
 		Algorithm func(childComplexity int) int
 		Digest    func(childComplexity int) int
+		ID        func(childComplexity int) int
 	}
 
 	Builder struct {
@@ -128,6 +129,7 @@ type ComplexityRoot struct {
 	HashEqual struct {
 		Artifacts     func(childComplexity int) int
 		Collector     func(childComplexity int) int
+		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
 	}
@@ -145,6 +147,7 @@ type ComplexityRoot struct {
 	IsOccurrence struct {
 		Artifact      func(childComplexity int) int
 		Collector     func(childComplexity int) int
+		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
 		Subject       func(childComplexity int) int
@@ -333,6 +336,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Artifact.Digest(childComplexity), true
+
+	case "Artifact.id":
+		if e.complexity.Artifact.ID == nil {
+			break
+		}
+
+		return e.complexity.Artifact.ID(childComplexity), true
 
 	case "Builder.uri":
 		if e.complexity.Builder.URI == nil {
@@ -649,6 +659,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.HashEqual.Collector(childComplexity), true
 
+	case "HashEqual.id":
+		if e.complexity.HashEqual.ID == nil {
+			break
+		}
+
+		return e.complexity.HashEqual.ID(childComplexity), true
+
 	case "HashEqual.justification":
 		if e.complexity.HashEqual.Justification == nil {
 			break
@@ -725,6 +742,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IsOccurrence.Collector(childComplexity), true
+
+	case "IsOccurrence.id":
+		if e.complexity.IsOccurrence.ID == nil {
+			break
+		}
+
+		return e.complexity.IsOccurrence.ID(childComplexity), true
 
 	case "IsOccurrence.justification":
 		if e.complexity.IsOccurrence.Justification == nil {
@@ -1796,6 +1820,7 @@ If having a ` + "`" + `checksum` + "`" + ` Go object, ` + "`" + `algorithm` + "`
 ` + "`" + `checksum.Value` + "`" + `.
 """
 type Artifact {
+  id: ID!
   algorithm: String!
   digest: String!
 }
@@ -1806,6 +1831,7 @@ ArtifactSpec allows filtering the list of artifacts to return.
 Both arguments will be canonicalized to lowercase.
 """
 input ArtifactSpec {
+  id: ID
   algorithm: String
   digest: String
 }
@@ -2892,6 +2918,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HashEqual {
+  id: ID!
   artifacts: [Artifact!]!
   justification: String!
   origin: String!
@@ -2904,6 +2931,7 @@ HashEqualSpec allows filtering the list of HashEqual to return.
 Specifying just the artifacts allows to query for all equivalent artifacts (if they exist)
 """
 input HashEqualSpec {
+  id: ID
   artifacts: [ArtifactSpec]
   justification: String
   origin: String
@@ -2932,7 +2960,6 @@ extend type Mutation {
   "certify that two artifacts are the same (hashes are equal)"
   ingestHashEqual(artifact: ArtifactInputSpec!, equalArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): HashEqual!
 }
-
 `, BuiltIn: false},
 	{Name: "../schema/isDependency.graphql", Input: `#
 # Copyright 2023 The GUAC Authors.
@@ -3055,6 +3082,7 @@ Note: Package or Source must be specified but not both at the same time.
 Attestation must occur at the PackageVersion or at the SourceName.
 """
 type IsOccurrence {
+  id: ID!
   "subject - union type that can be either a package or source object type"
   subject: PackageOrSource!
   "artifact (object) - artifact that represent the the package or source"
@@ -3075,6 +3103,7 @@ or it defaults to empty string for version, subpath and empty list for qualifier
 For source - a SourceName must be specified (name, tag or commit)
 """
 input IsOccurrenceSpec {
+  id: ID
   subject: PackageOrSourceSpec
   artifact: ArtifactSpec
   justification: String

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -42,6 +42,7 @@ type PackageSourceOrArtifact interface {
 // `strings.ToLower(string(checksum.Algorithm))` and `digest` can be
 // `checksum.Value`.
 type Artifact struct {
+	ID        string `json:"id"`
 	Algorithm string `json:"algorithm"`
 	Digest    string `json:"digest"`
 }
@@ -62,6 +63,7 @@ type ArtifactInputSpec struct {
 //
 // Both arguments will be canonicalized to lowercase.
 type ArtifactSpec struct {
+	ID        *string `json:"id"`
 	Algorithm *string `json:"algorithm"`
 	Digest    *string `json:"digest"`
 }
@@ -421,6 +423,7 @@ type HasSourceAtSpec struct {
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type HashEqual struct {
+	ID            string      `json:"id"`
 	Artifacts     []*Artifact `json:"artifacts"`
 	Justification string      `json:"justification"`
 	Origin        string      `json:"origin"`
@@ -440,6 +443,7 @@ type HashEqualInputSpec struct {
 //
 // Specifying just the artifacts allows to query for all equivalent artifacts (if they exist)
 type HashEqualSpec struct {
+	ID            *string         `json:"id"`
 	Artifacts     []*ArtifactSpec `json:"artifacts"`
 	Justification *string         `json:"justification"`
 	Origin        *string         `json:"origin"`
@@ -493,6 +497,7 @@ type IsDependencySpec struct {
 // Note: Package or Source must be specified but not both at the same time.
 // Attestation must occur at the PackageVersion or at the SourceName.
 type IsOccurrence struct {
+	ID string `json:"id"`
 	// subject - union type that can be either a package or source object type
 	Subject PackageOrSource `json:"subject"`
 	// artifact (object) - artifact that represent the the package or source
@@ -520,6 +525,7 @@ type IsOccurrenceInputSpec struct {
 // or it defaults to empty string for version, subpath and empty list for qualifiers
 // For source - a SourceName must be specified (name, tag or commit)
 type IsOccurrenceSpec struct {
+	ID            *string              `json:"id"`
 	Subject       *PackageOrSourceSpec `json:"subject"`
 	Artifact      *ArtifactSpec        `json:"artifact"`
 	Justification *string              `json:"justification"`

--- a/pkg/assembler/graphql/schema/artifact.graphql
+++ b/pkg/assembler/graphql/schema/artifact.graphql
@@ -28,6 +28,7 @@ If having a `checksum` Go object, `algorithm` can be
 `checksum.Value`.
 """
 type Artifact {
+  id: ID!
   algorithm: String!
   digest: String!
 }
@@ -38,6 +39,7 @@ ArtifactSpec allows filtering the list of artifacts to return.
 Both arguments will be canonicalized to lowercase.
 """
 input ArtifactSpec {
+  id: ID
   algorithm: String
   digest: String
 }

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -25,6 +25,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type HashEqual {
+  id: ID!
   artifacts: [Artifact!]!
   justification: String!
   origin: String!
@@ -37,6 +38,7 @@ HashEqualSpec allows filtering the list of HashEqual to return.
 Specifying just the artifacts allows to query for all equivalent artifacts (if they exist)
 """
 input HashEqualSpec {
+  id: ID
   artifacts: [ArtifactSpec]
   justification: String
   origin: String
@@ -65,4 +67,3 @@ extend type Mutation {
   "certify that two artifacts are the same (hashes are equal)"
   ingestHashEqual(artifact: ArtifactInputSpec!, equalArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): HashEqual!
 }
-

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -30,6 +30,7 @@ Note: Package or Source must be specified but not both at the same time.
 Attestation must occur at the PackageVersion or at the SourceName.
 """
 type IsOccurrence {
+  id: ID!
   "subject - union type that can be either a package or source object type"
   subject: PackageOrSource!
   "artifact (object) - artifact that represent the the package or source"
@@ -50,6 +51,7 @@ or it defaults to empty string for version, subpath and empty list for qualifier
 For source - a SourceName must be specified (name, tag or commit)
 """
 input IsOccurrenceSpec {
+  id: ID
   subject: PackageOrSourceSpec
   artifact: ArtifactSpec
   justification: String


### PR DESCRIPTION
This is working, but is pretty rough.

registerAlls are not all converted, some commented out.
Some code duplication, as we are trying to work on the files in parallel, and want to avoid bad merge conflicts.
The query optimizations are missing on verbs for when an ID is not specified, but one of the nouns is. In this case we could only search the backedges instead of searching the whole verb list.
Code consistency is not great between these and the others, again working in parallel.