### PR TITLE
Add reachability testdata

### DIFF
--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -1214,7 +1214,7 @@ func ingestReachabilityTestData(ctx context.Context, client graphql.Client) {
 			Collector:     "Demo ingestion",
 		},
 		cve: &model.CVEInputSpec{
-			Year:  "2019",
+			Year:  2019,
 			CveId: "CVE-2019-13110",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{

--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -52,6 +52,7 @@ func ingestData(port int) {
 	ingestHasSourceAt(ctx, gqlclient)
 	ingestIsVulnerability(ctx, gqlclient)
 	ingestVEXStatement(ctx, gqlclient)
+	ingestReachabilityTestData(ctx, gqlclient)
 	time := time.Now().Sub(start)
 	logger.Infof("Ingesting test data into backend server took %v", time)
 }

--- a/pkg/assembler/backends/testing/isDependency.go
+++ b/pkg/assembler/backends/testing/isDependency.go
@@ -76,8 +76,8 @@ func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgI
 		c.index[collectedIsDependencyLink.id] = &collectedIsDependencyLink
 		c.isDependencies = append(c.isDependencies, &collectedIsDependencyLink)
 		// set the backlinks
-		c.index[*packageID].(*pkgVersionNode).setIsDependencyLink(collectedIsDependencyLink.id)
-		c.index[*depPackageID].(*pkgVersionNode).setIsDependencyLink(collectedIsDependencyLink.id)
+		c.index[*packageID].(pkgNameOrVersion).setIsDependencyLink(collectedIsDependencyLink.id)
+		c.index[*depPackageID].(pkgNameOrVersion).setIsDependencyLink(collectedIsDependencyLink.id)
 	}
 
 	// build return GraphQL type

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -19,19 +19,25 @@ fragment allCertifyVuln on CertifyVuln {
   vulnerability {
     __typename
     ... on CVE {
+      id
       year
      cveIds{
       id
+      cveId
     }
     }
     ... on OSV {
+      id
      osvIds{
       id
+      osvId
     }
     }
     ... on GHSA {
+      id
       ghsaIds{
         id
+        ghsaId
       }
     }
   }

--- a/pkg/assembler/graphql/examples/has_source_at.gql
+++ b/pkg/assembler/graphql/examples/has_source_at.gql
@@ -53,8 +53,7 @@ query HasSourceAtQ2 {
   }
 }
 
-# this will return nothing as we are not ingesting package openssl in testdata
-query HasSourceAtQ3 {
+query Q3 {
   HasSourceAt(hasSourceAtSpec: {package: {name: "openssl", version: "3.0.3"}})  {
     ...allHasSourceAt
   }

--- a/pkg/assembler/graphql/examples/has_source_at.gql
+++ b/pkg/assembler/graphql/examples/has_source_at.gql
@@ -53,7 +53,7 @@ query HasSourceAtQ2 {
   }
 }
 
-query Q3 {
+query HasSourceAtQ3 {
   HasSourceAt(hasSourceAtSpec: {package: {name: "openssl", version: "3.0.3"}})  {
     ...allHasSourceAt
   }


### PR DESCRIPTION
- add `ingestReachabilityTestData`
- add `isDependencyLink` back to `pkgNameOrVersion` interface. FYI @jeffmendoza, I mistakenly told you to remove. The dependent package will be at the packageName node level.
- fix example queries