### PR TITLE
update certifyVuln and IsVuln to add IDs and backedges

### DIFF
--- a/cmd/graphql_playground/cmd/ingest.go
+++ b/cmd/graphql_playground/cmd/ingest.go
@@ -398,8 +398,8 @@ func ingestOccurrence(ctx context.Context, client graphql.Client) {
 }
 
 func ingestVulnerability(ctx context.Context, client graphql.Client) {
-
 	logger := logging.FromContext(ctx)
+	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
 
 	opensslNs := "openssl.org"
 	opensslVersion := "3.0.3"
@@ -429,7 +429,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			CveId: "CVE-2019-13110",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.0.0",
 			ScannerUri:     "osv.dev",
@@ -453,7 +453,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			OsvId: "CVE-2019-13110",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.0.0",
 			ScannerUri:     "osv.dev",
@@ -477,7 +477,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			GhsaId: "GHSA-h45f-rjvw-2rv2",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.0.0",
 			ScannerUri:     "osv.dev",
@@ -497,7 +497,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			CveId: "CVE-2018-12310",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.2.0",
 			ScannerUri:     "osv.dev",
@@ -516,7 +516,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			OsvId: "CVE-2018-12310",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.2.0",
 			ScannerUri:     "osv.dev",
@@ -535,9 +535,77 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			GhsaId: "GHSA-f45f-jj4w-2rv2",
 		},
 		vulnerability: model.VulnerabilityMetaDataInput{
-			TimeScanned:    time.Now(),
+			TimeScanned:    tm,
 			DbUri:          "MITRE",
 			DbVersion:      "v1.2.0",
+			ScannerUri:     "osv.dev",
+			ScannerVersion: "0.0.14",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
+		},
+	}, {
+		name: "cve openssl (duplicate)",
+		pkg: &model.PkgInputSpec{
+			Type:      "conan",
+			Namespace: &opensslNs,
+			Name:      "openssl",
+			Version:   &opensslVersion,
+			Qualifiers: []model.PackageQualifierInputSpec{
+				{Key: "user", Value: "bincrafters"},
+				{Key: "channel", Value: "stable"},
+			},
+		},
+		cve: &model.CVEInputSpec{
+			Year:  2019,
+			CveId: "CVE-2019-13110",
+		},
+		vulnerability: model.VulnerabilityMetaDataInput{
+			TimeScanned:    tm,
+			DbUri:          "MITRE",
+			DbVersion:      "v1.0.0",
+			ScannerUri:     "osv.dev",
+			ScannerVersion: "0.0.14",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
+		},
+	}, {
+		name: "ghsa django (duplicate)",
+		pkg: &model.PkgInputSpec{
+			Type:      "pypi",
+			Namespace: &djangoNs,
+			Name:      "django",
+		},
+		ghsa: &model.GHSAInputSpec{
+			GhsaId: "GHSA-f45f-jj4w-2rv2",
+		},
+		vulnerability: model.VulnerabilityMetaDataInput{
+			TimeScanned:    tm,
+			DbUri:          "MITRE",
+			DbVersion:      "v1.2.0",
+			ScannerUri:     "osv.dev",
+			ScannerVersion: "0.0.14",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
+		},
+	}, {
+		name: "osv openssl (duplicate)",
+		pkg: &model.PkgInputSpec{
+			Type:      "conan",
+			Namespace: &opensslNs,
+			Name:      "openssl",
+			Version:   &opensslVersion,
+			Qualifiers: []model.PackageQualifierInputSpec{
+				{Key: "user", Value: "bincrafters"},
+				{Key: "channel", Value: "stable"},
+			},
+		},
+		osv: &model.OSVInputSpec{
+			OsvId: "CVE-2019-13110",
+		},
+		vulnerability: model.VulnerabilityMetaDataInput{
+			TimeScanned:    tm,
+			DbUri:          "MITRE",
+			DbVersion:      "v1.0.0",
 			ScannerUri:     "osv.dev",
 			ScannerVersion: "0.0.14",
 			Origin:         "Demo ingestion",
@@ -555,7 +623,6 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 			if err != nil {
 				logger.Errorf("Error in ingesting: %v\n", err)
 			}
-
 		} else if ingest.ghsa != nil {
 			_, err := model.CertifyGHSA(context.Background(), client, *ingest.pkg, *ingest.ghsa, ingest.vulnerability)
 			if err != nil {
@@ -985,6 +1052,33 @@ func ingestIsVulnerability(ctx context.Context, client graphql.Client) {
 		},
 	}, {
 		name: "OSV maps to GHSA",
+		osv: &model.OSVInputSpec{
+			OsvId: "GHSA-h45f-rjvw-2rv2",
+		},
+		ghsa: &model.GHSAInputSpec{
+			GhsaId: "GHSA-h45f-rjvw-2rv2",
+		},
+		isVulnerability: model.IsVulnerabilityInputSpec{
+			Justification: "OSV maps to GHSA",
+			Origin:        "Demo ingestion",
+			Collector:     "Demo ingestion",
+		},
+	}, {
+		name: "OSV maps to CVE (duplicate)",
+		osv: &model.OSVInputSpec{
+			OsvId: "CVE-2019-13110",
+		},
+		cve: &model.CVEInputSpec{
+			Year:  2019,
+			CveId: "CVE-2019-13110",
+		},
+		isVulnerability: model.IsVulnerabilityInputSpec{
+			Justification: "OSV maps to CVE",
+			Origin:        "Demo ingestion",
+			Collector:     "Demo ingestion",
+		},
+	}, {
+		name: "OSV maps to GHSA (duplicate)",
 		osv: &model.OSVInputSpec{
 			OsvId: "GHSA-h45f-rjvw-2rv2",
 		},

--- a/pkg/assembler/backends/testing/backend.go
+++ b/pkg/assembler/backends/testing/backend.go
@@ -44,53 +44,57 @@ func (c *demoClient) getNextID() uint32 {
 }
 
 type demoClient struct {
-	builders            []*model.Builder
-	hasSBOM             []*model.HasSbom
-	certifyPkg          []*model.CertifyPkg
-	certifyVuln         []*model.CertifyVuln
-	certifyScorecard    []*model.CertifyScorecard
-	certifyBad          []*model.CertifyBad
-	isVulnerability     []*model.IsVulnerability
-	certifyVEXStatement []*model.CertifyVEXStatement
-	hasSLSA             []*model.HasSlsa
-	id                  uint32
-	index               indexType
-	packages            pkgTypeMap
-	sources             srcTypeMap
-	osvs                osvMap
-	ghsas               ghsaMap
-	cves                cveMap
-	hasSources          hasSrcList
-	isDependencies      isDependencyList
-	scorecards          scorecardList
-	artifacts           artMap
-	hashEquals          hashEqualList
-	occurrences         isOccurrenceList
+	builders             []*model.Builder
+	hasSBOM              []*model.HasSbom
+	certifyPkg           []*model.CertifyPkg
+	certifyVuln          []*model.CertifyVuln
+	certifyScorecard     []*model.CertifyScorecard
+	certifyBad           []*model.CertifyBad
+	isVulnerability      []*model.IsVulnerability
+	certifyVEXStatement  []*model.CertifyVEXStatement
+	hasSLSA              []*model.HasSlsa
+	id                   uint32
+	index                indexType
+	packages             pkgTypeMap
+	sources              srcTypeMap
+	osvs                 osvMap
+	ghsas                ghsaMap
+	cves                 cveMap
+	hasSources           hasSrcList
+	isDependencies       isDependencyList
+	scorecards           scorecardList
+	artifacts            artMap
+	hashEquals           hashEqualList
+	occurrences          isOccurrenceList
+	vulnerabilities      vulnerabilityList
+	equalVulnerabilities equalVulnerabilityList
 }
 
 func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 	client := &demoClient{
-		builders:            []*model.Builder{},
-		hasSBOM:             []*model.HasSbom{},
-		certifyPkg:          []*model.CertifyPkg{},
-		certifyVuln:         []*model.CertifyVuln{},
-		certifyScorecard:    []*model.CertifyScorecard{},
-		certifyBad:          []*model.CertifyBad{},
-		isVulnerability:     []*model.IsVulnerability{},
-		certifyVEXStatement: []*model.CertifyVEXStatement{},
-		hasSLSA:             []*model.HasSlsa{},
-		index:               indexType{},
-		packages:            pkgTypeMap{},
-		sources:             srcTypeMap{},
-		osvs:                osvMap{},
-		ghsas:               ghsaMap{},
-		cves:                cveMap{},
-		hasSources:          hasSrcList{},
-		isDependencies:      isDependencyList{},
-		scorecards:          scorecardList{},
-		artifacts:           artMap{},
-		hashEquals:          hashEqualList{},
-		occurrences:         isOccurrenceList{},
+		builders:             []*model.Builder{},
+		hasSBOM:              []*model.HasSbom{},
+		certifyPkg:           []*model.CertifyPkg{},
+		certifyVuln:          []*model.CertifyVuln{},
+		certifyScorecard:     []*model.CertifyScorecard{},
+		certifyBad:           []*model.CertifyBad{},
+		isVulnerability:      []*model.IsVulnerability{},
+		certifyVEXStatement:  []*model.CertifyVEXStatement{},
+		hasSLSA:              []*model.HasSlsa{},
+		index:                indexType{},
+		packages:             pkgTypeMap{},
+		sources:              srcTypeMap{},
+		osvs:                 osvMap{},
+		ghsas:                ghsaMap{},
+		cves:                 cveMap{},
+		hasSources:           hasSrcList{},
+		isDependencies:       isDependencyList{},
+		scorecards:           scorecardList{},
+		artifacts:            artMap{},
+		hashEquals:           hashEqualList{},
+		occurrences:          isOccurrenceList{},
+		vulnerabilities:      vulnerabilityList{},
+		equalVulnerabilities: equalVulnerabilityList{},
 	}
 	registerAllPackages(client)
 	registerAllSources(client)
@@ -104,27 +108,29 @@ func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
 
 func GetEmptyBackend(args backends.BackendArgs) (backends.Backend, error) {
 	client := &demoClient{
-		builders:            []*model.Builder{},
-		hasSBOM:             []*model.HasSbom{},
-		certifyPkg:          []*model.CertifyPkg{},
-		certifyVuln:         []*model.CertifyVuln{},
-		certifyScorecard:    []*model.CertifyScorecard{},
-		certifyBad:          []*model.CertifyBad{},
-		isVulnerability:     []*model.IsVulnerability{},
-		certifyVEXStatement: []*model.CertifyVEXStatement{},
-		hasSLSA:             []*model.HasSlsa{},
-		index:               indexType{},
-		packages:            pkgTypeMap{},
-		sources:             srcTypeMap{},
-		osvs:                osvMap{},
-		ghsas:               ghsaMap{},
-		cves:                cveMap{},
-		hasSources:          hasSrcList{},
-		isDependencies:      isDependencyList{},
-		scorecards:          scorecardList{},
-		artifacts:           artMap{},
-		hashEquals:          hashEqualList{},
-		occurrences:         isOccurrenceList{},
+		builders:             []*model.Builder{},
+		hasSBOM:              []*model.HasSbom{},
+		certifyPkg:           []*model.CertifyPkg{},
+		certifyVuln:          []*model.CertifyVuln{},
+		certifyScorecard:     []*model.CertifyScorecard{},
+		certifyBad:           []*model.CertifyBad{},
+		isVulnerability:      []*model.IsVulnerability{},
+		certifyVEXStatement:  []*model.CertifyVEXStatement{},
+		hasSLSA:              []*model.HasSlsa{},
+		index:                indexType{},
+		packages:             pkgTypeMap{},
+		sources:              srcTypeMap{},
+		osvs:                 osvMap{},
+		ghsas:                ghsaMap{},
+		cves:                 cveMap{},
+		hasSources:           hasSrcList{},
+		isDependencies:       isDependencyList{},
+		scorecards:           scorecardList{},
+		artifacts:            artMap{},
+		hashEquals:           hashEqualList{},
+		occurrences:          isOccurrenceList{},
+		vulnerabilities:      vulnerabilityList{},
+		equalVulnerabilities: equalVulnerabilityList{},
 	}
 	return client, nil
 }

--- a/pkg/assembler/backends/testing/certifyVuln.go
+++ b/pkg/assembler/backends/testing/certifyVuln.go
@@ -17,7 +17,8 @@ package testing
 
 import (
 	"context"
-	"reflect"
+	"errors"
+	"strconv"
 	"time"
 
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
@@ -25,307 +26,328 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-func registerAllCertifyVuln(client *demoClient) error {
-
-	// pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable
-	//	("conan", "openssl.org", "openssl", "3.0.3", "", "user=bincrafters", "channel=stable")
-
-	selectedType := "conan"
-	selectedNameSpace := "openssl.org"
-	selectedName := "openssl"
-	selectedVersion := "3.0.3"
-	selectedSubPath := ""
-	qualifierA := "bincrafters"
-	qualifierB := "stable"
-	selectedQualifiers := []*model.PackageQualifierSpec{{Key: "user", Value: &qualifierA}, {Key: "channel", Value: &qualifierB}}
-	selectedPkgSpec := &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Subpath: &selectedSubPath, Qualifiers: selectedQualifiers}
-	selectedPackage1, err := client.Packages(context.TODO(), selectedPkgSpec)
-	if err != nil {
-		return err
-	}
-	selectedYear := 2019
-	selectedCveID := "CVE-2019-13110"
-	selectedCVESpec := &model.CVESpec{Year: &selectedYear, CveID: &selectedCveID}
-	selectedCve, err := client.Cve(context.TODO(), selectedCVESpec)
-	if err != nil {
-		return err
-	}
-	client.registerCertifyVuln(selectedPackage1[0], nil, selectedCve[0], nil, time.Now(), "MITRE", "v1.0.0", "osv.dev", "0.0.14", "testing backend", "testing backend")
-
-	// pkg:pypi/django@1.11.1
-	// client.registerPackage("pypi", "", "django", "1.11.1", "")
-
-	selectedType = "pypi"
-	selectedNameSpace = ""
-	selectedName = "django"
-	selectedVersion = "1.11.1"
-	selectedSubPath = ""
-	selectedPkgSpec = &model.PkgSpec{Type: &selectedType, Namespace: &selectedNameSpace, Name: &selectedName, Version: &selectedVersion, Subpath: &selectedSubPath}
-	selectedPackage2, err := client.Packages(context.TODO(), selectedPkgSpec)
-	if err != nil {
-		return err
-	}
-	selectedOsvID := "CVE-2019-13110"
-	selectedOsvSpec := &model.OSVSpec{OsvID: &selectedOsvID}
-	selectedOsv, err := client.Osv(context.TODO(), selectedOsvSpec)
-	if err != nil {
-		return err
-	}
-	client.registerCertifyVuln(selectedPackage2[0], selectedOsv[0], nil, nil, time.Now(), "MITRE", "v1.0.0", "osv.dev", "0.0.14", "testing backend", "testing backend")
-
-	selectedGhsaID := "GHSA-h45f-rjvw-2rv2"
-	selectedGhsaSpec := &model.GHSASpec{GhsaID: &selectedGhsaID}
-	selectedGhsa, err := client.Ghsa(context.TODO(), selectedGhsaSpec)
-	if err != nil {
-		return err
-	}
-	client.registerCertifyVuln(selectedPackage1[0], nil, nil, selectedGhsa[0], time.Now(), "MITRE", "v1.0.0", "osv.dev", "0.0.14", "testing backend", "testing backend")
-
-	return nil
+// Internal data: link between packages and vulnerabilities (certifyVulnerability)
+type vulnerabilityList []*vulnerabilityLink
+type vulnerabilityLink struct {
+	id             uint32
+	packageID      uint32
+	osvID          uint32
+	cveID          uint32
+	ghsaID         uint32
+	timeScanned    time.Time
+	dbURI          string
+	dbVersion      string
+	scannerURI     string
+	scannerVersion string
+	origin         string
+	collector      string
 }
+
+func (n *vulnerabilityLink) getID() uint32 { return n.id }
 
 // Ingest CertifyVuln
-
-func (c *demoClient) registerCertifyVuln(selectedPackage *model.Package, selectedOsv *model.Osv, selectedCve *model.Cve, selectedGhsa *model.Ghsa, timeScanned time.Time,
-	dbUri, dbVersion, scannerUri, scannerVersion, origin, collector string) *model.CertifyVuln {
-
-	for _, vuln := range c.certifyVuln {
-		if reflect.DeepEqual(vuln.Package, selectedPackage) && vuln.Metadata.DbURI == dbUri && vuln.Metadata.DbVersion == dbVersion &&
-			vuln.Metadata.ScannerURI == scannerUri && vuln.Metadata.ScannerVersion == scannerVersion {
-			if val, ok := vuln.Vulnerability.(model.Osv); ok {
-				if &val == selectedOsv {
-					return vuln
-				}
-			} else if val, ok := vuln.Vulnerability.(model.Cve); ok {
-				if &val == selectedCve {
-					return vuln
-				}
-			} else if val, ok := vuln.Vulnerability.(model.Ghsa); ok {
-				if &val == selectedGhsa {
-					return vuln
-				}
-			}
-		}
-	}
-
-	metadata := &model.VulnerabilityMetaData{
-		TimeScanned:    timeScanned,
-		DbURI:          dbUri,
-		DbVersion:      dbVersion,
-		ScannerURI:     scannerUri,
-		ScannerVersion: scannerVersion,
-		Origin:         origin,
-		Collector:      collector,
-	}
-
-	newCertifyVuln := &model.CertifyVuln{
-		Package:  selectedPackage,
-		Metadata: metadata,
-	}
-	if selectedOsv != nil {
-		newCertifyVuln.Vulnerability = selectedOsv
-	} else if selectedCve != nil {
-		newCertifyVuln.Vulnerability = selectedCve
-	} else {
-		newCertifyVuln.Vulnerability = selectedGhsa
-	}
-
-	c.certifyVuln = append(c.certifyVuln, newCertifyVuln)
-	return newCertifyVuln
-}
-
-func (c *demoClient) IngestVulnerability(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.OsvCveOrGhsaInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error) {
+func (c *demoClient) IngestVulnerability(ctx context.Context, packageArg model.PkgInputSpec, vulnerability model.OsvCveOrGhsaInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error) {
 
 	err := helper.ValidateOsvCveOrGhsaIngestionInput(vulnerability)
 	if err != nil {
 		return nil, err
 	}
-
-	selectedPkgSpec := helper.ConvertPkgInputSpecToPkgSpec(&pkg)
-
-	collectedPkg, err := c.Packages(ctx, selectedPkgSpec)
+	packageID, err := getPackageIDFromInput(c, packageArg, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion})
 	if err != nil {
 		return nil, err
 	}
 
-	if len(collectedPkg) != 1 {
-		return nil, gqlerror.Errorf(
-			"IngestOccurrence :: multiple packages found")
-	}
-
+	var osvID uint32
+	var cveID uint32
+	var ghsaID uint32
+	vulnerabilityLinks := []uint32{}
 	if vulnerability.Osv != nil {
-		osvSpec := helper.ConvertOsvInputSpecToOsvSpec(vulnerability.Osv)
-
-		collectedOsv, err := c.Osv(ctx, osvSpec)
+		osvID, err = getOsvIDFromInput(c, *vulnerability.Osv)
 		if err != nil {
 			return nil, err
 		}
-		if len(collectedOsv) != 1 {
-			return nil, gqlerror.Errorf(
-				"IngestVulnerability :: osv argument must match one, found %d",
-				len(collectedOsv))
+		osvNode, ok := c.index[osvID].(*osvIDNode)
+		if ok {
+			vulnerabilityLinks = append(vulnerabilityLinks, osvNode.certifyVulnLink...)
 		}
-		return c.registerCertifyVuln(
-			collectedPkg[0],
-			collectedOsv[0],
-			nil,
-			nil,
-			certifyVuln.TimeScanned,
-			certifyVuln.DbURI,
-			certifyVuln.DbVersion,
-			certifyVuln.ScannerURI,
-			certifyVuln.ScannerVersion,
-			certifyVuln.Origin,
-			certifyVuln.Collector), nil
 	}
 
 	if vulnerability.Cve != nil {
-
-		cveSpec := helper.ConvertCveInputSpecToCveSpec(vulnerability.Cve)
-		collectedCve, err := c.Cve(ctx, cveSpec)
+		cveID, err = getCveIDFromInput(c, *vulnerability.Cve)
 		if err != nil {
 			return nil, err
 		}
-		if len(collectedCve) != 1 {
-			return nil, gqlerror.Errorf(
-				"IngestVulnerability :: cve argument must match one, found %d",
-				len(collectedCve))
+		cveNode, ok := c.index[cveID].(*cveIDNode)
+		if ok {
+			vulnerabilityLinks = append(vulnerabilityLinks, cveNode.certifyVulnLink...)
 		}
-		return c.registerCertifyVuln(
-			collectedPkg[0],
-			nil,
-			collectedCve[0],
-			nil,
-			certifyVuln.TimeScanned,
-			certifyVuln.DbURI,
-			certifyVuln.DbVersion,
-			certifyVuln.ScannerURI,
-			certifyVuln.ScannerVersion,
-			certifyVuln.Origin,
-			certifyVuln.Collector), nil
 	}
 
 	if vulnerability.Ghsa != nil {
-		ghsaSpec := helper.ConvertGhsaInputSpecToGhsaSpec(vulnerability.Ghsa)
-
-		collectedGhsa, err := c.Ghsa(ctx, ghsaSpec)
+		ghsaID, err = getGhsaIDFromInput(c, *vulnerability.Ghsa)
 		if err != nil {
 			return nil, err
 		}
-		if len(collectedGhsa) != 1 {
-			return nil, gqlerror.Errorf(
-				"IngestVulnerability :: ghsa argument must match one, found %d",
-				len(collectedGhsa))
+		ghsaNode, ok := c.index[ghsaID].(*ghsaIDNode)
+		if ok {
+			vulnerabilityLinks = append(vulnerabilityLinks, ghsaNode.certifyVulnLink...)
 		}
-		return c.registerCertifyVuln(
-			collectedPkg[0],
-			nil,
-			nil,
-			collectedGhsa[0],
-			certifyVuln.TimeScanned,
-			certifyVuln.DbURI,
-			certifyVuln.DbVersion,
-			certifyVuln.ScannerURI,
-			certifyVuln.ScannerVersion,
-			certifyVuln.Origin,
-			certifyVuln.Collector), nil
 	}
-	// it should never reach here else it failed
-	return nil, gqlerror.Errorf("IngestVulnerability failed")
-}
 
-// Query CertifyVuln
+	packageVulns := []uint32{}
+	foundPkgVersionNode, ok := c.index[packageID].(*pkgVersionNode)
+	if ok {
+		packageVulns = append(packageVulns, foundPkgVersionNode.certifyVulnLink...)
+	}
 
-func (c *demoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
+	searchIDs := []uint32{}
+	if len(packageVulns) > len(vulnerabilityLinks) {
+		searchIDs = append(searchIDs, vulnerabilityLinks...)
+	} else {
+		searchIDs = append(searchIDs, packageVulns...)
+	}
 
-	queryAll, err := helper.ValidateOsvCveOrGhsaQueryInput(certifyVulnSpec.Vulnerability)
+	// Don't insert duplicates
+	duplicate := false
+	collectedCertifyVulnLink := vulnerabilityLink{}
+	for _, id := range searchIDs {
+		v, _ := c.certifyVulnByID(id)
+		vulnMatch := false
+		if osvID != 0 && osvID == v.osvID {
+			vulnMatch = true
+		}
+		if cveID != 0 && cveID == v.cveID {
+			vulnMatch = true
+		}
+		if ghsaID != 0 && ghsaID == v.ghsaID {
+			vulnMatch = true
+		}
+		if vulnMatch && packageID == v.packageID && certifyVuln.TimeScanned.UTC() == v.timeScanned && certifyVuln.DbURI == v.dbURI &&
+			certifyVuln.DbVersion == v.dbVersion && certifyVuln.ScannerURI == v.scannerURI && certifyVuln.ScannerVersion == v.scannerVersion &&
+			certifyVuln.Origin == v.origin && certifyVuln.Collector == v.collector {
+
+			collectedCertifyVulnLink = *v
+			duplicate = true
+			break
+		}
+	}
+	if !duplicate {
+		// store the link
+		collectedCertifyVulnLink = vulnerabilityLink{
+			id:             c.getNextID(),
+			packageID:      packageID,
+			osvID:          osvID,
+			cveID:          cveID,
+			ghsaID:         ghsaID,
+			timeScanned:    certifyVuln.TimeScanned,
+			dbURI:          certifyVuln.DbURI,
+			dbVersion:      certifyVuln.DbVersion,
+			scannerURI:     certifyVuln.ScannerURI,
+			scannerVersion: certifyVuln.ScannerVersion,
+			origin:         certifyVuln.Origin,
+			collector:      certifyVuln.Collector,
+		}
+		c.index[collectedCertifyVulnLink.id] = &collectedCertifyVulnLink
+		c.vulnerabilities = append(c.vulnerabilities, &collectedCertifyVulnLink)
+		// set the backlinks
+		c.index[packageID].(*pkgVersionNode).setVulnerabilityLink(collectedCertifyVulnLink.id)
+		if osvID != 0 {
+			c.index[osvID].(*osvIDNode).setVulnerabilityLink(collectedCertifyVulnLink.id)
+		}
+		if cveID != 0 {
+			c.index[cveID].(*cveIDNode).setVulnerabilityLink(collectedCertifyVulnLink.id)
+		}
+		if ghsaID != 0 {
+			c.index[ghsaID].(*ghsaIDNode).setVulnerabilityLink(collectedCertifyVulnLink.id)
+		}
+	}
+
+	// build return GraphQL type
+	builtCertifyVuln, err := buildCertifyVulnerability(c, &collectedCertifyVulnLink, nil, true)
 	if err != nil {
 		return nil, err
 	}
-	var foundCertifyBad []*model.CertifyVuln
+	return builtCertifyVuln, nil
+}
 
-	for _, h := range c.certifyVuln {
-		matchOrSkip := true
+// Query CertifyVuln
+func (c *demoClient) CertifyVuln(ctx context.Context, filter *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
+	out := []*model.CertifyVuln{}
 
-		if certifyVulnSpec.DbURI != nil && h.Metadata.DbURI != *certifyVulnSpec.DbURI {
-			matchOrSkip = false
+	if filter != nil && filter.ID != nil {
+		id, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
 		}
-		if certifyVulnSpec.DbVersion != nil && h.Metadata.DbVersion != *certifyVulnSpec.DbVersion {
-			matchOrSkip = false
+		node, ok := c.index[uint32(id)]
+		if !ok {
+			return nil, gqlerror.Errorf("ID does not match existing node")
 		}
-		if certifyVulnSpec.ScannerURI != nil && h.Metadata.ScannerURI != *certifyVulnSpec.ScannerURI {
-			matchOrSkip = false
-		}
-		if certifyVulnSpec.ScannerVersion != nil && h.Metadata.ScannerVersion != *certifyVulnSpec.ScannerVersion {
-			matchOrSkip = false
-		}
-		if certifyVulnSpec.Collector != nil && h.Metadata.Collector != *certifyVulnSpec.Collector {
-			matchOrSkip = false
-		}
-		if certifyVulnSpec.Origin != nil && h.Metadata.Origin != *certifyVulnSpec.Origin {
-			matchOrSkip = false
-		}
-
-		if certifyVulnSpec.Package != nil && h.Package != nil {
-			if certifyVulnSpec.Package.Type == nil || h.Package.Type == *certifyVulnSpec.Package.Type {
-				newPkg := filterPackageNamespace(h.Package, certifyVulnSpec.Package)
-				if newPkg == nil {
-					matchOrSkip = false
-				}
-			} else {
-				matchOrSkip = false
+		if link, ok := node.(*vulnerabilityLink); ok {
+			foundCertifyVuln, err := buildCertifyVulnerability(c, link, filter, true)
+			if err != nil {
+				return nil, err
 			}
-		}
-		if !queryAll {
-			if certifyVulnSpec.Vulnerability != nil && certifyVulnSpec.Vulnerability.Cve != nil {
-				if val, ok := h.Vulnerability.(*model.Cve); ok {
-					if certifyVulnSpec.Vulnerability.Cve.Year == nil || val.Year == *certifyVulnSpec.Vulnerability.Cve.Year {
-						newCve, err := filterCVEID(val, certifyVulnSpec.Vulnerability.Cve)
-						if err != nil {
-							return nil, err
-						}
-						if newCve == nil {
-							matchOrSkip = false
-						}
-					}
-				} else {
-					matchOrSkip = false
-				}
-			}
-
-			if certifyVulnSpec.Vulnerability != nil && certifyVulnSpec.Vulnerability.Osv != nil {
-				if val, ok := h.Vulnerability.(*model.Osv); ok {
-					newOSV, err := filterOSVID(val, certifyVulnSpec.Vulnerability.Osv)
-					if err != nil {
-						return nil, err
-					}
-					if newOSV == nil {
-						matchOrSkip = false
-					}
-				} else {
-					matchOrSkip = false
-				}
-			}
-
-			if certifyVulnSpec.Vulnerability != nil && certifyVulnSpec.Vulnerability.Ghsa != nil {
-				if val, ok := h.Vulnerability.(*model.Ghsa); ok {
-					newGhsa, err := filterGHSAID(val, certifyVulnSpec.Vulnerability.Ghsa)
-					if err != nil {
-						return nil, err
-					}
-					if newGhsa == nil {
-						matchOrSkip = false
-					}
-				} else {
-					matchOrSkip = false
-				}
-			}
-		}
-
-		if matchOrSkip {
-			foundCertifyBad = append(foundCertifyBad, h)
+			return []*model.CertifyVuln{foundCertifyVuln}, nil
+		} else {
+			return nil, gqlerror.Errorf("ID does not match expected node type for certifyVuln")
 		}
 	}
 
-	return foundCertifyBad, nil
+	// TODO if any of the pkg/vulnerabilities are specified, ony search those backedges
+	for _, link := range c.vulnerabilities {
+		if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.UTC() == link.timeScanned {
+			continue
+		}
+		if filter != nil && noMatch(filter.DbURI, link.dbURI) {
+			continue
+		}
+		if filter != nil && noMatch(filter.DbVersion, link.dbVersion) {
+			continue
+		}
+		if filter != nil && noMatch(filter.ScannerURI, link.scannerURI) {
+			continue
+		}
+		if filter != nil && noMatch(filter.ScannerVersion, link.scannerVersion) {
+			continue
+		}
+		if filter != nil && noMatch(filter.Collector, link.collector) {
+			continue
+		}
+		if filter != nil && noMatch(filter.Origin, link.origin) {
+			continue
+		}
+
+		foundCertifyVuln, err := buildCertifyVulnerability(c, link, filter, false)
+		if err != nil {
+			return nil, err
+		}
+		if foundCertifyVuln == nil {
+			continue
+		}
+		out = append(out, foundCertifyVuln)
+	}
+
+	return out, nil
+}
+
+func buildCertifyVulnerability(c *demoClient, link *vulnerabilityLink, filter *model.CertifyVulnSpec, ingestOrIDProvided bool) (*model.CertifyVuln, error) {
+	var p *model.Package
+	var osv *model.Osv
+	var cve *model.Cve
+	var ghsa *model.Ghsa
+	var err error
+	if filter != nil {
+		p, err = c.buildPackageResponse(link.packageID, filter.Package)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		p, err = c.buildPackageResponse(link.packageID, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if filter != nil && filter.Vulnerability != nil {
+		if filter.Vulnerability.Osv != nil && link.osvID != 0 {
+			osv, err = c.buildOsvResponse(link.osvID, filter.Vulnerability.Osv)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if filter.Vulnerability.Cve != nil && link.cveID != 0 {
+			cve, err = c.buildCveResponse(link.cveID, filter.Vulnerability.Cve)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if filter.Vulnerability.Ghsa != nil && link.ghsaID != 0 {
+			ghsa, err = c.buildGhsaResponse(link.ghsaID, filter.Vulnerability.Ghsa)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		if link.osvID != 0 {
+			osv, err = c.buildOsvResponse(link.osvID, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if link.cveID != 0 {
+			cve, err = c.buildCveResponse(link.cveID, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if link.ghsaID != 0 {
+			ghsa, err = c.buildGhsaResponse(link.ghsaID, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	// if package not found during ingestion or if ID is provided in filter, send error. On query do not send error to continue search
+	if p == nil && ingestOrIDProvided {
+		return nil, gqlerror.Errorf("failed to retrieve package via packageID")
+	} else if p == nil && !ingestOrIDProvided {
+		return nil, nil
+	}
+
+	var vuln model.OsvCveOrGhsa
+	if link.osvID != 0 {
+		if osv == nil && ingestOrIDProvided {
+			return nil, gqlerror.Errorf("failed to retrieve osv via osvID")
+		} else if osv == nil && !ingestOrIDProvided {
+			return nil, nil
+		}
+		vuln = osv
+	}
+	if link.cveID != 0 {
+		if cve == nil && ingestOrIDProvided {
+			return nil, gqlerror.Errorf("failed to retrieve cve via cveID")
+		} else if cve == nil && !ingestOrIDProvided {
+			return nil, nil
+		}
+		vuln = cve
+	}
+	if link.ghsaID != 0 {
+		if ghsa == nil && ingestOrIDProvided {
+			return nil, gqlerror.Errorf("failed to retrieve ghsa via ghsaID")
+		} else if ghsa == nil && !ingestOrIDProvided {
+			return nil, nil
+		}
+		vuln = ghsa
+	}
+
+	metadata := &model.VulnerabilityMetaData{
+		TimeScanned:    link.timeScanned,
+		DbURI:          link.dbURI,
+		DbVersion:      link.dbVersion,
+		ScannerURI:     link.scannerURI,
+		ScannerVersion: link.scannerVersion,
+		Origin:         link.origin,
+		Collector:      link.collector,
+	}
+
+	certifyVuln := model.CertifyVuln{
+		ID:            nodeID(link.id),
+		Package:       p,
+		Vulnerability: vuln,
+		Metadata:      metadata,
+	}
+	return &certifyVuln, nil
+}
+
+func (c *demoClient) certifyVulnByID(id uint32) (*vulnerabilityLink, error) {
+	node, ok := c.index[id]
+	if !ok {
+		return nil, errors.New("could not find vulnerabilityLink")
+	}
+	link, ok := node.(*vulnerabilityLink)
+	if !ok {
+		return nil, errors.New("not an vulnerabilityLink")
+	}
+	return link, nil
 }

--- a/pkg/assembler/backends/testing/isOccurrence.go
+++ b/pkg/assembler/backends/testing/isOccurrence.go
@@ -101,7 +101,7 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestOccurrence :: %v", err)
 		}
-		packageID = *pid
+		packageID = pid
 	}
 
 	sourceID := maxUint32
@@ -110,7 +110,7 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestOccurrence :: %v", err)
 		}
-		sourceID = *sid
+		sourceID = sid
 	}
 
 	// could search backedges for pkg/src or artifiact, just do artifact

--- a/pkg/assembler/backends/testing/isVulnerability.go
+++ b/pkg/assembler/backends/testing/isVulnerability.go
@@ -17,215 +17,267 @@ package testing
 
 import (
 	"context"
-	"reflect"
+	"errors"
+	"strconv"
 
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-func registerAllIsVulnerability(client *demoClient) error {
-
-	selectedOsvID := "CVE-2019-13110"
-	selectedOsvSpec := &model.OSVSpec{OsvID: &selectedOsvID}
-	selectedOsv, err := client.Osv(context.TODO(), selectedOsvSpec)
-	if err != nil {
-		return err
-	}
-
-	selectedYear := 2019
-	selectedCveID := "CVE-2019-13110"
-	selectedCVESpec := &model.CVESpec{Year: &selectedYear, CveID: &selectedCveID}
-	selectedCve, err := client.Cve(context.TODO(), selectedCVESpec)
-	if err != nil {
-		return err
-	}
-	client.registerIsVulnerability(selectedOsv[0], selectedCve[0], nil, "OSV maps to CVE", "testing backend", "testing backend")
-
-	selectedOsvID = "GHSA-h45f-rjvw-2rv2"
-	selectedOsvSpec = &model.OSVSpec{OsvID: &selectedOsvID}
-	selectedOsv, err = client.Osv(context.TODO(), selectedOsvSpec)
-	if err != nil {
-		return err
-	}
-
-	selectedGhsaID := "GHSA-h45f-rjvw-2rv2"
-	selectedGhsaSpec := &model.GHSASpec{GhsaID: &selectedGhsaID}
-	selectedGhsa, err := client.Ghsa(context.TODO(), selectedGhsaSpec)
-	if err != nil {
-		return err
-	}
-	client.registerIsVulnerability(selectedOsv[0], nil, selectedGhsa[0], "OSV maps to GHSA", "testing backend", "testing backend")
-
-	return nil
+// Internal data: link between equal vulnerabilities (isVulnerability)
+type equalVulnerabilityList []*equalVulnerabilityLink
+type equalVulnerabilityLink struct {
+	id            uint32
+	osvID         uint32
+	cveID         uint32
+	ghsaID        uint32
+	justification string
+	origin        string
+	collector     string
 }
+
+func (n *equalVulnerabilityLink) getID() uint32 { return n.id }
 
 // Ingest CertifyPkg
-
-func (c *demoClient) registerIsVulnerability(selectedOsv *model.Osv, selectedCve *model.Cve, selectedGhsa *model.Ghsa, justification, origin, collector string) *model.IsVulnerability {
-
-	for _, vuln := range c.isVulnerability {
-		if vuln.Justification == justification && reflect.DeepEqual(vuln.Osv, selectedOsv) {
-			if val, ok := vuln.Vulnerability.(model.Cve); ok {
-				if reflect.DeepEqual(val, *selectedCve) {
-					return vuln
-				}
-			} else if val, ok := vuln.Vulnerability.(model.Ghsa); ok {
-				if reflect.DeepEqual(val, *selectedGhsa) {
-					return vuln
-				}
-			}
-		}
-	}
-
-	newIsVuln := &model.IsVulnerability{
-		Osv:           selectedOsv,
-		Justification: justification,
-		Origin:        origin,
-		Collector:     collector,
-	}
-	if selectedCve != nil {
-		newIsVuln.Vulnerability = selectedCve
-	} else {
-		newIsVuln.Vulnerability = selectedGhsa
-	}
-
-	c.isVulnerability = append(c.isVulnerability, newIsVuln)
-	return newIsVuln
-}
-
 func (c *demoClient) IngestIsVulnerability(ctx context.Context, osv model.OSVInputSpec, vulnerability model.CveOrGhsaInput, isVulnerability model.IsVulnerabilityInputSpec) (*model.IsVulnerability, error) {
 	err := helper.ValidateCveOrGhsaIngestionInput(vulnerability, "IngestIsVulnerability")
 	if err != nil {
 		return nil, err
 	}
-	osvSpec := helper.ConvertOsvInputSpecToOsvSpec(&osv)
 
-	collectedOsv, err := c.Osv(ctx, osvSpec)
+	osvID, err := getOsvIDFromInput(c, osv)
 	if err != nil {
 		return nil, err
 	}
-	if len(collectedOsv) != 1 {
-		return nil, gqlerror.Errorf(
-			"IngestVulnerability :: osv argument must match one, found %d",
-			len(collectedOsv))
+
+	osvEqualVulns := []uint32{}
+	osvNode, ok := c.index[osvID].(*osvIDNode)
+	if ok {
+		osvEqualVulns = append(osvEqualVulns, osvNode.equalVulnLink...)
 	}
 
+	var cveID uint32
+	var ghsaID uint32
+	vulnerabilityLinks := []uint32{}
 	if vulnerability.Cve != nil {
-
-		cveSpec := helper.ConvertCveInputSpecToCveSpec(vulnerability.Cve)
-		collectedCve, err := c.Cve(ctx, cveSpec)
+		cveID, err = getCveIDFromInput(c, *vulnerability.Cve)
 		if err != nil {
 			return nil, err
 		}
-		if len(collectedCve) != 1 {
-			return nil, gqlerror.Errorf(
-				"IngestIsVulnerability :: cve argument must match one, found %d",
-				len(collectedCve))
+		cveNode, ok := c.index[cveID].(*cveIDNode)
+		if ok {
+			vulnerabilityLinks = append(vulnerabilityLinks, cveNode.equalVulnLink...)
 		}
-		return c.registerIsVulnerability(
-			collectedOsv[0],
-			collectedCve[0],
-			nil,
-			isVulnerability.Justification,
-			isVulnerability.Origin,
-			isVulnerability.Collector), nil
 	}
 
 	if vulnerability.Ghsa != nil {
-		ghsaSpec := helper.ConvertGhsaInputSpecToGhsaSpec(vulnerability.Ghsa)
-
-		collectedGhsa, err := c.Ghsa(ctx, ghsaSpec)
+		ghsaID, err = getGhsaIDFromInput(c, *vulnerability.Ghsa)
 		if err != nil {
 			return nil, err
 		}
-		if len(collectedGhsa) != 1 {
-			return nil, gqlerror.Errorf(
-				"IngestIsVulnerability :: ghsa argument must match one, found %d",
-				len(collectedGhsa))
+		ghsaNode, ok := c.index[ghsaID].(*ghsaIDNode)
+		if ok {
+			vulnerabilityLinks = append(vulnerabilityLinks, ghsaNode.equalVulnLink...)
 		}
-		return c.registerIsVulnerability(
-			collectedOsv[0],
-			nil,
-			collectedGhsa[0],
-			isVulnerability.Justification,
-			isVulnerability.Origin,
-			isVulnerability.Collector), nil
 	}
-	// it should never reach here else it failed
-	return nil, gqlerror.Errorf("IngestIsVulnerability failed")
-}
 
-// Query CertifyPkg
+	searchIDs := []uint32{}
+	if len(osvEqualVulns) > len(vulnerabilityLinks) {
+		searchIDs = append(searchIDs, vulnerabilityLinks...)
+	} else {
+		searchIDs = append(searchIDs, osvEqualVulns...)
+	}
 
-func (c *demoClient) IsVulnerability(ctx context.Context, isVulnerabilitySpec *model.IsVulnerabilitySpec) ([]*model.IsVulnerability, error) {
+	// Don't insert duplicates
+	duplicate := false
+	collectedEqualVulnLink := equalVulnerabilityLink{}
+	for _, id := range searchIDs {
+		v, _ := c.equalVulnByID(id)
+		vulnMatch := false
+		if cveID != 0 && cveID == v.cveID {
+			vulnMatch = true
+		}
+		if ghsaID != 0 && ghsaID == v.ghsaID {
+			vulnMatch = true
+		}
+		if vulnMatch && osvID == v.osvID && isVulnerability.Justification == v.justification &&
+			isVulnerability.Origin == v.origin && isVulnerability.Collector == v.collector {
 
-	queryAll, err := helper.ValidateCveOrGhsaQueryInput(isVulnerabilitySpec.Vulnerability)
+			collectedEqualVulnLink = *v
+			duplicate = true
+			break
+		}
+	}
+	if !duplicate {
+		// store the link
+		collectedEqualVulnLink = equalVulnerabilityLink{
+			id:            c.getNextID(),
+			osvID:         osvID,
+			cveID:         cveID,
+			ghsaID:        ghsaID,
+			justification: isVulnerability.Justification,
+			origin:        isVulnerability.Origin,
+			collector:     isVulnerability.Collector,
+		}
+		c.index[collectedEqualVulnLink.id] = &collectedEqualVulnLink
+		c.equalVulnerabilities = append(c.equalVulnerabilities, &collectedEqualVulnLink)
+		// set the backlinks
+		c.index[osvID].(*osvIDNode).setEqualVulnLink(collectedEqualVulnLink.id)
+		if cveID != 0 {
+			c.index[cveID].(*cveIDNode).setEqualVulnLink(collectedEqualVulnLink.id)
+		}
+		if ghsaID != 0 {
+			c.index[ghsaID].(*ghsaIDNode).setEqualVulnLink(collectedEqualVulnLink.id)
+		}
+	}
+
+	// build return GraphQL type
+	builtIsVuln, err := buildIsVulnerability(c, &collectedEqualVulnLink, nil, true)
 	if err != nil {
 		return nil, err
 	}
+	return builtIsVuln, nil
+}
 
-	var foundIsVulnerability []*model.IsVulnerability
+// Query CertifyPkg
+func (c *demoClient) IsVulnerability(ctx context.Context, filter *model.IsVulnerabilitySpec) ([]*model.IsVulnerability, error) {
+	out := []*model.IsVulnerability{}
 
-	for _, h := range c.isVulnerability {
-		matchOrSkip := true
-
-		if isVulnerabilitySpec.Justification != nil && h.Justification != *isVulnerabilitySpec.Justification {
-			matchOrSkip = false
+	if filter != nil && filter.ID != nil {
+		id, err := strconv.Atoi(*filter.ID)
+		if err != nil {
+			return nil, err
 		}
-		if isVulnerabilitySpec.Collector != nil && h.Collector != *isVulnerabilitySpec.Collector {
-			matchOrSkip = false
+		node, ok := c.index[uint32(id)]
+		if !ok {
+			return nil, gqlerror.Errorf("ID does not match existing node")
 		}
-		if isVulnerabilitySpec.Origin != nil && h.Origin != *isVulnerabilitySpec.Origin {
-			matchOrSkip = false
-		}
-
-		if isVulnerabilitySpec.Osv != nil && h.Osv != nil {
-			newOSV, err := filterOSVID(h.Osv, isVulnerabilitySpec.Osv)
+		if link, ok := node.(*equalVulnerabilityLink); ok {
+			foundIsVuln, err := buildIsVulnerability(c, link, filter, true)
 			if err != nil {
 				return nil, err
 			}
-			if newOSV == nil {
-				matchOrSkip = false
-			}
-		}
-
-		if !queryAll {
-			if isVulnerabilitySpec.Vulnerability != nil && isVulnerabilitySpec.Vulnerability.Cve != nil && h.Vulnerability != nil {
-				if val, ok := h.Vulnerability.(*model.Cve); ok {
-					if isVulnerabilitySpec.Vulnerability.Cve.Year == nil || val.Year == *isVulnerabilitySpec.Vulnerability.Cve.Year {
-						newCve, err := filterCVEID(val, isVulnerabilitySpec.Vulnerability.Cve)
-						if err != nil {
-							return nil, err
-						}
-						if newCve == nil {
-							matchOrSkip = false
-						}
-					}
-				} else {
-					matchOrSkip = false
-				}
-			}
-
-			if isVulnerabilitySpec.Vulnerability != nil && isVulnerabilitySpec.Vulnerability.Ghsa != nil && h.Vulnerability != nil {
-				if val, ok := h.Vulnerability.(*model.Ghsa); ok {
-					newGhsa, err := filterGHSAID(val, isVulnerabilitySpec.Vulnerability.Ghsa)
-					if err != nil {
-						return nil, err
-					}
-					if newGhsa == nil {
-						matchOrSkip = false
-					}
-				} else {
-					matchOrSkip = false
-				}
-			}
-		}
-
-		if matchOrSkip {
-			foundIsVulnerability = append(foundIsVulnerability, h)
+			return []*model.IsVulnerability{foundIsVuln}, nil
+		} else {
+			return nil, gqlerror.Errorf("ID does not match expected node type for equalVulnerabilityLink")
 		}
 	}
 
-	return foundIsVulnerability, nil
+	// TODO if any of the osv/vulnerabilities are specified, ony search those backedges
+	for _, link := range c.equalVulnerabilities {
+		if filter != nil && noMatch(filter.Justification, link.justification) {
+			continue
+		}
+		if filter != nil && noMatch(filter.Collector, link.collector) {
+			continue
+		}
+		if filter != nil && noMatch(filter.Origin, link.origin) {
+			continue
+		}
+
+		foundIsVuln, err := buildIsVulnerability(c, link, filter, false)
+		if err != nil {
+			return nil, err
+		}
+		if foundIsVuln == nil {
+			continue
+		}
+		out = append(out, foundIsVuln)
+	}
+
+	return out, nil
+}
+
+func buildIsVulnerability(c *demoClient, link *equalVulnerabilityLink, filter *model.IsVulnerabilitySpec, ingestOrIDProvided bool) (*model.IsVulnerability, error) {
+	var osv *model.Osv
+	var cve *model.Cve
+	var ghsa *model.Ghsa
+	var err error
+	if filter != nil {
+		osv, err = c.buildOsvResponse(link.osvID, filter.Osv)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+		osv, err = c.buildOsvResponse(link.osvID, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if filter != nil && filter.Vulnerability != nil {
+		if filter.Vulnerability.Cve != nil && link.cveID != 0 {
+			cve, err = c.buildCveResponse(link.cveID, filter.Vulnerability.Cve)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if filter.Vulnerability.Ghsa != nil && link.ghsaID != 0 {
+			ghsa, err = c.buildGhsaResponse(link.ghsaID, filter.Vulnerability.Ghsa)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		if link.cveID != 0 {
+			cve, err = c.buildCveResponse(link.cveID, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if link.ghsaID != 0 {
+			ghsa, err = c.buildGhsaResponse(link.ghsaID, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	// if osv not found during ingestion or if ID is provided in filter, send error. On query do not send error to continue search
+	if osv == nil && ingestOrIDProvided {
+		return nil, gqlerror.Errorf("failed to retrieve osv via osvID")
+	} else if osv == nil && !ingestOrIDProvided {
+		return nil, nil
+	}
+
+	var vuln model.CveOrGhsa
+	if link.cveID != 0 {
+		if cve == nil && ingestOrIDProvided {
+			return nil, gqlerror.Errorf("failed to retrieve cve via cveID")
+		} else if cve == nil && !ingestOrIDProvided {
+			return nil, nil
+		}
+		vuln = cve
+	}
+	if link.ghsaID != 0 {
+		if ghsa == nil && ingestOrIDProvided {
+			return nil, gqlerror.Errorf("failed to retrieve ghsa via ghsaID")
+		} else if ghsa == nil && !ingestOrIDProvided {
+			return nil, nil
+		}
+		vuln = ghsa
+	}
+
+	isVuln := model.IsVulnerability{
+		ID:            nodeID(link.id),
+		Osv:           osv,
+		Vulnerability: vuln,
+		Justification: link.justification,
+		Origin:        link.origin,
+		Collector:     link.collector,
+	}
+	return &isVuln, nil
+}
+
+func (c *demoClient) equalVulnByID(id uint32) (*equalVulnerabilityLink, error) {
+	node, ok := c.index[id]
+	if !ok {
+		return nil, errors.New("could not find equalVulnerabilityLink")
+	}
+	link, ok := node.(*equalVulnerabilityLink)
+	if !ok {
+		return nil, errors.New("not an equalVulnerabilityLink")
+	}
+	return link, nil
 }

--- a/pkg/assembler/backends/testing/osv.go
+++ b/pkg/assembler/backends/testing/osv.go
@@ -59,14 +59,27 @@ type osvNode struct {
 }
 type osvIDMap map[string]*osvIDNode
 type osvIDNode struct {
-	id     uint32
-	parent uint32
-	osvID  string
-	//TODO: add other back edges
+	id              uint32
+	parent          uint32
+	osvID           string
+	certifyVulnLink []uint32
+	equalVulnLink   []uint32
 }
 
 func (n *osvIDNode) getID() uint32 { return n.id }
 func (n *osvNode) getID() uint32   { return n.id }
+
+// certifyVulnerability back edges
+func (n *osvIDNode) setVulnerabilityLink(id uint32) {
+	n.certifyVulnLink = append(n.certifyVulnLink, id)
+}
+func (n *osvIDNode) getVulnerabilityLink() []uint32 { return n.certifyVulnLink }
+
+// isVulnerability back edges
+func (n *osvIDNode) setEqualVulnLink(id uint32) {
+	n.equalVulnLink = append(n.equalVulnLink, id)
+}
+func (n *osvIDNode) gettEqualVulnLink() []uint32 { return n.equalVulnLink }
 
 // Ingest OSV
 func (c *demoClient) IngestOsv(ctx context.Context, input *model.OSVInputSpec) (*model.Osv, error) {
@@ -179,6 +192,22 @@ func (c *demoClient) buildOsvResponse(id uint32, filter *model.OSVSpec) (*model.
 		OsvIds: osvIDList,
 	}
 	return &s, nil
+}
+
+func getOsvIDFromInput(c *demoClient, input model.OSVInputSpec) (uint32, error) {
+	osvStruct, hasOsv := c.osvs[osv]
+	if !hasOsv {
+		return 0, gqlerror.Errorf("osv type \"%s\" not found", osv)
+	}
+	osvIDs := osvStruct.osvIDs
+	osvID := strings.ToLower(input.OsvID)
+
+	osvIDStruct, hasOsvID := osvIDs[osvID]
+	if !hasOsvID {
+		return 0, gqlerror.Errorf("osv id \"%s\" not found", input.OsvID)
+	}
+
+	return osvIDStruct.id, nil
 }
 
 // TODO: remove

--- a/pkg/assembler/backends/testing/src.go
+++ b/pkg/assembler/backends/testing/src.go
@@ -332,14 +332,14 @@ func (c *demoClient) buildSourceResponse(id uint32, filter *model.SourceSpec) (*
 	return &s, nil
 }
 
-func getSourceIDFromInput(c *demoClient, input model.SourceInputSpec) (*uint32, error) {
+func getSourceIDFromInput(c *demoClient, input model.SourceInputSpec) (uint32, error) {
 	srcNamespace, srcHasNamespace := c.sources[input.Type]
 	if !srcHasNamespace {
-		return nil, gqlerror.Errorf("Source type \"%s\" not found", input.Type)
+		return 0, gqlerror.Errorf("Source type \"%s\" not found", input.Type)
 	}
 	srcName, srcHasName := srcNamespace.namespaces[input.Namespace]
 	if !srcHasName {
-		return nil, gqlerror.Errorf("Source namespace \"%s\" not found", input.Namespace)
+		return 0, gqlerror.Errorf("Source namespace \"%s\" not found", input.Namespace)
 	}
 	found := false
 	var sourceID uint32
@@ -354,15 +354,15 @@ func getSourceIDFromInput(c *demoClient, input model.SourceInputSpec) (*uint32, 
 			continue
 		}
 		if found {
-			return nil, gqlerror.Errorf("More than one source matches input")
+			return 0, gqlerror.Errorf("More than one source matches input")
 		}
 		sourceID = src.id
 		found = true
 	}
 	if !found {
-		return nil, gqlerror.Errorf("No source matches input")
+		return 0, gqlerror.Errorf("No source matches input")
 	}
-	return &sourceID, nil
+	return sourceID, nil
 }
 
 // TODO: remove these once the other components don't utilize it

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -753,6 +753,9 @@ type CertifyCVEIngestVulnerabilityCertifyVuln struct {
 	allCertifyVuln `json:"-"`
 }
 
+// GetId returns CertifyCVEIngestVulnerabilityCertifyVuln.Id, and is useful for accessing the field via an interface.
+func (v *CertifyCVEIngestVulnerabilityCertifyVuln) GetId() string { return v.allCertifyVuln.Id }
+
 // GetPackage returns CertifyCVEIngestVulnerabilityCertifyVuln.Package, and is useful for accessing the field via an interface.
 func (v *CertifyCVEIngestVulnerabilityCertifyVuln) GetPackage() allCertifyVulnPackage {
 	return v.allCertifyVuln.Package
@@ -794,6 +797,8 @@ func (v *CertifyCVEIngestVulnerabilityCertifyVuln) UnmarshalJSON(b []byte) error
 }
 
 type __premarshalCertifyCVEIngestVulnerabilityCertifyVuln struct {
+	Id string `json:"id"`
+
 	Package allCertifyVulnPackage `json:"package"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -812,6 +817,7 @@ func (v *CertifyCVEIngestVulnerabilityCertifyVuln) MarshalJSON() ([]byte, error)
 func (v *CertifyCVEIngestVulnerabilityCertifyVuln) __premarshalJSON() (*__premarshalCertifyCVEIngestVulnerabilityCertifyVuln, error) {
 	var retval __premarshalCertifyCVEIngestVulnerabilityCertifyVuln
 
+	retval.Id = v.allCertifyVuln.Id
 	retval.Package = v.allCertifyVuln.Package
 	{
 
@@ -1001,6 +1007,9 @@ type CertifyGHSAIngestVulnerabilityCertifyVuln struct {
 	allCertifyVuln `json:"-"`
 }
 
+// GetId returns CertifyGHSAIngestVulnerabilityCertifyVuln.Id, and is useful for accessing the field via an interface.
+func (v *CertifyGHSAIngestVulnerabilityCertifyVuln) GetId() string { return v.allCertifyVuln.Id }
+
 // GetPackage returns CertifyGHSAIngestVulnerabilityCertifyVuln.Package, and is useful for accessing the field via an interface.
 func (v *CertifyGHSAIngestVulnerabilityCertifyVuln) GetPackage() allCertifyVulnPackage {
 	return v.allCertifyVuln.Package
@@ -1042,6 +1051,8 @@ func (v *CertifyGHSAIngestVulnerabilityCertifyVuln) UnmarshalJSON(b []byte) erro
 }
 
 type __premarshalCertifyGHSAIngestVulnerabilityCertifyVuln struct {
+	Id string `json:"id"`
+
 	Package allCertifyVulnPackage `json:"package"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -1060,6 +1071,7 @@ func (v *CertifyGHSAIngestVulnerabilityCertifyVuln) MarshalJSON() ([]byte, error
 func (v *CertifyGHSAIngestVulnerabilityCertifyVuln) __premarshalJSON() (*__premarshalCertifyGHSAIngestVulnerabilityCertifyVuln, error) {
 	var retval __premarshalCertifyGHSAIngestVulnerabilityCertifyVuln
 
+	retval.Id = v.allCertifyVuln.Id
 	retval.Package = v.allCertifyVuln.Package
 	{
 
@@ -1249,6 +1261,9 @@ type CertifyOSVIngestVulnerabilityCertifyVuln struct {
 	allCertifyVuln `json:"-"`
 }
 
+// GetId returns CertifyOSVIngestVulnerabilityCertifyVuln.Id, and is useful for accessing the field via an interface.
+func (v *CertifyOSVIngestVulnerabilityCertifyVuln) GetId() string { return v.allCertifyVuln.Id }
+
 // GetPackage returns CertifyOSVIngestVulnerabilityCertifyVuln.Package, and is useful for accessing the field via an interface.
 func (v *CertifyOSVIngestVulnerabilityCertifyVuln) GetPackage() allCertifyVulnPackage {
 	return v.allCertifyVuln.Package
@@ -1290,6 +1305,8 @@ func (v *CertifyOSVIngestVulnerabilityCertifyVuln) UnmarshalJSON(b []byte) error
 }
 
 type __premarshalCertifyOSVIngestVulnerabilityCertifyVuln struct {
+	Id string `json:"id"`
+
 	Package allCertifyVulnPackage `json:"package"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -1308,6 +1325,7 @@ func (v *CertifyOSVIngestVulnerabilityCertifyVuln) MarshalJSON() ([]byte, error)
 func (v *CertifyOSVIngestVulnerabilityCertifyVuln) __premarshalJSON() (*__premarshalCertifyOSVIngestVulnerabilityCertifyVuln, error) {
 	var retval __premarshalCertifyOSVIngestVulnerabilityCertifyVuln
 
+	retval.Id = v.allCertifyVuln.Id
 	retval.Package = v.allCertifyVuln.Package
 	{
 
@@ -3590,6 +3608,9 @@ type IsVulnerabilityCVEIngestIsVulnerability struct {
 	allIsVulnerability `json:"-"`
 }
 
+// GetId returns IsVulnerabilityCVEIngestIsVulnerability.Id, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityCVEIngestIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+
 // GetOsv returns IsVulnerabilityCVEIngestIsVulnerability.Osv, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
 	return v.allIsVulnerability.Osv
@@ -3641,6 +3662,8 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) UnmarshalJSON(b []byte) error 
 }
 
 type __premarshalIsVulnerabilityCVEIngestIsVulnerability struct {
+	Id string `json:"id"`
+
 	Osv allIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -3663,6 +3686,7 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) MarshalJSON() ([]byte, error) 
 func (v *IsVulnerabilityCVEIngestIsVulnerability) __premarshalJSON() (*__premarshalIsVulnerabilityCVEIngestIsVulnerability, error) {
 	var retval __premarshalIsVulnerabilityCVEIngestIsVulnerability
 
+	retval.Id = v.allIsVulnerability.Id
 	retval.Osv = v.allIsVulnerability.Osv
 	{
 
@@ -3845,6 +3869,9 @@ type IsVulnerabilityGHSAIngestIsVulnerability struct {
 	allIsVulnerability `json:"-"`
 }
 
+// GetId returns IsVulnerabilityGHSAIngestIsVulnerability.Id, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+
 // GetOsv returns IsVulnerabilityGHSAIngestIsVulnerability.Osv, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
 	return v.allIsVulnerability.Osv
@@ -3896,6 +3923,8 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) UnmarshalJSON(b []byte) error
 }
 
 type __premarshalIsVulnerabilityGHSAIngestIsVulnerability struct {
+	Id string `json:"id"`
+
 	Osv allIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -3918,6 +3947,7 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) MarshalJSON() ([]byte, error)
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) __premarshalJSON() (*__premarshalIsVulnerabilityGHSAIngestIsVulnerability, error) {
 	var retval __premarshalIsVulnerabilityGHSAIngestIsVulnerability
 
+	retval.Id = v.allIsVulnerability.Id
 	retval.Osv = v.allIsVulnerability.Osv
 	{
 
@@ -9356,6 +9386,7 @@ func (v *allCertifyVEXStatementVulnerabilityGHSA) __premarshalJSON() (*__premars
 //
 // CertifyVuln is an attestation that represents when a package has a vulnerability
 type allCertifyVuln struct {
+	Id string `json:"id"`
 	// package (subject) - the package object type that represents the package
 	Package allCertifyVulnPackage `json:"package"`
 	// vulnerability (object) - union type that consists of osv, cve or ghsa
@@ -9363,6 +9394,9 @@ type allCertifyVuln struct {
 	// metadata (property) - contains all the vulnerability metadata
 	Metadata allCertifyVulnMetadataVulnerabilityMetaData `json:"metadata"`
 }
+
+// GetId returns allCertifyVuln.Id, and is useful for accessing the field via an interface.
+func (v *allCertifyVuln) GetId() string { return v.Id }
 
 // GetPackage returns allCertifyVuln.Package, and is useful for accessing the field via an interface.
 func (v *allCertifyVuln) GetPackage() allCertifyVulnPackage { return v.Package }
@@ -9409,6 +9443,8 @@ func (v *allCertifyVuln) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalallCertifyVuln struct {
+	Id string `json:"id"`
+
 	Package allCertifyVulnPackage `json:"package"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -9427,6 +9463,7 @@ func (v *allCertifyVuln) MarshalJSON() ([]byte, error) {
 func (v *allCertifyVuln) __premarshalJSON() (*__premarshalallCertifyVuln, error) {
 	var retval __premarshalallCertifyVuln
 
+	retval.Id = v.Id
 	retval.Package = v.Package
 	{
 
@@ -11298,12 +11335,16 @@ func (v *allIsOccurrencesTreeSubjectSource) __premarshalJSON() (*__premarshalall
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type allIsVulnerability struct {
+	Id            string                                   `json:"id"`
 	Osv           allIsVulnerabilityOsvOSV                 `json:"osv"`
 	Vulnerability allIsVulnerabilityVulnerabilityCveOrGhsa `json:"-"`
 	Justification string                                   `json:"justification"`
 	Origin        string                                   `json:"origin"`
 	Collector     string                                   `json:"collector"`
 }
+
+// GetId returns allIsVulnerability.Id, and is useful for accessing the field via an interface.
+func (v *allIsVulnerability) GetId() string { return v.Id }
 
 // GetOsv returns allIsVulnerability.Osv, and is useful for accessing the field via an interface.
 func (v *allIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV { return v.Osv }
@@ -11356,6 +11397,8 @@ func (v *allIsVulnerability) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalallIsVulnerability struct {
+	Id string `json:"id"`
+
 	Osv allIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
@@ -11378,6 +11421,7 @@ func (v *allIsVulnerability) MarshalJSON() ([]byte, error) {
 func (v *allIsVulnerability) __premarshalJSON() (*__premarshalallIsVulnerability, error) {
 	var retval __premarshalallIsVulnerability
 
+	retval.Id = v.Id
 	retval.Osv = v.Osv
 	{
 
@@ -13314,6 +13358,7 @@ fragment allCveTree on CVE {
 	}
 }
 fragment allCertifyVuln on CertifyVuln {
+	id
 	package {
 		... allPkgTree
 	}
@@ -13424,6 +13469,7 @@ fragment allGHSATree on GHSA {
 	}
 }
 fragment allCertifyVuln on CertifyVuln {
+	id
 	package {
 		... allPkgTree
 	}
@@ -13535,6 +13581,7 @@ fragment allOSVTree on OSV {
 	}
 }
 fragment allCertifyVuln on CertifyVuln {
+	id
 	package {
 		... allPkgTree
 	}
@@ -14300,6 +14347,7 @@ fragment allCveTree on CVE {
 	}
 }
 fragment allIsVulnerability on IsVulnerability {
+	id
 	osv {
 		... allOSVTree
 	}
@@ -14380,6 +14428,7 @@ fragment allGHSATree on GHSA {
 	}
 }
 fragment allIsVulnerability on IsVulnerability {
+	id
 	osv {
 		... allOSVTree
 	}

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -237,6 +237,7 @@ fragment allHasSourceAt on HasSourceAt {
 }
 
 fragment allCertifyVuln on CertifyVuln {
+  id
   package {
     ...allPkgTree
   }
@@ -264,6 +265,7 @@ fragment allCertifyVuln on CertifyVuln {
 }
 
 fragment allIsVulnerability on IsVulnerability {
+  id
   osv {
     ...allOSVTree
   }

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -1,11 +1,16 @@
 fragment allCertifyVulnTree on CertifyVuln {
+  id
   package {
+      id
       type
       namespaces {
+        id
         namespace
         names {
+          id
           name
           versions {
+            id
             version
             qualifiers {
               key

--- a/pkg/assembler/graphql/examples/is_vulnerability.gql
+++ b/pkg/assembler/graphql/examples/is_vulnerability.gql
@@ -1,20 +1,27 @@
 fragment allIsVulnerabilityTree on IsVulnerability {
+  id
   osv {
+    id
     osvIds{
       id
+      osvId
     }
   }
   vulnerability {
     __typename
     ... on CVE {
+      id
       year
       cveIds{
        id
+       cveId
       }
     }
     ... on GHSA {
+      id
       ghsaIds{
         id
+        ghsaId
       }
     }
   }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -1479,6 +1479,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnerability(ctx contex
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyVuln_id(ctx, field)
 			case "package":
 				return ec.fieldContext_CertifyVuln_package(ctx, field)
 			case "vulnerability":
@@ -2125,6 +2127,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestIsVulnerability(ctx cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsVulnerability_id(ctx, field)
 			case "osv":
 				return ec.fieldContext_IsVulnerability_osv(ctx, field)
 			case "vulnerability":
@@ -2763,6 +2767,8 @@ func (ec *executionContext) fieldContext_Query_CertifyVuln(ctx context.Context, 
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyVuln_id(ctx, field)
 			case "package":
 				return ec.fieldContext_CertifyVuln_package(ctx, field)
 			case "vulnerability":
@@ -3354,6 +3360,8 @@ func (ec *executionContext) fieldContext_Query_IsVulnerability(ctx context.Conte
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsVulnerability_id(ctx, field)
 			case "osv":
 				return ec.fieldContext_IsVulnerability_osv(ctx, field)
 			case "vulnerability":

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -29,6 +29,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _CertifyVuln_id(ctx context.Context, field graphql.CollectedField, obj *model.CertifyVuln) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyVuln_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CertifyVuln_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CertifyVuln",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CertifyVuln_package(ctx context.Context, field graphql.CollectedField, obj *model.CertifyVuln) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CertifyVuln_package(ctx, field)
 	if err != nil {
@@ -504,13 +548,21 @@ func (ec *executionContext) unmarshalInputCertifyVulnSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"package", "vulnerability", "timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "package", "vulnerability", "timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "package":
 			var err error
 
@@ -801,6 +853,13 @@ func (ec *executionContext) _CertifyVuln(ctx context.Context, sel ast.SelectionS
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CertifyVuln")
+		case "id":
+
+			out.Values[i] = ec._CertifyVuln_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "package":
 
 			out.Values[i] = ec._CertifyVuln_package(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/isVulnerability.generated.go
+++ b/pkg/assembler/graphql/generated/isVulnerability.generated.go
@@ -28,6 +28,50 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
+func (ec *executionContext) _IsVulnerability_id(ctx context.Context, field graphql.CollectedField, obj *model.IsVulnerability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IsVulnerability_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IsVulnerability_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IsVulnerability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _IsVulnerability_osv(ctx context.Context, field graphql.CollectedField, obj *model.IsVulnerability) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_IsVulnerability_osv(ctx, field)
 	if err != nil {
@@ -381,13 +425,21 @@ func (ec *executionContext) unmarshalInputIsVulnerabilitySpec(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"osv", "vulnerability", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "osv", "vulnerability", "justification", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "osv":
 			var err error
 
@@ -475,6 +527,13 @@ func (ec *executionContext) _IsVulnerability(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IsVulnerability")
+		case "id":
+
+			out.Values[i] = ec._IsVulnerability_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "osv":
 
 			out.Values[i] = ec._IsVulnerability_osv(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -89,6 +89,7 @@ type ComplexityRoot struct {
 	}
 
 	CertifyVuln struct {
+		ID            func(childComplexity int) int
 		Metadata      func(childComplexity int) int
 		Package       func(childComplexity int) int
 		Vulnerability func(childComplexity int) int
@@ -155,6 +156,7 @@ type ComplexityRoot struct {
 
 	IsVulnerability struct {
 		Collector     func(childComplexity int) int
+		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
 		Osv           func(childComplexity int) int
@@ -506,6 +508,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CertifyVEXStatement.Vulnerability(childComplexity), true
 
+	case "CertifyVuln.id":
+		if e.complexity.CertifyVuln.ID == nil {
+			break
+		}
+
+		return e.complexity.CertifyVuln.ID(childComplexity), true
+
 	case "CertifyVuln.metadata":
 		if e.complexity.CertifyVuln.Metadata == nil {
 			break
@@ -778,6 +787,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IsVulnerability.Collector(childComplexity), true
+
+	case "IsVulnerability.id":
+		if e.complexity.IsVulnerability.ID == nil {
+			break
+		}
+
+		return e.complexity.IsVulnerability.ID(childComplexity), true
 
 	case "IsVulnerability.justification":
 		if e.complexity.IsVulnerability.Justification == nil {
@@ -2334,6 +2350,7 @@ CertifyVuln is an attestation that represents when a package has a vulnerability
 
 """
 type CertifyVuln {
+  id: ID!
   "package (subject) - the package object type that represents the package"
   package: Package!
   "vulnerability (object) - union type that consists of osv, cve or ghsa"
@@ -2382,6 +2399,7 @@ Specifying just the package allows to query for all vulnerabilities associated w
 Only OSV, CVE or GHSA can be specified at once
 """
 input CertifyVulnSpec {
+  id: ID
   package: PkgSpec
   vulnerability: OsvCveOrGhsaSpec
   timeScanned: Time
@@ -3211,6 +3229,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type IsVulnerability {
+  id: ID!
   osv: OSV!
   vulnerability: CveOrGhsa!
   justification: String!
@@ -3223,6 +3242,7 @@ IsVulnerabilitySpec allows filtering the list of IsVulnerability to return.
 Only CVE or GHSA can be specified at once.
 """
 input IsVulnerabilitySpec {
+  id: ID
   osv: OSVSpec
   vulnerability: CveOrGhsaSpec
   justification: String

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -266,6 +266,7 @@ type CertifyVEXStatementSpec struct {
 
 // CertifyVuln is an attestation that represents when a package has a vulnerability
 type CertifyVuln struct {
+	ID string `json:"id"`
 	// package (subject) - the package object type that represents the package
 	Package *Package `json:"package"`
 	// vulnerability (object) - union type that consists of osv, cve or ghsa
@@ -281,6 +282,7 @@ func (CertifyVuln) IsNodes() {}
 // Specifying just the package allows to query for all vulnerabilities associated with the package.
 // Only OSV, CVE or GHSA can be specified at once
 type CertifyVulnSpec struct {
+	ID             *string           `json:"id,omitempty"`
 	Package        *PkgSpec          `json:"package,omitempty"`
 	Vulnerability  *OsvCveOrGhsaSpec `json:"vulnerability,omitempty"`
 	TimeScanned    *time.Time        `json:"timeScanned,omitempty"`
@@ -578,6 +580,7 @@ type IsOccurrenceSpec struct {
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 type IsVulnerability struct {
+	ID            string    `json:"id"`
 	Osv           *Osv      `json:"osv"`
 	Vulnerability CveOrGhsa `json:"vulnerability"`
 	Justification string    `json:"justification"`
@@ -599,6 +602,7 @@ type IsVulnerabilityInputSpec struct {
 // IsVulnerabilitySpec allows filtering the list of IsVulnerability to return.
 // Only CVE or GHSA can be specified at once.
 type IsVulnerabilitySpec struct {
+	ID            *string        `json:"id,omitempty"`
 	Osv           *OSVSpec       `json:"osv,omitempty"`
 	Vulnerability *CveOrGhsaSpec `json:"vulnerability,omitempty"`
 	Justification *string        `json:"justification,omitempty"`

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -22,6 +22,7 @@ CertifyVuln is an attestation that represents when a package has a vulnerability
 
 """
 type CertifyVuln {
+  id: ID!
   "package (subject) - the package object type that represents the package"
   package: Package!
   "vulnerability (object) - union type that consists of osv, cve or ghsa"
@@ -70,6 +71,7 @@ Specifying just the package allows to query for all vulnerabilities associated w
 Only OSV, CVE or GHSA can be specified at once
 """
 input CertifyVulnSpec {
+  id: ID
   package: PkgSpec
   vulnerability: OsvCveOrGhsaSpec
   timeScanned: Time

--- a/pkg/assembler/graphql/schema/isVulnerability.graphql
+++ b/pkg/assembler/graphql/schema/isVulnerability.graphql
@@ -42,6 +42,7 @@ origin (property) - where this attestation was generated from (based on which do
 collector (property) - the GUAC collector that collected the document that generated this attestation
 """
 type IsVulnerability {
+  id: ID!
   osv: OSV!
   vulnerability: CveOrGhsa!
   justification: String!
@@ -54,6 +55,7 @@ IsVulnerabilitySpec allows filtering the list of IsVulnerability to return.
 Only CVE or GHSA can be specified at once.
 """
 input IsVulnerabilitySpec {
+  id: ID
   osv: OSVSpec
   vulnerability: CveOrGhsaSpec
   justification: String


### PR DESCRIPTION
- update `certifyVuln` and `isVuln` to add IDs and back edges
- update ingestion query of `certifyScorecard`, `hasSourceAt` to check subject/object back edges for duplicates
- fix duplicated code
- add back edges to cve, osv and ghsa
- updates examples and test cases (to add duplicates)
- update `get*IDFromInput` to return a "0" for not found instead of nil pointer