### PR TITLE
Backend cleanup and rename

### DIFF
--- a/cmd/graphql_playground/cmd/server.go
+++ b/cmd/graphql_playground/cmd/server.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
-	neo4j "github.com/guacsec/guac/pkg/assembler/backends/neo4j"
-	testing "github.com/guacsec/guac/pkg/assembler/backends/testing"
+
+	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends/neo4j"
 	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
 	"github.com/guacsec/guac/pkg/logging"
@@ -58,10 +59,10 @@ func startServer() {
 
 		topResolver = resolvers.Resolver{Backend: backend}
 	} else {
-		args := testing.DemoCredentials{}
-		backend, err := testing.GetBackend(&args)
+		args := inmem.DemoCredentials{}
+		backend, err := inmem.GetBackend(&args)
 		if err != nil {
-			fmt.Printf("Error creating testing backend: %v", err)
+			fmt.Printf("Error creating inmem backend: %v", err)
 			os.Exit(1)
 		}
 

--- a/cmd/guacone/cmd/graphql_server.go
+++ b/cmd/guacone/cmd/graphql_server.go
@@ -23,13 +23,14 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
-	neo4j "github.com/guacsec/guac/pkg/assembler/backends/neo4j"
-	"github.com/guacsec/guac/pkg/assembler/backends/testing"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends/neo4j"
 	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
 	"github.com/guacsec/guac/pkg/logging"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -131,8 +132,8 @@ func getGraphqlServer(opts graphqlServerOptions) (*handler.Server, error) {
 
 		topResolver = resolvers.Resolver{Backend: backend}
 	case gqlBackendInmem:
-		args := testing.DemoCredentials{}
-		backend, err := testing.GetBackend(&args)
+		args := inmem.DemoCredentials{}
+		backend, err := inmem.GetBackend(&args)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating inmem backend: %w", err)
 		}

--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
@@ -40,9 +40,9 @@ type artStruct struct {
 	badLinks    []uint32
 }
 
-func (n *artStruct) getID() uint32 { return n.id }
+func (n *artStruct) ID() uint32 { return n.id }
 
-func (n *artStruct) neighbors() []uint32 {
+func (n *artStruct) Neighbors() []uint32 {
 	out := make([]uint32, 0, len(n.hashEquals)+len(n.occurrences)+len(n.hasSLSAs)+len(n.vexLinks)+len(n.badLinks))
 	out = append(out, n.hashEquals...)
 	out = append(out, n.occurrences...)
@@ -52,22 +52,15 @@ func (n *artStruct) neighbors() []uint32 {
 	return out
 }
 
-func (n *artStruct) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *artStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convArtifact(n), nil
 }
 
-func (n *artStruct) setHashEquals(id uint32) { n.hashEquals = append(n.hashEquals, id) }
-
-func (n *artStruct) setOccurrences(id uint32) { n.occurrences = append(n.occurrences, id) }
-
-func (n *artStruct) getHasSLSAs() []uint32 { return n.hasSLSAs }
-func (n *artStruct) setHasSLSAs(id uint32) { n.hasSLSAs = append(n.hasSLSAs, id) }
-
-// certifyVexStatement back edges
-func (n *artStruct) setVexLinks(id uint32) { n.vexLinks = append(n.vexLinks, id) }
-
-// occurrence back edges
-func (p *artStruct) setCertifyBadLinks(id uint32) { p.badLinks = append(p.badLinks, id) }
+func (n *artStruct) setHashEquals(id uint32)      { n.hashEquals = append(n.hashEquals, id) }
+func (n *artStruct) setOccurrences(id uint32)     { n.occurrences = append(n.occurrences, id) }
+func (n *artStruct) setHasSLSAs(id uint32)        { n.hasSLSAs = append(n.hasSLSAs, id) }
+func (n *artStruct) setVexLinks(id uint32)        { n.vexLinks = append(n.vexLinks, id) }
+func (n *artStruct) setCertifyBadLinks(id uint32) { n.badLinks = append(n.badLinks, id) }
 
 // TODO convert to unit tests
 // func registerAllArtifacts(c *demoClient) {

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"fmt"
@@ -28,7 +28,7 @@ type DemoCredentials struct{}
 
 // node is the common interface of all backend nodes.
 type node interface {
-	// getID provides global IDs for all nodes that can be referenced from
+	// ID provides global IDs for all nodes that can be referenced from
 	// other places in GUAC.
 	//
 	// Since we always ingest data and never remove,
@@ -39,16 +39,16 @@ type node interface {
 	//
 	// IDs are stored as string in graphql even though we ask for integers
 	// See https://github.com/99designs/gqlgen/issues/2561
-	getID() uint32
+	ID() uint32
 
-	// neighbors allows retrieving neighbors of a node using the backlinks.
+	// Neighbors allows retrieving neighbors of a node using the backlinks.
 	//
 	// This is useful for path related queries where the type of the node
 	// is not as relevant as its connections.
-	neighbors() []uint32
+	Neighbors() []uint32
 
-	// buildModelNode builds a GraphQL return type for a backend node,
-	buildModelNode(c *demoClient) (model.Node, error)
+	// BuildModelNode builds a GraphQL return type for a backend node,
+	BuildModelNode(c *demoClient) (model.Node, error)
 }
 
 type indexType map[uint32]node

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -13,15 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 type builderMap map[string]*builderStruct
@@ -31,11 +32,11 @@ type builderStruct struct {
 	hasSLSAs []uint32
 }
 
-func (b *builderStruct) getID() uint32 { return b.id }
+func (b *builderStruct) ID() uint32 { return b.id }
 
-func (b *builderStruct) neighbors() []uint32 { return b.hasSLSAs }
+func (b *builderStruct) Neighbors() []uint32 { return b.hasSLSAs }
 
-func (b *builderStruct) buildModelNode(c *demoClient) (model.Node, error) {
+func (b *builderStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convBuilder(b), nil
 }
 

--- a/pkg/assembler/backends/inmem/certifyBad.go
+++ b/pkg/assembler/backends/inmem/certifyBad.go
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Internal data: link that a package/source/artifact is bad
@@ -37,9 +38,9 @@ type badLink struct {
 	collector     string
 }
 
-func (n *badLink) getID() uint32 { return n.id }
+func (n *badLink) ID() uint32 { return n.id }
 
-func (n *badLink) neighbors() []uint32 {
+func (n *badLink) Neighbors() []uint32 {
 	out := make([]uint32, 0, 1)
 	if n.packageID != 0 {
 		out = append(out, n.packageID)
@@ -53,7 +54,7 @@ func (n *badLink) neighbors() []uint32 {
 	return out
 }
 
-func (n *badLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *badLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildCertifyBad(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/certifyPkg.go
+++ b/pkg/assembler/backends/inmem/certifyPkg.go
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"golang.org/x/exp/slices"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 type certifyPkgList []*certifyPkgStruct
@@ -34,10 +35,10 @@ type certifyPkgStruct struct {
 	collector     string
 }
 
-func (n *certifyPkgStruct) getID() uint32       { return n.id }
-func (n *certifyPkgStruct) neighbors() []uint32 { return n.pkgs }
+func (n *certifyPkgStruct) ID() uint32          { return n.id }
+func (n *certifyPkgStruct) Neighbors() []uint32 { return n.pkgs }
 
-func (n *certifyPkgStruct) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *certifyPkgStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convCertifyPkg(n), nil
 }
 
@@ -72,7 +73,7 @@ func (n *certifyPkgStruct) buildModelNode(c *demoClient) (model.Node, error) {
 // 	if err != nil {
 // 		return err
 // 	}
-// 	client.registerCertifyPkg([]*model.Package{selectedPackage1[0], selectedPackage2[0]}, "these two opnessl packages are the same", "testing backend", "testing backend")
+// 	client.registerCertifyPkg([]*model.Package{selectedPackage1[0], selectedPackage2[0]}, "these two opnessl packages are the same", "inmem backend", "inmem backend")
 
 // 	// pkg:pypi/django@1.11.1
 // 	// client.registerPackage("pypi", "", "django", "1.11.1", "")
@@ -101,7 +102,7 @@ func (n *certifyPkgStruct) buildModelNode(c *demoClient) (model.Node, error) {
 // 	if err != nil {
 // 		return err
 // 	}
-// 	client.registerCertifyPkg([]*model.Package{selectedPackage3[0], selectedPackage4[0]}, "these two pypi packages are the same", "testing backend", "testing backend")
+// 	client.registerCertifyPkg([]*model.Package{selectedPackage3[0], selectedPackage4[0]}, "these two pypi packages are the same", "inmem backend", "inmem backend")
 
 // 	return nil
 // }

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
@@ -22,8 +22,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 // Internal data: link between source and scorecard (certifyScorecard)
@@ -40,13 +41,13 @@ type scorecardLink struct {
 	collector        string
 }
 
-func (n *scorecardLink) getID() uint32 { return n.id }
+func (n *scorecardLink) ID() uint32 { return n.id }
 
-func (n *scorecardLink) neighbors() []uint32 {
+func (n *scorecardLink) Neighbors() []uint32 {
 	return []uint32{n.sourceID}
 }
 
-func (n *scorecardLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *scorecardLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildScorecard(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
@@ -21,9 +21,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Internal data: link between a package or an artifact with its corresponding vulnerability VEX statement
@@ -40,9 +41,9 @@ type vexLink struct {
 	collector     string
 }
 
-func (n *vexLink) getID() uint32 { return n.id }
+func (n *vexLink) ID() uint32 { return n.id }
 
-func (n *vexLink) neighbors() []uint32 {
+func (n *vexLink) Neighbors() []uint32 {
 	out := make([]uint32, 0, 2)
 	if n.packageID != 0 {
 		out = append(out, n.packageID)
@@ -59,7 +60,7 @@ func (n *vexLink) neighbors() []uint32 {
 	return out
 }
 
-func (n *vexLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *vexLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildCertifyVEXStatement(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
@@ -21,9 +21,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Internal data: link between packages and vulnerabilities (certifyVulnerability)
@@ -43,9 +44,9 @@ type vulnerabilityLink struct {
 	collector      string
 }
 
-func (n *vulnerabilityLink) getID() uint32 { return n.id }
+func (n *vulnerabilityLink) ID() uint32 { return n.id }
 
-func (n *vulnerabilityLink) neighbors() []uint32 {
+func (n *vulnerabilityLink) Neighbors() []uint32 {
 	out := make([]uint32, 0, 2)
 	out = append(out, n.packageID)
 	if n.osvID != 0 {
@@ -60,7 +61,7 @@ func (n *vulnerabilityLink) neighbors() []uint32 {
 	return out
 }
 
-func (n *vulnerabilityLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *vulnerabilityLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildCertifyVulnerability(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/cve.go
+++ b/pkg/assembler/backends/inmem/cve.go
@@ -13,44 +13,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
-	"log"
 	"strconv"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-func registerAllCVE(client *demoClient) {
-	ctx := context.Background()
+// func registerAllCVE(client *demoClient) {
+// 	ctx := context.Background()
 
-	inputs := []model.CVEInputSpec{{
-		Year:  2019,
-		CveID: "CVE-2019-13110",
-	}, {
-		Year:  2014,
-		CveID: "CVE-2014-8139",
-	}, {
-		Year:  2014,
-		CveID: "CVE-2014-8140",
-	}, {
-		Year:  2022,
-		CveID: "CVE-2022-26499",
-	}, {
-		Year:  2014,
-		CveID: "CVE-2014-8140",
-	}}
-	for _, input := range inputs {
-		_, err := client.IngestCve(ctx, &input)
-		if err != nil {
-			log.Printf("Error in ingesting: %v\n", err)
-		}
-	}
-}
+// 	inputs := []model.CVEInputSpec{{
+// 		Year:  2019,
+// 		CveID: "CVE-2019-13110",
+// 	}, {
+// 		Year:  2014,
+// 		CveID: "CVE-2014-8139",
+// 	}, {
+// 		Year:  2014,
+// 		CveID: "CVE-2014-8140",
+// 	}, {
+// 		Year:  2022,
+// 		CveID: "CVE-2022-26499",
+// 	}, {
+// 		Year:  2014,
+// 		CveID: "CVE-2014-8140",
+// 	}}
+// 	for _, input := range inputs {
+// 		_, err := client.IngestCve(ctx, &input)
+// 		if err != nil {
+// 			log.Printf("Error in ingesting: %v\n", err)
+// 		}
+// 	}
+// }
 
 // Internal data: osv
 type cveMap map[int]*cveNode
@@ -69,10 +69,10 @@ type cveIDNode struct {
 	vexLinks         []uint32
 }
 
-func (n *cveIDNode) getID() uint32 { return n.id }
-func (n *cveNode) getID() uint32   { return n.id }
+func (n *cveIDNode) ID() uint32 { return n.id }
+func (n *cveNode) ID() uint32   { return n.id }
 
-func (n *cveNode) neighbors() []uint32 {
+func (n *cveNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, len(n.cveIDs))
 	for _, v := range n.cveIDs {
 		out = append(out, v.id)
@@ -80,7 +80,7 @@ func (n *cveNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *cveIDNode) neighbors() []uint32 {
+func (n *cveIDNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, 1+len(n.certifyVulnLinks)+len(n.equalVulnLinks)+len(n.vexLinks))
 	out = append(out, n.certifyVulnLinks...)
 	out = append(out, n.equalVulnLinks...)
@@ -89,10 +89,10 @@ func (n *cveIDNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *cveIDNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *cveIDNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildCveResponse(n.id, nil)
 }
-func (n *cveNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *cveNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildCveResponse(n.id, nil)
 }
 

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -13,36 +13,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
-	"log"
 	"strconv"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 // TODO: convert to unit test
-func registerAllGHSA(client *demoClient) {
-	ctx := context.Background()
+// func registerAllGHSA(client *demoClient) {
+// 	ctx := context.Background()
 
-	inputs := []model.GHSAInputSpec{{
-		GhsaID: "GHSA-h45f-rjvw-2rv2",
-	}, {
-		GhsaID: "GHSA-xrw3-wqph-3fxg",
-	}, {
-		GhsaID: "GHSA-8v4j-7jgf-5rg9",
-	}}
-	for _, input := range inputs {
-		_, err := client.IngestGhsa(ctx, &input)
-		if err != nil {
-			log.Printf("Error in ingesting: %v\n", err)
-		}
-	}
-}
+// 	inputs := []model.GHSAInputSpec{{
+// 		GhsaID: "GHSA-h45f-rjvw-2rv2",
+// 	}, {
+// 		GhsaID: "GHSA-xrw3-wqph-3fxg",
+// 	}, {
+// 		GhsaID: "GHSA-8v4j-7jgf-5rg9",
+// 	}}
+// 	for _, input := range inputs {
+// 		_, err := client.IngestGhsa(ctx, &input)
+// 		if err != nil {
+// 			log.Printf("Error in ingesting: %v\n", err)
+// 		}
+// 	}
+// }
 
 const ghsa string = "ghsa"
 
@@ -63,10 +63,10 @@ type ghsaIDNode struct {
 	vexLinks         []uint32
 }
 
-func (n *ghsaIDNode) getID() uint32 { return n.id }
-func (n *ghsaNode) getID() uint32   { return n.id }
+func (n *ghsaIDNode) ID() uint32 { return n.id }
+func (n *ghsaNode) ID() uint32   { return n.id }
 
-func (n *ghsaNode) neighbors() []uint32 {
+func (n *ghsaNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, len(n.ghsaIDs))
 	for _, v := range n.ghsaIDs {
 		out = append(out, v.id)
@@ -74,7 +74,7 @@ func (n *ghsaNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *ghsaIDNode) neighbors() []uint32 {
+func (n *ghsaIDNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, 1+len(n.certifyVulnLinks)+len(n.equalVulnLinks)+len(n.vexLinks))
 	out = append(out, n.certifyVulnLinks...)
 	out = append(out, n.equalVulnLinks...)
@@ -83,10 +83,10 @@ func (n *ghsaIDNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *ghsaIDNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *ghsaIDNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildGhsaResponse(n.id, nil)
 }
-func (n *ghsaNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *ghsaNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildGhsaResponse(n.id, nil)
 }
 

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 type hasSBOMList []*hasSBOMStruct
@@ -35,16 +36,16 @@ type hasSBOMStruct struct {
 	collector string
 }
 
-func (n *hasSBOMStruct) getID() uint32 { return n.id }
+func (n *hasSBOMStruct) ID() uint32 { return n.id }
 
-func (n *hasSBOMStruct) neighbors() []uint32 {
+func (n *hasSBOMStruct) Neighbors() []uint32 {
 	if n.pkg != 0 {
 		return []uint32{n.pkg}
 	}
 	return []uint32{n.src}
 }
 
-func (n *hasSBOMStruct) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *hasSBOMStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convHasSBOM(n), nil
 }
 
@@ -64,7 +65,7 @@ func (n *hasSBOMStruct) buildModelNode(c *demoClient) (model.Node, error) {
 // 	if err != nil {
 // 		return err
 // 	}
-// 	_, err = client.registerHasSBOM(selectedPackage[0], nil, "uri:location of SBOM", "testing backend", "testing backend")
+// 	_, err = client.registerHasSBOM(selectedPackage[0], nil, "uri:location of SBOM", "inmem backend", "inmem backend")
 // 	if err != nil {
 // 		return err
 // 	}
@@ -78,7 +79,7 @@ func (n *hasSBOMStruct) buildModelNode(c *demoClient) (model.Node, error) {
 // 	if err != nil {
 // 		return err
 // 	}
-// 	_, err = client.registerHasSBOM(nil, selectedSource[0], "uri:location of SBOM", "testing backend", "testing backend")
+// 	_, err = client.registerHasSBOM(nil, selectedSource[0], "uri:location of SBOM", "inmem backend", "inmem backend")
 // 	if err != nil {
 // 		return err
 // 	}
@@ -117,7 +118,7 @@ func (c *demoClient) IngestHasSbom(ctx context.Context, subject model.PackageOrS
 		}
 		sourceID = sid
 		src, _ = c.sourceByID(sid)
-		search = src.getHasSBOM()
+		search = src.hasSBOMs
 	}
 
 	for _, id := range search {

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
@@ -21,8 +21,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 // Internal data: link between sources and packages (HasSourceAt)
@@ -37,13 +38,13 @@ type srcMapLink struct {
 	collector     string
 }
 
-func (n *srcMapLink) getID() uint32 { return n.id }
+func (n *srcMapLink) ID() uint32 { return n.id }
 
-func (n *srcMapLink) neighbors() []uint32 {
+func (n *srcMapLink) Neighbors() []uint32 {
 	return []uint32{n.sourceID, n.packageID}
 }
 
-func (n *srcMapLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *srcMapLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildHasSourceAt(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -39,17 +38,17 @@ type hashEqualStruct struct {
 	collector     string
 }
 
-func (n *hashEqualStruct) getID() uint32       { return n.id }
-func (n *hashEqualStruct) neighbors() []uint32 { return n.artifacts }
+func (n *hashEqualStruct) ID() uint32          { return n.id }
+func (n *hashEqualStruct) Neighbors() []uint32 { return n.artifacts }
 
-func (n *hashEqualStruct) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *hashEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convHashEqual(n), nil
 }
 
 // TODO convert to unit tests
 // func registerAllHashEqual(client *demoClient) {
 // 	strings.ToLower(string(checksum.Algorithm)) + ":" + checksum.Value
-// 	-client.registerHashEqual([]*model.Artifact{client.artifacts[0], client.artifacts[1], client.artifacts[2]}, "different algorithm for the same artifact", "testing backend", "testing backend")
+// 	-client.registerHashEqual([]*model.Artifact{client.artifacts[0], client.artifacts[1], client.artifacts[2]}, "different algorithm for the same artifact", "inmem backend", "inmem backend")
 // 	client.IngestHashEqual(
 // 		context.Background(),
 // 		model.ArtifactInputSpec{
@@ -62,8 +61,8 @@ func (n *hashEqualStruct) buildModelNode(c *demoClient) (model.Node, error) {
 // 		},
 // 		model.HashEqualInputSpec{
 // 			Justification: "these two are the same",
-// 			Origin:        "testing backend",
-// 			Collector:     "testing backend",
+// 			Origin:        "inmem backend",
+// 			Collector:     "inmem backend",
 // 		})
 // }
 
@@ -91,7 +90,7 @@ func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.Artifac
 		return nil, gqlerror.Errorf("IngestHashEqual :: Artifact not found")
 	}
 	artIDs := []uint32{aInt1.id, aInt2.id}
-	sort.Slice(artIDs, func(i, j int) bool { return artIDs[i] < artIDs[j] })
+	slices.Sort(artIDs)
 
 	// Search backedges for existing.
 	searchHEs := slices.Clone(aInt1.hashEquals)

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -13,15 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 // Internal data: link between packages and dependent packages (isDependency)
@@ -36,13 +37,13 @@ type isDependencyLink struct {
 	collector     string
 }
 
-func (n *isDependencyLink) getID() uint32 { return n.id }
+func (n *isDependencyLink) ID() uint32 { return n.id }
 
-func (n *isDependencyLink) neighbors() []uint32 {
+func (n *isDependencyLink) Neighbors() []uint32 {
 	return []uint32{n.packageID, n.depPackageID}
 }
 
-func (n *isDependencyLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *isDependencyLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildIsDependency(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/isOccurrence_test.go
+++ b/pkg/assembler/backends/inmem/isOccurrence_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing_test
+package inmem_test
 
 import (
 	"context"
@@ -21,8 +21,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	inmem "github.com/guacsec/guac/pkg/assembler/backends/testing"
+	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"errors"
 	"strconv"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Internal data: link between equal vulnerabilities (isVulnerability)
@@ -37,9 +38,9 @@ type equalVulnerabilityLink struct {
 	collector     string
 }
 
-func (n *equalVulnerabilityLink) getID() uint32 { return n.id }
+func (n *equalVulnerabilityLink) ID() uint32 { return n.id }
 
-func (n *equalVulnerabilityLink) neighbors() []uint32 {
+func (n *equalVulnerabilityLink) Neighbors() []uint32 {
 	out := make([]uint32, 0, 2)
 	if n.osvID != 0 {
 		out = append(out, n.osvID)
@@ -53,7 +54,7 @@ func (n *equalVulnerabilityLink) neighbors() []uint32 {
 	return out
 }
 
-func (n *equalVulnerabilityLink) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *equalVulnerabilityLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildIsVulnerability(n, nil, true)
 }
 

--- a/pkg/assembler/backends/inmem/osv.go
+++ b/pkg/assembler/backends/inmem/osv.go
@@ -13,40 +13,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
-	"log"
 	"strconv"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 // TODO: convert to unit test
-func registerAllOSV(client *demoClient) {
-	ctx := context.Background()
+// func registerAllOSV(client *demoClient) {
+// 	ctx := context.Background()
 
-	inputs := []model.OSVInputSpec{{
-		OsvID: "CVE-2019-13110",
-	}, {
-		OsvID: "CVE-2014-8139",
-	}, {
-		OsvID: "CVE-2014-8140",
-	}, {
-		OsvID: "CVE-2022-26499",
-	}, {
-		OsvID: "GHSA-h45f-rjvw-2rv2",
-	}}
-	for _, input := range inputs {
-		_, err := client.IngestOsv(ctx, &input)
-		if err != nil {
-			log.Printf("Error in ingesting: %v\n", err)
-		}
-	}
-}
+// 	inputs := []model.OSVInputSpec{{
+// 		OsvID: "CVE-2019-13110",
+// 	}, {
+// 		OsvID: "CVE-2014-8139",
+// 	}, {
+// 		OsvID: "CVE-2014-8140",
+// 	}, {
+// 		OsvID: "CVE-2022-26499",
+// 	}, {
+// 		OsvID: "GHSA-h45f-rjvw-2rv2",
+// 	}}
+// 	for _, input := range inputs {
+// 		_, err := client.IngestOsv(ctx, &input)
+// 		if err != nil {
+// 			log.Printf("Error in ingesting: %v\n", err)
+// 		}
+// 	}
+// }
 
 const osv string = "osv"
 
@@ -66,10 +66,10 @@ type osvIDNode struct {
 	equalVulnLinks   []uint32
 }
 
-func (n *osvIDNode) getID() uint32 { return n.id }
-func (n *osvNode) getID() uint32   { return n.id }
+func (n *osvIDNode) ID() uint32 { return n.id }
+func (n *osvNode) ID() uint32   { return n.id }
 
-func (n *osvNode) neighbors() []uint32 {
+func (n *osvNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, len(n.osvIDs))
 	for _, v := range n.osvIDs {
 		out = append(out, v.id)
@@ -77,7 +77,7 @@ func (n *osvNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *osvIDNode) neighbors() []uint32 {
+func (n *osvIDNode) Neighbors() []uint32 {
 	out := make([]uint32, 0, 1+len(n.certifyVulnLinks)+len(n.equalVulnLinks))
 	out = append(out, n.certifyVulnLinks...)
 	out = append(out, n.equalVulnLinks...)
@@ -85,10 +85,10 @@ func (n *osvIDNode) neighbors() []uint32 {
 	return out
 }
 
-func (n *osvIDNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *osvIDNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildOsvResponse(n.id, nil)
 }
-func (n *osvNode) buildModelNode(c *demoClient) (model.Node, error) {
+func (n *osvNode) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildOsvResponse(n.id, nil)
 }
 

--- a/pkg/assembler/backends/inmem/path.go
+++ b/pkg/assembler/backends/inmem/path.go
@@ -13,14 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package inmem
 
 import (
 	"context"
 	"strconv"
 
-	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *demoClient) Path(ctx context.Context, source string, target string, maxPathLength int) ([]model.Node, error) {
@@ -63,7 +64,7 @@ func (c *demoClient) buildModelNodes(nodeIDs []uint32) ([]model.Node, error) {
 		}
 		var err error
 
-		out[i], err = node.buildModelNode(c)
+		out[i], err = node.BuildModelNode(c)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +78,7 @@ func (c *demoClient) neighborsFromId(id uint32) ([]uint32, error) {
 	if !ok {
 		return nil, gqlerror.Errorf("ID does not match existing node")
 	}
-	return node.neighbors(), nil
+	return node.Neighbors(), nil
 }
 
 func (c *demoClient) bfs(from, to uint32, maxLength int) ([]model.Node, error) {

--- a/pkg/assembler/backends/neo4j/artifact.go
+++ b/pkg/assembler/backends/neo4j/artifact.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/builder.go
+++ b/pkg/assembler/backends/neo4j/builder.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/certifyBad.go
+++ b/pkg/assembler/backends/neo4j/certifyBad.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/certifyPkg.go
+++ b/pkg/assembler/backends/neo4j/certifyPkg.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/certifyVEXStatement.go
+++ b/pkg/assembler/backends/neo4j/certifyVEXStatement.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/certifyVuln.go
+++ b/pkg/assembler/backends/neo4j/certifyVuln.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/cve.go
+++ b/pkg/assembler/backends/neo4j/cve.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/ghsa.go
+++ b/pkg/assembler/backends/neo4j/ghsa.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/hasSLSA.go
+++ b/pkg/assembler/backends/neo4j/hasSLSA.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/hasSourceAt.go
+++ b/pkg/assembler/backends/neo4j/hasSourceAt.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/hashEqual.go
+++ b/pkg/assembler/backends/neo4j/hashEqual.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/ingest_testdata.go
+++ b/pkg/assembler/backends/neo4j/ingest_testdata.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"sort"

--- a/pkg/assembler/backends/neo4j/isDependency.go
+++ b/pkg/assembler/backends/neo4j/isDependency.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/isOccurrence.go
+++ b/pkg/assembler/backends/neo4j/isOccurrence.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/isVulnerability.go
+++ b/pkg/assembler/backends/neo4j/isVulnerability.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/osv.go
+++ b/pkg/assembler/backends/neo4j/osv.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/path.go
+++ b/pkg/assembler/backends/neo4j/path.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/pkg.go
+++ b/pkg/assembler/backends/neo4j/pkg.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"

--- a/pkg/assembler/backends/neo4j/src.go
+++ b/pkg/assembler/backends/neo4j/src.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package neo4jBackend
+package neo4j
 
 import (
 	"context"


### PR DESCRIPTION
Rename the testing backend to inmem, so that it does not clash with the Go
testing framework. Also rename the neo4j backend to match its directory
name. Make the required functions capital in the node interface. Organize the
imports properly. Remove the MaxUint usage. Use the generics-based
slices.Sort() where appropriate.