### PR TITLE
Improve query performance for verbs / links.

### DIFF
--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -98,18 +98,6 @@ func (c *demoClient) IngestArtifact(ctx context.Context, artifact *model.Artifac
 	return c.convArtifact(a), nil
 }
 
-func (c *demoClient) artifactByID(id uint32) (*artStruct, error) {
-	o, ok := c.index[id]
-	if !ok {
-		return nil, errors.New("could not find artifact")
-	}
-	a, ok := o.(*artStruct)
-	if !ok {
-		return nil, errors.New("not an artifact")
-	}
-	return a, nil
-}
-
 func (c *demoClient) artifactByKey(alg, dig string) (*artStruct, error) {
 	algorithm := strings.ToLower(alg)
 	digest := strings.ToLower(dig)
@@ -130,7 +118,7 @@ func (c *demoClient) artifactExact(artifactSpec *model.ArtifactSpec) (*artStruct
 			return nil, fmt.Errorf("couldn't parse id %w", err)
 		}
 		id := uint32(id64)
-		a, err := c.artifactByID(id)
+		a, err := byID[*artStruct](id, c)
 		if err != nil {
 			// Not found
 			return nil, nil
@@ -192,7 +180,7 @@ func (c *demoClient) convArtifact(a *artStruct) *model.Artifact {
 // The optional filter allows restricting output (on selection operations).
 func (c *demoClient) buildArtifactResponse(id uint32, filter *model.ArtifactSpec) (*model.Artifact, error) {
 	if filter != nil && filter.ID != nil {
-		filteredID, err := strconv.Atoi(*filter.ID)
+		filteredID, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -16,6 +16,7 @@
 package inmem
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -141,4 +142,17 @@ func toLower(filter *string) *string {
 		return &lower
 	}
 	return nil
+}
+
+func byID[E node](id uint32, c *demoClient) (E, error) {
+	var nl E
+	o, ok := c.index[id]
+	if !ok {
+		return nl, errors.New("could not find node")
+	}
+	s, ok := o.(E)
+	if !ok {
+		return nl, fmt.Errorf("not a %T", nl)
+	}
+	return s, nil
 }

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -17,7 +17,6 @@ package inmem
 
 import (
 	"context"
-	"errors"
 	"strconv"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -112,7 +111,7 @@ func (c *demoClient) IngestIsVulnerability(ctx context.Context, osv model.OSVInp
 	duplicate := false
 	collectedEqualVulnLink := equalVulnerabilityLink{}
 	for _, id := range searchIDs {
-		v, _ := c.equalVulnByID(id)
+		v, _ := byID[*equalVulnerabilityLink](id, c)
 		vulnMatch := false
 		if cveID != 0 && cveID == v.cveID {
 			vulnMatch = true
@@ -159,58 +158,109 @@ func (c *demoClient) IngestIsVulnerability(ctx context.Context, osv model.OSVInp
 	return builtIsVuln, nil
 }
 
-// Query CertifyPkg
+// Query IsVulnerability
 func (c *demoClient) IsVulnerability(ctx context.Context, filter *model.IsVulnerabilitySpec) ([]*model.IsVulnerability, error) {
-	err := helper.ValidateCveOrGhsaQueryFilter(filter.Vulnerability)
-	if err != nil {
+	funcName := "IsVulnerability"
+	if err := helper.ValidateCveOrGhsaQueryFilter(filter.Vulnerability); err != nil {
 		return nil, err
 	}
 
-	out := []*model.IsVulnerability{}
-
 	if filter != nil && filter.ID != nil {
-		id, err := strconv.Atoi(*filter.ID)
+		id64, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {
-			return nil, err
+			return nil, gqlerror.Errorf("%v :: invalid ID %s", funcName, err)
 		}
-		node, ok := c.index[uint32(id)]
-		if !ok {
-			return nil, gqlerror.Errorf("ID does not match existing node")
+		id := uint32(id64)
+		link, err := byID[*equalVulnerabilityLink](id, c)
+		if err != nil {
+			return nil, nil
 		}
-		if link, ok := node.(*equalVulnerabilityLink); ok {
-			foundIsVuln, err := c.buildIsVulnerability(link, filter, true)
-			if err != nil {
-				return nil, err
-			}
-			return []*model.IsVulnerability{foundIsVuln}, nil
-		} else {
-			return nil, gqlerror.Errorf("ID does not match expected node type for equalVulnerabilityLink")
+		foundIsVuln, err := c.buildIsVulnerability(link, filter, true)
+		if err != nil {
+			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
+		return []*model.IsVulnerability{foundIsVuln}, nil
 	}
 
-	// TODO if any of the osv/vulnerabilities are specified, ony search those backedges
-	for _, link := range c.equalVulnerabilities {
-		if filter != nil && noMatch(filter.Justification, link.justification) {
-			continue
-		}
-		if filter != nil && noMatch(filter.Collector, link.collector) {
-			continue
-		}
-		if filter != nil && noMatch(filter.Origin, link.origin) {
-			continue
-		}
-
-		foundIsVuln, err := c.buildIsVulnerability(link, filter, false)
+	var search []uint32
+	foundOne := false
+	if filter != nil && filter.Osv != nil {
+		exactOSV, err := c.exactOSV(filter.Osv)
 		if err != nil {
-			return nil, err
+			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if foundIsVuln == nil {
-			continue
+		if exactOSV != nil {
+			search = append(search, exactOSV.equalVulnLinks...)
+			foundOne = true
 		}
-		out = append(out, foundIsVuln)
+	}
+	if !foundOne && filter != nil && filter.Vulnerability != nil && filter.Vulnerability.Cve != nil {
+		exactCVE, err := c.exactCVE(filter.Vulnerability.Cve)
+		if err != nil {
+			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+		}
+		if exactCVE != nil {
+			search = append(search, exactCVE.equalVulnLinks...)
+			foundOne = true
+		}
+	}
+	if !foundOne && filter != nil && filter.Vulnerability != nil && filter.Vulnerability.Ghsa != nil {
+		exactGHSA, err := c.exactGHSA(filter.Vulnerability.Ghsa)
+		if err != nil {
+			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+		}
+		if exactGHSA != nil {
+			search = append(search, exactGHSA.equalVulnLinks...)
+			foundOne = true
+		}
+	}
+	var out []*model.IsVulnerability
+	if foundOne {
+		for _, id := range search {
+			link, err := byID[*equalVulnerabilityLink](id, c)
+			if err != nil {
+				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			}
+			out, err = c.addVulnIfMatch(out, filter, link)
+			if err != nil {
+				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			}
+		}
+	} else {
+		for _, link := range c.equalVulnerabilities {
+			var err error
+			out, err = c.addVulnIfMatch(out, filter, link)
+			if err != nil {
+				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			}
+		}
 	}
 
 	return out, nil
+}
+
+func (c *demoClient) addVulnIfMatch(out []*model.IsVulnerability,
+	filter *model.IsVulnerabilitySpec, link *equalVulnerabilityLink) (
+	[]*model.IsVulnerability, error) {
+
+	if filter != nil && noMatch(filter.Justification, link.justification) {
+		return out, nil
+	}
+	if filter != nil && noMatch(filter.Collector, link.collector) {
+		return out, nil
+	}
+	if filter != nil && noMatch(filter.Origin, link.origin) {
+		return out, nil
+	}
+
+	foundIsVuln, err := c.buildIsVulnerability(link, filter, false)
+	if err != nil {
+		return nil, err
+	}
+	if foundIsVuln == nil {
+		return out, nil
+	}
+	return append(out, foundIsVuln), nil
 }
 
 func (c *demoClient) buildIsVulnerability(link *equalVulnerabilityLink, filter *model.IsVulnerabilitySpec, ingestOrIDProvided bool) (*model.IsVulnerability, error) {
@@ -292,16 +342,4 @@ func (c *demoClient) buildIsVulnerability(link *equalVulnerabilityLink, filter *
 		Collector:     link.collector,
 	}
 	return &isVuln, nil
-}
-
-func (c *demoClient) equalVulnByID(id uint32) (*equalVulnerabilityLink, error) {
-	node, ok := c.index[id]
-	if !ok {
-		return nil, errors.New("could not find equalVulnerabilityLink")
-	}
-	link, ok := node.(*equalVulnerabilityLink)
-	if !ok {
-		return nil, errors.New("not an equalVulnerabilityLink")
-	}
-	return link, nil
 }

--- a/pkg/assembler/backends/inmem/path.go
+++ b/pkg/assembler/backends/inmem/path.go
@@ -28,11 +28,12 @@ func (c *demoClient) Path(ctx context.Context, source string, target string, max
 	if maxPathLength <= 0 {
 		return nil, gqlerror.Errorf("maxPathLength argument must be positive, got %d", maxPathLength)
 	}
-	sourceID, err := strconv.Atoi(source)
+
+	sourceID, err := strconv.ParseUint(source, 10, 32)
 	if err != nil {
 		return nil, err
 	}
-	targetID, err := strconv.Atoi(target)
+	targetID, err := strconv.ParseUint(target, 10, 32)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func (c *demoClient) Path(ctx context.Context, source string, target string, max
 }
 
 func (c *demoClient) Neighbors(ctx context.Context, source string) ([]model.Node, error) {
-	id, err := strconv.Atoi(source)
+	id, err := strconv.ParseUint(source, 10, 32)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a subject or object is specified on a verb query that exactly maps to a single node (ex: ID or full details are specified), then only search the backedges of that node for any matching verbs. Code cleanup on these functions for consistancy, and ease of copying. Change byid functions to use a single one with generic types. Standardise on using ParseUint() instead of Atoi().

Fixes #627 