### PR TITLE
Graphql changes for consistency

### DIFF
--- a/pkg/assembler/graphql/examples/artifact_builder.gql
+++ b/pkg/assembler/graphql/examples/artifact_builder.gql
@@ -50,6 +50,11 @@ mutation ArtifactM2 {
   }
 }
 
+fragment allBuilderTree on Builder {
+    id
+    uri
+}
+
 query BuilderQ1 {
   builders(builderSpec: {}) {
     id


### PR DESCRIPTION
Made HasSLSA have `Slsa` be compulsory
Made Vex be able to apply to OSV as well
Add misc missing fragments and renames