### PR TITLE
Update inmem backend to be concurrency-safe.

### DIFF
--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -88,8 +88,8 @@ func (c *demoClient) ingestArtifact(ctx context.Context, artifact *model.Artifac
 	algorithm := strings.ToLower(artifact.Algorithm)
 	digest := strings.ToLower(artifact.Digest)
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	a, err := c.artifactByKey(algorithm, digest)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/guacsec/guac/pkg/assembler/backends"
@@ -61,6 +62,7 @@ func (c *demoClient) getNextID() uint32 {
 
 type demoClient struct {
 	id uint32
+	m  sync.RWMutex
 
 	artifacts            artMap
 	builders             builderMap
@@ -155,4 +157,20 @@ func byID[E node](id uint32, c *demoClient) (E, error) {
 		return nl, fmt.Errorf("not a %T", nl)
 	}
 	return s, nil
+}
+
+func (c *demoClient) lock(readOnly bool) {
+	if readOnly {
+		c.m.RLock()
+	} else {
+		c.m.Lock()
+	}
+}
+
+func (c *demoClient) unlock(readOnly bool) {
+	if readOnly {
+		c.m.RUnlock()
+	} else {
+		c.m.Unlock()
+	}
 }

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -159,18 +159,18 @@ func byID[E node](id uint32, c *demoClient) (E, error) {
 	return s, nil
 }
 
-func (c *demoClient) lock(readOnly bool) {
+func lock(m *sync.RWMutex, readOnly bool) {
 	if readOnly {
-		c.m.RLock()
+		m.RLock()
 	} else {
-		c.m.Lock()
+		m.Lock()
 	}
 }
 
-func (c *demoClient) unlock(readOnly bool) {
+func unlock(m *sync.RWMutex, readOnly bool) {
 	if readOnly {
-		c.m.RUnlock()
+		m.RUnlock()
 	} else {
-		c.m.Unlock()
+		m.Unlock()
 	}
 }

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -61,8 +61,8 @@ func (c *demoClient) IngestBuilder(ctx context.Context, builder *model.BuilderIn
 }
 
 func (c *demoClient) ingestBuilder(ctx context.Context, builder *model.BuilderInputSpec, readOnly bool) (*model.Builder, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	b, err := c.builderByKey(builder.URI)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -57,8 +57,21 @@ func (c *demoClient) builderByKey(uri string) (*builderStruct, error) {
 
 // Ingest Builder
 func (c *demoClient) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {
+	return c.ingestBuilder(ctx, builder, true)
+}
+
+func (c *demoClient) ingestBuilder(ctx context.Context, builder *model.BuilderInputSpec, readOnly bool) (*model.Builder, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
+
 	b, err := c.builderByKey(builder.URI)
 	if err != nil {
+		if readOnly {
+			c.m.RUnlock()
+			b, err := c.ingestBuilder(ctx, builder, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return b, err
+		}
 		b = &builderStruct{
 			id:  c.getNextID(),
 			uri: builder.URI,
@@ -71,6 +84,8 @@ func (c *demoClient) IngestBuilder(ctx context.Context, builder *model.BuilderIn
 
 // Query Builder
 func (c *demoClient) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if builderSpec.ID != nil {
 		id64, err := strconv.ParseUint(*builderSpec.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/certifyBad.go
+++ b/pkg/assembler/backends/inmem/certifyBad.go
@@ -66,8 +66,8 @@ func (c *demoClient) ingestCertifyBad(ctx context.Context, subject model.Package
 		return nil, err
 	}
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	var packageID uint32
 	var artifactID uint32

--- a/pkg/assembler/backends/inmem/certifyPkg.go
+++ b/pkg/assembler/backends/inmem/certifyPkg.go
@@ -127,8 +127,8 @@ func (c *demoClient) IngestCertifyPkg(ctx context.Context, pkg model.PkgInputSpe
 }
 
 func (c *demoClient) ingestCertifyPkg(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, certifyPkg model.CertifyPkgInputSpec, readOnly bool) (*model.CertifyPkg, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	pIDs := make([]uint32, 0, 2)
 	for _, pi := range []model.PkgInputSpec{pkg, depPkg} {

--- a/pkg/assembler/backends/inmem/certifyPkg.go
+++ b/pkg/assembler/backends/inmem/certifyPkg.go
@@ -123,12 +123,16 @@ func (c *demoClient) convCertifyPkg(in *certifyPkgStruct) *model.CertifyPkg {
 }
 
 func (c *demoClient) IngestCertifyPkg(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, certifyPkg model.CertifyPkgInputSpec) (*model.CertifyPkg, error) {
-	var pmt model.MatchFlags
-	pmt.Pkg = model.PkgMatchTypeSpecificVersion
+	return c.ingestCertifyPkg(ctx, pkg, depPkg, certifyPkg, true)
+}
+
+func (c *demoClient) ingestCertifyPkg(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, certifyPkg model.CertifyPkgInputSpec, readOnly bool) (*model.CertifyPkg, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	pIDs := make([]uint32, 0, 2)
 	for _, pi := range []model.PkgInputSpec{pkg, depPkg} {
-		pid, err := getPackageIDFromInput(c, pi, pmt)
+		pid, err := getPackageIDFromInput(c, pi, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion})
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestCertifyPkg :: %v", err)
 		}
@@ -152,6 +156,13 @@ func (c *demoClient) IngestCertifyPkg(ctx context.Context, pkg model.PkgInputSpe
 		}
 	}
 
+	if readOnly {
+		c.m.RUnlock()
+		cp, err := c.ingestCertifyPkg(ctx, pkg, depPkg, certifyPkg, false)
+		c.m.RLock() // relock so that defer unlock does not panic
+		return cp, err
+	}
+
 	cp := &certifyPkgStruct{
 		id:            c.getNextID(),
 		pkgs:          pIDs,
@@ -171,6 +182,8 @@ func (c *demoClient) IngestCertifyPkg(ctx context.Context, pkg model.PkgInputSpe
 // Query CertifyPkg
 
 func (c *demoClient) CertifyPkg(ctx context.Context, filter *model.CertifyPkgSpec) ([]*model.CertifyPkg, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	funcName := "CertifyPkg"
 	if filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -56,8 +56,8 @@ func (c *demoClient) CertifyScorecard(ctx context.Context, source model.SourceIn
 }
 
 func (c *demoClient) certifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec, readOnly bool) (*model.CertifyScorecard, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 	sourceID, err := getSourceIDFromInput(c, source)
 	if err != nil {
 		return nil, err

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -81,8 +81,8 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		return nil, err
 	}
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	var packageID uint32
 	var artifactID uint32

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -74,8 +74,8 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		return nil, err
 	}
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	packageID, err := getPackageIDFromInput(c, packageArg, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion})
 	if err != nil {

--- a/pkg/assembler/backends/inmem/cve.go
+++ b/pkg/assembler/backends/inmem/cve.go
@@ -117,8 +117,8 @@ func (c *demoClient) IngestCve(ctx context.Context, input *model.CVEInputSpec) (
 }
 
 func (c *demoClient) ingestCve(ctx context.Context, input *model.CVEInputSpec, readOnly bool) (*model.Cve, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 	cveStruct, hasCve := c.cves[input.Year]
 	if !hasCve {
 		cveStruct = &cveNode{

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -111,8 +111,8 @@ func (c *demoClient) IngestGhsa(ctx context.Context, input *model.GHSAInputSpec)
 }
 
 func (c *demoClient) ingestGhsa(ctx context.Context, input *model.GHSAInputSpec, readOnly bool) (*model.Ghsa, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 	ghsaStruct, hasGhsa := c.ghsas[ghsa]
 	if !hasGhsa {
 		ghsaStruct = &ghsaNode{

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -107,6 +107,12 @@ func (n *ghsaIDNode) setVexLinks(id uint32) {
 
 // Ingest GHSA
 func (c *demoClient) IngestGhsa(ctx context.Context, input *model.GHSAInputSpec) (*model.Ghsa, error) {
+	return c.ingestGhsa(ctx, input, true)
+}
+
+func (c *demoClient) ingestGhsa(ctx context.Context, input *model.GHSAInputSpec, readOnly bool) (*model.Ghsa, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 	ghsaStruct, hasGhsa := c.ghsas[ghsa]
 	if !hasGhsa {
 		ghsaStruct = &ghsaNode{
@@ -122,6 +128,12 @@ func (c *demoClient) IngestGhsa(ctx context.Context, input *model.GHSAInputSpec)
 
 	ghsaIDStruct, hasGhsaID := ghsaIDs[ghsaID]
 	if !hasGhsaID {
+		if readOnly {
+			c.m.RUnlock()
+			g, err := c.ingestGhsa(ctx, input, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return g, err
+		}
 		ghsaIDStruct = &ghsaIDNode{
 			id:     c.getNextID(),
 			parent: ghsaStruct.id,
@@ -137,6 +149,8 @@ func (c *demoClient) IngestGhsa(ctx context.Context, input *model.GHSAInputSpec)
 
 // Query GHSA
 func (c *demoClient) Ghsa(ctx context.Context, filter *model.GHSASpec) ([]*model.Ghsa, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter != nil && filter.ID != nil {
 		id, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -96,8 +96,8 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 	if err != nil {
 		return nil, err
 	}
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	var search []uint32
 	var packageID uint32

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -88,10 +88,16 @@ func (n *hasSBOMStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest HasSBOM
 
 func (c *demoClient) IngestHasSbom(ctx context.Context, subject model.PackageOrSourceInput, input model.HasSBOMInputSpec) (*model.HasSbom, error) {
+	return c.ingestHasSbom(ctx, subject, input, true)
+}
+
+func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrSourceInput, input model.HasSBOMInputSpec, readOnly bool) (*model.HasSbom, error) {
 	err := helper.ValidatePackageOrSourceInput(&subject, "IngestHasSbom")
 	if err != nil {
 		return nil, err
 	}
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	var search []uint32
 	var packageID uint32
@@ -129,6 +135,13 @@ func (c *demoClient) IngestHasSbom(ctx context.Context, subject model.PackageOrS
 			h.collector == input.Collector {
 			return c.convHasSBOM(h), nil
 		}
+	}
+
+	if readOnly {
+		c.m.RUnlock()
+		b, err := c.ingestHasSbom(ctx, subject, input, false)
+		c.m.RLock() // relock so that defer unlock does not panic
+		return b, err
 	}
 
 	h := &hasSBOMStruct{
@@ -173,6 +186,8 @@ func (c *demoClient) HasSBOM(ctx context.Context, filter *model.HasSBOMSpec) ([]
 	if err := helper.ValidatePackageOrSourceQueryFilter(filter.Subject); err != nil {
 		return nil, err
 	}
+	c.m.RLock()
+	defer c.m.RUnlock()
 
 	if filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/exp/slices"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -61,6 +62,8 @@ func (n *hasSLSAStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 
 func (c *demoClient) HasSlsa(ctx context.Context, filter *model.HasSLSASpec) ([]*model.HasSlsa, error) {
 	funcName := "HasSlsa"
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter != nil && filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {
@@ -165,10 +168,19 @@ func (c *demoClient) IngestMaterials(ctx context.Context,
 func (c *demoClient) IngestSLSA(ctx context.Context,
 	subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec,
 	builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
+	return c.ingestSLSA(ctx, subject, builtFrom, builtBy, slsa, true)
+}
+
+func (c *demoClient) ingestSLSA(ctx context.Context,
+	subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec,
+	builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec, readOnly bool) (
+	*model.HasSlsa, error) {
 
 	if len(builtFrom) < 1 {
 		return nil, gqlerror.Errorf("IngestSLSA :: Must have at least 1 builtFrom")
 	}
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	s, err := c.artifactByKey(subject.Algorithm, subject.Digest)
 	if err != nil {
@@ -203,7 +215,7 @@ func (c *demoClient) IngestSLSA(ctx context.Context,
 			slices.Equal(sl.builtFrom, bfIDs) &&
 			sl.builtBy == b.id &&
 			sl.buildType == slsa.BuildType &&
-			slices.Equal(sl.predicates, preds) &&
+			cmp.Equal(sl.predicates, preds) &&
 			sl.version == slsa.SlsaVersion &&
 			sl.start == slsa.StartedOn &&
 			sl.finish == slsa.FinishedOn &&
@@ -211,6 +223,13 @@ func (c *demoClient) IngestSLSA(ctx context.Context,
 			sl.collector == slsa.Collector {
 			return c.convSLSA(sl), nil
 		}
+	}
+
+	if readOnly {
+		c.m.RUnlock()
+		s, err := c.ingestSLSA(ctx, subject, builtFrom, builtBy, slsa, false)
+		c.m.RLock() // relock so that defer unlock does not panic
+		return s, err
 	}
 
 	sl := &hasSLSAStruct{

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -179,8 +179,8 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 	if len(builtFrom) < 1 {
 		return nil, gqlerror.Errorf("IngestSLSA :: Must have at least 1 builtFrom")
 	}
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	s, err := c.artifactByKey(subject.Algorithm, subject.Digest)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -53,8 +53,8 @@ func (c *demoClient) IngestHasSourceAt(ctx context.Context, packageArg model.Pkg
 }
 
 func (c *demoClient) ingestHasSourceAt(ctx context.Context, packageArg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec, readOnly bool) (*model.HasSourceAt, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	sourceID, err := getSourceIDFromInput(c, source)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -71,8 +71,8 @@ func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.Artifac
 }
 
 func (c *demoClient) ingestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec, readOnly bool) (*model.HashEqual, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	aInt1, err := c.artifactByKey(artifact.Algorithm, artifact.Digest)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -67,6 +67,12 @@ func (n *hashEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 
 // Ingest HashEqual
 func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error) {
+	return c.ingestHashEqual(ctx, artifact, equalArtifact, hashEqual, true)
+}
+
+func (c *demoClient) ingestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec, readOnly bool) (*model.HashEqual, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	aInt1, err := c.artifactByKey(artifact.Algorithm, artifact.Digest)
 	if err != nil {
@@ -95,6 +101,13 @@ func (c *demoClient) IngestHashEqual(ctx context.Context, artifact model.Artifac
 			slices.Equal(h.artifacts, artIDs) {
 			return c.convHashEqual(h), nil
 		}
+	}
+
+	if readOnly {
+		c.m.RUnlock()
+		he, err := c.ingestHashEqual(ctx, artifact, equalArtifact, hashEqual, false)
+		c.m.RLock() // relock so that defer unlock does not panic
+		return he, err
 	}
 
 	he := &hashEqualStruct{
@@ -162,7 +175,8 @@ func (c *demoClient) HashEqual(ctx context.Context, filter *model.HashEqualSpec)
 		return nil, gqlerror.Errorf(
 			"%v :: Provided spec has too many Artifacts", funcName)
 	}
-
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -52,8 +52,8 @@ func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgI
 }
 
 func (c *demoClient) ingestDependency(ctx context.Context, packageArg model.PkgInputSpec, dependentPackageArg model.PkgInputSpec, dependency model.IsDependencyInputSpec, readOnly bool) (*model.IsDependency, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 	packageID, err := getPackageIDFromInput(c, packageArg, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion})
 	if err != nil {
 		return nil, err

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -48,6 +48,12 @@ func (n *isDependencyLink) BuildModelNode(c *demoClient) (model.Node, error) {
 
 // Ingest IsDependency
 func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgInputSpec, dependentPackageArg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
+	return c.ingestDependency(ctx, packageArg, dependentPackageArg, dependency, true)
+}
+
+func (c *demoClient) ingestDependency(ctx context.Context, packageArg model.PkgInputSpec, dependentPackageArg model.PkgInputSpec, dependency model.IsDependencyInputSpec, readOnly bool) (*model.IsDependency, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 	packageID, err := getPackageIDFromInput(c, packageArg, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion})
 	if err != nil {
 		return nil, err
@@ -92,6 +98,12 @@ func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgI
 		}
 	}
 	if !duplicate {
+		if readOnly {
+			c.m.RUnlock()
+			d, err := c.ingestDependency(ctx, packageArg, dependentPackageArg, dependency, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return d, err
+		}
 		// store the link
 		collectedIsDependencyLink = isDependencyLink{
 			id:            c.getNextID(),
@@ -120,6 +132,8 @@ func (c *demoClient) IngestDependency(ctx context.Context, packageArg model.PkgI
 
 // Query IsDependency
 func (c *demoClient) IsDependency(ctx context.Context, filter *model.IsDependencySpec) ([]*model.IsDependency, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	funcName := "IsDependency"
 	if filter != nil && filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -104,8 +104,8 @@ func (c *demoClient) ingestOccurrence(ctx context.Context, subject model.Package
 		return nil, err
 	}
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	a, err := c.artifactByKey(artifact.Algorithm, artifact.Digest)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -96,10 +96,16 @@ func (n *isOccurrenceStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 
 // Ingest IsOccurrence
 func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error) {
-	err := helper.ValidatePackageOrSourceInput(&subject, "IngestOccurrence")
-	if err != nil {
+	return c.ingestOccurrence(ctx, subject, artifact, occurrence, true)
+}
+
+func (c *demoClient) ingestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec, readOnly bool) (*model.IsOccurrence, error) {
+	if err := helper.ValidatePackageOrSourceInput(&subject, "IngestOccurrence"); err != nil {
 		return nil, err
 	}
+
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	a, err := c.artifactByKey(artifact.Algorithm, artifact.Digest)
 	if err != nil {
@@ -137,6 +143,12 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 			o.collector == occurrence.Collector {
 			return c.convOccurrence(o), nil
 		}
+	}
+	if readOnly {
+		c.m.RUnlock()
+		o, err := c.ingestOccurrence(ctx, subject, artifact, occurrence, false)
+		c.m.RLock() // relock so that defer unlock does not panic
+		return o, err
 	}
 	o := &isOccurrenceStruct{
 		id:            c.getNextID(),
@@ -205,6 +217,9 @@ func (c *demoClient) IsOccurrence(ctx context.Context, filter *model.IsOccurrenc
 	if err := helper.ValidatePackageOrSourceQueryFilter(filter.Subject); err != nil {
 		return nil, err
 	}
+
+	c.m.RLock()
+	defer c.m.RUnlock()
 
 	if filter != nil && filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -67,8 +67,8 @@ func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInp
 		return nil, err
 	}
 
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	osvID, err := getOsvIDFromInput(c, osv)
 	if err != nil {

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -57,12 +57,18 @@ func (n *equalVulnerabilityLink) BuildModelNode(c *demoClient) (model.Node, erro
 	return c.buildIsVulnerability(n, nil, true)
 }
 
-// Ingest CertifyPkg
+// Ingest IsVulnerability
 func (c *demoClient) IngestIsVulnerability(ctx context.Context, osv model.OSVInputSpec, vulnerability model.CveOrGhsaInput, isVulnerability model.IsVulnerabilityInputSpec) (*model.IsVulnerability, error) {
-	err := helper.ValidateCveOrGhsaIngestionInput(vulnerability, "IngestIsVulnerability")
-	if err != nil {
+	return c.ingestIsVulnerability(ctx, osv, vulnerability, isVulnerability, true)
+}
+
+func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInputSpec, vulnerability model.CveOrGhsaInput, isVulnerability model.IsVulnerabilityInputSpec, readOnly bool) (*model.IsVulnerability, error) {
+	if err := helper.ValidateCveOrGhsaIngestionInput(vulnerability, "IngestIsVulnerability"); err != nil {
 		return nil, err
 	}
+
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
 
 	osvID, err := getOsvIDFromInput(c, osv)
 	if err != nil {
@@ -128,6 +134,12 @@ func (c *demoClient) IngestIsVulnerability(ctx context.Context, osv model.OSVInp
 		}
 	}
 	if !duplicate {
+		if readOnly {
+			c.m.RUnlock()
+			iv, err := c.ingestIsVulnerability(ctx, osv, vulnerability, isVulnerability, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return iv, err
+		}
 		// store the link
 		collectedEqualVulnLink = equalVulnerabilityLink{
 			id:            c.getNextID(),
@@ -165,6 +177,8 @@ func (c *demoClient) IsVulnerability(ctx context.Context, filter *model.IsVulner
 		return nil, err
 	}
 
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter != nil && filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/osv.go
+++ b/pkg/assembler/backends/inmem/osv.go
@@ -115,8 +115,8 @@ func (c *demoClient) IngestOsv(ctx context.Context, input *model.OSVInputSpec) (
 }
 
 func (c *demoClient) ingestOsv(ctx context.Context, input *model.OSVInputSpec, readOnly bool) (*model.Osv, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 	osvStruct, hasOsv := c.osvs[osv]
 	if !hasOsv {
 		osvStruct = &osvNode{

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -234,6 +234,13 @@ func (p *pkgVersionNode) setCertifyPkgs(id uint32) { p.certifyPkgs = append(p.ce
 
 // Ingest Package
 func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec) (*model.Package, error) {
+	return c.ingestPackage(ctx, input, true)
+}
+
+func (c *demoClient) ingestPackage(ctx context.Context, input model.PkgInputSpec, readOnly bool) (*model.Package, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
+
 	namespacesStruct, hasNamespace := c.packages[input.Type]
 	if !hasNamespace {
 		namespacesStruct = &pkgNamespaceStruct{
@@ -289,6 +296,12 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 		break
 	}
 	if !duplicate {
+		if readOnly {
+			c.m.RUnlock()
+			p, err := c.ingestPackage(ctx, input, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return p, err
+		}
 		collectedVersion = pkgVersionNode{
 			id:         c.getNextID(),
 			parent:     versionStruct.id,
@@ -311,6 +324,8 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 
 // Query Package
 func (c *demoClient) Packages(ctx context.Context, filter *model.PkgSpec) ([]*model.Package, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter != nil && filter.ID != nil {
 		id, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -238,8 +238,8 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 }
 
 func (c *demoClient) ingestPackage(ctx context.Context, input model.PkgInputSpec, readOnly bool) (*model.Package, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	namespacesStruct, hasNamespace := c.packages[input.Type]
 	if !hasNamespace {

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -138,8 +138,8 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 }
 
 func (c *demoClient) ingestSource(ctx context.Context, input model.SourceInputSpec, readOnly bool) (*model.Source, error) {
-	c.lock(readOnly)
-	defer c.unlock(readOnly)
+	lock(&c.m, readOnly)
+	defer unlock(&c.m, readOnly)
 
 	namespacesStruct, hasNamespace := c.sources[input.Type]
 	if !hasNamespace {

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -134,6 +134,13 @@ func (p *srcNameNode) setCertifyBadLinks(id uint32) { p.badLinks = append(p.badL
 
 // Ingest Source
 func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSpec) (*model.Source, error) {
+	return c.ingestSource(ctx, input, true)
+}
+
+func (c *demoClient) ingestSource(ctx context.Context, input model.SourceInputSpec, readOnly bool) (*model.Source, error) {
+	c.lock(readOnly)
+	defer c.unlock(readOnly)
+
 	namespacesStruct, hasNamespace := c.sources[input.Type]
 	if !hasNamespace {
 		namespacesStruct = &srcNamespaceStruct{
@@ -176,6 +183,12 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 		break
 	}
 	if !duplicate {
+		if readOnly {
+			c.m.RUnlock()
+			s, err := c.ingestSource(ctx, input, false)
+			c.m.RLock() // relock so that defer unlock does not panic
+			return s, err
+		}
 		collectedSrcName = srcNameNode{
 			id:     c.getNextID(),
 			parent: namesStruct.id,
@@ -200,6 +213,8 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 // Query Source
 
 func (c *demoClient) Sources(ctx context.Context, filter *model.SourceSpec) ([]*model.Source, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if filter != nil && filter.Commit != nil && filter.Tag != nil {
 		if *filter.Commit != "" && *filter.Tag != "" {
 			return nil, gqlerror.Errorf("Passing both commit and tag selectors is an error")

--- a/pkg/assembler/graphql/examples/has_slsa.gql
+++ b/pkg/assembler/graphql/examples/has_slsa.gql
@@ -63,3 +63,49 @@ query SLSAQ6 {
     ...allHasSLSATree
   }
 }
+
+fragment allArtifactTree on Artifact {
+  id
+  algorithm
+  digest
+}
+
+mutation ArtifactM1 {
+  ingestArtifact(artifact: {algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf"}) {
+    ...allArtifactTree
+  }
+}
+
+mutation ArtifactM2 {
+  ingestArtifact(artifact: {algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0"}) {
+    ...allArtifactTree
+  }
+}
+
+
+mutation BuilderM1 {
+  ingestBuilder(builder: {uri: "https://github.com/Attestations/GitHubHostedActions@v2"}) {
+    id
+    uri
+  }
+}
+
+
+mutation SLSAM1 {
+  ingestSLSA(
+    subject: {algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf"},
+    builtFrom: [{algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0"}],
+    builtBy: {uri: "https://github.com/Attestations/GitHubHostedActions@v2"},
+    slsa: {
+      buildType: "type",
+      slsaVersion: "v1",
+      origin: "here",
+      collector: "there",
+      startedOn:"2023-03-28T11:01:23-07:00",
+      finishedOn: "2023-03-28T11:01:35-07:00",
+      slsaPredicate: [{key:"key1", value: "value1"}]
+    }
+  ){
+    ...allSLSATree
+  }
+}


### PR DESCRIPTION
Add a global RW mutex. All reads lock a read mutex. Any ingest will first lock
read, then check if exists. If it does not exist it will release read, lock
write, then check if exists again and insert if it still does not.
Also fixed a bug with the HasSLSA comparison.

Fixes #645