### PR TITLE
Make SPDX parser work properly with DEPENDENCY_OF and CONTAINED_BY 

### DIFF
--- a/internal/testing/testdata/exampledata/alpine-small-spdx.json
+++ b/internal/testing/testdata/exampledata/alpine-small-spdx.json
@@ -475,9 +475,9 @@
    "relatedSpdxElement": "SPDXRef-879bdb5c61068a44"
   },
   {
-   "spdxElementId": "SPDXRef-3f53edc3b14056c3",
-   "relationshipType": "CONTAINS",
-   "relatedSpdxElement": "SPDXRef-9b559b61986fccb0"
+    "spdxElementId": "SPDXRef-9b559b61986fccb0",
+    "relationshipType": "CONTAINED_BY",
+    "relatedSpdxElement": "SPDXRef-3f53edc3b14056c3"
   },
   {
    "spdxElementId": "SPDXRef-3f53edc3b14056c3",

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -316,6 +316,9 @@ var (
 	isDepJustifyContains = &model.IsDependencyInputSpec{
 		Justification: "Derived from SPDX CONTAINS relationship",
 	}
+	isDepJustifyContainedBy = &model.IsDependencyInputSpec{
+		Justification: "Derived from SPDX CONTAINED_BY relationship",
+	}
 	isDepJustifyDepends = &model.IsDependencyInputSpec{
 		Justification: "Derived from SPDX DEPENDS_ON relationship",
 	}
@@ -385,7 +388,7 @@ var (
 		{
 			Pkg:          keysPack,
 			DepPkg:       rsaPubFilePack,
-			IsDependency: isDepJustifyContains,
+			IsDependency: isDepJustifyContainedBy,
 		},
 	}
 

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -103,7 +103,6 @@ func (s *spdxParser) getPackages() error {
 			}
 
 		}
-
 		if purl == "" {
 			purl = asmhelpers.GuacPkgPurl(pac.PackageName, &pac.PackageVersion)
 		}
@@ -188,18 +187,23 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 		preds.IsDependency = append(preds.IsDependency, common.CreateTopLevelIsDeps(toplevel[0], s.packagePackages, s.filePackages, "top-level package GUAC heuristic connecting to each file/package")...)
 	}
 	for _, rel := range s.spdxDoc.Relationships {
+		var foundId string
+		var relatedId string
 
-		if !map[string]bool{
-			spdx_common.TypeRelationshipContains:  true,
-			spdx_common.TypeRelationshipDependsOn: true,
-		}[rel.Relationship] {
+		if isDependency(rel.Relationship) {
+			foundId = string(rel.RefA.ElementRefID)
+			relatedId = string(rel.RefB.ElementRefID)
+		} else if isDependent(rel.Relationship) {
+			foundId = string(rel.RefB.ElementRefID)
+			relatedId = string(rel.RefA.ElementRefID)
+		} else {
 			continue
 		}
 
-		foundPackNodes := s.getPackageElement(string(rel.RefA.ElementRefID))
-		foundFileNodes := s.getFileElement(string(rel.RefA.ElementRefID))
-		relatedPackNodes := s.getPackageElement(string(rel.RefB.ElementRefID))
-		relatedFileNodes := s.getFileElement(string(rel.RefB.ElementRefID))
+		foundPackNodes := s.getPackageElement(foundId)
+		foundFileNodes := s.getFileElement(foundId)
+		relatedPackNodes := s.getPackageElement(relatedId)
+		relatedFileNodes := s.getFileElement(relatedId)
 
 		justification := getJustification(rel)
 
@@ -255,6 +259,20 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 	}
 
 	return preds
+}
+
+func isDependency(rel string) bool {
+	return map[string]bool{
+		spdx_common.TypeRelationshipContains:  true,
+		spdx_common.TypeRelationshipDependsOn: true,
+	}[rel]
+}
+
+func isDependent(rel string) bool {
+	return map[string]bool{
+		spdx_common.TypeRelationshipContainedBy:     true,
+		spdx_common.TypeRelationshipDevDependencyOf: true,
+	}[rel]
 }
 
 func (s *spdxParser) GetIdentities(ctx context.Context) []common.TrustInformation {


### PR DESCRIPTION
I come across an sbom that doesn't use CONTAINS relationship, but CONTAINED_BY. This fix should support that use cases. I also added DEPENDENCY_OF for now. From the brief look at the spec, there could be more cases we should support in the future so I refactored code a bit to make it easier to change in the future.
Unfortunately, I can't share the sbom in question so I modified existing test data a bit. I hope that's OK. Let me know if you think there's a better way to handle it.