### PR TITLE
add ability to parse identifier strings for PURLs

### DIFF
--- a/pkg/collectsub/collectsub/input/identifier_strings.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings.go
@@ -50,6 +50,13 @@ func identifierStringsToCollectEntry(i *parser_common.IdentifierStrings) []*pb.C
 		})
 	}
 
+	for _, v := range i.PurlStrings {
+		entries = append(entries, &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_PURL,
+			Value: v,
+		})
+	}
+
 	for _, v := range i.UnclassifiedStrings {
 		e, err := guessUnknownIdentifierString(v)
 		if err == nil {
@@ -72,5 +79,11 @@ func guessUnknownIdentifierString(s string) (*pb.CollectEntry, error) {
 		}, nil
 	}
 
+	if strings.HasPrefix(s, "pkg:") {
+		return &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_PURL,
+			Value: s,
+		}, nil
+	}
 	return nil, fmt.Errorf("unable to guess collect entry")
 }

--- a/pkg/collectsub/collectsub/input/identifier_strings.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/guacsec/guac/pkg/assembler/helpers"
 	pb "github.com/guacsec/guac/pkg/collectsub/collectsub"
 	parser_common "github.com/guacsec/guac/pkg/ingestor/parser/common"
 )
@@ -79,7 +80,7 @@ func guessUnknownIdentifierString(s string) (*pb.CollectEntry, error) {
 		}, nil
 	}
 
-	if strings.HasPrefix(s, "pkg:") {
+	if _, err := helpers.PurlToPkg(s); err == nil {
 		return &pb.CollectEntry{
 			Type:  pb.CollectDataType_DATATYPE_PURL,
 			Value: s,

--- a/pkg/collectsub/collectsub/input/identifier_strings_test.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings_test.go
@@ -35,13 +35,15 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 		name: "simple test",
 		input: []*parser_common.IdentifierStrings{
 			{
-				OciStrings: []string{"index.docker.io/guacsec/local-organic-guac"},
-				VcsStrings: []string{"git+https://github.com/guacsec/guac"},
+				OciStrings:  []string{"index.docker.io/guacsec/local-organic-guac"},
+				VcsStrings:  []string{"git+https://github.com/guacsec/guac"},
+				PurlStrings: []string{"pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease"},
 			},
 		},
 		expected: []*pb.CollectEntry{
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
 			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
+			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease"},
 		},
 	}, {
 		name: "simple unclassified string test",
@@ -49,14 +51,18 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 			{
 				UnclassifiedStrings: []string{"index.docker.io/guacsec/local-organic-guac",
 					"ghcr.io/guacsec/local-organic-guac",
+					"pkg:npm/%40angular/animation@12.3.1",
 					"https://not-oci-registry.com/guacsec/local-organic-guac",
-					"gcr.io/guacsec/local-organic-guac"},
+					"gcr.io/guacsec/local-organic-guac",
+					"pkg:golang/google.golang.org/genproto#googleapis/api/annotations"},
 			},
 		},
 		expected: []*pb.CollectEntry{
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "ghcr.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:npm/%40angular/animation@12.3.1"},
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "gcr.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:golang/google.golang.org/genproto#googleapis/api/annotations"},
 		},
 	}, {
 		name: "simple slice test",
@@ -69,6 +75,19 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 		},
 		expected: []*pb.CollectEntry{
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
+			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
+		},
+	}, {
+		name: "simple purl test",
+		input: []*parser_common.IdentifierStrings{
+			{
+				PurlStrings: []string{"pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie"},
+			}, {
+				VcsStrings: []string{"git+https://github.com/guacsec/guac"},
+			},
+		},
+		expected: []*pb.CollectEntry{
+			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie"},
 			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
 		},
 	}}

--- a/pkg/ingestor/parser/common/types.go
+++ b/pkg/ingestor/parser/common/types.go
@@ -50,6 +50,8 @@ type IdentifierStrings struct {
 	OciStrings []string
 	// VcsStrings should contain VCS strings for source control
 	VcsStrings []string
+	// PurlStrings should contain package url to specific packages
+	PurlStrings []string
 	// UnclassifiedStrings contains other strings that have identifiers that
 	// parsers may not be sure what category they fall under.
 	UnclassifiedStrings []string


### PR DESCRIPTION
closes #590 

Will work on https://github.com/guacsec/guac/issues/592 next.