### PR TITLE
Remove root nodes from vulnerabilities

### DIFF
--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -120,7 +120,7 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		if err != nil {
 			return nil, err
 		}
-		osvNode, ok := c.index[osvID].(*osvIDNode)
+		osvNode, ok := c.index[osvID].(*osvNode)
 		if ok {
 			vulnerabilityVexLinks = append(vulnerabilityVexLinks, osvNode.vexLinks...)
 		}
@@ -132,7 +132,7 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		if err != nil {
 			return nil, err
 		}
-		cveNode, ok := c.index[cveID].(*cveIDNode)
+		cveNode, ok := c.index[cveID].(*cveNode)
 		if ok {
 			vulnerabilityVexLinks = append(vulnerabilityVexLinks, cveNode.vexLinks...)
 		}
@@ -144,7 +144,7 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		if err != nil {
 			return nil, err
 		}
-		ghsaNode, ok := c.index[ghsaID].(*ghsaIDNode)
+		ghsaNode, ok := c.index[ghsaID].(*ghsaNode)
 		if ok {
 			vulnerabilityVexLinks = append(vulnerabilityVexLinks, ghsaNode.vexLinks...)
 		}
@@ -217,13 +217,13 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 			c.index[artifactID].(*artStruct).setVexLinks(collectedCertifyVexLink.id)
 		}
 		if osvID != 0 {
-			c.index[osvID].(*osvIDNode).setVexLinks(collectedCertifyVexLink.id)
+			c.index[osvID].(*osvNode).setVexLinks(collectedCertifyVexLink.id)
 		}
 		if cveID != 0 {
-			c.index[cveID].(*cveIDNode).setVexLinks(collectedCertifyVexLink.id)
+			c.index[cveID].(*cveNode).setVexLinks(collectedCertifyVexLink.id)
 		}
 		if ghsaID != 0 {
-			c.index[ghsaID].(*ghsaIDNode).setVexLinks(collectedCertifyVexLink.id)
+			c.index[ghsaID].(*ghsaNode).setVexLinks(collectedCertifyVexLink.id)
 		}
 	}
 

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -90,7 +90,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		if err != nil {
 			return nil, err
 		}
-		osvNode, ok := c.index[osvID].(*osvIDNode)
+		osvNode, ok := c.index[osvID].(*osvNode)
 		if ok {
 			vulnerabilityLinks = append(vulnerabilityLinks, osvNode.certifyVulnLinks...)
 		}
@@ -101,7 +101,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		if err != nil {
 			return nil, err
 		}
-		cveNode, ok := c.index[cveID].(*cveIDNode)
+		cveNode, ok := c.index[cveID].(*cveNode)
 		if ok {
 			vulnerabilityLinks = append(vulnerabilityLinks, cveNode.certifyVulnLinks...)
 		}
@@ -112,7 +112,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		if err != nil {
 			return nil, err
 		}
-		ghsaNode, ok := c.index[ghsaID].(*ghsaIDNode)
+		ghsaNode, ok := c.index[ghsaID].(*ghsaNode)
 		if ok {
 			vulnerabilityLinks = append(vulnerabilityLinks, ghsaNode.certifyVulnLinks...)
 		}
@@ -182,13 +182,13 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		// set the backlinks
 		c.index[packageID].(*pkgVersionNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
 		if osvID != 0 {
-			c.index[osvID].(*osvIDNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
+			c.index[osvID].(*osvNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
 		}
 		if cveID != 0 {
-			c.index[cveID].(*cveIDNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
+			c.index[cveID].(*cveNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
 		}
 		if ghsaID != 0 {
-			c.index[ghsaID].(*ghsaIDNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
+			c.index[ghsaID].(*ghsaNode).setVulnerabilityLinks(collectedCertifyVulnLink.id)
 		}
 	}
 

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -76,9 +76,9 @@ func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInp
 	}
 
 	osvEqualVulns := []uint32{}
-	osvNode, ok := c.index[osvID].(*osvIDNode)
+	osvN, ok := c.index[osvID].(*osvNode)
 	if ok {
-		osvEqualVulns = append(osvEqualVulns, osvNode.equalVulnLinks...)
+		osvEqualVulns = append(osvEqualVulns, osvN.equalVulnLinks...)
 	}
 
 	var cveID uint32
@@ -89,7 +89,7 @@ func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInp
 		if err != nil {
 			return nil, err
 		}
-		cveNode, ok := c.index[cveID].(*cveIDNode)
+		cveNode, ok := c.index[cveID].(*cveNode)
 		if ok {
 			vulnerabilityLinks = append(vulnerabilityLinks, cveNode.equalVulnLinks...)
 		}
@@ -100,7 +100,7 @@ func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInp
 		if err != nil {
 			return nil, err
 		}
-		ghsaNode, ok := c.index[ghsaID].(*ghsaIDNode)
+		ghsaNode, ok := c.index[ghsaID].(*ghsaNode)
 		if ok {
 			vulnerabilityLinks = append(vulnerabilityLinks, ghsaNode.equalVulnLinks...)
 		}
@@ -153,12 +153,12 @@ func (c *demoClient) ingestIsVulnerability(ctx context.Context, osv model.OSVInp
 		c.index[collectedEqualVulnLink.id] = &collectedEqualVulnLink
 		c.equalVulnerabilities = append(c.equalVulnerabilities, &collectedEqualVulnLink)
 		// set the backlinks
-		c.index[osvID].(*osvIDNode).setEqualVulnLinks(collectedEqualVulnLink.id)
+		c.index[osvID].(*osvNode).setEqualVulnLinks(collectedEqualVulnLink.id)
 		if cveID != 0 {
-			c.index[cveID].(*cveIDNode).setEqualVulnLinks(collectedEqualVulnLink.id)
+			c.index[cveID].(*cveNode).setEqualVulnLinks(collectedEqualVulnLink.id)
 		}
 		if ghsaID != 0 {
-			c.index[ghsaID].(*ghsaIDNode).setEqualVulnLinks(collectedEqualVulnLink.id)
+			c.index[ghsaID].(*ghsaNode).setEqualVulnLinks(collectedEqualVulnLink.id)
 		}
 	}
 

--- a/pkg/assembler/backends/neo4j/cve.go
+++ b/pkg/assembler/backends/neo4j/cve.go
@@ -173,32 +173,33 @@ func (c *neo4jClient) Cve(ctx context.Context, cveSpec *model.CVESpec) ([]*model
 
 	result, err := session.ReadTransaction(
 		func(tx neo4j.Transaction) (interface{}, error) {
-			result, err := tx.Run(sb.String(), queryValues)
-			if err != nil {
-				return nil, err
-			}
+			// FIXME update to GHSA without root node.
+			// result, err := tx.Run(sb.String(), queryValues)
+			// if err != nil {
+			// 	return nil, err
+			// }
 
-			cvesPerYear := map[int][]*model.CVEId{}
-			for result.Next() {
-				cveID := &model.CVEId{
-					CveID: result.Record().Values[1].(string),
-				}
-				cvesPerYear[result.Record().Values[0].(int)] = append(cvesPerYear[result.Record().Values[0].(int)], cveID)
-			}
-			if err = result.Err(); err != nil {
-				return nil, err
-			}
+			// cvesPerYear := map[int][]*model.CVEId{}
+			// for result.Next() {
+			// 	cveID := &model.CVEId{
+			// 		CveID: result.Record().Values[1].(string),
+			// 	}
+			// 	cvesPerYear[result.Record().Values[0].(int)] = append(cvesPerYear[result.Record().Values[0].(int)], cveID)
+			// }
+			// if err = result.Err(); err != nil {
+			// 	return nil, err
+			// }
 
-			cves := []*model.Cve{}
-			for year := range cvesPerYear {
-				cve := &model.Cve{
-					Year:   year,
-					CveIds: cvesPerYear[year],
-				}
-				cves = append(cves, cve)
+			// cves := []*model.Cve{}
+			// for year := range cvesPerYear {
+			cve := &model.Cve{
+				// Year:   year,
+				// CveIds: cvesPerYear[year],
 			}
+			// cves = append(cves, cve)
+			// }
 
-			return cves, nil
+			return cve, nil
 		})
 	if err != nil {
 		return nil, err
@@ -225,24 +226,25 @@ func (c *neo4jClient) cveYear(ctx context.Context, cveSpec *model.CVESpec) ([]*m
 
 	result, err := session.ReadTransaction(
 		func(tx neo4j.Transaction) (interface{}, error) {
-			result, err := tx.Run(sb.String(), queryValues)
-			if err != nil {
-				return nil, err
-			}
+			// FIXME update to GHSA without root node.
+			// result, err := tx.Run(sb.String(), queryValues)
+			// if err != nil {
+			// 	return nil, err
+			// }
 
-			cves := []*model.Cve{}
-			for result.Next() {
-				cve := &model.Cve{
-					Year:   result.Record().Values[0].(int),
-					CveIds: []*model.CVEId{},
-				}
-				cves = append(cves, cve)
+			// cves := []*model.Cve{}
+			// for result.Next() {
+			cve := &model.Cve{
+				// Year: result.Record().Values[0].(int),
+				// CveIds: []*model.CVEId{},
 			}
-			if err = result.Err(); err != nil {
-				return nil, err
-			}
+			// 	cves = append(cves, cve)
+			// }
+			// if err = result.Err(); err != nil {
+			// 	return nil, err
+			// }
 
-			return cves, nil
+			return cve, nil
 		})
 	if err != nil {
 		return nil, err
@@ -307,10 +309,11 @@ RETURN cveYear.year, cveID.id`
 
 // TODO: update to pass in the ID from neo4j
 func generateModelCve(yearStr int, idStr string) *model.Cve {
-	id := &model.CVEId{CveID: idStr}
+	// FIXME update to GHSA without root node.
+	// id := &model.CVEId{CveID: idStr}
 	cve := model.Cve{
-		Year:   yearStr,
-		CveIds: []*model.CVEId{id},
+		Year: yearStr,
+		// CveIds: []*model.CVEId{id},
 	}
 	return &cve
 }

--- a/pkg/assembler/backends/neo4j/ghsa.go
+++ b/pkg/assembler/backends/neo4j/ghsa.go
@@ -111,24 +111,25 @@ func (c *neo4jClient) Ghsa(ctx context.Context, ghsaSpec *model.GHSASpec) ([]*mo
 
 	result, err := session.ReadTransaction(
 		func(tx neo4j.Transaction) (interface{}, error) {
-			result, err := tx.Run(sb.String(), queryValues)
-			if err != nil {
-				return nil, err
-			}
+			// FIXME update to GHSA without root node.
+			// result, err := tx.Run(sb.String(), queryValues)
+			// if err != nil {
+			// 	return nil, err
+			// }
 
-			ghsaIds := []*model.GHSAId{}
-			for result.Next() {
-				ghsaId := &model.GHSAId{
-					GhsaID: result.Record().Values[0].(string),
-				}
-				ghsaIds = append(ghsaIds, ghsaId)
-			}
-			if err = result.Err(); err != nil {
-				return nil, err
-			}
+			// ghsaIds := []*model.GHSAId{}
+			// for result.Next() {
+			// 	ghsaId := &model.GHSAId{
+			// 		GhsaID: result.Record().Values[0].(string),
+			// 	}
+			// 	ghsaIds = append(ghsaIds, ghsaId)
+			// }
+			// if err = result.Err(); err != nil {
+			// 	return nil, err
+			// }
 
 			ghsa := &model.Ghsa{
-				GhsaIds: ghsaIds,
+				// GhsaIds: ghsaIds,
 			}
 
 			return []*model.Ghsa{ghsa}, nil
@@ -187,9 +188,10 @@ RETURN ghsaID.id`
 
 // TODO: update to pass in the ID from neo4j
 func generateModelGhsa(id string) *model.Ghsa {
-	ghsaID := &model.GHSAId{GhsaID: id}
+	// FIXME update to GHSA without root node.
+	// ghsaID := &model.GHSAId{GhsaID: id}
 	ghsa := model.Ghsa{
-		GhsaIds: []*model.GHSAId{ghsaID},
+		// GhsaIds: []*model.GHSAId{ghsaID},
 	}
 	return &ghsa
 }

--- a/pkg/assembler/backends/neo4j/osv.go
+++ b/pkg/assembler/backends/neo4j/osv.go
@@ -111,24 +111,25 @@ func (c *neo4jClient) Osv(ctx context.Context, osvSpec *model.OSVSpec) ([]*model
 
 	result, err := session.ReadTransaction(
 		func(tx neo4j.Transaction) (interface{}, error) {
-			result, err := tx.Run(sb.String(), queryValues)
-			if err != nil {
-				return nil, err
-			}
+			// FIXME update to OSV without root node.
+			// result, err := tx.Run(sb.String(), queryValues)
+			// if err != nil {
+			// 	return nil, err
+			// }
 
-			osvIds := []*model.OSVId{}
-			for result.Next() {
-				osvId := &model.OSVId{
-					OsvID: result.Record().Values[0].(string),
-				}
-				osvIds = append(osvIds, osvId)
-			}
-			if err = result.Err(); err != nil {
-				return nil, err
-			}
+			// osvIds := []*model.OSVId{}
+			// for result.Next() {
+			// 	osvId := &model.OSVId{
+			// 		OsvID: result.Record().Values[0].(string),
+			// 	}
+			// 	osvIds = append(osvIds, osvId)
+			// }
+			// if err = result.Err(); err != nil {
+			// 	return nil, err
+			// }
 
 			osv := &model.Osv{
-				OsvIds: osvIds,
+				// OsvIds: osvIds,
 			}
 
 			return []*model.Osv{osv}, nil
@@ -187,9 +188,10 @@ RETURN osvID.id`
 
 // TODO: update to pass in the ID from neo4j
 func generateModelOsv(id string) *model.Osv {
-	osvID := &model.OSVId{OsvID: id}
+	// FIXME update to GHSA without root node.
+	// osvID := &model.OSVId{OsvID: id}
 	osv := model.Osv{
-		OsvIds: []*model.OSVId{osvID},
+		// OsvIds: []*model.OSVId{osvID},
 	}
 	return &osv
 }

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -415,10 +415,10 @@ func (v *AllCertifyVulnPackage) __premarshalJSON() (*__premarshalAllCertifyVulnP
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type AllCertifyVulnVulnerabilityCVE struct {
 	Typename   *string `json:"__typename"`
 	allCveTree `json:"-"`
@@ -433,10 +433,8 @@ func (v *AllCertifyVulnVulnerabilityCVE) GetId() string { return v.allCveTree.Id
 // GetYear returns AllCertifyVulnVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
 func (v *AllCertifyVulnVulnerabilityCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns AllCertifyVulnVulnerabilityCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *AllCertifyVulnVulnerabilityCVE) GetCveIds() []allCveTreeCveIdsCVEId {
-	return v.allCveTree.CveIds
-}
+// GetCveId returns AllCertifyVulnVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVulnVulnerabilityCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *AllCertifyVulnVulnerabilityCVE) UnmarshalJSON(b []byte) error {
 
@@ -470,7 +468,7 @@ type __premarshalAllCertifyVulnVulnerabilityCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *AllCertifyVulnVulnerabilityCVE) MarshalJSON() ([]byte, error) {
@@ -487,7 +485,7 @@ func (v *AllCertifyVulnVulnerabilityCVE) __premarshalJSON() (*__premarshalAllCer
 	retval.Typename = v.Typename
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -496,7 +494,9 @@ func (v *AllCertifyVulnVulnerabilityCVE) __premarshalJSON() (*__premarshalAllCer
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type AllCertifyVulnVulnerabilityGHSA struct {
 	Typename    *string `json:"__typename"`
 	allGHSATree `json:"-"`
@@ -508,10 +508,8 @@ func (v *AllCertifyVulnVulnerabilityGHSA) GetTypename() *string { return v.Typen
 // GetId returns AllCertifyVulnVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
 func (v *AllCertifyVulnVulnerabilityGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns AllCertifyVulnVulnerabilityGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *AllCertifyVulnVulnerabilityGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns AllCertifyVulnVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVulnVulnerabilityGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *AllCertifyVulnVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
 
@@ -543,7 +541,7 @@ type __premarshalAllCertifyVulnVulnerabilityGHSA struct {
 
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *AllCertifyVulnVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
@@ -559,7 +557,7 @@ func (v *AllCertifyVulnVulnerabilityGHSA) __premarshalJSON() (*__premarshalAllCe
 
 	retval.Typename = v.Typename
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -568,7 +566,12 @@ func (v *AllCertifyVulnVulnerabilityGHSA) __premarshalJSON() (*__premarshalAllCe
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type AllCertifyVulnVulnerabilityOSV struct {
 	Typename   *string `json:"__typename"`
 	allOSVTree `json:"-"`
@@ -580,10 +583,8 @@ func (v *AllCertifyVulnVulnerabilityOSV) GetTypename() *string { return v.Typena
 // GetId returns AllCertifyVulnVulnerabilityOSV.Id, and is useful for accessing the field via an interface.
 func (v *AllCertifyVulnVulnerabilityOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns AllCertifyVulnVulnerabilityOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *AllCertifyVulnVulnerabilityOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId {
-	return v.allOSVTree.OsvIds
-}
+// GetOsvId returns AllCertifyVulnVulnerabilityOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVulnVulnerabilityOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *AllCertifyVulnVulnerabilityOSV) UnmarshalJSON(b []byte) error {
 
@@ -615,7 +616,7 @@ type __premarshalAllCertifyVulnVulnerabilityOSV struct {
 
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *AllCertifyVulnVulnerabilityOSV) MarshalJSON() ([]byte, error) {
@@ -631,7 +632,7 @@ func (v *AllCertifyVulnVulnerabilityOSV) __premarshalJSON() (*__premarshalAllCer
 
 	retval.Typename = v.Typename
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -2066,10 +2067,10 @@ func (v *CertifyBadSrcResponse) GetIngestCertifyBad() CertifyBadSrcIngestCertify
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type CertifyCVEIngestCVE struct {
 	allCveTree `json:"-"`
 }
@@ -2080,8 +2081,8 @@ func (v *CertifyCVEIngestCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns CertifyCVEIngestCVE.Year, and is useful for accessing the field via an interface.
 func (v *CertifyCVEIngestCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns CertifyCVEIngestCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *CertifyCVEIngestCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns CertifyCVEIngestCVE.CveId, and is useful for accessing the field via an interface.
+func (v *CertifyCVEIngestCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *CertifyCVEIngestCVE) UnmarshalJSON(b []byte) error {
 
@@ -2113,7 +2114,7 @@ type __premarshalCertifyCVEIngestCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *CertifyCVEIngestCVE) MarshalJSON() ([]byte, error) {
@@ -2129,7 +2130,7 @@ func (v *CertifyCVEIngestCVE) __premarshalJSON() (*__premarshalCertifyCVEIngestC
 
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -2329,7 +2330,9 @@ func (v *CertifyCVEResponse) GetIngestVulnerability() CertifyCVEIngestVulnerabil
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type CertifyGHSAIngestGHSA struct {
 	allGHSATree `json:"-"`
 }
@@ -2337,8 +2340,8 @@ type CertifyGHSAIngestGHSA struct {
 // GetId returns CertifyGHSAIngestGHSA.Id, and is useful for accessing the field via an interface.
 func (v *CertifyGHSAIngestGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns CertifyGHSAIngestGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *CertifyGHSAIngestGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId { return v.allGHSATree.GhsaIds }
+// GetGhsaId returns CertifyGHSAIngestGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *CertifyGHSAIngestGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *CertifyGHSAIngestGHSA) UnmarshalJSON(b []byte) error {
 
@@ -2368,7 +2371,7 @@ func (v *CertifyGHSAIngestGHSA) UnmarshalJSON(b []byte) error {
 type __premarshalCertifyGHSAIngestGHSA struct {
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *CertifyGHSAIngestGHSA) MarshalJSON() ([]byte, error) {
@@ -2383,7 +2386,7 @@ func (v *CertifyGHSAIngestGHSA) __premarshalJSON() (*__premarshalCertifyGHSAInge
 	var retval __premarshalCertifyGHSAIngestGHSA
 
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -3188,7 +3191,12 @@ func (v *CertifyGoodSrcResponse) GetIngestCertifyGood() CertifyGoodSrcIngestCert
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type CertifyOSVIngestOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -3196,8 +3204,8 @@ type CertifyOSVIngestOSV struct {
 // GetId returns CertifyOSVIngestOSV.Id, and is useful for accessing the field via an interface.
 func (v *CertifyOSVIngestOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns CertifyOSVIngestOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *CertifyOSVIngestOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns CertifyOSVIngestOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *CertifyOSVIngestOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *CertifyOSVIngestOSV) UnmarshalJSON(b []byte) error {
 
@@ -3227,7 +3235,7 @@ func (v *CertifyOSVIngestOSV) UnmarshalJSON(b []byte) error {
 type __premarshalCertifyOSVIngestOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *CertifyOSVIngestOSV) MarshalJSON() ([]byte, error) {
@@ -3242,7 +3250,7 @@ func (v *CertifyOSVIngestOSV) __premarshalJSON() (*__premarshalCertifyOSVIngestO
 	var retval __premarshalCertifyOSVIngestOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -5333,10 +5341,10 @@ func (v *IsOccurrenceSrcResponse) GetIngestOccurrence() IsOccurrenceSrcIngestOcc
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type IsVulnerabilityCVEIngestCVE struct {
 	allCveTree `json:"-"`
 }
@@ -5347,8 +5355,8 @@ func (v *IsVulnerabilityCVEIngestCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns IsVulnerabilityCVEIngestCVE.Year, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns IsVulnerabilityCVEIngestCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityCVEIngestCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns IsVulnerabilityCVEIngestCVE.CveId, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityCVEIngestCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *IsVulnerabilityCVEIngestCVE) UnmarshalJSON(b []byte) error {
 
@@ -5380,7 +5388,7 @@ type __premarshalIsVulnerabilityCVEIngestCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *IsVulnerabilityCVEIngestCVE) MarshalJSON() ([]byte, error) {
@@ -5396,7 +5404,7 @@ func (v *IsVulnerabilityCVEIngestCVE) __premarshalJSON() (*__premarshalIsVulnera
 
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -5517,7 +5525,12 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) __premarshalJSON() (*__premars
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type IsVulnerabilityCVEIngestOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -5525,8 +5538,8 @@ type IsVulnerabilityCVEIngestOSV struct {
 // GetId returns IsVulnerabilityCVEIngestOSV.Id, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns IsVulnerabilityCVEIngestOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityCVEIngestOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns IsVulnerabilityCVEIngestOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityCVEIngestOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *IsVulnerabilityCVEIngestOSV) UnmarshalJSON(b []byte) error {
 
@@ -5556,7 +5569,7 @@ func (v *IsVulnerabilityCVEIngestOSV) UnmarshalJSON(b []byte) error {
 type __premarshalIsVulnerabilityCVEIngestOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *IsVulnerabilityCVEIngestOSV) MarshalJSON() ([]byte, error) {
@@ -5571,7 +5584,7 @@ func (v *IsVulnerabilityCVEIngestOSV) __premarshalJSON() (*__premarshalIsVulnera
 	var retval __premarshalIsVulnerabilityCVEIngestOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -5601,7 +5614,9 @@ func (v *IsVulnerabilityCVEResponse) GetIngestIsVulnerability() IsVulnerabilityC
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type IsVulnerabilityGHSAIngestGHSA struct {
 	allGHSATree `json:"-"`
 }
@@ -5609,10 +5624,8 @@ type IsVulnerabilityGHSAIngestGHSA struct {
 // GetId returns IsVulnerabilityGHSAIngestGHSA.Id, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns IsVulnerabilityGHSAIngestGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityGHSAIngestGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns IsVulnerabilityGHSAIngestGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityGHSAIngestGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *IsVulnerabilityGHSAIngestGHSA) UnmarshalJSON(b []byte) error {
 
@@ -5642,7 +5655,7 @@ func (v *IsVulnerabilityGHSAIngestGHSA) UnmarshalJSON(b []byte) error {
 type __premarshalIsVulnerabilityGHSAIngestGHSA struct {
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *IsVulnerabilityGHSAIngestGHSA) MarshalJSON() ([]byte, error) {
@@ -5657,7 +5670,7 @@ func (v *IsVulnerabilityGHSAIngestGHSA) __premarshalJSON() (*__premarshalIsVulne
 	var retval __premarshalIsVulnerabilityGHSAIngestGHSA
 
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -5778,7 +5791,12 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) __premarshalJSON() (*__premar
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type IsVulnerabilityGHSAIngestOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -5786,10 +5804,8 @@ type IsVulnerabilityGHSAIngestOSV struct {
 // GetId returns IsVulnerabilityGHSAIngestOSV.Id, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns IsVulnerabilityGHSAIngestOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityGHSAIngestOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId {
-	return v.allOSVTree.OsvIds
-}
+// GetOsvId returns IsVulnerabilityGHSAIngestOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *IsVulnerabilityGHSAIngestOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *IsVulnerabilityGHSAIngestOSV) UnmarshalJSON(b []byte) error {
 
@@ -5819,7 +5835,7 @@ func (v *IsVulnerabilityGHSAIngestOSV) UnmarshalJSON(b []byte) error {
 type __premarshalIsVulnerabilityGHSAIngestOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *IsVulnerabilityGHSAIngestOSV) MarshalJSON() ([]byte, error) {
@@ -5834,7 +5850,7 @@ func (v *IsVulnerabilityGHSAIngestOSV) __premarshalJSON() (*__premarshalIsVulner
 	var retval __premarshalIsVulnerabilityGHSAIngestOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -6043,10 +6059,10 @@ func (v *NeighborsNeighborsBuilder) __premarshalJSON() (*__premarshalNeighborsNe
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type NeighborsNeighborsCVE struct {
 	Typename   *string `json:"__typename"`
 	allCveTree `json:"-"`
@@ -6061,8 +6077,8 @@ func (v *NeighborsNeighborsCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns NeighborsNeighborsCVE.Year, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns NeighborsNeighborsCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns NeighborsNeighborsCVE.CveId, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *NeighborsNeighborsCVE) UnmarshalJSON(b []byte) error {
 
@@ -6096,7 +6112,7 @@ type __premarshalNeighborsNeighborsCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *NeighborsNeighborsCVE) MarshalJSON() ([]byte, error) {
@@ -6113,7 +6129,7 @@ func (v *NeighborsNeighborsCVE) __premarshalJSON() (*__premarshalNeighborsNeighb
 	retval.Typename = v.Typename
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -6563,7 +6579,9 @@ func (v *NeighborsNeighborsCertifyVuln) __premarshalJSON() (*__premarshalNeighbo
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type NeighborsNeighborsGHSA struct {
 	Typename    *string `json:"__typename"`
 	allGHSATree `json:"-"`
@@ -6575,10 +6593,8 @@ func (v *NeighborsNeighborsGHSA) GetTypename() *string { return v.Typename }
 // GetId returns NeighborsNeighborsGHSA.Id, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns NeighborsNeighborsGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns NeighborsNeighborsGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *NeighborsNeighborsGHSA) UnmarshalJSON(b []byte) error {
 
@@ -6610,7 +6626,7 @@ type __premarshalNeighborsNeighborsGHSA struct {
 
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *NeighborsNeighborsGHSA) MarshalJSON() ([]byte, error) {
@@ -6626,7 +6642,7 @@ func (v *NeighborsNeighborsGHSA) __premarshalJSON() (*__premarshalNeighborsNeigh
 
 	retval.Typename = v.Typename
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -7751,7 +7767,12 @@ func __marshalNeighborsNeighborsNode(v *NeighborsNeighborsNode) ([]byte, error) 
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type NeighborsNeighborsOSV struct {
 	Typename   *string `json:"__typename"`
 	allOSVTree `json:"-"`
@@ -7763,8 +7784,8 @@ func (v *NeighborsNeighborsOSV) GetTypename() *string { return v.Typename }
 // GetId returns NeighborsNeighborsOSV.Id, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns NeighborsNeighborsOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns NeighborsNeighborsOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *NeighborsNeighborsOSV) UnmarshalJSON(b []byte) error {
 
@@ -7796,7 +7817,7 @@ type __premarshalNeighborsNeighborsOSV struct {
 
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *NeighborsNeighborsOSV) MarshalJSON() ([]byte, error) {
@@ -7812,7 +7833,7 @@ func (v *NeighborsNeighborsOSV) __premarshalJSON() (*__premarshalNeighborsNeighb
 
 	retval.Typename = v.Typename
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -8460,10 +8481,10 @@ func (v *PathPathBuilder) __premarshalJSON() (*__premarshalPathPathBuilder, erro
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type PathPathCVE struct {
 	Typename   *string `json:"__typename"`
 	allCveTree `json:"-"`
@@ -8478,8 +8499,8 @@ func (v *PathPathCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns PathPathCVE.Year, and is useful for accessing the field via an interface.
 func (v *PathPathCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns PathPathCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *PathPathCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns PathPathCVE.CveId, and is useful for accessing the field via an interface.
+func (v *PathPathCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *PathPathCVE) UnmarshalJSON(b []byte) error {
 
@@ -8513,7 +8534,7 @@ type __premarshalPathPathCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *PathPathCVE) MarshalJSON() ([]byte, error) {
@@ -8530,7 +8551,7 @@ func (v *PathPathCVE) __premarshalJSON() (*__premarshalPathPathCVE, error) {
 	retval.Typename = v.Typename
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -8974,7 +8995,9 @@ func (v *PathPathCertifyVuln) __premarshalJSON() (*__premarshalPathPathCertifyVu
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type PathPathGHSA struct {
 	Typename    *string `json:"__typename"`
 	allGHSATree `json:"-"`
@@ -8986,8 +9009,8 @@ func (v *PathPathGHSA) GetTypename() *string { return v.Typename }
 // GetId returns PathPathGHSA.Id, and is useful for accessing the field via an interface.
 func (v *PathPathGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns PathPathGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *PathPathGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId { return v.allGHSATree.GhsaIds }
+// GetGhsaId returns PathPathGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *PathPathGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *PathPathGHSA) UnmarshalJSON(b []byte) error {
 
@@ -9019,7 +9042,7 @@ type __premarshalPathPathGHSA struct {
 
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *PathPathGHSA) MarshalJSON() ([]byte, error) {
@@ -9035,7 +9058,7 @@ func (v *PathPathGHSA) __premarshalJSON() (*__premarshalPathPathGHSA, error) {
 
 	retval.Typename = v.Typename
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -10136,7 +10159,12 @@ func __marshalPathPathNode(v *PathPathNode) ([]byte, error) {
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type PathPathOSV struct {
 	Typename   *string `json:"__typename"`
 	allOSVTree `json:"-"`
@@ -10148,8 +10176,8 @@ func (v *PathPathOSV) GetTypename() *string { return v.Typename }
 // GetId returns PathPathOSV.Id, and is useful for accessing the field via an interface.
 func (v *PathPathOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns PathPathOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *PathPathOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns PathPathOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *PathPathOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *PathPathOSV) UnmarshalJSON(b []byte) error {
 
@@ -10181,7 +10209,7 @@ type __premarshalPathPathOSV struct {
 
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *PathPathOSV) MarshalJSON() ([]byte, error) {
@@ -10197,7 +10225,7 @@ func (v *PathPathOSV) __premarshalJSON() (*__premarshalPathPathOSV, error) {
 
 	retval.Typename = v.Typename
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -11599,7 +11627,9 @@ func (v *SourcesSourcesSource) __premarshalJSON() (*__premarshalSourcesSourcesSo
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type VEXPackageAndGhsaIngestGHSA struct {
 	allGHSATree `json:"-"`
 }
@@ -11607,10 +11637,8 @@ type VEXPackageAndGhsaIngestGHSA struct {
 // GetId returns VEXPackageAndGhsaIngestGHSA.Id, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns VEXPackageAndGhsaIngestGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *VEXPackageAndGhsaIngestGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns VEXPackageAndGhsaIngestGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *VEXPackageAndGhsaIngestGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *VEXPackageAndGhsaIngestGHSA) UnmarshalJSON(b []byte) error {
 
@@ -11640,7 +11668,7 @@ func (v *VEXPackageAndGhsaIngestGHSA) UnmarshalJSON(b []byte) error {
 type __premarshalVEXPackageAndGhsaIngestGHSA struct {
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *VEXPackageAndGhsaIngestGHSA) MarshalJSON() ([]byte, error) {
@@ -11655,7 +11683,7 @@ func (v *VEXPackageAndGhsaIngestGHSA) __premarshalJSON() (*__premarshalVEXPackag
 	var retval __premarshalVEXPackageAndGhsaIngestGHSA
 
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -11975,10 +12003,10 @@ func (v *VexArtifactAndCveIngestArtifact) __premarshalJSON() (*__premarshalVexAr
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type VexArtifactAndCveIngestCVE struct {
 	allCveTree `json:"-"`
 }
@@ -11989,8 +12017,8 @@ func (v *VexArtifactAndCveIngestCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns VexArtifactAndCveIngestCVE.Year, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns VexArtifactAndCveIngestCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndCveIngestCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns VexArtifactAndCveIngestCVE.CveId, and is useful for accessing the field via an interface.
+func (v *VexArtifactAndCveIngestCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *VexArtifactAndCveIngestCVE) UnmarshalJSON(b []byte) error {
 
@@ -12022,7 +12050,7 @@ type __premarshalVexArtifactAndCveIngestCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *VexArtifactAndCveIngestCVE) MarshalJSON() ([]byte, error) {
@@ -12038,7 +12066,7 @@ func (v *VexArtifactAndCveIngestCVE) __premarshalJSON() (*__premarshalVexArtifac
 
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -12277,7 +12305,9 @@ func (v *VexArtifactAndGhsaIngestArtifact) __premarshalJSON() (*__premarshalVexA
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type VexArtifactAndGhsaIngestGHSA struct {
 	allGHSATree `json:"-"`
 }
@@ -12285,10 +12315,8 @@ type VexArtifactAndGhsaIngestGHSA struct {
 // GetId returns VexArtifactAndGhsaIngestGHSA.Id, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns VexArtifactAndGhsaIngestGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndGhsaIngestGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns VexArtifactAndGhsaIngestGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *VexArtifactAndGhsaIngestGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *VexArtifactAndGhsaIngestGHSA) UnmarshalJSON(b []byte) error {
 
@@ -12318,7 +12346,7 @@ func (v *VexArtifactAndGhsaIngestGHSA) UnmarshalJSON(b []byte) error {
 type __premarshalVexArtifactAndGhsaIngestGHSA struct {
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *VexArtifactAndGhsaIngestGHSA) MarshalJSON() ([]byte, error) {
@@ -12333,7 +12361,7 @@ func (v *VexArtifactAndGhsaIngestGHSA) __premarshalJSON() (*__premarshalVexArtif
 	var retval __premarshalVexArtifactAndGhsaIngestGHSA
 
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -12574,7 +12602,12 @@ func (v *VexArtifactAndOsvIngestArtifact) __premarshalJSON() (*__premarshalVexAr
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type VexArtifactAndOsvIngestOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -12582,8 +12615,8 @@ type VexArtifactAndOsvIngestOSV struct {
 // GetId returns VexArtifactAndOsvIngestOSV.Id, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns VexArtifactAndOsvIngestOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndOsvIngestOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns VexArtifactAndOsvIngestOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *VexArtifactAndOsvIngestOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *VexArtifactAndOsvIngestOSV) UnmarshalJSON(b []byte) error {
 
@@ -12613,7 +12646,7 @@ func (v *VexArtifactAndOsvIngestOSV) UnmarshalJSON(b []byte) error {
 type __premarshalVexArtifactAndOsvIngestOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *VexArtifactAndOsvIngestOSV) MarshalJSON() ([]byte, error) {
@@ -12628,7 +12661,7 @@ func (v *VexArtifactAndOsvIngestOSV) __premarshalJSON() (*__premarshalVexArtifac
 	var retval __premarshalVexArtifactAndOsvIngestOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -12795,10 +12828,10 @@ func (v *VexArtifactAndOsvResponse) GetIngestVEXStatement() VexArtifactAndOsvIng
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type VexPackageAndCveIngestCVE struct {
 	allCveTree `json:"-"`
 }
@@ -12809,8 +12842,8 @@ func (v *VexPackageAndCveIngestCVE) GetId() string { return v.allCveTree.Id }
 // GetYear returns VexPackageAndCveIngestCVE.Year, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns VexPackageAndCveIngestCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *VexPackageAndCveIngestCVE) GetCveIds() []allCveTreeCveIdsCVEId { return v.allCveTree.CveIds }
+// GetCveId returns VexPackageAndCveIngestCVE.CveId, and is useful for accessing the field via an interface.
+func (v *VexPackageAndCveIngestCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *VexPackageAndCveIngestCVE) UnmarshalJSON(b []byte) error {
 
@@ -12842,7 +12875,7 @@ type __premarshalVexPackageAndCveIngestCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *VexPackageAndCveIngestCVE) MarshalJSON() ([]byte, error) {
@@ -12858,7 +12891,7 @@ func (v *VexPackageAndCveIngestCVE) __premarshalJSON() (*__premarshalVexPackageA
 
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -13104,7 +13137,12 @@ func (v *VexPackageAndCveResponse) GetIngestVEXStatement() VexPackageAndCveInges
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type VexPackageAndOsvIngestOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -13112,8 +13150,8 @@ type VexPackageAndOsvIngestOSV struct {
 // GetId returns VexPackageAndOsvIngestOSV.Id, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns VexPackageAndOsvIngestOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *VexPackageAndOsvIngestOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns VexPackageAndOsvIngestOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *VexPackageAndOsvIngestOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *VexPackageAndOsvIngestOSV) UnmarshalJSON(b []byte) error {
 
@@ -13143,7 +13181,7 @@ func (v *VexPackageAndOsvIngestOSV) UnmarshalJSON(b []byte) error {
 type __premarshalVexPackageAndOsvIngestOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *VexPackageAndOsvIngestOSV) MarshalJSON() ([]byte, error) {
@@ -13158,7 +13196,7 @@ func (v *VexPackageAndOsvIngestOSV) __premarshalJSON() (*__premarshalVexPackageA
 	var retval __premarshalVexPackageAndOsvIngestOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -15288,10 +15326,10 @@ func __marshalallCertifyVEXStatementSubjectPackageOrArtifact(v *allCertifyVEXSta
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type allCertifyVEXStatementVulnerabilityCVE struct {
 	Typename   *string `json:"__typename"`
 	allCveTree `json:"-"`
@@ -15306,10 +15344,8 @@ func (v *allCertifyVEXStatementVulnerabilityCVE) GetId() string { return v.allCv
 // GetYear returns allCertifyVEXStatementVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
 func (v *allCertifyVEXStatementVulnerabilityCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns allCertifyVEXStatementVulnerabilityCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityCVE) GetCveIds() []allCveTreeCveIdsCVEId {
-	return v.allCveTree.CveIds
-}
+// GetCveId returns allCertifyVEXStatementVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
+func (v *allCertifyVEXStatementVulnerabilityCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *allCertifyVEXStatementVulnerabilityCVE) UnmarshalJSON(b []byte) error {
 
@@ -15343,7 +15379,7 @@ type __premarshalallCertifyVEXStatementVulnerabilityCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *allCertifyVEXStatementVulnerabilityCVE) MarshalJSON() ([]byte, error) {
@@ -15360,7 +15396,7 @@ func (v *allCertifyVEXStatementVulnerabilityCVE) __premarshalJSON() (*__premarsh
 	retval.Typename = v.Typename
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -15369,7 +15405,9 @@ func (v *allCertifyVEXStatementVulnerabilityCVE) __premarshalJSON() (*__premarsh
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type allCertifyVEXStatementVulnerabilityGHSA struct {
 	Typename    *string `json:"__typename"`
 	allGHSATree `json:"-"`
@@ -15381,10 +15419,8 @@ func (v *allCertifyVEXStatementVulnerabilityGHSA) GetTypename() *string { return
 // GetId returns allCertifyVEXStatementVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
 func (v *allCertifyVEXStatementVulnerabilityGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns allCertifyVEXStatementVulnerabilityGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns allCertifyVEXStatementVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *allCertifyVEXStatementVulnerabilityGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *allCertifyVEXStatementVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
 
@@ -15416,7 +15452,7 @@ type __premarshalallCertifyVEXStatementVulnerabilityGHSA struct {
 
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *allCertifyVEXStatementVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
@@ -15432,7 +15468,7 @@ func (v *allCertifyVEXStatementVulnerabilityGHSA) __premarshalJSON() (*__premars
 
 	retval.Typename = v.Typename
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -15441,7 +15477,12 @@ func (v *allCertifyVEXStatementVulnerabilityGHSA) __premarshalJSON() (*__premars
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type allCertifyVEXStatementVulnerabilityOSV struct {
 	Typename   *string `json:"__typename"`
 	allOSVTree `json:"-"`
@@ -15453,10 +15494,8 @@ func (v *allCertifyVEXStatementVulnerabilityOSV) GetTypename() *string { return 
 // GetId returns allCertifyVEXStatementVulnerabilityOSV.Id, and is useful for accessing the field via an interface.
 func (v *allCertifyVEXStatementVulnerabilityOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns allCertifyVEXStatementVulnerabilityOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId {
-	return v.allOSVTree.OsvIds
-}
+// GetOsvId returns allCertifyVEXStatementVulnerabilityOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *allCertifyVEXStatementVulnerabilityOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *allCertifyVEXStatementVulnerabilityOSV) UnmarshalJSON(b []byte) error {
 
@@ -15488,7 +15527,7 @@ type __premarshalallCertifyVEXStatementVulnerabilityOSV struct {
 
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *allCertifyVEXStatementVulnerabilityOSV) MarshalJSON() ([]byte, error) {
@@ -15504,7 +15543,7 @@ func (v *allCertifyVEXStatementVulnerabilityOSV) __premarshalJSON() (*__premarsh
 
 	retval.Typename = v.Typename
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -15616,14 +15655,14 @@ func __marshalallCertifyVEXStatementVulnerabilityOsvCveOrGhsa(v *allCertifyVEXSt
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type allCveTree struct {
-	Id     string                  `json:"id"`
-	Year   int                     `json:"year"`
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	Id    string `json:"id"`
+	Year  int    `json:"year"`
+	CveId string `json:"cveId"`
 }
 
 // GetId returns allCveTree.Id, and is useful for accessing the field via an interface.
@@ -15632,63 +15671,27 @@ func (v *allCveTree) GetId() string { return v.Id }
 // GetYear returns allCveTree.Year, and is useful for accessing the field via an interface.
 func (v *allCveTree) GetYear() int { return v.Year }
 
-// GetCveIds returns allCveTree.CveIds, and is useful for accessing the field via an interface.
-func (v *allCveTree) GetCveIds() []allCveTreeCveIdsCVEId { return v.CveIds }
-
-// allCveTreeCveIdsCVEId includes the requested fields of the GraphQL type CVEId.
-// The GraphQL type's documentation follows.
-//
-// # CVEId is the actual ID that is given to a specific vulnerability
-//
-// The `id` field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allCveTreeCveIdsCVEId struct {
-	Id    string `json:"id"`
-	CveId string `json:"cveId"`
-}
-
-// GetId returns allCveTreeCveIdsCVEId.Id, and is useful for accessing the field via an interface.
-func (v *allCveTreeCveIdsCVEId) GetId() string { return v.Id }
-
-// GetCveId returns allCveTreeCveIdsCVEId.CveId, and is useful for accessing the field via an interface.
-func (v *allCveTreeCveIdsCVEId) GetCveId() string { return v.CveId }
+// GetCveId returns allCveTree.CveId, and is useful for accessing the field via an interface.
+func (v *allCveTree) GetCveId() string { return v.CveId }
 
 // allGHSATree includes the GraphQL fields of GHSA requested by the fragment allGHSATree.
 // The GraphQL type's documentation follows.
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type allGHSATree struct {
-	Id      string                     `json:"id"`
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	Id     string `json:"id"`
+	GhsaId string `json:"ghsaId"`
 }
 
 // GetId returns allGHSATree.Id, and is useful for accessing the field via an interface.
 func (v *allGHSATree) GetId() string { return v.Id }
 
-// GetGhsaIds returns allGHSATree.GhsaIds, and is useful for accessing the field via an interface.
-func (v *allGHSATree) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId { return v.GhsaIds }
-
-// allGHSATreeGhsaIdsGHSAId includes the requested fields of the GraphQL type GHSAId.
-// The GraphQL type's documentation follows.
-//
-// # GHSAId is the actual ID that is given to a specific vulnerability on GitHub
-//
-// The `id` field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allGHSATreeGhsaIdsGHSAId struct {
-	Id     string `json:"id"`
-	GhsaId string `json:"ghsaId"`
-}
-
-// GetId returns allGHSATreeGhsaIdsGHSAId.Id, and is useful for accessing the field via an interface.
-func (v *allGHSATreeGhsaIdsGHSAId) GetId() string { return v.Id }
-
-// GetGhsaId returns allGHSATreeGhsaIdsGHSAId.GhsaId, and is useful for accessing the field via an interface.
-func (v *allGHSATreeGhsaIdsGHSAId) GetGhsaId() string { return v.GhsaId }
+// GetGhsaId returns allGHSATree.GhsaId, and is useful for accessing the field via an interface.
+func (v *allGHSATree) GetGhsaId() string { return v.GhsaId }
 
 // allHasSBOMTree includes the GraphQL fields of HasSBOM requested by the fragment allHasSBOMTree.
 // The GraphQL type's documentation follows.
@@ -16684,7 +16687,12 @@ func (v *allIsVulnerability) __premarshalJSON() (*__premarshalallIsVulnerability
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
+// The `osvId` field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
 type allIsVulnerabilityOsvOSV struct {
 	allOSVTree `json:"-"`
 }
@@ -16692,8 +16700,8 @@ type allIsVulnerabilityOsvOSV struct {
 // GetId returns allIsVulnerabilityOsvOSV.Id, and is useful for accessing the field via an interface.
 func (v *allIsVulnerabilityOsvOSV) GetId() string { return v.allOSVTree.Id }
 
-// GetOsvIds returns allIsVulnerabilityOsvOSV.OsvIds, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityOsvOSV) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.allOSVTree.OsvIds }
+// GetOsvId returns allIsVulnerabilityOsvOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *allIsVulnerabilityOsvOSV) GetOsvId() string { return v.allOSVTree.OsvId }
 
 func (v *allIsVulnerabilityOsvOSV) UnmarshalJSON(b []byte) error {
 
@@ -16723,7 +16731,7 @@ func (v *allIsVulnerabilityOsvOSV) UnmarshalJSON(b []byte) error {
 type __premarshalallIsVulnerabilityOsvOSV struct {
 	Id string `json:"id"`
 
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
+	OsvId string `json:"osvId"`
 }
 
 func (v *allIsVulnerabilityOsvOSV) MarshalJSON() ([]byte, error) {
@@ -16738,7 +16746,7 @@ func (v *allIsVulnerabilityOsvOSV) __premarshalJSON() (*__premarshalallIsVulnera
 	var retval __premarshalallIsVulnerabilityOsvOSV
 
 	retval.Id = v.allOSVTree.Id
-	retval.OsvIds = v.allOSVTree.OsvIds
+	retval.OsvId = v.allOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -16748,10 +16756,10 @@ func (v *allIsVulnerabilityOsvOSV) __premarshalJSON() (*__premarshalallIsVulnera
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type allIsVulnerabilityVulnerabilityCVE struct {
 	Typename   *string `json:"__typename"`
 	allCveTree `json:"-"`
@@ -16766,10 +16774,8 @@ func (v *allIsVulnerabilityVulnerabilityCVE) GetId() string { return v.allCveTre
 // GetYear returns allIsVulnerabilityVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
 func (v *allIsVulnerabilityVulnerabilityCVE) GetYear() int { return v.allCveTree.Year }
 
-// GetCveIds returns allIsVulnerabilityVulnerabilityCVE.CveIds, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityCVE) GetCveIds() []allCveTreeCveIdsCVEId {
-	return v.allCveTree.CveIds
-}
+// GetCveId returns allIsVulnerabilityVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
+func (v *allIsVulnerabilityVulnerabilityCVE) GetCveId() string { return v.allCveTree.CveId }
 
 func (v *allIsVulnerabilityVulnerabilityCVE) UnmarshalJSON(b []byte) error {
 
@@ -16803,7 +16809,7 @@ type __premarshalallIsVulnerabilityVulnerabilityCVE struct {
 
 	Year int `json:"year"`
 
-	CveIds []allCveTreeCveIdsCVEId `json:"cveIds"`
+	CveId string `json:"cveId"`
 }
 
 func (v *allIsVulnerabilityVulnerabilityCVE) MarshalJSON() ([]byte, error) {
@@ -16820,7 +16826,7 @@ func (v *allIsVulnerabilityVulnerabilityCVE) __premarshalJSON() (*__premarshalal
 	retval.Typename = v.Typename
 	retval.Id = v.allCveTree.Id
 	retval.Year = v.allCveTree.Year
-	retval.CveIds = v.allCveTree.CveIds
+	retval.CveId = v.allCveTree.CveId
 	return &retval, nil
 }
 
@@ -16913,7 +16919,9 @@ func __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(v *allIsVulnerabilityVuln
 //
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type allIsVulnerabilityVulnerabilityGHSA struct {
 	Typename    *string `json:"__typename"`
 	allGHSATree `json:"-"`
@@ -16925,10 +16933,8 @@ func (v *allIsVulnerabilityVulnerabilityGHSA) GetTypename() *string { return v.T
 // GetId returns allIsVulnerabilityVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
 func (v *allIsVulnerabilityVulnerabilityGHSA) GetId() string { return v.allGHSATree.Id }
 
-// GetGhsaIds returns allIsVulnerabilityVulnerabilityGHSA.GhsaIds, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityGHSA) GetGhsaIds() []allGHSATreeGhsaIdsGHSAId {
-	return v.allGHSATree.GhsaIds
-}
+// GetGhsaId returns allIsVulnerabilityVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *allIsVulnerabilityVulnerabilityGHSA) GetGhsaId() string { return v.allGHSATree.GhsaId }
 
 func (v *allIsVulnerabilityVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
 
@@ -16960,7 +16966,7 @@ type __premarshalallIsVulnerabilityVulnerabilityGHSA struct {
 
 	Id string `json:"id"`
 
-	GhsaIds []allGHSATreeGhsaIdsGHSAId `json:"ghsaIds"`
+	GhsaId string `json:"ghsaId"`
 }
 
 func (v *allIsVulnerabilityVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
@@ -16976,7 +16982,7 @@ func (v *allIsVulnerabilityVulnerabilityGHSA) __premarshalJSON() (*__premarshala
 
 	retval.Typename = v.Typename
 	retval.Id = v.allGHSATree.Id
-	retval.GhsaIds = v.allGHSATree.GhsaIds
+	retval.GhsaId = v.allGHSATree.GhsaId
 	return &retval, nil
 }
 
@@ -16985,39 +16991,22 @@ func (v *allIsVulnerabilityVulnerabilityGHSA) __premarshalJSON() (*__premarshala
 //
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
-type allOSVTree struct {
-	Id     string                  `json:"id"`
-	OsvIds []allOSVTreeOsvIdsOSVId `json:"osvIds"`
-}
-
-// GetId returns allOSVTree.Id, and is useful for accessing the field via an interface.
-func (v *allOSVTree) GetId() string { return v.Id }
-
-// GetOsvIds returns allOSVTree.OsvIds, and is useful for accessing the field via an interface.
-func (v *allOSVTree) GetOsvIds() []allOSVTreeOsvIdsOSVId { return v.OsvIds }
-
-// allOSVTreeOsvIdsOSVId includes the requested fields of the GraphQL type OSVId.
-// The GraphQL type's documentation follows.
-//
-// OSVId is the actual ID that is given to a specific vulnerability.
-//
 // The `osvId` field is mandatory and canonicalized to be lowercase.
 //
 // This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
 // CVE ID).
 //
 // This node can be referred to by other parts of GUAC.
-type allOSVTreeOsvIdsOSVId struct {
+type allOSVTree struct {
 	Id    string `json:"id"`
 	OsvId string `json:"osvId"`
 }
 
-// GetId returns allOSVTreeOsvIdsOSVId.Id, and is useful for accessing the field via an interface.
-func (v *allOSVTreeOsvIdsOSVId) GetId() string { return v.Id }
+// GetId returns allOSVTree.Id, and is useful for accessing the field via an interface.
+func (v *allOSVTree) GetId() string { return v.Id }
 
-// GetOsvId returns allOSVTreeOsvIdsOSVId.OsvId, and is useful for accessing the field via an interface.
-func (v *allOSVTreeOsvIdsOSVId) GetOsvId() string { return v.OsvId }
+// GetOsvId returns allOSVTree.OsvId, and is useful for accessing the field via an interface.
+func (v *allOSVTree) GetOsvId() string { return v.OsvId }
 
 // allPkgEqual includes the GraphQL fields of PkgEqual requested by the fragment allPkgEqual.
 // The GraphQL type's documentation follows.
@@ -17749,10 +17738,7 @@ fragment AllPkgTree on Package {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment AllCertifyVuln on CertifyVuln {
 	id
@@ -17783,17 +17769,11 @@ fragment AllCertifyVuln on CertifyVuln {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 `,
 		Variables: &__CertifyCVEInput{
@@ -17860,10 +17840,7 @@ fragment AllPkgTree on Package {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment AllCertifyVuln on CertifyVuln {
 	id
@@ -17895,17 +17872,11 @@ fragment AllCertifyVuln on CertifyVuln {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 `,
 		Variables: &__CertifyGHSAInput{
@@ -18259,10 +18230,7 @@ fragment AllPkgTree on Package {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment AllCertifyVuln on CertifyVuln {
 	id
@@ -18294,17 +18262,11 @@ fragment AllCertifyVuln on CertifyVuln {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 `,
 		Variables: &__CertifyOSVInput{
@@ -18948,18 +18910,12 @@ mutation IsVulnerabilityCVE ($osv: OSVInputSpec!, $cve: CVEInputSpec!, $isVulner
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allIsVulnerability on IsVulnerability {
 	id
@@ -18981,10 +18937,7 @@ fragment allIsVulnerability on IsVulnerability {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 `,
 		Variables: &__IsVulnerabilityCVEInput{
@@ -19030,17 +18983,11 @@ mutation IsVulnerabilityGHSA ($osv: OSVInputSpec!, $ghsa: GHSAInputSpec!, $isVul
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment allIsVulnerability on IsVulnerability {
 	id
@@ -19063,10 +19010,7 @@ fragment allIsVulnerability on IsVulnerability {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 `,
 		Variables: &__IsVulnerabilityGHSAInput{
@@ -19208,25 +19152,16 @@ fragment allBuilderTree on Builder {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment AllCertifyScorecard on CertifyScorecard {
 	id
@@ -19631,25 +19566,16 @@ fragment allBuilderTree on Builder {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment AllCertifyScorecard on CertifyScorecard {
 	id
@@ -20189,10 +20115,7 @@ fragment AllPkgTree on Package {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20230,17 +20153,11 @@ fragment allArtifactTree on Artifact {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 `,
 		Variables: &__VEXPackageAndGhsaInput{
@@ -20292,10 +20209,7 @@ fragment allArtifactTree on Artifact {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20348,17 +20262,11 @@ fragment AllPkgTree on Package {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 `,
 		Variables: &__VexArtifactAndCveInput{
@@ -20409,10 +20317,7 @@ fragment allArtifactTree on Artifact {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20466,17 +20371,11 @@ fragment AllPkgTree on Package {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 `,
 		Variables: &__VexArtifactAndGhsaInput{
@@ -20527,10 +20426,7 @@ fragment allArtifactTree on Artifact {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20584,17 +20480,11 @@ fragment AllPkgTree on Package {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 `,
 		Variables: &__VexArtifactAndOsvInput{
@@ -20662,10 +20552,7 @@ fragment AllPkgTree on Package {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20702,17 +20589,11 @@ fragment allArtifactTree on Artifact {
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 `,
 		Variables: &__VexPackageAndCveInput{
@@ -20779,10 +20660,7 @@ fragment AllPkgTree on Package {
 }
 fragment allOSVTree on OSV {
 	id
-	osvIds {
-		id
-		osvId
-	}
+	osvId
 }
 fragment allCertifyVEXStatement on CertifyVEXStatement {
 	id
@@ -20820,17 +20698,11 @@ fragment allArtifactTree on Artifact {
 fragment allCveTree on CVE {
 	id
 	year
-	cveIds {
-		id
-		cveId
-	}
+	cveId
 }
 fragment allGHSATree on GHSA {
 	id
-	ghsaIds {
-		id
-		ghsaId
-	}
+	ghsaId
 }
 `,
 		Variables: &__VexPackageAndOsvInput{

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -70,26 +70,17 @@ fragment allBuilderTree on Builder {
 fragment allCveTree on CVE {
   id
   year
-  cveIds {
-    id
-    cveId
-  }
+  cveId
 }
 
 fragment allGHSATree on GHSA {
   id
-  ghsaIds {
-    id
-    ghsaId
-  }
+  ghsaId
 }
 
 fragment allOSVTree on OSV {
   id
-  osvIds {
-    id
-    osvId
-  }
+  osvId
 }
 
 fragment AllCertifyScorecard on CertifyScorecard {

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -26,24 +26,15 @@ fragment allCertifyVulnTree on CertifyVuln {
     ... on CVE {
       id
       year
-     cveIds{
-      id
       cveId
-    }
     }
     ... on OSV {
       id
-     osvIds{
-      id
       osvId
-    }
     }
     ... on GHSA {
       id
-      ghsaIds{
-        id
-        ghsaId
-      }
+      ghsaId
     }
   }
   metadata {

--- a/pkg/assembler/graphql/examples/cve_ghsa_osv.gql
+++ b/pkg/assembler/graphql/examples/cve_ghsa_osv.gql
@@ -1,26 +1,17 @@
 fragment allCveTree on CVE {
   id
   year
-  cveIds {
-    id
-    cveId
-  }
+  cveId
 }
 
 fragment allGHSATree on GHSA {
   id
-  ghsaIds {
-    id
-    ghsaId
-  }
+  ghsaId
 }
 
 fragment allOSVTree on OSV {
   id
-  osvIds {
-    id
-    osvId
-  }
+  osvId
 }
 
 query CVEQ1 {

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -1622,8 +1622,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestCVE(ctx context.Context,
 				return ec.fieldContext_CVE_id(ctx, field)
 			case "year":
 				return ec.fieldContext_CVE_year(ctx, field)
-			case "cveIds":
-				return ec.fieldContext_CVE_cveIds(ctx, field)
+			case "cveId":
+				return ec.fieldContext_CVE_cveId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CVE", field.Name)
 		},
@@ -1683,8 +1683,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestGHSA(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_GHSA_id(ctx, field)
-			case "ghsaIds":
-				return ec.fieldContext_GHSA_ghsaIds(ctx, field)
+			case "ghsaId":
+				return ec.fieldContext_GHSA_ghsaId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GHSA", field.Name)
 		},
@@ -2284,8 +2284,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestOSV(ctx context.Context,
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_OSV_id(ctx, field)
-			case "osvIds":
-				return ec.fieldContext_OSV_osvIds(ctx, field)
+			case "osvId":
+				return ec.fieldContext_OSV_osvId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OSV", field.Name)
 		},
@@ -2997,8 +2997,8 @@ func (ec *executionContext) fieldContext_Query_cve(ctx context.Context, field gr
 				return ec.fieldContext_CVE_id(ctx, field)
 			case "year":
 				return ec.fieldContext_CVE_year(ctx, field)
-			case "cveIds":
-				return ec.fieldContext_CVE_cveIds(ctx, field)
+			case "cveId":
+				return ec.fieldContext_CVE_cveId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CVE", field.Name)
 		},
@@ -3058,8 +3058,8 @@ func (ec *executionContext) fieldContext_Query_ghsa(ctx context.Context, field g
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_GHSA_id(ctx, field)
-			case "ghsaIds":
-				return ec.fieldContext_GHSA_ghsaIds(ctx, field)
+			case "ghsaId":
+				return ec.fieldContext_GHSA_ghsaId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GHSA", field.Name)
 		},
@@ -3596,8 +3596,8 @@ func (ec *executionContext) fieldContext_Query_osv(ctx context.Context, field gr
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_OSV_id(ctx, field)
-			case "osvIds":
-				return ec.fieldContext_OSV_osvIds(ctx, field)
+			case "osvId":
+				return ec.fieldContext_OSV_osvId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OSV", field.Name)
 		},

--- a/pkg/assembler/graphql/generated/cve.generated.go
+++ b/pkg/assembler/graphql/generated/cve.generated.go
@@ -5,7 +5,6 @@ package generated
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -116,102 +115,8 @@ func (ec *executionContext) fieldContext_CVE_year(ctx context.Context, field gra
 	return fc, nil
 }
 
-func (ec *executionContext) _CVE_cveIds(ctx context.Context, field graphql.CollectedField, obj *model.Cve) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CVE_cveIds(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.CveIds, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.CVEId)
-	fc.Result = res
-	return ec.marshalNCVEId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCVEIdᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CVE_cveIds(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CVE",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CVEId_id(ctx, field)
-			case "cveId":
-				return ec.fieldContext_CVEId_cveId(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CVEId", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CVEId_id(ctx context.Context, field graphql.CollectedField, obj *model.CVEId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CVEId_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CVEId_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CVEId",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CVEId_cveId(ctx context.Context, field graphql.CollectedField, obj *model.CVEId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CVEId_cveId(ctx, field)
+func (ec *executionContext) _CVE_cveId(ctx context.Context, field graphql.CollectedField, obj *model.Cve) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CVE_cveId(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -241,9 +146,9 @@ func (ec *executionContext) _CVEId_cveId(ctx context.Context, field graphql.Coll
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_CVEId_cveId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_CVE_cveId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "CVEId",
+		Object:     "CVE",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -370,44 +275,9 @@ func (ec *executionContext) _CVE(ctx context.Context, sel ast.SelectionSet, obj 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "cveIds":
-
-			out.Values[i] = ec._CVE_cveIds(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var cVEIdImplementors = []string{"CVEId"}
-
-func (ec *executionContext) _CVEId(ctx context.Context, sel ast.SelectionSet, obj *model.CVEId) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, cVEIdImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("CVEId")
-		case "id":
-
-			out.Values[i] = ec._CVEId_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "cveId":
 
-			out.Values[i] = ec._CVEId_cveId(ctx, field, obj)
+			out.Values[i] = ec._CVE_cveId(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -483,60 +353,6 @@ func (ec *executionContext) marshalNCVE2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkg�
 		return graphql.Null
 	}
 	return ec._CVE(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNCVEId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCVEIdᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CVEId) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNCVEId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCVEId(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalNCVEId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCVEId(ctx context.Context, sel ast.SelectionSet, v *model.CVEId) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._CVEId(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOCVEInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCVEInputSpec(ctx context.Context, v interface{}) (*model.CVEInputSpec, error) {

--- a/pkg/assembler/graphql/generated/ghsa.generated.go
+++ b/pkg/assembler/graphql/generated/ghsa.generated.go
@@ -5,7 +5,6 @@ package generated
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -72,102 +71,8 @@ func (ec *executionContext) fieldContext_GHSA_id(ctx context.Context, field grap
 	return fc, nil
 }
 
-func (ec *executionContext) _GHSA_ghsaIds(ctx context.Context, field graphql.CollectedField, obj *model.Ghsa) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GHSA_ghsaIds(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.GhsaIds, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.GHSAId)
-	fc.Result = res
-	return ec.marshalNGHSAId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐGHSAIdᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_GHSA_ghsaIds(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "GHSA",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_GHSAId_id(ctx, field)
-			case "ghsaId":
-				return ec.fieldContext_GHSAId_ghsaId(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type GHSAId", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _GHSAId_id(ctx context.Context, field graphql.CollectedField, obj *model.GHSAId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GHSAId_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_GHSAId_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "GHSAId",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _GHSAId_ghsaId(ctx context.Context, field graphql.CollectedField, obj *model.GHSAId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GHSAId_ghsaId(ctx, field)
+func (ec *executionContext) _GHSA_ghsaId(ctx context.Context, field graphql.CollectedField, obj *model.Ghsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GHSA_ghsaId(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -197,9 +102,9 @@ func (ec *executionContext) _GHSAId_ghsaId(ctx context.Context, field graphql.Co
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_GHSAId_ghsaId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_GHSA_ghsaId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "GHSAId",
+		Object:     "GHSA",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -303,44 +208,9 @@ func (ec *executionContext) _GHSA(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "ghsaIds":
-
-			out.Values[i] = ec._GHSA_ghsaIds(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var gHSAIdImplementors = []string{"GHSAId"}
-
-func (ec *executionContext) _GHSAId(ctx context.Context, sel ast.SelectionSet, obj *model.GHSAId) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, gHSAIdImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("GHSAId")
-		case "id":
-
-			out.Values[i] = ec._GHSAId_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "ghsaId":
 
-			out.Values[i] = ec._GHSAId_ghsaId(ctx, field, obj)
+			out.Values[i] = ec._GHSA_ghsaId(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -416,60 +286,6 @@ func (ec *executionContext) marshalNGHSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkg�
 		return graphql.Null
 	}
 	return ec._GHSA(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNGHSAId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐGHSAIdᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.GHSAId) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGHSAId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐGHSAId(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalNGHSAId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐGHSAId(ctx context.Context, sel ast.SelectionSet, v *model.GHSAId) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._GHSAId(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOGHSAInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐGHSAInputSpec(ctx context.Context, v interface{}) (*model.GHSAInputSpec, error) {

--- a/pkg/assembler/graphql/generated/isVulnerability.generated.go
+++ b/pkg/assembler/graphql/generated/isVulnerability.generated.go
@@ -113,8 +113,8 @@ func (ec *executionContext) fieldContext_IsVulnerability_osv(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_OSV_id(ctx, field)
-			case "osvIds":
-				return ec.fieldContext_OSV_osvIds(ctx, field)
+			case "osvId":
+				return ec.fieldContext_OSV_osvId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OSV", field.Name)
 		},

--- a/pkg/assembler/graphql/generated/osv.generated.go
+++ b/pkg/assembler/graphql/generated/osv.generated.go
@@ -5,7 +5,6 @@ package generated
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -72,102 +71,8 @@ func (ec *executionContext) fieldContext_OSV_id(ctx context.Context, field graph
 	return fc, nil
 }
 
-func (ec *executionContext) _OSV_osvIds(ctx context.Context, field graphql.CollectedField, obj *model.Osv) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_OSV_osvIds(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.OsvIds, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.OSVId)
-	fc.Result = res
-	return ec.marshalNOSVId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐOSVIdᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_OSV_osvIds(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "OSV",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_OSVId_id(ctx, field)
-			case "osvId":
-				return ec.fieldContext_OSVId_osvId(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type OSVId", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _OSVId_id(ctx context.Context, field graphql.CollectedField, obj *model.OSVId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_OSVId_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_OSVId_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "OSVId",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _OSVId_osvId(ctx context.Context, field graphql.CollectedField, obj *model.OSVId) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_OSVId_osvId(ctx, field)
+func (ec *executionContext) _OSV_osvId(ctx context.Context, field graphql.CollectedField, obj *model.Osv) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OSV_osvId(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -197,9 +102,9 @@ func (ec *executionContext) _OSVId_osvId(ctx context.Context, field graphql.Coll
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_OSVId_osvId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_OSV_osvId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "OSVId",
+		Object:     "OSV",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -303,44 +208,9 @@ func (ec *executionContext) _OSV(ctx context.Context, sel ast.SelectionSet, obj 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "osvIds":
-
-			out.Values[i] = ec._OSV_osvIds(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var oSVIdImplementors = []string{"OSVId"}
-
-func (ec *executionContext) _OSVId(ctx context.Context, sel ast.SelectionSet, obj *model.OSVId) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, oSVIdImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("OSVId")
-		case "id":
-
-			out.Values[i] = ec._OSVId_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "osvId":
 
-			out.Values[i] = ec._OSVId_osvId(ctx, field, obj)
+			out.Values[i] = ec._OSV_osvId(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -416,60 +286,6 @@ func (ec *executionContext) marshalNOSV2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkg�
 		return graphql.Null
 	}
 	return ec._OSV(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNOSVId2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐOSVIdᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.OSVId) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNOSVId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐOSVId(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalNOSVId2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐOSVId(ctx context.Context, sel ast.SelectionSet, v *model.OSVId) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._OSVId(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNOSVInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐOSVInputSpec(ctx context.Context, v interface{}) (model.OSVInputSpec, error) {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -50,14 +50,9 @@ type ComplexityRoot struct {
 	}
 
 	CVE struct {
-		CveIds func(childComplexity int) int
-		ID     func(childComplexity int) int
-		Year   func(childComplexity int) int
-	}
-
-	CVEId struct {
 		CveID func(childComplexity int) int
 		ID    func(childComplexity int) int
+		Year  func(childComplexity int) int
 	}
 
 	CertifyBad struct {
@@ -100,11 +95,6 @@ type ComplexityRoot struct {
 	}
 
 	GHSA struct {
-		GhsaIds func(childComplexity int) int
-		ID      func(childComplexity int) int
-	}
-
-	GHSAId struct {
 		GhsaID func(childComplexity int) int
 		ID     func(childComplexity int) int
 	}
@@ -194,11 +184,6 @@ type ComplexityRoot struct {
 	}
 
 	OSV struct {
-		ID     func(childComplexity int) int
-		OsvIds func(childComplexity int) int
-	}
-
-	OSVId struct {
 		ID    func(childComplexity int) int
 		OsvID func(childComplexity int) int
 	}
@@ -378,12 +363,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Builder.URI(childComplexity), true
 
-	case "CVE.cveIds":
-		if e.complexity.CVE.CveIds == nil {
+	case "CVE.cveId":
+		if e.complexity.CVE.CveID == nil {
 			break
 		}
 
-		return e.complexity.CVE.CveIds(childComplexity), true
+		return e.complexity.CVE.CveID(childComplexity), true
 
 	case "CVE.id":
 		if e.complexity.CVE.ID == nil {
@@ -398,20 +383,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CVE.Year(childComplexity), true
-
-	case "CVEId.cveId":
-		if e.complexity.CVEId.CveID == nil {
-			break
-		}
-
-		return e.complexity.CVEId.CveID(childComplexity), true
-
-	case "CVEId.id":
-		if e.complexity.CVEId.ID == nil {
-			break
-		}
-
-		return e.complexity.CVEId.ID(childComplexity), true
 
 	case "CertifyBad.collector":
 		if e.complexity.CertifyBad.Collector == nil {
@@ -581,12 +552,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CertifyVuln.Vulnerability(childComplexity), true
 
-	case "GHSA.ghsaIds":
-		if e.complexity.GHSA.GhsaIds == nil {
+	case "GHSA.ghsaId":
+		if e.complexity.GHSA.GhsaID == nil {
 			break
 		}
 
-		return e.complexity.GHSA.GhsaIds(childComplexity), true
+		return e.complexity.GHSA.GhsaID(childComplexity), true
 
 	case "GHSA.id":
 		if e.complexity.GHSA.ID == nil {
@@ -594,20 +565,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GHSA.ID(childComplexity), true
-
-	case "GHSAId.ghsaId":
-		if e.complexity.GHSAId.GhsaID == nil {
-			break
-		}
-
-		return e.complexity.GHSAId.GhsaID(childComplexity), true
-
-	case "GHSAId.id":
-		if e.complexity.GHSAId.ID == nil {
-			break
-		}
-
-		return e.complexity.GHSAId.ID(childComplexity), true
 
 	case "HasSBOM.collector":
 		if e.complexity.HasSBOM.Collector == nil {
@@ -1141,26 +1098,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OSV.ID(childComplexity), true
 
-	case "OSV.osvIds":
-		if e.complexity.OSV.OsvIds == nil {
+	case "OSV.osvId":
+		if e.complexity.OSV.OsvID == nil {
 			break
 		}
 
-		return e.complexity.OSV.OsvIds(childComplexity), true
-
-	case "OSVId.id":
-		if e.complexity.OSVId.ID == nil {
-			break
-		}
-
-		return e.complexity.OSVId.ID(childComplexity), true
-
-	case "OSVId.osvId":
-		if e.complexity.OSVId.OsvID == nil {
-			break
-		}
-
-		return e.complexity.OSVId.OsvID(childComplexity), true
+		return e.complexity.OSV.OsvID(childComplexity), true
 
 	case "Package.id":
 		if e.complexity.Package.ID == nil {
@@ -2641,26 +2584,14 @@ extend type Mutation {
 CVE represents common vulnerabilities and exposures. It contains the year along
 with the CVE ID.
 
-The year is mandatory.
+The ` + "`" + `year` + "`" + ` is mandatory.
+The ` + "`" + `cveId` + "`" + ` field is mandatory and canonicalized to be lowercase.
 
-This node is a singleton: backends guarantee that there is exactly one node
-with the same ` + "`" + `year` + "`" + ` value.
+This node can be referred to by other parts of GUAC.
 """
 type CVE {
   id: ID!
   year: Int!
-  cveIds: [CVEId!]!
-}
-
-"""
-CVEId is the actual ID that is given to a specific vulnerability
-
-The ` + "`" + `id` + "`" + ` field is mandatory and canonicalized to be lowercase.
-
-This node can be referred to by other parts of GUAC.
-"""
-type CVEId {
-  id: ID!
   cveId: String!
 }
 
@@ -2715,21 +2646,11 @@ extend type Mutation {
 """
 GHSA represents GitHub security advisories.
 
-We create a separate node to allow retrieving all GHSAs.
-"""
-type GHSA {
-  id: ID!
-  ghsaIds: [GHSAId!]!
-}
-
-"""
-GHSAId is the actual ID that is given to a specific vulnerability on GitHub
-
 The ` + "`" + `id` + "`" + ` field is mandatory and canonicalized to be lowercase.
 
 This node can be referred to by other parts of GUAC.
 """
-type GHSAId {
+type GHSA {
   id: ID!
   ghsaId: String!
 }
@@ -3451,16 +3372,6 @@ extend type Mutation {
 """
 OSV represents an Open Source Vulnerability.
 
-We create a separate node to allow retrieving all OSVs.
-"""
-type OSV {
-  id: ID!
-  osvIds: [OSVId!]!
-}
-
-"""
-OSVId is the actual ID that is given to a specific vulnerability.
-
 The ` + "`" + `osvId` + "`" + ` field is mandatory and canonicalized to be lowercase.
 
 This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
@@ -3468,7 +3379,7 @@ CVE ID).
 
 This node can be referred to by other parts of GUAC.
 """
-type OSVId {
+type OSV {
   id: ID!
   osvId: String!
 }

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -103,14 +103,14 @@ type BuilderSpec struct {
 // CVE represents common vulnerabilities and exposures. It contains the year along
 // with the CVE ID.
 //
-// The year is mandatory.
+// The `year` is mandatory.
+// The `cveId` field is mandatory and canonicalized to be lowercase.
 //
-// This node is a singleton: backends guarantee that there is exactly one node
-// with the same `year` value.
+// This node can be referred to by other parts of GUAC.
 type Cve struct {
-	ID     string   `json:"id"`
-	Year   int      `json:"year"`
-	CveIds []*CVEId `json:"cveIds"`
+	ID    string `json:"id"`
+	Year  int    `json:"year"`
+	CveID string `json:"cveId"`
 }
 
 func (Cve) IsOsvCveOrGhsa() {}
@@ -118,16 +118,6 @@ func (Cve) IsOsvCveOrGhsa() {}
 func (Cve) IsCveOrGhsa() {}
 
 func (Cve) IsNode() {}
-
-// CVEId is the actual ID that is given to a specific vulnerability
-//
-// The `id` field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type CVEId struct {
-	ID    string `json:"id"`
-	CveID string `json:"cveId"`
-}
 
 // CVEInputSpec is the same as CVESpec, but used for mutation ingestion.
 type CVEInputSpec struct {
@@ -325,10 +315,12 @@ type CveOrGhsaSpec struct {
 
 // GHSA represents GitHub security advisories.
 //
-// We create a separate node to allow retrieving all GHSAs.
+// The `id` field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
 type Ghsa struct {
-	ID      string    `json:"id"`
-	GhsaIds []*GHSAId `json:"ghsaIds"`
+	ID     string `json:"id"`
+	GhsaID string `json:"ghsaId"`
 }
 
 func (Ghsa) IsOsvCveOrGhsa() {}
@@ -336,16 +328,6 @@ func (Ghsa) IsOsvCveOrGhsa() {}
 func (Ghsa) IsCveOrGhsa() {}
 
 func (Ghsa) IsNode() {}
-
-// GHSAId is the actual ID that is given to a specific vulnerability on GitHub
-//
-// The `id` field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type GHSAId struct {
-	ID     string `json:"id"`
-	GhsaID string `json:"ghsaId"`
-}
 
 // GHSAInputSpec is the same as GHSASpec, but used for mutation ingestion.
 type GHSAInputSpec struct {
@@ -634,28 +616,20 @@ type MatchFlags struct {
 
 // OSV represents an Open Source Vulnerability.
 //
-// We create a separate node to allow retrieving all OSVs.
-type Osv struct {
-	ID     string   `json:"id"`
-	OsvIds []*OSVId `json:"osvIds"`
-}
-
-func (Osv) IsOsvCveOrGhsa() {}
-
-func (Osv) IsNode() {}
-
-// OSVId is the actual ID that is given to a specific vulnerability.
-//
 // The `osvId` field is mandatory and canonicalized to be lowercase.
 //
 // This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
 // CVE ID).
 //
 // This node can be referred to by other parts of GUAC.
-type OSVId struct {
+type Osv struct {
 	ID    string `json:"id"`
 	OsvID string `json:"osvId"`
 }
+
+func (Osv) IsOsvCveOrGhsa() {}
+
+func (Osv) IsNode() {}
 
 // OSVInputSpec is the same as OSVSpec, but used for mutation ingestion.
 type OSVInputSpec struct {

--- a/pkg/assembler/graphql/schema/cve.graphql
+++ b/pkg/assembler/graphql/schema/cve.graphql
@@ -22,26 +22,14 @@
 CVE represents common vulnerabilities and exposures. It contains the year along
 with the CVE ID.
 
-The year is mandatory.
+The `year` is mandatory.
+The `cveId` field is mandatory and canonicalized to be lowercase.
 
-This node is a singleton: backends guarantee that there is exactly one node
-with the same `year` value.
+This node can be referred to by other parts of GUAC.
 """
 type CVE {
   id: ID!
   year: Int!
-  cveIds: [CVEId!]!
-}
-
-"""
-CVEId is the actual ID that is given to a specific vulnerability
-
-The `id` field is mandatory and canonicalized to be lowercase.
-
-This node can be referred to by other parts of GUAC.
-"""
-type CVEId {
-  id: ID!
   cveId: String!
 }
 

--- a/pkg/assembler/graphql/schema/ghsa.graphql
+++ b/pkg/assembler/graphql/schema/ghsa.graphql
@@ -22,21 +22,11 @@
 """
 GHSA represents GitHub security advisories.
 
-We create a separate node to allow retrieving all GHSAs.
-"""
-type GHSA {
-  id: ID!
-  ghsaIds: [GHSAId!]!
-}
-
-"""
-GHSAId is the actual ID that is given to a specific vulnerability on GitHub
-
 The `id` field is mandatory and canonicalized to be lowercase.
 
 This node can be referred to by other parts of GUAC.
 """
-type GHSAId {
+type GHSA {
   id: ID!
   ghsaId: String!
 }

--- a/pkg/assembler/graphql/schema/osv.graphql
+++ b/pkg/assembler/graphql/schema/osv.graphql
@@ -21,16 +21,6 @@
 """
 OSV represents an Open Source Vulnerability.
 
-We create a separate node to allow retrieving all OSVs.
-"""
-type OSV {
-  id: ID!
-  osvIds: [OSVId!]!
-}
-
-"""
-OSVId is the actual ID that is given to a specific vulnerability.
-
 The `osvId` field is mandatory and canonicalized to be lowercase.
 
 This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
@@ -38,7 +28,7 @@ CVE ID).
 
 This node can be referred to by other parts of GUAC.
 """
-type OSVId {
+type OSV {
   id: ID!
   osvId: String!
 }


### PR DESCRIPTION
Looking at #653 we don't want "path" to find a path between two vulns through the root node (or year node for cve).

