### PR TITLE
added cli for certifyBad and good

### DIFF
--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -1,0 +1,196 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/guacsec/guac/pkg/assembler"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/assembler/helpers"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var certifyFlags = struct {
+	justification string
+	subjectType   string
+	good          bool
+	pkgName       bool
+}{}
+
+var certifyCmd = &cobra.Command{
+	Use:              "certify [flags] purl / source (<vcs_tool>+<transport>) / artifact (algorithm:digest)",
+	Short:            "certify can either certify a package, source or artifact to be good or bad based on a justification",
+	TraverseChildren: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateCertifyFlags(
+			viper.GetString("gdbuser"),
+			viper.GetString("gdbpass"),
+			viper.GetString("gdbaddr"),
+			viper.GetString("realm"),
+			viper.GetString("gql-endpoint"),
+			viper.GetString("type"),
+			viper.GetString("justification"),
+			viper.GetBool("good"),
+			viper.GetBool("pkgName"),
+			args,
+		)
+
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		assemblerFunc, err := getAssembler(ctx, opts)
+		if err != nil {
+			logger.Fatalf("error: %v", err)
+		}
+
+		preds := &assembler.IngestPredicates{}
+		var pkgInput *model.PkgInputSpec
+		var matchFlag model.MatchFlags
+		var srcInput *model.SourceInputSpec
+		var artifact *model.ArtifactInputSpec
+
+		if opts.certifyType == "package" {
+			pkgInput, err = helpers.PurlToPkg(opts.subject)
+			if err != nil {
+				logger.Fatalf("failed to parse PURL: %v", err)
+			}
+			if opts.pkgName {
+				matchFlag = model.MatchFlags{
+					Pkg: model.PkgMatchTypeAllVersions,
+				}
+			} else {
+				matchFlag = model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				}
+			}
+		} else if opts.certifyType == "source" {
+			srcInput, err = helpers.VcsToSrc(opts.subject)
+			if err != nil {
+				logger.Fatalf("failed to parse source: %v", err)
+			}
+		} else {
+			split := strings.Split(opts.subject, ":")
+			if len(split) != 2 {
+				logger.Fatalf("failed to parse artifact. Needs to be in algorithm:digest form")
+			}
+			artifact = &model.ArtifactInputSpec{
+				Algorithm: strings.ToLower(string(split[0])),
+				Digest:    strings.ToLower(string(split[1])),
+			}
+		}
+
+		if opts.good {
+			certifyGood := &assembler.CertifyGoodIngest{}
+			if pkgInput != nil {
+				certifyGood.Pkg = pkgInput
+				certifyGood.Pkg = pkgInput
+				certifyGood.PkgMatchFlag = matchFlag
+
+			} else if srcInput != nil {
+				certifyGood.Src = srcInput
+			} else {
+				certifyGood.Artifact = artifact
+			}
+			certifyGood.CertifyGood = &model.CertifyGoodInputSpec{
+				Justification: opts.justification,
+				Origin:        "GUAC Certify CLI",
+				Collector:     "GUAC",
+			}
+			preds.CertifyGood = append(preds.CertifyGood, *certifyGood)
+		} else {
+			certifyBad := &assembler.CertifyBadIngest{}
+			if pkgInput != nil {
+				certifyBad.Pkg = pkgInput
+				certifyBad.Pkg = pkgInput
+				certifyBad.PkgMatchFlag = matchFlag
+
+			} else if srcInput != nil {
+				certifyBad.Src = srcInput
+			} else {
+				certifyBad.Artifact = artifact
+			}
+			certifyBad.CertifyBad = &model.CertifyBadInputSpec{
+				Justification: opts.justification,
+				Origin:        "GUAC Certify CLI",
+				Collector:     "GUAC",
+			}
+			preds.CertifyBad = append(preds.CertifyBad, *certifyBad)
+		}
+
+		assemblerInputs := []assembler.IngestPredicates{*preds}
+
+		err = assemblerFunc(assemblerInputs)
+		if err != nil {
+			logger.Fatalf("unable to assemble graphs: %v", err)
+		}
+	},
+}
+
+func validateCertifyFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint, certifyType, justification string, good, pkgName bool, args []string) (options, error) {
+	var opts options
+	opts.user = user
+	opts.pass = pass
+	opts.dbAddr = dbAddr
+	opts.realm = realm
+	opts.graphqlEndpoint = graphqlEndpoint
+	opts.good = good
+	opts.pkgName = pkgName
+	if certifyType != "package" && certifyType != "source" && certifyType != "artifact" {
+		return opts, fmt.Errorf("expected type to be either a package, source or artifact")
+	}
+	opts.certifyType = certifyType
+	if justification == "" {
+		return opts, fmt.Errorf("missing justification")
+	}
+	opts.justification = justification
+	if len(args) != 1 {
+		return opts, fmt.Errorf("expected positional argument for subject")
+	}
+
+	opts.subject = args[0]
+
+	return opts, nil
+}
+
+func init() {
+	localFlags := certifyCmd.Flags()
+	localFlags.BoolVarP(&certifyFlags.good, "good", "g", true, "set true if certifyGood or false for certifyBad")
+	localFlags.StringVarP(&certifyFlags.subjectType, "type", "t", "", "package, source or artifact that is being certified")
+	localFlags.StringVarP(&certifyFlags.justification, "justification", "j", "", "justification for the certification (either good or bad)")
+	localFlags.BoolVarP(&certifyFlags.pkgName, "pkgName", "p", false, "if type is package, true if attestation is at pkgName (for all versions) or false for a specific version")
+	flagNames := []string{"good", "type", "justification", "pkgName"}
+	for _, name := range flagNames {
+		if flag := localFlags.Lookup(name); flag != nil {
+			if err := viper.BindPFlag(name, flag); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to bind flag: %v", err)
+				os.Exit(1)
+			}
+		}
+	}
+	rootCmd.AddCommand(certifyCmd)
+}

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -59,6 +59,14 @@ type options struct {
 
 	// gql endpoint
 	graphqlEndpoint string
+
+	// certifyBad/certifyGood
+	good          bool
+	certifyType   string
+	justification string
+	subject       string
+	// if type is package, true if attestation is at pkgName (for all versions) or false for a specific version
+	pkgName bool
 }
 
 var exampleCmd = &cobra.Command{

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -154,6 +154,8 @@ type IngestPredicates struct {
 	CertifyVuln      []CertifyVulnIngest
 	IsVuln           []IsVulnIngest
 	HasSourceAt      []HasSourceAtIngest
+	CertifyBad       []CertifyBadIngest
+	CertifyGood      []CertifyGoodIngest
 }
 
 type CertifyScorecardIngest struct {
@@ -210,6 +212,24 @@ type HasSourceAtIngest struct {
 	PkgMatchFlag generated.MatchFlags
 	Src          *generated.SourceInputSpec
 	HasSourceAt  *generated.HasSourceAtInputSpec
+}
+
+type CertifyBadIngest struct {
+	// certifyBad describes either pkg, src or artifact
+	Pkg          *generated.PkgInputSpec
+	PkgMatchFlag generated.MatchFlags
+	Src          *generated.SourceInputSpec
+	Artifact     *generated.ArtifactInputSpec
+	CertifyBad   *generated.CertifyBadInputSpec
+}
+
+type CertifyGoodIngest struct {
+	// certifyGood describes either pkg, src or artifact
+	Pkg          *generated.PkgInputSpec
+	PkgMatchFlag generated.MatchFlags
+	Src          *generated.SourceInputSpec
+	Artifact     *generated.ArtifactInputSpec
+	CertifyGood  *generated.CertifyGoodInputSpec
 }
 
 // AssemblerInput represents the inputs to add to the graph


### PR DESCRIPTION
```
Usage:
  guacone certify [flags] purl / source (<vcs_tool>+<transport>) / artifact (algorithm:digest)

Flags:
  -g, --good                   set true if certifyGood or false for certifyBad (default true)
  -h, --help                   help for certify
  -j, --justification string   justification for the certification (either good or bad)
  -p, --pkgName                if type is package, true if attestation is at pkgName (for all versions) or false for a specific version
  -t, --type string            package, source or artifact that is being certified

Global Flags:
      --csub-addr string          address to connect to collect-sub service (default "localhost:2782")
      --csub-listen-port int      port to listen to on collect-sub service (default 2782)
      --gdbaddr string            address to neo4j db (default "neo4j://localhost:7687")
      --gdbpass string            neo4j password credential to connect to graph db
      --gdbuser string            neo4j user credential to connect to graph db
      --gql-backend string        backend used for graphql api server: [neo4j | inmem] (default "inmem")
      --gql-debug                 debug flag which enables the graphQL playground
      --gql-endpoint string       endpoint used to connect to graphQL server (default "http://localhost:8080/query")
      --gql-port int              port used for graphql api server (default 8080)
      --realm string              realm to connect to graph db (default "neo4j")
      --verifier-keyID string     ID of the key to be stored
      --verifier-keyPath string   path to pem file to verify dsse
```
Package example:
`./bin/guacone certify -t package -g=false -p=true -j "i said so" pkg:pypi/django`

Source example:
`./bin/guacone certify -t source -g=false -j "i said so" git+https://github.com/guacsec/guac`

Artifact example:
`./bin/guacone certify -t artifact -g=false -j "i said so" "sha256:6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"`