### PR TITLE
Allow filtering neighbors and paths on GUAC verbs

### DIFF
--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -75,9 +75,9 @@ type Backend interface {
 	IngestVulnerability(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error)
 
 	// Topological queries: queries where node connectivity matters more than node type
-	Neighbors(ctx context.Context, node string) ([]model.Node, error)
+	Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error)
 	Node(ctx context.Context, node string) (model.Node, error)
-	Path(ctx context.Context, subject string, target string, maxPathLength int) ([]model.Node, error)
+	Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -45,22 +45,22 @@ func (n *artStruct) ID() uint32 { return n.id }
 
 func (n *artStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{}
-	if allowedEdges[model.EdgeHashEqual] {
+	if allowedEdges[model.EdgeArtifactHashEqual] {
 		out = append(out, n.hashEquals...)
 	}
-	if allowedEdges[model.EdgeIsOccurrence] {
+	if allowedEdges[model.EdgeArtifactIsOccurrence] {
 		out = append(out, n.occurrences...)
 	}
-	if allowedEdges[model.EdgeHasSlsa] {
+	if allowedEdges[model.EdgeArtifactHasSlsa] {
 		out = append(out, n.hasSLSAs...)
 	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
+	if allowedEdges[model.EdgeArtifactCertifyVexStatement] {
 		out = append(out, n.vexLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyBad] {
+	if allowedEdges[model.EdgeArtifactCertifyBad] {
 		out = append(out, n.badLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyGood] {
+	if allowedEdges[model.EdgeArtifactCertifyGood] {
 		out = append(out, n.goodLinks...)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -44,30 +44,7 @@ type artStruct struct {
 func (n *artStruct) ID() uint32 { return n.id }
 
 func (n *artStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 0
-	if allowedEdges[model.EdgeHashEqual] {
-		maxLen = maxLen + len(n.hashEquals)
-	}
-	if allowedEdges[model.EdgeIsOccurrence] {
-		maxLen = maxLen + len(n.occurrences)
-	}
-	if allowedEdges[model.EdgeHasSlsa] {
-		maxLen = maxLen + len(n.hasSLSAs)
-	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
-		maxLen = maxLen + len(n.vexLinks)
-	}
-	if allowedEdges[model.EdgeCertifyBad] {
-		maxLen = maxLen + len(n.badLinks)
-	}
-	if allowedEdges[model.EdgeCertifyGood] {
-		maxLen = maxLen + len(n.goodLinks)
-	}
-	if maxLen == 0 {
-		return []uint32{}
-	}
-
-	out := make([]uint32, 0, maxLen)
+	out := []uint32{}
 	if allowedEdges[model.EdgeHashEqual] {
 		out = append(out, n.hashEquals...)
 	}

--- a/pkg/assembler/backends/inmem/artifact.go
+++ b/pkg/assembler/backends/inmem/artifact.go
@@ -43,14 +43,49 @@ type artStruct struct {
 
 func (n *artStruct) ID() uint32 { return n.id }
 
-func (n *artStruct) Neighbors() []uint32 {
-	out := make([]uint32, 0, len(n.hashEquals)+len(n.occurrences)+len(n.hasSLSAs)+len(n.vexLinks)+len(n.badLinks)+len(n.goodLinks))
-	out = append(out, n.hashEquals...)
-	out = append(out, n.occurrences...)
-	out = append(out, n.hasSLSAs...)
-	out = append(out, n.vexLinks...)
-	out = append(out, n.badLinks...)
-	out = append(out, n.goodLinks...)
+func (n *artStruct) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 0
+	if allowedEdges[model.EdgeHashEqual] {
+		maxLen = maxLen + len(n.hashEquals)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		maxLen = maxLen + len(n.occurrences)
+	}
+	if allowedEdges[model.EdgeHasSlsa] {
+		maxLen = maxLen + len(n.hasSLSAs)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		maxLen = maxLen + len(n.vexLinks)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		maxLen = maxLen + len(n.badLinks)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		maxLen = maxLen + len(n.goodLinks)
+	}
+	if maxLen == 0 {
+		return []uint32{}
+	}
+
+	out := make([]uint32, 0, maxLen)
+	if allowedEdges[model.EdgeHashEqual] {
+		out = append(out, n.hashEquals...)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		out = append(out, n.occurrences...)
+	}
+	if allowedEdges[model.EdgeHasSlsa] {
+		out = append(out, n.hasSLSAs...)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		out = append(out, n.vexLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		out = append(out, n.badLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		out = append(out, n.goodLinks...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -47,7 +47,10 @@ type node interface {
 	//
 	// This is useful for path related queries where the type of the node
 	// is not as relevant as its connections.
-	Neighbors() []uint32
+	//
+	// The allowedEdges argument allows filtering the set of neighbors to
+	// only include certain GUAC verbs.
+	Neighbors(allowedEdges edgeMap) []uint32
 
 	// BuildModelNode builds a GraphQL return type for a backend node,
 	BuildModelNode(c *demoClient) (model.Node, error)
@@ -99,8 +102,11 @@ type noKnownVuln struct {
 
 func (n *noKnownVuln) ID() uint32 { return n.id }
 
-func (n *noKnownVuln) Neighbors() []uint32 {
-	return n.certifyVulnLinks
+func (n *noKnownVuln) Neighbors(allowedEdges edgeMap) []uint32 {
+	if allowedEdges[model.EdgeCertifyVuln] {
+		return n.certifyVulnLinks
+	}
+	return []uint32{}
 }
 
 func (n *noKnownVuln) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -103,7 +103,7 @@ type noKnownVuln struct {
 func (n *noKnownVuln) ID() uint32 { return n.id }
 
 func (n *noKnownVuln) Neighbors(allowedEdges edgeMap) []uint32 {
-	if allowedEdges[model.EdgeCertifyVuln] {
+	if allowedEdges[model.EdgeNoVulnCertifyVuln] {
 		return n.certifyVulnLinks
 	}
 	return []uint32{}

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -35,7 +35,7 @@ type builderStruct struct {
 func (b *builderStruct) ID() uint32 { return b.id }
 
 func (b *builderStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	if allowedEdges[model.EdgeHasSlsa] {
+	if allowedEdges[model.EdgeBuilderHasSlsa] {
 		return b.hasSLSAs
 	}
 	return []uint32{}

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -34,7 +34,12 @@ type builderStruct struct {
 
 func (b *builderStruct) ID() uint32 { return b.id }
 
-func (b *builderStruct) Neighbors() []uint32 { return b.hasSLSAs }
+func (b *builderStruct) Neighbors(allowedEdges edgeMap) []uint32 {
+	if allowedEdges[model.EdgeHasSlsa] {
+		return b.hasSLSAs
+	}
+	return []uint32{}
+}
 
 func (b *builderStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convBuilder(b), nil

--- a/pkg/assembler/backends/inmem/certifyBad.go
+++ b/pkg/assembler/backends/inmem/certifyBad.go
@@ -41,13 +41,13 @@ func (n *badLink) ID() uint32 { return n.id }
 
 func (n *badLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1)
-	if n.packageID != 0 {
+	if n.packageID != 0 && allowedEdges[model.EdgeCertifyBadPackage] {
 		out = append(out, n.packageID)
 	}
-	if n.artifactID != 0 {
+	if n.artifactID != 0 && allowedEdges[model.EdgeCertifyBadArtifact] {
 		out = append(out, n.artifactID)
 	}
-	if n.sourceID != 0 {
+	if n.sourceID != 0 && allowedEdges[model.EdgeCertifyBadSource] {
 		out = append(out, n.sourceID)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/certifyBad.go
+++ b/pkg/assembler/backends/inmem/certifyBad.go
@@ -39,7 +39,7 @@ type badLink struct {
 
 func (n *badLink) ID() uint32 { return n.id }
 
-func (n *badLink) Neighbors() []uint32 {
+func (n *badLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1)
 	if n.packageID != 0 {
 		out = append(out, n.packageID)

--- a/pkg/assembler/backends/inmem/certifyGood.go
+++ b/pkg/assembler/backends/inmem/certifyGood.go
@@ -39,7 +39,7 @@ type goodLink struct {
 
 func (n *goodLink) ID() uint32 { return n.id }
 
-func (n *goodLink) Neighbors() []uint32 {
+func (n *goodLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1)
 	if n.packageID != 0 {
 		out = append(out, n.packageID)

--- a/pkg/assembler/backends/inmem/certifyGood.go
+++ b/pkg/assembler/backends/inmem/certifyGood.go
@@ -41,13 +41,13 @@ func (n *goodLink) ID() uint32 { return n.id }
 
 func (n *goodLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1)
-	if n.packageID != 0 {
+	if n.packageID != 0 && allowedEdges[model.EdgeCertifyGoodPackage] {
 		out = append(out, n.packageID)
 	}
-	if n.artifactID != 0 {
+	if n.artifactID != 0 && allowedEdges[model.EdgeCertifyGoodArtifact] {
 		out = append(out, n.artifactID)
 	}
-	if n.sourceID != 0 {
+	if n.sourceID != 0 && allowedEdges[model.EdgeCertifyGoodSource] {
 		out = append(out, n.sourceID)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -42,7 +42,7 @@ type scorecardLink struct {
 
 func (n *scorecardLink) ID() uint32 { return n.id }
 
-func (n *scorecardLink) Neighbors() []uint32 {
+func (n *scorecardLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	return []uint32{n.sourceID}
 }
 

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -43,7 +43,10 @@ type scorecardLink struct {
 func (n *scorecardLink) ID() uint32 { return n.id }
 
 func (n *scorecardLink) Neighbors(allowedEdges edgeMap) []uint32 {
-	return []uint32{n.sourceID}
+	if allowedEdges[model.EdgeCertifyScorecardSource] {
+		return []uint32{n.sourceID}
+	}
+	return []uint32{}
 }
 
 func (n *scorecardLink) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -43,7 +43,7 @@ type vexLink struct {
 
 func (n *vexLink) ID() uint32 { return n.id }
 
-func (n *vexLink) Neighbors() []uint32 {
+func (n *vexLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
 	if n.packageID != 0 {
 		out = append(out, n.packageID)

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -45,19 +45,19 @@ func (n *vexLink) ID() uint32 { return n.id }
 
 func (n *vexLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
-	if n.packageID != 0 {
+	if n.packageID != 0 && allowedEdges[model.EdgeCertifyVexStatementPackage] {
 		out = append(out, n.packageID)
 	}
-	if n.artifactID != 0 {
+	if n.artifactID != 0 && allowedEdges[model.EdgeCertifyVexStatementArtifact] {
 		out = append(out, n.artifactID)
 	}
-	if n.cveID != 0 {
+	if n.cveID != 0 && allowedEdges[model.EdgeCertifyVexStatementCve] {
 		out = append(out, n.cveID)
 	}
-	if n.ghsaID != 0 {
+	if n.ghsaID != 0 && allowedEdges[model.EdgeCertifyVexStatementGhsa] {
 		out = append(out, n.ghsaID)
 	}
-	if n.osvID != 0 {
+	if n.osvID != 0 && allowedEdges[model.EdgeCertifyVexStatementOsv] {
 		out = append(out, n.osvID)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -48,7 +48,7 @@ func (n *vulnerabilityLink) ID() uint32 { return n.id }
 
 func (n *vulnerabilityLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
-	if allowedEdges[model.EdgeCertifyVulnPackage]{
+	if allowedEdges[model.EdgeCertifyVulnPackage] {
 		out = append(out, n.packageID)
 	}
 	if n.osvID != 0 && allowedEdges[model.EdgeCertifyVulnOsv] {

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -46,7 +46,7 @@ type vulnerabilityLink struct {
 
 func (n *vulnerabilityLink) ID() uint32 { return n.id }
 
-func (n *vulnerabilityLink) Neighbors() []uint32 {
+func (n *vulnerabilityLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
 	out = append(out, n.packageID)
 	if n.osvID != 0 {

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -48,17 +48,19 @@ func (n *vulnerabilityLink) ID() uint32 { return n.id }
 
 func (n *vulnerabilityLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
-	out = append(out, n.packageID)
-	if n.osvID != 0 {
+	if allowedEdges[model.EdgeCertifyVulnPackage]{
+		out = append(out, n.packageID)
+	}
+	if n.osvID != 0 && allowedEdges[model.EdgeCertifyVulnOsv] {
 		out = append(out, n.osvID)
 	}
-	if n.cveID != 0 {
+	if n.cveID != 0 && allowedEdges[model.EdgeCertifyVulnCve] {
 		out = append(out, n.cveID)
 	}
-	if n.ghsaID != 0 {
+	if n.ghsaID != 0 && allowedEdges[model.EdgeCertifyVulnGhsa] {
 		out = append(out, n.ghsaID)
 	}
-	if n.noKnownVulnID != 0 {
+	if n.noKnownVulnID != 0 && allowedEdges[model.EdgeCertifyVulnNoVuln] {
 		out = append(out, n.noKnownVulnID)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/cve.go
+++ b/pkg/assembler/backends/inmem/cve.go
@@ -65,11 +65,31 @@ type cveNode struct {
 
 func (n *cveNode) ID() uint32 { return n.id }
 
-func (n *cveNode) Neighbors() []uint32 {
-	out := make([]uint32, 0, len(n.certifyVulnLinks)+len(n.equalVulnLinks)+len(n.vexLinks))
-	out = append(out, n.certifyVulnLinks...)
-	out = append(out, n.equalVulnLinks...)
-	out = append(out, n.vexLinks...)
+func (n *cveNode) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 0
+	if allowedEdges[model.EdgeCertifyVuln] {
+		maxLen = maxLen + len(n.certifyVulnLinks)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		maxLen = maxLen + len(n.equalVulnLinks)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		maxLen = maxLen + len(n.vexLinks)
+	}
+	if maxLen == 0 {
+		return []uint32{}
+	}
+
+	out := make([]uint32, 0, maxLen)
+	if allowedEdges[model.EdgeCertifyVuln] {
+		out = append(out, n.certifyVulnLinks...)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		out = append(out, n.equalVulnLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		out = append(out, n.vexLinks...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/cve.go
+++ b/pkg/assembler/backends/inmem/cve.go
@@ -66,21 +66,7 @@ type cveNode struct {
 func (n *cveNode) ID() uint32 { return n.id }
 
 func (n *cveNode) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 0
-	if allowedEdges[model.EdgeCertifyVuln] {
-		maxLen = maxLen + len(n.certifyVulnLinks)
-	}
-	if allowedEdges[model.EdgeIsVulnerability] {
-		maxLen = maxLen + len(n.equalVulnLinks)
-	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
-		maxLen = maxLen + len(n.vexLinks)
-	}
-	if maxLen == 0 {
-		return []uint32{}
-	}
-
-	out := make([]uint32, 0, maxLen)
+	out := []uint32{}
 	if allowedEdges[model.EdgeCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}

--- a/pkg/assembler/backends/inmem/cve.go
+++ b/pkg/assembler/backends/inmem/cve.go
@@ -67,13 +67,13 @@ func (n *cveNode) ID() uint32 { return n.id }
 
 func (n *cveNode) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{}
-	if allowedEdges[model.EdgeCertifyVuln] {
+	if allowedEdges[model.EdgeCveCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}
-	if allowedEdges[model.EdgeIsVulnerability] {
+	if allowedEdges[model.EdgeCveIsVulnerability] {
 		out = append(out, n.equalVulnLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
+	if allowedEdges[model.EdgeCveCertifyVexStatement] {
 		out = append(out, n.vexLinks...)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -57,21 +57,7 @@ type ghsaNode struct {
 func (n *ghsaNode) ID() uint32 { return n.id }
 
 func (n *ghsaNode) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 0
-	if allowedEdges[model.EdgeCertifyVuln] {
-		maxLen = maxLen + len(n.certifyVulnLinks)
-	}
-	if allowedEdges[model.EdgeIsVulnerability] {
-		maxLen = maxLen + len(n.equalVulnLinks)
-	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
-		maxLen = maxLen + len(n.vexLinks)
-	}
-	if maxLen == 0 {
-		return []uint32{}
-	}
-
-	out := make([]uint32, 0, maxLen)
+	out := []uint32{}
 	if allowedEdges[model.EdgeCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -56,11 +56,31 @@ type ghsaNode struct {
 
 func (n *ghsaNode) ID() uint32 { return n.id }
 
-func (n *ghsaNode) Neighbors() []uint32 {
-	out := make([]uint32, 0, len(n.certifyVulnLinks)+len(n.equalVulnLinks)+len(n.vexLinks))
-	out = append(out, n.certifyVulnLinks...)
-	out = append(out, n.equalVulnLinks...)
-	out = append(out, n.vexLinks...)
+func (n *ghsaNode) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 0
+	if allowedEdges[model.EdgeCertifyVuln] {
+		maxLen = maxLen + len(n.certifyVulnLinks)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		maxLen = maxLen + len(n.equalVulnLinks)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		maxLen = maxLen + len(n.vexLinks)
+	}
+	if maxLen == 0 {
+		return []uint32{}
+	}
+
+	out := make([]uint32, 0, maxLen)
+	if allowedEdges[model.EdgeCertifyVuln] {
+		out = append(out, n.certifyVulnLinks...)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		out = append(out, n.equalVulnLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		out = append(out, n.vexLinks...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/ghsa.go
+++ b/pkg/assembler/backends/inmem/ghsa.go
@@ -58,13 +58,13 @@ func (n *ghsaNode) ID() uint32 { return n.id }
 
 func (n *ghsaNode) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{}
-	if allowedEdges[model.EdgeCertifyVuln] {
+	if allowedEdges[model.EdgeGhsaCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}
-	if allowedEdges[model.EdgeIsVulnerability] {
+	if allowedEdges[model.EdgeGhsaIsVulnerability] {
 		out = append(out, n.equalVulnLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
+	if allowedEdges[model.EdgeGhsaCertifyVexStatement] {
 		out = append(out, n.vexLinks...)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -37,7 +37,7 @@ type hasSBOMStruct struct {
 
 func (n *hasSBOMStruct) ID() uint32 { return n.id }
 
-func (n *hasSBOMStruct) Neighbors() []uint32 {
+func (n *hasSBOMStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	if n.pkg != 0 {
 		return []uint32{n.pkg}
 	}

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -38,10 +38,13 @@ type hasSBOMStruct struct {
 func (n *hasSBOMStruct) ID() uint32 { return n.id }
 
 func (n *hasSBOMStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	if n.pkg != 0 {
+	if n.pkg != 0 && allowedEdges[model.EdgeHasSbomPackage] {
 		return []uint32{n.pkg}
 	}
-	return []uint32{n.src}
+	if allowedEdges[model.EdgeHasSbomSource] {
+		return []uint32{n.src}
+	}
+	return []uint32{}
 }
 
 func (n *hasSBOMStruct) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -48,9 +48,15 @@ func (n *hasSLSAStruct) ID() uint32 { return n.id }
 
 func (n *hasSLSAStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2+len(n.builtFrom))
-	out = append(out, n.subject)
-	out = append(out, n.builtBy)
-	out = append(out, n.builtFrom...)
+	if allowedEdges[model.EdgeHasSlsaSubject] {
+		out = append(out, n.subject)
+	}
+	if allowedEdges[model.EdgeHasSlsaBuiltBy] {
+		out = append(out, n.builtBy)
+	}
+	if allowedEdges[model.EdgeHasSlsaMaterials] {
+		out = append(out, n.builtFrom...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -46,7 +46,7 @@ type hasSLSAStruct struct {
 
 func (n *hasSLSAStruct) ID() uint32 { return n.id }
 
-func (n *hasSLSAStruct) Neighbors() []uint32 {
+func (n *hasSLSAStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2+len(n.builtFrom))
 	out = append(out, n.subject)
 	out = append(out, n.builtBy)

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -39,7 +39,7 @@ type srcMapLink struct {
 
 func (n *srcMapLink) ID() uint32 { return n.id }
 
-func (n *srcMapLink) Neighbors() []uint32 {
+func (n *srcMapLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	return []uint32{n.sourceID, n.packageID}
 }
 

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -40,7 +40,14 @@ type srcMapLink struct {
 func (n *srcMapLink) ID() uint32 { return n.id }
 
 func (n *srcMapLink) Neighbors(allowedEdges edgeMap) []uint32 {
-	return []uint32{n.sourceID, n.packageID}
+	out := make([]uint32, 0, 2)
+	if allowedEdges[model.EdgeHasSourceAtPackage] {
+		out = append(out, n.packageID)
+	}
+	if allowedEdges[model.EdgeHasSourceAtSource] {
+		out = append(out, n.sourceID)
+	}
+	return out
 }
 
 func (n *srcMapLink) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -37,8 +37,11 @@ type hashEqualStruct struct {
 	collector     string
 }
 
-func (n *hashEqualStruct) ID() uint32          { return n.id }
-func (n *hashEqualStruct) Neighbors() []uint32 { return n.artifacts }
+func (n *hashEqualStruct) ID() uint32 { return n.id }
+
+func (n *hashEqualStruct) Neighbors(allowedEdges edgeMap) []uint32 {
+	return n.artifacts
+}
 
 func (n *hashEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convHashEqual(n), nil

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -40,7 +40,10 @@ type hashEqualStruct struct {
 func (n *hashEqualStruct) ID() uint32 { return n.id }
 
 func (n *hashEqualStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	return n.artifacts
+	if allowedEdges[model.EdgeHashEqualArtifact] {
+		return n.artifacts
+	}
+	return []uint32{}
 }
 
 func (n *hashEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -39,7 +39,10 @@ type isDependencyLink struct {
 func (n *isDependencyLink) ID() uint32 { return n.id }
 
 func (n *isDependencyLink) Neighbors(allowedEdges edgeMap) []uint32 {
-	return []uint32{n.packageID, n.depPackageID}
+	if allowedEdges[model.EdgeIsDependencyPackage] {
+		return []uint32{n.packageID, n.depPackageID}
+	}
+	return []uint32{}
 }
 
 func (n *isDependencyLink) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -38,7 +38,7 @@ type isDependencyLink struct {
 
 func (n *isDependencyLink) ID() uint32 { return n.id }
 
-func (n *isDependencyLink) Neighbors() []uint32 {
+func (n *isDependencyLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	return []uint32{n.packageID, n.depPackageID}
 }
 

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -41,7 +41,7 @@ type isOccurrenceStruct struct {
 
 func (n *isOccurrenceStruct) ID() uint32 { return n.id }
 
-func (n *isOccurrenceStruct) Neighbors() []uint32 {
+func (n *isOccurrenceStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 3)
 	if n.pkg != 0 {
 		out = append(out, n.pkg)

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -43,13 +43,15 @@ func (n *isOccurrenceStruct) ID() uint32 { return n.id }
 
 func (n *isOccurrenceStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 3)
-	if n.pkg != 0 {
+	if n.pkg != 0 && allowedEdges[model.EdgeIsOccurrencePackage] {
 		out = append(out, n.pkg)
 	}
-	if n.source != 0 {
+	if n.source != 0 && allowedEdges[model.EdgeIsOccurrenceSource] {
 		out = append(out, n.source)
 	}
-	out = append(out, n.artifact)
+	if allowedEdges[model.EdgeIsOccurrenceArtifact] {
+		out = append(out, n.artifact)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -39,7 +39,7 @@ type equalVulnerabilityLink struct {
 
 func (n *equalVulnerabilityLink) ID() uint32 { return n.id }
 
-func (n *equalVulnerabilityLink) Neighbors() []uint32 {
+func (n *equalVulnerabilityLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
 	if n.osvID != 0 {
 		out = append(out, n.osvID)

--- a/pkg/assembler/backends/inmem/isVulnerability.go
+++ b/pkg/assembler/backends/inmem/isVulnerability.go
@@ -41,13 +41,13 @@ func (n *equalVulnerabilityLink) ID() uint32 { return n.id }
 
 func (n *equalVulnerabilityLink) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 2)
-	if n.osvID != 0 {
+	if n.osvID != 0 && allowedEdges[model.EdgeIsVulnerabilityOsv] {
 		out = append(out, n.osvID)
 	}
-	if n.cveID != 0 {
+	if n.cveID != 0 && allowedEdges[model.EdgeIsVulnerabilityCve] {
 		out = append(out, n.cveID)
 	}
-	if n.ghsaID != 0 {
+	if n.ghsaID != 0 && allowedEdges[model.EdgeIsVulnerabilityGhsa] {
 		out = append(out, n.ghsaID)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/osv.go
+++ b/pkg/assembler/backends/inmem/osv.go
@@ -61,21 +61,7 @@ type osvNode struct {
 func (n *osvNode) ID() uint32 { return n.id }
 
 func (n *osvNode) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 0
-	if allowedEdges[model.EdgeCertifyVuln] {
-		maxLen = maxLen + len(n.certifyVulnLinks)
-	}
-	if allowedEdges[model.EdgeIsVulnerability] {
-		maxLen = maxLen + len(n.equalVulnLinks)
-	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
-		maxLen = maxLen + len(n.vexLinks)
-	}
-	if maxLen == 0 {
-		return []uint32{}
-	}
-
-	out := make([]uint32, 0, maxLen)
+	out := []uint32{}
 	if allowedEdges[model.EdgeCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}

--- a/pkg/assembler/backends/inmem/osv.go
+++ b/pkg/assembler/backends/inmem/osv.go
@@ -62,13 +62,13 @@ func (n *osvNode) ID() uint32 { return n.id }
 
 func (n *osvNode) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{}
-	if allowedEdges[model.EdgeCertifyVuln] {
+	if allowedEdges[model.EdgeOsvCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}
-	if allowedEdges[model.EdgeIsVulnerability] {
+	if allowedEdges[model.EdgeOsvIsVulnerability] {
 		out = append(out, n.equalVulnLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
+	if allowedEdges[model.EdgeOsvCertifyVexStatement] {
 		out = append(out, n.vexLinks...)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/osv.go
+++ b/pkg/assembler/backends/inmem/osv.go
@@ -60,11 +60,31 @@ type osvNode struct {
 
 func (n *osvNode) ID() uint32 { return n.id }
 
-func (n *osvNode) Neighbors() []uint32 {
-	out := make([]uint32, 0, len(n.certifyVulnLinks)+len(n.equalVulnLinks)+len(n.vexLinks))
-	out = append(out, n.certifyVulnLinks...)
-	out = append(out, n.equalVulnLinks...)
-	out = append(out, n.vexLinks...)
+func (n *osvNode) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 0
+	if allowedEdges[model.EdgeCertifyVuln] {
+		maxLen = maxLen + len(n.certifyVulnLinks)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		maxLen = maxLen + len(n.equalVulnLinks)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		maxLen = maxLen + len(n.vexLinks)
+	}
+	if maxLen == 0 {
+		return []uint32{}
+	}
+
+	out := make([]uint32, 0, maxLen)
+	if allowedEdges[model.EdgeCertifyVuln] {
+		out = append(out, n.certifyVulnLinks...)
+	}
+	if allowedEdges[model.EdgeIsVulnerability] {
+		out = append(out, n.equalVulnLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		out = append(out, n.vexLinks...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -159,16 +159,16 @@ func (n *pkgVersionStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 		out = append(out, v.id)
 	}
 
-	if allowedEdges[model.EdgeHasSourceAt] {
+	if allowedEdges[model.EdgePackageHasSourceAt] {
 		out = append(out, n.srcMapLinks...)
 	}
-	if allowedEdges[model.EdgeIsDependency] {
+	if allowedEdges[model.EdgePackageIsDependency] {
 		out = append(out, n.isDependencyLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyBad] {
+	if allowedEdges[model.EdgePackageCertifyBad] {
 		out = append(out, n.badLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyGood] {
+	if allowedEdges[model.EdgePackageCertifyGood] {
 		out = append(out, n.goodLinks...)
 	}
 	return out
@@ -176,31 +176,31 @@ func (n *pkgVersionStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 func (n *pkgVersionNode) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{n.parent}
 
-	if allowedEdges[model.EdgeHasSourceAt] {
+	if allowedEdges[model.EdgePackageHasSourceAt] {
 		out = append(out, n.srcMapLinks...)
 	}
-	if allowedEdges[model.EdgeIsDependency] {
+	if allowedEdges[model.EdgePackageIsDependency] {
 		out = append(out, n.isDependencyLinks...)
 	}
-	if allowedEdges[model.EdgeIsOccurrence] {
+	if allowedEdges[model.EdgePackageIsOccurrence] {
 		out = append(out, n.occurrences...)
 	}
-	if allowedEdges[model.EdgeCertifyVuln] {
+	if allowedEdges[model.EdgePackageCertifyVuln] {
 		out = append(out, n.certifyVulnLinks...)
 	}
-	if allowedEdges[model.EdgeHasSbom] {
+	if allowedEdges[model.EdgePackageHasSbom] {
 		out = append(out, n.hasSBOMs...)
 	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
+	if allowedEdges[model.EdgePackageCertifyVexStatement] {
 		out = append(out, n.vexLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyBad] {
+	if allowedEdges[model.EdgePackageCertifyBad] {
 		out = append(out, n.badLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyGood] {
+	if allowedEdges[model.EdgePackageCertifyGood] {
 		out = append(out, n.goodLinks...)
 	}
-	if allowedEdges[model.EdgePkgEqual] {
+	if allowedEdges[model.EdgePackagePkgEqual] {
 		out = append(out, n.pkgEquals...)
 	}
 

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -138,14 +138,14 @@ func (n *pkgNameStruct) ID() uint32      { return n.id }
 func (n *pkgVersionStruct) ID() uint32   { return n.id }
 func (n *pkgVersionNode) ID() uint32     { return n.id }
 
-func (n *pkgNamespaceStruct) Neighbors() []uint32 {
+func (n *pkgNamespaceStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1+len(n.namespaces))
 	for _, v := range n.namespaces {
 		out = append(out, v.id)
 	}
 	return out
 }
-func (n *pkgNameStruct) Neighbors() []uint32 {
+func (n *pkgNameStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1+len(n.names))
 	for _, v := range n.names {
 		out = append(out, v.id)
@@ -153,30 +153,102 @@ func (n *pkgNameStruct) Neighbors() []uint32 {
 	out = append(out, n.parent)
 	return out
 }
-func (n *pkgVersionStruct) Neighbors() []uint32 {
-	out := make([]uint32, 0, 1+len(n.versions)+len(n.srcMapLinks)+len(n.isDependencyLinks)+len(n.badLinks)+len(n.goodLinks))
+func (n *pkgVersionStruct) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 1 + len(n.versions)
+	if allowedEdges[model.EdgeHasSourceAt] {
+		maxLen = maxLen + len(n.srcMapLinks)
+	}
+	if allowedEdges[model.EdgeIsDependency] {
+		maxLen = maxLen + len(n.isDependencyLinks)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		maxLen = maxLen + len(n.badLinks)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		maxLen = maxLen + len(n.goodLinks)
+	}
+
+	out := make([]uint32, 0, maxLen)
+	out = append(out, n.parent)
 	for _, v := range n.versions {
 		out = append(out, v.id)
 	}
-	out = append(out, n.srcMapLinks...)
-	out = append(out, n.isDependencyLinks...)
-	out = append(out, n.badLinks...)
-	out = append(out, n.goodLinks...)
-	out = append(out, n.parent)
+
+	if allowedEdges[model.EdgeHasSourceAt] {
+		out = append(out, n.srcMapLinks...)
+	}
+	if allowedEdges[model.EdgeIsDependency] {
+		out = append(out, n.isDependencyLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		out = append(out, n.badLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		out = append(out, n.goodLinks...)
+	}
 	return out
 }
-func (n *pkgVersionNode) Neighbors() []uint32 {
-	out := make([]uint32, 0, 1+len(n.srcMapLinks)+len(n.isDependencyLinks)+len(n.occurrences)+len(n.certifyVulnLinks)+len(n.hasSBOMs)+len(n.vexLinks)+len(n.badLinks)+len(n.goodLinks)+len(n.pkgEquals))
-	out = append(out, n.srcMapLinks...)
-	out = append(out, n.isDependencyLinks...)
-	out = append(out, n.occurrences...)
-	out = append(out, n.certifyVulnLinks...)
-	out = append(out, n.hasSBOMs...)
-	out = append(out, n.vexLinks...)
-	out = append(out, n.badLinks...)
-	out = append(out, n.goodLinks...)
-	out = append(out, n.pkgEquals...)
+func (n *pkgVersionNode) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 1
+	if allowedEdges[model.EdgeHasSourceAt] {
+		maxLen = maxLen + len(n.srcMapLinks)
+	}
+	if allowedEdges[model.EdgeIsDependency] {
+		maxLen = maxLen + len(n.isDependencyLinks)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		maxLen = maxLen + len(n.occurrences)
+	}
+	if allowedEdges[model.EdgeCertifyVuln] {
+		maxLen = maxLen + len(n.certifyVulnLinks)
+	}
+	if allowedEdges[model.EdgeHasSbom] {
+		maxLen = maxLen + len(n.hasSBOMs)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		maxLen = maxLen + len(n.vexLinks)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		maxLen = maxLen + len(n.badLinks)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		maxLen = maxLen + len(n.goodLinks)
+	}
+	if allowedEdges[model.EdgePkgEqual] {
+		maxLen = maxLen + len(n.pkgEquals)
+	}
+
+	out := make([]uint32, 0, maxLen)
 	out = append(out, n.parent)
+
+	if allowedEdges[model.EdgeHasSourceAt] {
+		out = append(out, n.srcMapLinks...)
+	}
+	if allowedEdges[model.EdgeIsDependency] {
+		out = append(out, n.isDependencyLinks...)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		out = append(out, n.occurrences...)
+	}
+	if allowedEdges[model.EdgeCertifyVuln] {
+		out = append(out, n.certifyVulnLinks...)
+	}
+	if allowedEdges[model.EdgeHasSbom] {
+		out = append(out, n.hasSBOMs...)
+	}
+	if allowedEdges[model.EdgeCertifyVexStatement] {
+		out = append(out, n.vexLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		out = append(out, n.badLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		out = append(out, n.goodLinks...)
+	}
+	if allowedEdges[model.EdgePkgEqual] {
+		out = append(out, n.pkgEquals...)
+	}
+
 	return out
 }
 

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -154,22 +154,7 @@ func (n *pkgNameStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	return out
 }
 func (n *pkgVersionStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 1 + len(n.versions)
-	if allowedEdges[model.EdgeHasSourceAt] {
-		maxLen = maxLen + len(n.srcMapLinks)
-	}
-	if allowedEdges[model.EdgeIsDependency] {
-		maxLen = maxLen + len(n.isDependencyLinks)
-	}
-	if allowedEdges[model.EdgeCertifyBad] {
-		maxLen = maxLen + len(n.badLinks)
-	}
-	if allowedEdges[model.EdgeCertifyGood] {
-		maxLen = maxLen + len(n.goodLinks)
-	}
-
-	out := make([]uint32, 0, maxLen)
-	out = append(out, n.parent)
+	out := []uint32{n.parent}
 	for _, v := range n.versions {
 		out = append(out, v.id)
 	}
@@ -189,37 +174,7 @@ func (n *pkgVersionStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	return out
 }
 func (n *pkgVersionNode) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 1
-	if allowedEdges[model.EdgeHasSourceAt] {
-		maxLen = maxLen + len(n.srcMapLinks)
-	}
-	if allowedEdges[model.EdgeIsDependency] {
-		maxLen = maxLen + len(n.isDependencyLinks)
-	}
-	if allowedEdges[model.EdgeIsOccurrence] {
-		maxLen = maxLen + len(n.occurrences)
-	}
-	if allowedEdges[model.EdgeCertifyVuln] {
-		maxLen = maxLen + len(n.certifyVulnLinks)
-	}
-	if allowedEdges[model.EdgeHasSbom] {
-		maxLen = maxLen + len(n.hasSBOMs)
-	}
-	if allowedEdges[model.EdgeCertifyVexStatement] {
-		maxLen = maxLen + len(n.vexLinks)
-	}
-	if allowedEdges[model.EdgeCertifyBad] {
-		maxLen = maxLen + len(n.badLinks)
-	}
-	if allowedEdges[model.EdgeCertifyGood] {
-		maxLen = maxLen + len(n.goodLinks)
-	}
-	if allowedEdges[model.EdgePkgEqual] {
-		maxLen = maxLen + len(n.pkgEquals)
-	}
-
-	out := make([]uint32, 0, maxLen)
-	out = append(out, n.parent)
+	out := []uint32{n.parent}
 
 	if allowedEdges[model.EdgeHasSourceAt] {
 		out = append(out, n.srcMapLinks...)

--- a/pkg/assembler/backends/inmem/pkgEqual.go
+++ b/pkg/assembler/backends/inmem/pkgEqual.go
@@ -37,7 +37,10 @@ type pkgEqualStruct struct {
 func (n *pkgEqualStruct) ID() uint32 { return n.id }
 
 func (n *pkgEqualStruct) Neighbors(allowedEdges edgeMap) []uint32 {
-	return n.pkgs
+	if allowedEdges[model.EdgePkgEqualPackage] {
+		return n.pkgs
+	}
+	return []uint32{}
 }
 
 func (n *pkgEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {

--- a/pkg/assembler/backends/inmem/pkgEqual.go
+++ b/pkg/assembler/backends/inmem/pkgEqual.go
@@ -34,8 +34,11 @@ type pkgEqualStruct struct {
 	collector     string
 }
 
-func (n *pkgEqualStruct) ID() uint32          { return n.id }
-func (n *pkgEqualStruct) Neighbors() []uint32 { return n.pkgs }
+func (n *pkgEqualStruct) ID() uint32 { return n.id }
+
+func (n *pkgEqualStruct) Neighbors(allowedEdges edgeMap) []uint32 {
+	return n.pkgs
+}
 
 func (n *pkgEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.convPkgEqual(n), nil

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -107,28 +107,7 @@ func (n *srcNameStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	return out
 }
 func (n *srcNameNode) Neighbors(allowedEdges edgeMap) []uint32 {
-	maxLen := 1
-	if allowedEdges[model.EdgeHasSourceAt] {
-		maxLen = maxLen + len(n.srcMapLinks)
-	}
-	if allowedEdges[model.EdgeCertifyScorecard] {
-		maxLen = maxLen + len(n.scorecardLinks)
-	}
-	if allowedEdges[model.EdgeIsOccurrence] {
-		maxLen = maxLen + len(n.occurrences)
-	}
-	if allowedEdges[model.EdgeHasSbom] {
-		maxLen = maxLen + len(n.hasSBOMs)
-	}
-	if allowedEdges[model.EdgeCertifyBad] {
-		maxLen = maxLen + len(n.badLinks)
-	}
-	if allowedEdges[model.EdgeCertifyGood] {
-		maxLen = maxLen + len(n.goodLinks)
-	}
-
-	out := make([]uint32, 0, maxLen)
-	out = append(out, n.parent)
+	out := []uint32{n.parent}
 
 	if allowedEdges[model.EdgeHasSourceAt] {
 		out = append(out, n.srcMapLinks...)

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -109,22 +109,22 @@ func (n *srcNameStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 func (n *srcNameNode) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := []uint32{n.parent}
 
-	if allowedEdges[model.EdgeHasSourceAt] {
+	if allowedEdges[model.EdgeSourceHasSourceAt] {
 		out = append(out, n.srcMapLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyScorecard] {
+	if allowedEdges[model.EdgeSourceCertifyScorecard] {
 		out = append(out, n.scorecardLinks...)
 	}
-	if allowedEdges[model.EdgeIsOccurrence] {
+	if allowedEdges[model.EdgeSourceIsOccurrence] {
 		out = append(out, n.occurrences...)
 	}
-	if allowedEdges[model.EdgeHasSbom] {
+	if allowedEdges[model.EdgeSourceHasSbom] {
 		out = append(out, n.hasSBOMs...)
 	}
-	if allowedEdges[model.EdgeCertifyBad] {
+	if allowedEdges[model.EdgeSourceCertifyBad] {
 		out = append(out, n.badLinks...)
 	}
-	if allowedEdges[model.EdgeCertifyGood] {
+	if allowedEdges[model.EdgeSourceCertifyGood] {
 		out = append(out, n.goodLinks...)
 	}
 	return out

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -91,14 +91,14 @@ func (n *srcNamespaceStruct) ID() uint32 { return n.id }
 func (n *srcNameStruct) ID() uint32      { return n.id }
 func (n *srcNameNode) ID() uint32        { return n.id }
 
-func (n *srcNamespaceStruct) Neighbors() []uint32 {
+func (n *srcNamespaceStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, len(n.namespaces))
 	for _, v := range n.namespaces {
 		out = append(out, v.id)
 	}
 	return out
 }
-func (n *srcNameStruct) Neighbors() []uint32 {
+func (n *srcNameStruct) Neighbors(allowedEdges edgeMap) []uint32 {
 	out := make([]uint32, 0, 1+len(n.names))
 	for _, v := range n.names {
 		out = append(out, v.id)
@@ -106,15 +106,48 @@ func (n *srcNameStruct) Neighbors() []uint32 {
 	out = append(out, n.parent)
 	return out
 }
-func (n *srcNameNode) Neighbors() []uint32 {
-	out := make([]uint32, 0, 1+len(n.srcMapLinks)+len(n.scorecardLinks)+len(n.occurrences)+len(n.hasSBOMs)+len(n.badLinks)+len(n.goodLinks))
-	out = append(out, n.srcMapLinks...)
-	out = append(out, n.scorecardLinks...)
-	out = append(out, n.occurrences...)
-	out = append(out, n.hasSBOMs...)
-	out = append(out, n.badLinks...)
-	out = append(out, n.goodLinks...)
+func (n *srcNameNode) Neighbors(allowedEdges edgeMap) []uint32 {
+	maxLen := 1
+	if allowedEdges[model.EdgeHasSourceAt] {
+		maxLen = maxLen + len(n.srcMapLinks)
+	}
+	if allowedEdges[model.EdgeCertifyScorecard] {
+		maxLen = maxLen + len(n.scorecardLinks)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		maxLen = maxLen + len(n.occurrences)
+	}
+	if allowedEdges[model.EdgeHasSbom] {
+		maxLen = maxLen + len(n.hasSBOMs)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		maxLen = maxLen + len(n.badLinks)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		maxLen = maxLen + len(n.goodLinks)
+	}
+
+	out := make([]uint32, 0, maxLen)
 	out = append(out, n.parent)
+
+	if allowedEdges[model.EdgeHasSourceAt] {
+		out = append(out, n.srcMapLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyScorecard] {
+		out = append(out, n.scorecardLinks...)
+	}
+	if allowedEdges[model.EdgeIsOccurrence] {
+		out = append(out, n.occurrences...)
+	}
+	if allowedEdges[model.EdgeHasSbom] {
+		out = append(out, n.hasSBOMs...)
+	}
+	if allowedEdges[model.EdgeCertifyBad] {
+		out = append(out, n.badLinks...)
+	}
+	if allowedEdges[model.EdgeCertifyGood] {
+		out = append(out, n.goodLinks...)
+	}
 	return out
 }
 

--- a/pkg/assembler/backends/neo4j/path.go
+++ b/pkg/assembler/backends/neo4j/path.go
@@ -22,11 +22,11 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-func (c *neo4jClient) Path(ctx context.Context, subject string, target string, maxPathLength int) ([]model.Node, error) {
+func (c *neo4jClient) Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error) {
 	panic(fmt.Errorf("not implemented: Path - path"))
 }
 
-func (c *neo4jClient) Neighbors(ctx context.Context, node string) ([]model.Node, error) {
+func (c *neo4jClient) Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error) {
 	panic(fmt.Errorf("not implemented: Neighbors - neighbors"))
 }
 

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -6512,11 +6512,101 @@ func (v *NeighborsNeighborsCertifyBad) __premarshalJSON() (*__premarshalNeighbor
 //
 // Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 type NeighborsNeighborsCertifyGood struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	allCertifyGood `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyGood) GetTypename() *string { return v.Typename }
+
+// GetId returns NeighborsNeighborsCertifyGood.Id, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCertifyGood) GetId() string { return v.allCertifyGood.Id }
+
+// GetJustification returns NeighborsNeighborsCertifyGood.Justification, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCertifyGood) GetJustification() string {
+	return v.allCertifyGood.Justification
+}
+
+// GetSubject returns NeighborsNeighborsCertifyGood.Subject, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.allCertifyGood.Subject
+}
+
+// GetOrigin returns NeighborsNeighborsCertifyGood.Origin, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+
+// GetCollector returns NeighborsNeighborsCertifyGood.Collector, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+
+func (v *NeighborsNeighborsCertifyGood) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NeighborsNeighborsCertifyGood
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NeighborsNeighborsCertifyGood = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allCertifyGood)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNeighborsNeighborsCertifyGood struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Justification string `json:"justification"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NeighborsNeighborsCertifyGood) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NeighborsNeighborsCertifyGood) __premarshalJSON() (*__premarshalNeighborsNeighborsCertifyGood, error) {
+	var retval __premarshalNeighborsNeighborsCertifyGood
+
+	retval.Typename = v.Typename
+	retval.Id = v.allCertifyGood.Id
+	retval.Justification = v.allCertifyGood.Justification
+	{
+
+		dst := &retval.Subject
+		src := v.allCertifyGood.Subject
+		var err error
+		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal NeighborsNeighborsCertifyGood.allCertifyGood.Subject: %w", err)
+		}
+	}
+	retval.Origin = v.allCertifyGood.Origin
+	retval.Collector = v.allCertifyGood.Collector
+	return &retval, nil
+}
 
 // NeighborsNeighborsCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
 // The GraphQL type's documentation follows.
@@ -7965,10 +8055,14 @@ func __marshalNeighborsNeighborsNode(v *NeighborsNeighborsNode) ([]byte, error) 
 	case *NeighborsNeighborsCertifyGood:
 		typename = "CertifyGood"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NeighborsNeighborsCertifyGood
-		}{typename, v}
+			*__premarshalNeighborsNeighborsCertifyGood
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NeighborsNeighborsPkgEqual:
 		typename = "PkgEqual"
@@ -8794,10 +8888,14 @@ func __marshalNodeNode(v *NodeNode) ([]byte, error) {
 	case *NodeNodeCertifyGood:
 		typename = "CertifyGood"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NodeNodeCertifyGood
-		}{typename, v}
+			*__premarshalNodeNodeCertifyGood
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NodeNodePkgEqual:
 		typename = "PkgEqual"
@@ -9227,11 +9325,99 @@ func (v *NodeNodeCertifyBad) __premarshalJSON() (*__premarshalNodeNodeCertifyBad
 //
 // Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 type NodeNodeCertifyGood struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	allCertifyGood `json:"-"`
 }
 
 // GetTypename returns NodeNodeCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyGood) GetTypename() *string { return v.Typename }
+
+// GetId returns NodeNodeCertifyGood.Id, and is useful for accessing the field via an interface.
+func (v *NodeNodeCertifyGood) GetId() string { return v.allCertifyGood.Id }
+
+// GetJustification returns NodeNodeCertifyGood.Justification, and is useful for accessing the field via an interface.
+func (v *NodeNodeCertifyGood) GetJustification() string { return v.allCertifyGood.Justification }
+
+// GetSubject returns NodeNodeCertifyGood.Subject, and is useful for accessing the field via an interface.
+func (v *NodeNodeCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.allCertifyGood.Subject
+}
+
+// GetOrigin returns NodeNodeCertifyGood.Origin, and is useful for accessing the field via an interface.
+func (v *NodeNodeCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+
+// GetCollector returns NodeNodeCertifyGood.Collector, and is useful for accessing the field via an interface.
+func (v *NodeNodeCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+
+func (v *NodeNodeCertifyGood) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NodeNodeCertifyGood
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NodeNodeCertifyGood = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allCertifyGood)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNodeNodeCertifyGood struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Justification string `json:"justification"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NodeNodeCertifyGood) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NodeNodeCertifyGood) __premarshalJSON() (*__premarshalNodeNodeCertifyGood, error) {
+	var retval __premarshalNodeNodeCertifyGood
+
+	retval.Typename = v.Typename
+	retval.Id = v.allCertifyGood.Id
+	retval.Justification = v.allCertifyGood.Justification
+	{
+
+		dst := &retval.Subject
+		src := v.allCertifyGood.Subject
+		var err error
+		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal NodeNodeCertifyGood.allCertifyGood.Subject: %w", err)
+		}
+	}
+	retval.Origin = v.allCertifyGood.Origin
+	retval.Collector = v.allCertifyGood.Collector
+	return &retval, nil
+}
 
 // NodeNodeCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
 // The GraphQL type's documentation follows.
@@ -10327,10 +10513,14 @@ func (v *NodeNodeIsVulnerability) __premarshalJSON() (*__premarshalNodeNodeIsVul
 // We define an ID field due to GraphQL restrictions.
 type NodeNodeNoVuln struct {
 	Typename *string `json:"__typename"`
+	Id       string  `json:"id"`
 }
 
 // GetTypename returns NodeNodeNoVuln.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeNoVuln) GetTypename() *string { return v.Typename }
+
+// GetId returns NodeNodeNoVuln.Id, and is useful for accessing the field via an interface.
+func (v *NodeNodeNoVuln) GetId() string { return v.Id }
 
 // NodeNodeOSV includes the requested fields of the GraphQL type OSV.
 // The GraphQL type's documentation follows.
@@ -11229,11 +11419,99 @@ func (v *PathPathCertifyBad) __premarshalJSON() (*__premarshalPathPathCertifyBad
 //
 // Note: Attestation must occur at the PackageName or the PackageVersion or at the SourceName.
 type PathPathCertifyGood struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	allCertifyGood `json:"-"`
 }
 
 // GetTypename returns PathPathCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyGood) GetTypename() *string { return v.Typename }
+
+// GetId returns PathPathCertifyGood.Id, and is useful for accessing the field via an interface.
+func (v *PathPathCertifyGood) GetId() string { return v.allCertifyGood.Id }
+
+// GetJustification returns PathPathCertifyGood.Justification, and is useful for accessing the field via an interface.
+func (v *PathPathCertifyGood) GetJustification() string { return v.allCertifyGood.Justification }
+
+// GetSubject returns PathPathCertifyGood.Subject, and is useful for accessing the field via an interface.
+func (v *PathPathCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.allCertifyGood.Subject
+}
+
+// GetOrigin returns PathPathCertifyGood.Origin, and is useful for accessing the field via an interface.
+func (v *PathPathCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+
+// GetCollector returns PathPathCertifyGood.Collector, and is useful for accessing the field via an interface.
+func (v *PathPathCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+
+func (v *PathPathCertifyGood) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*PathPathCertifyGood
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.PathPathCertifyGood = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.allCertifyGood)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalPathPathCertifyGood struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Justification string `json:"justification"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *PathPathCertifyGood) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *PathPathCertifyGood) __premarshalJSON() (*__premarshalPathPathCertifyGood, error) {
+	var retval __premarshalPathPathCertifyGood
+
+	retval.Typename = v.Typename
+	retval.Id = v.allCertifyGood.Id
+	retval.Justification = v.allCertifyGood.Justification
+	{
+
+		dst := &retval.Subject
+		src := v.allCertifyGood.Subject
+		var err error
+		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal PathPathCertifyGood.allCertifyGood.Subject: %w", err)
+		}
+	}
+	retval.Origin = v.allCertifyGood.Origin
+	retval.Collector = v.allCertifyGood.Collector
+	return &retval, nil
+}
 
 // PathPathCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
 // The GraphQL type's documentation follows.
@@ -12654,10 +12932,14 @@ func __marshalPathPathNode(v *PathPathNode) ([]byte, error) {
 	case *PathPathCertifyGood:
 		typename = "CertifyGood"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*PathPathCertifyGood
-		}{typename, v}
+			*__premarshalPathPathCertifyGood
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *PathPathPkgEqual:
 		typename = "PkgEqual"
@@ -21819,6 +22101,9 @@ query Neighbors ($node: ID!, $usingOnly: [Edge!]!) {
 		... on CertifyBad {
 			... allCertifyBad
 		}
+		... on CertifyGood {
+			... allCertifyGood
+		}
 		... on HashEqual {
 			... allHashEqualTree
 		}
@@ -21982,6 +22267,24 @@ fragment allSLSATree on HasSLSA {
 	}
 }
 fragment allCertifyBad on CertifyBad {
+	id
+	justification
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	origin
+	collector
+}
+fragment allCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -22164,6 +22467,9 @@ query Node ($node: ID!) {
 		... on GHSA {
 			... allGHSATree
 		}
+		... on NoVuln {
+			id
+		}
 		... on CertifyScorecard {
 			... AllCertifyScorecard
 		}
@@ -22181,6 +22487,9 @@ query Node ($node: ID!) {
 		}
 		... on CertifyBad {
 			... allCertifyBad
+		}
+		... on CertifyGood {
+			... allCertifyGood
 		}
 		... on HashEqual {
 			... allHashEqualTree
@@ -22345,6 +22654,24 @@ fragment allSLSATree on HasSLSA {
 	}
 }
 fragment allCertifyBad on CertifyBad {
+	id
+	justification
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	origin
+	collector
+}
+fragment allCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -22603,6 +22930,9 @@ query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge
 		... on CertifyBad {
 			... allCertifyBad
 		}
+		... on CertifyGood {
+			... allCertifyGood
+		}
 		... on HashEqual {
 			... allHashEqualTree
 		}
@@ -22766,6 +23096,24 @@ fragment allSLSATree on HasSLSA {
 	}
 }
 fragment allCertifyBad on CertifyBad {
+	id
+	justification
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... allArtifactTree
+		}
+	}
+	origin
+	collector
+}
+fragment allCertifyGood on CertifyGood {
 	id
 	justification
 	subject {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -3680,7 +3680,8 @@ func (v *CertifyOSVResponse) GetIngestVulnerability() CertifyOSVIngestVulnerabil
 // possible GUAC verbs.
 //
 // Each member of the enum matches with one of the verbs. The naming scheme is
-// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
+// node in CAPITALS.
 //
 // Note that each GUAC verb is at the same time both an Edge and a Node. We need
 // to return it as a Node to have it show up in the return type of the queries and
@@ -3689,19 +3690,38 @@ func (v *CertifyOSVResponse) GetIngestVulnerability() CertifyOSVIngestVulnerabil
 type Edge string
 
 const (
-	EdgeIsOccurrence        Edge = "IS_OCCURRENCE"
-	EdgeIsDependency        Edge = "IS_DEPENDENCY"
-	EdgeIsVulnerability     Edge = "IS_VULNERABILITY"
-	EdgeCertifyVexStatement Edge = "CERTIFY_VEX_STATEMENT"
-	EdgeHashEqual           Edge = "HASH_EQUAL"
-	EdgeCertifyBad          Edge = "CERTIFY_BAD"
-	EdgeCertifyGood         Edge = "CERTIFY_GOOD"
-	EdgePkgEqual            Edge = "PKG_EQUAL"
-	EdgeCertifyScorecard    Edge = "CERTIFY_SCORECARD"
-	EdgeCertifyVuln         Edge = "CERTIFY_VULN"
-	EdgeHasSourceAt         Edge = "HAS_SOURCE_AT"
-	EdgeHasSbom             Edge = "HAS_SBOM"
-	EdgeHasSlsa             Edge = "HAS_SLSA"
+	EdgeArtifactCertifyBad          Edge = "ARTIFACT_CERTIFY_BAD"
+	EdgeArtifactCertifyGood         Edge = "ARTIFACT_CERTIFY_GOOD"
+	EdgeArtifactCertifyVexStatement Edge = "ARTIFACT_CERTIFY_VEX_STATEMENT"
+	EdgeArtifactHashEqual           Edge = "ARTIFACT_HASH_EQUAL"
+	EdgeArtifactHasSlsa             Edge = "ARTIFACT_HAS_SLSA"
+	EdgeArtifactIsOccurrence        Edge = "ARTIFACT_IS_OCCURRENCE"
+	EdgeBuilderHasSlsa              Edge = "BUILDER_HAS_SLSA"
+	EdgeCveCertifyVexStatement      Edge = "CVE_CERTIFY_VEX_STATEMENT"
+	EdgeCveCertifyVuln              Edge = "CVE_CERTIFY_VULN"
+	EdgeCveIsVulnerability          Edge = "CVE_IS_VULNERABILITY"
+	EdgeGhsaCertifyVexStatement     Edge = "GHSA_CERTIFY_VEX_STATEMENT"
+	EdgeGhsaCertifyVuln             Edge = "GHSA_CERTIFY_VULN"
+	EdgeGhsaIsVulnerability         Edge = "GHSA_IS_VULNERABILITY"
+	EdgeNoVulnCertifyVuln           Edge = "NO_VULN_CERTIFY_VULN"
+	EdgeOsvCertifyVexStatement      Edge = "OSV_CERTIFY_VEX_STATEMENT"
+	EdgeOsvCertifyVuln              Edge = "OSV_CERTIFY_VULN"
+	EdgeOsvIsVulnerability          Edge = "OSV_IS_VULNERABILITY"
+	EdgePackageCertifyBad           Edge = "PACKAGE_CERTIFY_BAD"
+	EdgePackageCertifyGood          Edge = "PACKAGE_CERTIFY_GOOD"
+	EdgePackageCertifyVexStatement  Edge = "PACKAGE_CERTIFY_VEX_STATEMENT"
+	EdgePackageCertifyVuln          Edge = "PACKAGE_CERTIFY_VULN"
+	EdgePackageHasSbom              Edge = "PACKAGE_HAS_SBOM"
+	EdgePackageHasSourceAt          Edge = "PACKAGE_HAS_SOURCE_AT"
+	EdgePackageIsDependency         Edge = "PACKAGE_IS_DEPENDENCY"
+	EdgePackageIsOccurrence         Edge = "PACKAGE_IS_OCCURRENCE"
+	EdgePackagePkgEqual             Edge = "PACKAGE_PKG_EQUAL"
+	EdgeSourceCertifyBad            Edge = "SOURCE_CERTIFY_BAD"
+	EdgeSourceCertifyGood           Edge = "SOURCE_CERTIFY_GOOD"
+	EdgeSourceCertifyScorecard      Edge = "SOURCE_CERTIFY_SCORECARD"
+	EdgeSourceHasSbom               Edge = "SOURCE_HAS_SBOM"
+	EdgeSourceHasSourceAt           Edge = "SOURCE_HAS_SOURCE_AT"
+	EdgeSourceIsOccurrence          Edge = "SOURCE_IS_OCCURRENCE"
 )
 
 // GHSAInputSpec is the same as GHSASpec, but used for mutation ingestion.

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -8366,6 +8366,9 @@ type NeighborsResponse struct {
 	// neighbors returns all the direct neighbors of a node
 	//
 	// Similarly, the input is only specified by its ID.
+	//
+	// Specifying any Edge value in `usingOnly` will make the neighbors list only
+	// contain the corresponding GUAC evidence trees (GUAC verbs).
 	Neighbors []NeighborsNeighborsNode `json:"-"`
 }
 
@@ -13051,6 +13054,9 @@ type PathResponse struct {
 	//
 	// Since we want to uniquely identify endpoints, nodes must be specified by
 	// valid IDs only (instead of using filters/input spec structs).
+	//
+	// Specifying any Edge value in `usingOnly` will make the path only contain the
+	// corresponding GUAC evidence trees (GUAC verbs).
 	Path []PathPathNode `json:"-"`
 }
 
@@ -21732,7 +21738,7 @@ func Neighbors(
 		OpName: "Neighbors",
 		Query: `
 query Neighbors ($node: ID!) {
-	neighbors(node: $node) {
+	neighbors(node: $node, usingOnly: []) {
 		__typename
 		... on Package {
 			... AllPkgTree
@@ -22514,7 +22520,7 @@ func Path(
 		OpName: "Path",
 		Query: `
 query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!) {
-	path(subject: $subject, target: $target, maxPathLength: $maxPathLength) {
+	path(subject: $subject, target: $target, maxPathLength: $maxPathLength, usingOnly: []) {
 		__typename
 		... on Package {
 			... AllPkgTree

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -3677,16 +3677,15 @@ func (v *CertifyOSVResponse) GetIngestVulnerability() CertifyOSVIngestVulnerabil
 }
 
 // Edge allows filtering path/neighbors output to only contain a subset of all
-// possible GUAC verbs.
+// possible GUAC links.
 //
-// Each member of the enum matches with one of the verbs. The naming scheme is
-// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
-// node in CAPITALS.
+// Each member of the enum is formed by merging two Node names with _. Each name
+// is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
+// (pairs from Node to Node) are included.
 //
-// Note that each GUAC verb is at the same time both an Edge and a Node. We need
-// to return it as a Node to have it show up in the return type of the queries and
-// we need it to be an edge to allow filtering paths to only consider certain
-// predicates.
+// The only exception to the above rule is for links out of HasSLSA. The names are
+// HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because
+// ARTIFACT_HAS_SLSA is only from subject Artifact to HasSLSA.
 type Edge string
 
 const (
@@ -3722,6 +3721,39 @@ const (
 	EdgeSourceHasSbom               Edge = "SOURCE_HAS_SBOM"
 	EdgeSourceHasSourceAt           Edge = "SOURCE_HAS_SOURCE_AT"
 	EdgeSourceIsOccurrence          Edge = "SOURCE_IS_OCCURRENCE"
+	EdgeCertifyBadArtifact          Edge = "CERTIFY_BAD_ARTIFACT"
+	EdgeCertifyBadPackage           Edge = "CERTIFY_BAD_PACKAGE"
+	EdgeCertifyBadSource            Edge = "CERTIFY_BAD_SOURCE"
+	EdgeCertifyGoodArtifact         Edge = "CERTIFY_GOOD_ARTIFACT"
+	EdgeCertifyGoodPackage          Edge = "CERTIFY_GOOD_PACKAGE"
+	EdgeCertifyGoodSource           Edge = "CERTIFY_GOOD_SOURCE"
+	EdgeCertifyScorecardSource      Edge = "CERTIFY_SCORECARD_SOURCE"
+	EdgeCertifyVexStatementArtifact Edge = "CERTIFY_VEX_STATEMENT_ARTIFACT"
+	EdgeCertifyVexStatementCve      Edge = "CERTIFY_VEX_STATEMENT_CVE"
+	EdgeCertifyVexStatementGhsa     Edge = "CERTIFY_VEX_STATEMENT_GHSA"
+	EdgeCertifyVexStatementOsv      Edge = "CERTIFY_VEX_STATEMENT_OSV"
+	EdgeCertifyVexStatementPackage  Edge = "CERTIFY_VEX_STATEMENT_PACKAGE"
+	EdgeCertifyVulnCve              Edge = "CERTIFY_VULN_CVE"
+	EdgeCertifyVulnGhsa             Edge = "CERTIFY_VULN_GHSA"
+	EdgeCertifyVulnNoVuln           Edge = "CERTIFY_VULN_NO_VULN"
+	EdgeCertifyVulnOsv              Edge = "CERTIFY_VULN_OSV"
+	EdgeCertifyVulnPackage          Edge = "CERTIFY_VULN_PACKAGE"
+	EdgeHashEqualArtifact           Edge = "HASH_EQUAL_ARTIFACT"
+	EdgeHasSbomPackage              Edge = "HAS_SBOM_PACKAGE"
+	EdgeHasSbomSource               Edge = "HAS_SBOM_SOURCE"
+	EdgeHasSlsaBuiltBy              Edge = "HAS_SLSA_BUILT_BY"
+	EdgeHasSlsaMaterials            Edge = "HAS_SLSA_MATERIALS"
+	EdgeHasSlsaSubject              Edge = "HAS_SLSA_SUBJECT"
+	EdgeHasSourceAtPackage          Edge = "HAS_SOURCE_AT_PACKAGE"
+	EdgeHasSourceAtSource           Edge = "HAS_SOURCE_AT_SOURCE"
+	EdgeIsDependencyPackage         Edge = "IS_DEPENDENCY_PACKAGE"
+	EdgeIsOccurrenceArtifact        Edge = "IS_OCCURRENCE_ARTIFACT"
+	EdgeIsOccurrencePackage         Edge = "IS_OCCURRENCE_PACKAGE"
+	EdgeIsOccurrenceSource          Edge = "IS_OCCURRENCE_SOURCE"
+	EdgeIsVulnerabilityCve          Edge = "IS_VULNERABILITY_CVE"
+	EdgeIsVulnerabilityGhsa         Edge = "IS_VULNERABILITY_GHSA"
+	EdgeIsVulnerabilityOsv          Edge = "IS_VULNERABILITY_OSV"
+	EdgePkgEqualPackage             Edge = "PKG_EQUAL_PACKAGE"
 )
 
 // GHSAInputSpec is the same as GHSASpec, but used for mutation ingestion.

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -18,7 +18,7 @@
 # Exposes GraphQL queries to retrieve GUAC graph connectivity data
 
 query Path($subject: ID!, $target: ID!, $maxPathLength: Int!) {
-  path(subject: $subject, target: $target, maxPathLength: $maxPathLength) {
+  path(subject: $subject, target: $target, maxPathLength: $maxPathLength, usingOnly: []) {
     __typename
     ... on Package {
       ... AllPkgTree
@@ -87,7 +87,7 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!) {
 }
 
 query Neighbors($node: ID!) {
-  neighbors(node: $node) {
+  neighbors(node: $node, usingOnly: []) {
     __typename
     ... on Package {
       ... AllPkgTree

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -62,6 +62,9 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!
     ... on CertifyBad {
       ...allCertifyBad
     }
+    ... on CertifyGood {
+      ...allCertifyGood
+    }
     ... on HashEqual {
       ...allHashEqualTree
     }
@@ -131,6 +134,9 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
     ... on CertifyBad {
       ...allCertifyBad
     }
+    ... on CertifyGood {
+      ...allCertifyGood
+    }
     ... on HashEqual {
       ...allHashEqualTree
     }
@@ -179,6 +185,9 @@ query Node($node: ID!) {
     ... on GHSA {
       ...allGHSATree
     }
+    ... on NoVuln {
+      id
+    }
     ... on CertifyScorecard {
       ...AllCertifyScorecard
     }
@@ -196,6 +205,9 @@ query Node($node: ID!) {
     }
     ... on CertifyBad {
       ...allCertifyBad
+    }
+    ... on CertifyGood {
+      ...allCertifyGood
     }
     ... on HashEqual {
       ...allHashEqualTree

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -17,8 +17,8 @@
 
 # Exposes GraphQL queries to retrieve GUAC graph connectivity data
 
-query Path($subject: ID!, $target: ID!, $maxPathLength: Int!) {
-  path(subject: $subject, target: $target, maxPathLength: $maxPathLength, usingOnly: []) {
+query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!]!) {
+  path(subject: $subject, target: $target, maxPathLength: $maxPathLength, usingOnly: $usingOnly) {
     __typename
     ... on Package {
       ... AllPkgTree
@@ -86,8 +86,8 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!) {
   }
 }
 
-query Neighbors($node: ID!) {
-  neighbors(node: $node, usingOnly: []) {
+query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
+  neighbors(node: $node, usingOnly: $usingOnly) {
     __typename
     ... on Package {
       ... AllPkgTree

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -60,8 +60,8 @@ type QueryResolver interface {
 	IsVulnerability(ctx context.Context, isVulnerabilitySpec *model.IsVulnerabilitySpec) ([]*model.IsVulnerability, error)
 	Osv(ctx context.Context, osvSpec *model.OSVSpec) ([]*model.Osv, error)
 	Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error)
-	Path(ctx context.Context, subject string, target string, maxPathLength int) ([]model.Node, error)
-	Neighbors(ctx context.Context, node string) ([]model.Node, error)
+	Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error)
+	Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error)
 	Node(ctx context.Context, node string) (model.Node, error)
 	PkgEqual(ctx context.Context, pkgEqualSpec *model.PkgEqualSpec) ([]*model.PkgEqual, error)
 	Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error)
@@ -887,6 +887,15 @@ func (ec *executionContext) field_Query_neighbors_args(ctx context.Context, rawA
 		}
 	}
 	args["node"] = arg0
+	var arg1 []model.Edge
+	if tmp, ok := rawArgs["usingOnly"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("usingOnly"))
+		arg1, err = ec.unmarshalNEdge2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdgeᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["usingOnly"] = arg1
 	return args, nil
 }
 
@@ -965,6 +974,15 @@ func (ec *executionContext) field_Query_path_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["maxPathLength"] = arg2
+	var arg3 []model.Edge
+	if tmp, ok := rawArgs["usingOnly"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("usingOnly"))
+		arg3, err = ec.unmarshalNEdge2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdgeᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["usingOnly"] = arg3
 	return args, nil
 }
 
@@ -3709,7 +3727,7 @@ func (ec *executionContext) _Query_path(ctx context.Context, field graphql.Colle
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Path(rctx, fc.Args["subject"].(string), fc.Args["target"].(string), fc.Args["maxPathLength"].(int))
+		return ec.resolvers.Query().Path(rctx, fc.Args["subject"].(string), fc.Args["target"].(string), fc.Args["maxPathLength"].(int), fc.Args["usingOnly"].([]model.Edge))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3764,7 +3782,7 @@ func (ec *executionContext) _Query_neighbors(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Neighbors(rctx, fc.Args["node"].(string))
+		return ec.resolvers.Query().Neighbors(rctx, fc.Args["node"].(string), fc.Args["usingOnly"].([]model.Edge))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/pkg/assembler/graphql/generated/path.generated.go
+++ b/pkg/assembler/graphql/generated/path.generated.go
@@ -198,6 +198,77 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 
 // region    ***************************** type.gotpl *****************************
 
+func (ec *executionContext) unmarshalNEdge2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdge(ctx context.Context, v interface{}) (model.Edge, error) {
+	var res model.Edge
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNEdge2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdge(ctx context.Context, sel ast.SelectionSet, v model.Edge) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNEdge2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdgeᚄ(ctx context.Context, v interface{}) ([]model.Edge, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]model.Edge, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNEdge2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdge(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNEdge2ᚕgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []model.Edge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNEdge2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNNode2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐNode(ctx context.Context, sel ast.SelectionSet, v model.Node) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3724,7 +3724,8 @@ Edge allows filtering path/neighbors output to only contain a subset of all
 possible GUAC verbs.
 
 Each member of the enum matches with one of the verbs. The naming scheme is
-converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
+node in CAPITALS.
 
 Note that each GUAC verb is at the same time both an Edge and a Node. We need
 to return it as a Node to have it show up in the return type of the queries and
@@ -3732,19 +3733,38 @@ we need it to be an edge to allow filtering paths to only consider certain
 predicates.
 """
 enum Edge {
-  IS_OCCURRENCE
-  IS_DEPENDENCY
-  IS_VULNERABILITY
-  CERTIFY_VEX_STATEMENT
-  HASH_EQUAL
-  CERTIFY_BAD
-  CERTIFY_GOOD
-  PKG_EQUAL
-  CERTIFY_SCORECARD
-  CERTIFY_VULN
-  HAS_SOURCE_AT
-  HAS_SBOM
-  HAS_SLSA
+  ARTIFACT_CERTIFY_BAD
+  ARTIFACT_CERTIFY_GOOD
+  ARTIFACT_CERTIFY_VEX_STATEMENT
+  ARTIFACT_HASH_EQUAL
+  ARTIFACT_HAS_SLSA
+  ARTIFACT_IS_OCCURRENCE
+  BUILDER_HAS_SLSA
+  CVE_CERTIFY_VEX_STATEMENT
+  CVE_CERTIFY_VULN
+  CVE_IS_VULNERABILITY
+  GHSA_CERTIFY_VEX_STATEMENT
+  GHSA_CERTIFY_VULN
+  GHSA_IS_VULNERABILITY
+  NO_VULN_CERTIFY_VULN
+  OSV_CERTIFY_VEX_STATEMENT
+  OSV_CERTIFY_VULN
+  OSV_IS_VULNERABILITY
+  PACKAGE_CERTIFY_BAD
+  PACKAGE_CERTIFY_GOOD
+  PACKAGE_CERTIFY_VEX_STATEMENT
+  PACKAGE_CERTIFY_VULN
+  PACKAGE_HAS_SBOM
+  PACKAGE_HAS_SOURCE_AT
+  PACKAGE_IS_DEPENDENCY
+  PACKAGE_IS_OCCURRENCE
+  PACKAGE_PKG_EQUAL
+  SOURCE_CERTIFY_BAD
+  SOURCE_CERTIFY_GOOD
+  SOURCE_CERTIFY_SCORECARD
+  SOURCE_HAS_SBOM
+  SOURCE_HAS_SOURCE_AT
+  SOURCE_IS_OCCURRENCE
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3721,16 +3721,15 @@ union Node
 
 """
 Edge allows filtering path/neighbors output to only contain a subset of all
-possible GUAC verbs.
+possible GUAC links.
 
-Each member of the enum matches with one of the verbs. The naming scheme is
-converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
-node in CAPITALS.
+Each member of the enum is formed by merging two Node names with _. Each name
+is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
+(pairs from Node to Node) are included.
 
-Note that each GUAC verb is at the same time both an Edge and a Node. We need
-to return it as a Node to have it show up in the return type of the queries and
-we need it to be an edge to allow filtering paths to only consider certain
-predicates.
+The only exception to the above rule is for links out of HasSLSA. The names are
+HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because
+ARTIFACT_HAS_SLSA is only from subject Artifact to HasSLSA.
 """
 enum Edge {
   ARTIFACT_CERTIFY_BAD
@@ -3765,6 +3764,40 @@ enum Edge {
   SOURCE_HAS_SBOM
   SOURCE_HAS_SOURCE_AT
   SOURCE_IS_OCCURRENCE
+
+  CERTIFY_BAD_ARTIFACT
+  CERTIFY_BAD_PACKAGE
+  CERTIFY_BAD_SOURCE
+  CERTIFY_GOOD_ARTIFACT
+  CERTIFY_GOOD_PACKAGE
+  CERTIFY_GOOD_SOURCE
+  CERTIFY_SCORECARD_SOURCE
+  CERTIFY_VEX_STATEMENT_ARTIFACT
+  CERTIFY_VEX_STATEMENT_CVE
+  CERTIFY_VEX_STATEMENT_GHSA
+  CERTIFY_VEX_STATEMENT_OSV
+  CERTIFY_VEX_STATEMENT_PACKAGE
+  CERTIFY_VULN_CVE
+  CERTIFY_VULN_GHSA
+  CERTIFY_VULN_NO_VULN
+  CERTIFY_VULN_OSV
+  CERTIFY_VULN_PACKAGE
+  HASH_EQUAL_ARTIFACT
+  HAS_SBOM_PACKAGE
+  HAS_SBOM_SOURCE
+  HAS_SLSA_BUILT_BY
+  HAS_SLSA_MATERIALS
+  HAS_SLSA_SUBJECT
+  HAS_SOURCE_AT_PACKAGE
+  HAS_SOURCE_AT_SOURCE
+  IS_DEPENDENCY_PACKAGE
+  IS_OCCURRENCE_ARTIFACT
+  IS_OCCURRENCE_PACKAGE
+  IS_OCCURRENCE_SOURCE
+  IS_VULNERABILITY_CVE
+  IS_VULNERABILITY_GHSA
+  IS_VULNERABILITY_OSV
+  PKG_EQUAL_PACKAGE
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1231,16 +1231,15 @@ type VulnerabilitySpec struct {
 }
 
 // Edge allows filtering path/neighbors output to only contain a subset of all
-// possible GUAC verbs.
+// possible GUAC links.
 //
-// Each member of the enum matches with one of the verbs. The naming scheme is
-// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
-// node in CAPITALS.
+// Each member of the enum is formed by merging two Node names with _. Each name
+// is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
+// (pairs from Node to Node) are included.
 //
-// Note that each GUAC verb is at the same time both an Edge and a Node. We need
-// to return it as a Node to have it show up in the return type of the queries and
-// we need it to be an edge to allow filtering paths to only consider certain
-// predicates.
+// The only exception to the above rule is for links out of HasSLSA. The names are
+// HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because
+// ARTIFACT_HAS_SLSA is only from subject Artifact to HasSLSA.
 type Edge string
 
 const (
@@ -1276,6 +1275,39 @@ const (
 	EdgeSourceHasSbom               Edge = "SOURCE_HAS_SBOM"
 	EdgeSourceHasSourceAt           Edge = "SOURCE_HAS_SOURCE_AT"
 	EdgeSourceIsOccurrence          Edge = "SOURCE_IS_OCCURRENCE"
+	EdgeCertifyBadArtifact          Edge = "CERTIFY_BAD_ARTIFACT"
+	EdgeCertifyBadPackage           Edge = "CERTIFY_BAD_PACKAGE"
+	EdgeCertifyBadSource            Edge = "CERTIFY_BAD_SOURCE"
+	EdgeCertifyGoodArtifact         Edge = "CERTIFY_GOOD_ARTIFACT"
+	EdgeCertifyGoodPackage          Edge = "CERTIFY_GOOD_PACKAGE"
+	EdgeCertifyGoodSource           Edge = "CERTIFY_GOOD_SOURCE"
+	EdgeCertifyScorecardSource      Edge = "CERTIFY_SCORECARD_SOURCE"
+	EdgeCertifyVexStatementArtifact Edge = "CERTIFY_VEX_STATEMENT_ARTIFACT"
+	EdgeCertifyVexStatementCve      Edge = "CERTIFY_VEX_STATEMENT_CVE"
+	EdgeCertifyVexStatementGhsa     Edge = "CERTIFY_VEX_STATEMENT_GHSA"
+	EdgeCertifyVexStatementOsv      Edge = "CERTIFY_VEX_STATEMENT_OSV"
+	EdgeCertifyVexStatementPackage  Edge = "CERTIFY_VEX_STATEMENT_PACKAGE"
+	EdgeCertifyVulnCve              Edge = "CERTIFY_VULN_CVE"
+	EdgeCertifyVulnGhsa             Edge = "CERTIFY_VULN_GHSA"
+	EdgeCertifyVulnNoVuln           Edge = "CERTIFY_VULN_NO_VULN"
+	EdgeCertifyVulnOsv              Edge = "CERTIFY_VULN_OSV"
+	EdgeCertifyVulnPackage          Edge = "CERTIFY_VULN_PACKAGE"
+	EdgeHashEqualArtifact           Edge = "HASH_EQUAL_ARTIFACT"
+	EdgeHasSbomPackage              Edge = "HAS_SBOM_PACKAGE"
+	EdgeHasSbomSource               Edge = "HAS_SBOM_SOURCE"
+	EdgeHasSlsaBuiltBy              Edge = "HAS_SLSA_BUILT_BY"
+	EdgeHasSlsaMaterials            Edge = "HAS_SLSA_MATERIALS"
+	EdgeHasSlsaSubject              Edge = "HAS_SLSA_SUBJECT"
+	EdgeHasSourceAtPackage          Edge = "HAS_SOURCE_AT_PACKAGE"
+	EdgeHasSourceAtSource           Edge = "HAS_SOURCE_AT_SOURCE"
+	EdgeIsDependencyPackage         Edge = "IS_DEPENDENCY_PACKAGE"
+	EdgeIsOccurrenceArtifact        Edge = "IS_OCCURRENCE_ARTIFACT"
+	EdgeIsOccurrencePackage         Edge = "IS_OCCURRENCE_PACKAGE"
+	EdgeIsOccurrenceSource          Edge = "IS_OCCURRENCE_SOURCE"
+	EdgeIsVulnerabilityCve          Edge = "IS_VULNERABILITY_CVE"
+	EdgeIsVulnerabilityGhsa         Edge = "IS_VULNERABILITY_GHSA"
+	EdgeIsVulnerabilityOsv          Edge = "IS_VULNERABILITY_OSV"
+	EdgePkgEqualPackage             Edge = "PKG_EQUAL_PACKAGE"
 )
 
 var AllEdge = []Edge{
@@ -1311,11 +1343,44 @@ var AllEdge = []Edge{
 	EdgeSourceHasSbom,
 	EdgeSourceHasSourceAt,
 	EdgeSourceIsOccurrence,
+	EdgeCertifyBadArtifact,
+	EdgeCertifyBadPackage,
+	EdgeCertifyBadSource,
+	EdgeCertifyGoodArtifact,
+	EdgeCertifyGoodPackage,
+	EdgeCertifyGoodSource,
+	EdgeCertifyScorecardSource,
+	EdgeCertifyVexStatementArtifact,
+	EdgeCertifyVexStatementCve,
+	EdgeCertifyVexStatementGhsa,
+	EdgeCertifyVexStatementOsv,
+	EdgeCertifyVexStatementPackage,
+	EdgeCertifyVulnCve,
+	EdgeCertifyVulnGhsa,
+	EdgeCertifyVulnNoVuln,
+	EdgeCertifyVulnOsv,
+	EdgeCertifyVulnPackage,
+	EdgeHashEqualArtifact,
+	EdgeHasSbomPackage,
+	EdgeHasSbomSource,
+	EdgeHasSlsaBuiltBy,
+	EdgeHasSlsaMaterials,
+	EdgeHasSlsaSubject,
+	EdgeHasSourceAtPackage,
+	EdgeHasSourceAtSource,
+	EdgeIsDependencyPackage,
+	EdgeIsOccurrenceArtifact,
+	EdgeIsOccurrencePackage,
+	EdgeIsOccurrenceSource,
+	EdgeIsVulnerabilityCve,
+	EdgeIsVulnerabilityGhsa,
+	EdgeIsVulnerabilityOsv,
+	EdgePkgEqualPackage,
 }
 
 func (e Edge) IsValid() bool {
 	switch e {
-	case EdgeArtifactCertifyBad, EdgeArtifactCertifyGood, EdgeArtifactCertifyVexStatement, EdgeArtifactHashEqual, EdgeArtifactHasSlsa, EdgeArtifactIsOccurrence, EdgeBuilderHasSlsa, EdgeCveCertifyVexStatement, EdgeCveCertifyVuln, EdgeCveIsVulnerability, EdgeGhsaCertifyVexStatement, EdgeGhsaCertifyVuln, EdgeGhsaIsVulnerability, EdgeNoVulnCertifyVuln, EdgeOsvCertifyVexStatement, EdgeOsvCertifyVuln, EdgeOsvIsVulnerability, EdgePackageCertifyBad, EdgePackageCertifyGood, EdgePackageCertifyVexStatement, EdgePackageCertifyVuln, EdgePackageHasSbom, EdgePackageHasSourceAt, EdgePackageIsDependency, EdgePackageIsOccurrence, EdgePackagePkgEqual, EdgeSourceCertifyBad, EdgeSourceCertifyGood, EdgeSourceCertifyScorecard, EdgeSourceHasSbom, EdgeSourceHasSourceAt, EdgeSourceIsOccurrence:
+	case EdgeArtifactCertifyBad, EdgeArtifactCertifyGood, EdgeArtifactCertifyVexStatement, EdgeArtifactHashEqual, EdgeArtifactHasSlsa, EdgeArtifactIsOccurrence, EdgeBuilderHasSlsa, EdgeCveCertifyVexStatement, EdgeCveCertifyVuln, EdgeCveIsVulnerability, EdgeGhsaCertifyVexStatement, EdgeGhsaCertifyVuln, EdgeGhsaIsVulnerability, EdgeNoVulnCertifyVuln, EdgeOsvCertifyVexStatement, EdgeOsvCertifyVuln, EdgeOsvIsVulnerability, EdgePackageCertifyBad, EdgePackageCertifyGood, EdgePackageCertifyVexStatement, EdgePackageCertifyVuln, EdgePackageHasSbom, EdgePackageHasSourceAt, EdgePackageIsDependency, EdgePackageIsOccurrence, EdgePackagePkgEqual, EdgeSourceCertifyBad, EdgeSourceCertifyGood, EdgeSourceCertifyScorecard, EdgeSourceHasSbom, EdgeSourceHasSourceAt, EdgeSourceIsOccurrence, EdgeCertifyBadArtifact, EdgeCertifyBadPackage, EdgeCertifyBadSource, EdgeCertifyGoodArtifact, EdgeCertifyGoodPackage, EdgeCertifyGoodSource, EdgeCertifyScorecardSource, EdgeCertifyVexStatementArtifact, EdgeCertifyVexStatementCve, EdgeCertifyVexStatementGhsa, EdgeCertifyVexStatementOsv, EdgeCertifyVexStatementPackage, EdgeCertifyVulnCve, EdgeCertifyVulnGhsa, EdgeCertifyVulnNoVuln, EdgeCertifyVulnOsv, EdgeCertifyVulnPackage, EdgeHashEqualArtifact, EdgeHasSbomPackage, EdgeHasSbomSource, EdgeHasSlsaBuiltBy, EdgeHasSlsaMaterials, EdgeHasSlsaSubject, EdgeHasSourceAtPackage, EdgeHasSourceAtSource, EdgeIsDependencyPackage, EdgeIsOccurrenceArtifact, EdgeIsOccurrencePackage, EdgeIsOccurrenceSource, EdgeIsVulnerabilityCve, EdgeIsVulnerabilityGhsa, EdgeIsVulnerabilityOsv, EdgePkgEqualPackage:
 		return true
 	}
 	return false

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1230,6 +1230,79 @@ type VulnerabilitySpec struct {
 	NoVuln *bool     `json:"noVuln,omitempty"`
 }
 
+// Edge allows filtering path/neighbors output to only contain a subset of all
+// possible GUAC verbs.
+//
+// Each member of the enum matches with one of the verbs. The naming scheme is
+// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+//
+// Note that each GUAC verb is at the same time both an Edge and a Node. We need
+// to return it as a Node to have it show up in the return type of the queries and
+// we need it to be an edge to allow filtering paths to only consider certain
+// predicates.
+type Edge string
+
+const (
+	EdgeIsOccurrence        Edge = "IS_OCCURRENCE"
+	EdgeIsDependency        Edge = "IS_DEPENDENCY"
+	EdgeIsVulnerability     Edge = "IS_VULNERABILITY"
+	EdgeCertifyVexStatement Edge = "CERTIFY_VEX_STATEMENT"
+	EdgeHashEqual           Edge = "HASH_EQUAL"
+	EdgeCertifyBad          Edge = "CERTIFY_BAD"
+	EdgeCertifyGood         Edge = "CERTIFY_GOOD"
+	EdgePkgEqual            Edge = "PKG_EQUAL"
+	EdgeCertifyScorecard    Edge = "CERTIFY_SCORECARD"
+	EdgeCertifyVuln         Edge = "CERTIFY_VULN"
+	EdgeHasSourceAt         Edge = "HAS_SOURCE_AT"
+	EdgeHasSbom             Edge = "HAS_SBOM"
+	EdgeHasSlsa             Edge = "HAS_SLSA"
+)
+
+var AllEdge = []Edge{
+	EdgeIsOccurrence,
+	EdgeIsDependency,
+	EdgeIsVulnerability,
+	EdgeCertifyVexStatement,
+	EdgeHashEqual,
+	EdgeCertifyBad,
+	EdgeCertifyGood,
+	EdgePkgEqual,
+	EdgeCertifyScorecard,
+	EdgeCertifyVuln,
+	EdgeHasSourceAt,
+	EdgeHasSbom,
+	EdgeHasSlsa,
+}
+
+func (e Edge) IsValid() bool {
+	switch e {
+	case EdgeIsOccurrence, EdgeIsDependency, EdgeIsVulnerability, EdgeCertifyVexStatement, EdgeHashEqual, EdgeCertifyBad, EdgeCertifyGood, EdgePkgEqual, EdgeCertifyScorecard, EdgeCertifyVuln, EdgeHasSourceAt, EdgeHasSbom, EdgeHasSlsa:
+		return true
+	}
+	return false
+}
+
+func (e Edge) String() string {
+	return string(e)
+}
+
+func (e *Edge) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Edge(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Edge", str)
+	}
+	return nil
+}
+
+func (e Edge) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // PkgMatchType is an enum to determine if the attestation should be done at the
 // specific version or package name
 type PkgMatchType string

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1234,7 +1234,8 @@ type VulnerabilitySpec struct {
 // possible GUAC verbs.
 //
 // Each member of the enum matches with one of the verbs. The naming scheme is
-// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+// converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
+// node in CAPITALS.
 //
 // Note that each GUAC verb is at the same time both an Edge and a Node. We need
 // to return it as a Node to have it show up in the return type of the queries and
@@ -1243,40 +1244,78 @@ type VulnerabilitySpec struct {
 type Edge string
 
 const (
-	EdgeIsOccurrence        Edge = "IS_OCCURRENCE"
-	EdgeIsDependency        Edge = "IS_DEPENDENCY"
-	EdgeIsVulnerability     Edge = "IS_VULNERABILITY"
-	EdgeCertifyVexStatement Edge = "CERTIFY_VEX_STATEMENT"
-	EdgeHashEqual           Edge = "HASH_EQUAL"
-	EdgeCertifyBad          Edge = "CERTIFY_BAD"
-	EdgeCertifyGood         Edge = "CERTIFY_GOOD"
-	EdgePkgEqual            Edge = "PKG_EQUAL"
-	EdgeCertifyScorecard    Edge = "CERTIFY_SCORECARD"
-	EdgeCertifyVuln         Edge = "CERTIFY_VULN"
-	EdgeHasSourceAt         Edge = "HAS_SOURCE_AT"
-	EdgeHasSbom             Edge = "HAS_SBOM"
-	EdgeHasSlsa             Edge = "HAS_SLSA"
+	EdgeArtifactCertifyBad          Edge = "ARTIFACT_CERTIFY_BAD"
+	EdgeArtifactCertifyGood         Edge = "ARTIFACT_CERTIFY_GOOD"
+	EdgeArtifactCertifyVexStatement Edge = "ARTIFACT_CERTIFY_VEX_STATEMENT"
+	EdgeArtifactHashEqual           Edge = "ARTIFACT_HASH_EQUAL"
+	EdgeArtifactHasSlsa             Edge = "ARTIFACT_HAS_SLSA"
+	EdgeArtifactIsOccurrence        Edge = "ARTIFACT_IS_OCCURRENCE"
+	EdgeBuilderHasSlsa              Edge = "BUILDER_HAS_SLSA"
+	EdgeCveCertifyVexStatement      Edge = "CVE_CERTIFY_VEX_STATEMENT"
+	EdgeCveCertifyVuln              Edge = "CVE_CERTIFY_VULN"
+	EdgeCveIsVulnerability          Edge = "CVE_IS_VULNERABILITY"
+	EdgeGhsaCertifyVexStatement     Edge = "GHSA_CERTIFY_VEX_STATEMENT"
+	EdgeGhsaCertifyVuln             Edge = "GHSA_CERTIFY_VULN"
+	EdgeGhsaIsVulnerability         Edge = "GHSA_IS_VULNERABILITY"
+	EdgeNoVulnCertifyVuln           Edge = "NO_VULN_CERTIFY_VULN"
+	EdgeOsvCertifyVexStatement      Edge = "OSV_CERTIFY_VEX_STATEMENT"
+	EdgeOsvCertifyVuln              Edge = "OSV_CERTIFY_VULN"
+	EdgeOsvIsVulnerability          Edge = "OSV_IS_VULNERABILITY"
+	EdgePackageCertifyBad           Edge = "PACKAGE_CERTIFY_BAD"
+	EdgePackageCertifyGood          Edge = "PACKAGE_CERTIFY_GOOD"
+	EdgePackageCertifyVexStatement  Edge = "PACKAGE_CERTIFY_VEX_STATEMENT"
+	EdgePackageCertifyVuln          Edge = "PACKAGE_CERTIFY_VULN"
+	EdgePackageHasSbom              Edge = "PACKAGE_HAS_SBOM"
+	EdgePackageHasSourceAt          Edge = "PACKAGE_HAS_SOURCE_AT"
+	EdgePackageIsDependency         Edge = "PACKAGE_IS_DEPENDENCY"
+	EdgePackageIsOccurrence         Edge = "PACKAGE_IS_OCCURRENCE"
+	EdgePackagePkgEqual             Edge = "PACKAGE_PKG_EQUAL"
+	EdgeSourceCertifyBad            Edge = "SOURCE_CERTIFY_BAD"
+	EdgeSourceCertifyGood           Edge = "SOURCE_CERTIFY_GOOD"
+	EdgeSourceCertifyScorecard      Edge = "SOURCE_CERTIFY_SCORECARD"
+	EdgeSourceHasSbom               Edge = "SOURCE_HAS_SBOM"
+	EdgeSourceHasSourceAt           Edge = "SOURCE_HAS_SOURCE_AT"
+	EdgeSourceIsOccurrence          Edge = "SOURCE_IS_OCCURRENCE"
 )
 
 var AllEdge = []Edge{
-	EdgeIsOccurrence,
-	EdgeIsDependency,
-	EdgeIsVulnerability,
-	EdgeCertifyVexStatement,
-	EdgeHashEqual,
-	EdgeCertifyBad,
-	EdgeCertifyGood,
-	EdgePkgEqual,
-	EdgeCertifyScorecard,
-	EdgeCertifyVuln,
-	EdgeHasSourceAt,
-	EdgeHasSbom,
-	EdgeHasSlsa,
+	EdgeArtifactCertifyBad,
+	EdgeArtifactCertifyGood,
+	EdgeArtifactCertifyVexStatement,
+	EdgeArtifactHashEqual,
+	EdgeArtifactHasSlsa,
+	EdgeArtifactIsOccurrence,
+	EdgeBuilderHasSlsa,
+	EdgeCveCertifyVexStatement,
+	EdgeCveCertifyVuln,
+	EdgeCveIsVulnerability,
+	EdgeGhsaCertifyVexStatement,
+	EdgeGhsaCertifyVuln,
+	EdgeGhsaIsVulnerability,
+	EdgeNoVulnCertifyVuln,
+	EdgeOsvCertifyVexStatement,
+	EdgeOsvCertifyVuln,
+	EdgeOsvIsVulnerability,
+	EdgePackageCertifyBad,
+	EdgePackageCertifyGood,
+	EdgePackageCertifyVexStatement,
+	EdgePackageCertifyVuln,
+	EdgePackageHasSbom,
+	EdgePackageHasSourceAt,
+	EdgePackageIsDependency,
+	EdgePackageIsOccurrence,
+	EdgePackagePkgEqual,
+	EdgeSourceCertifyBad,
+	EdgeSourceCertifyGood,
+	EdgeSourceCertifyScorecard,
+	EdgeSourceHasSbom,
+	EdgeSourceHasSourceAt,
+	EdgeSourceIsOccurrence,
 }
 
 func (e Edge) IsValid() bool {
 	switch e {
-	case EdgeIsOccurrence, EdgeIsDependency, EdgeIsVulnerability, EdgeCertifyVexStatement, EdgeHashEqual, EdgeCertifyBad, EdgeCertifyGood, EdgePkgEqual, EdgeCertifyScorecard, EdgeCertifyVuln, EdgeHasSourceAt, EdgeHasSbom, EdgeHasSlsa:
+	case EdgeArtifactCertifyBad, EdgeArtifactCertifyGood, EdgeArtifactCertifyVexStatement, EdgeArtifactHashEqual, EdgeArtifactHasSlsa, EdgeArtifactIsOccurrence, EdgeBuilderHasSlsa, EdgeCveCertifyVexStatement, EdgeCveCertifyVuln, EdgeCveIsVulnerability, EdgeGhsaCertifyVexStatement, EdgeGhsaCertifyVuln, EdgeGhsaIsVulnerability, EdgeNoVulnCertifyVuln, EdgeOsvCertifyVexStatement, EdgeOsvCertifyVuln, EdgeOsvIsVulnerability, EdgePackageCertifyBad, EdgePackageCertifyGood, EdgePackageCertifyVexStatement, EdgePackageCertifyVuln, EdgePackageHasSbom, EdgePackageHasSourceAt, EdgePackageIsDependency, EdgePackageIsOccurrence, EdgePackagePkgEqual, EdgeSourceCertifyBad, EdgeSourceCertifyGood, EdgeSourceCertifyScorecard, EdgeSourceHasSbom, EdgeSourceHasSourceAt, EdgeSourceIsOccurrence:
 		return true
 	}
 	return false

--- a/pkg/assembler/graphql/resolvers/path.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/path.resolvers.go
@@ -11,13 +11,13 @@ import (
 )
 
 // Path is the resolver for the path field.
-func (r *queryResolver) Path(ctx context.Context, subject string, target string, maxPathLength int) ([]model.Node, error) {
-	return r.Backend.Path(ctx, subject, target, maxPathLength)
+func (r *queryResolver) Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error) {
+	return r.Backend.Path(ctx, subject, target, maxPathLength, usingOnly)
 }
 
 // Neighbors is the resolver for the neighbors field.
-func (r *queryResolver) Neighbors(ctx context.Context, node string) ([]model.Node, error) {
-	return r.Backend.Neighbors(ctx, node)
+func (r *queryResolver) Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error) {
+	return r.Backend.Neighbors(ctx, node, usingOnly)
 }
 
 // Node is the resolver for the node field.

--- a/pkg/assembler/graphql/schema/path.graphql
+++ b/pkg/assembler/graphql/schema/path.graphql
@@ -49,16 +49,15 @@ union Node
 
 """
 Edge allows filtering path/neighbors output to only contain a subset of all
-possible GUAC verbs.
+possible GUAC links.
 
-Each member of the enum matches with one of the verbs. The naming scheme is
-converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
-node in CAPITALS.
+Each member of the enum is formed by merging two Node names with _. Each name
+is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
+(pairs from Node to Node) are included.
 
-Note that each GUAC verb is at the same time both an Edge and a Node. We need
-to return it as a Node to have it show up in the return type of the queries and
-we need it to be an edge to allow filtering paths to only consider certain
-predicates.
+The only exception to the above rule is for links out of HasSLSA. The names are
+HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because
+ARTIFACT_HAS_SLSA is only from subject Artifact to HasSLSA.
 """
 enum Edge {
   ARTIFACT_CERTIFY_BAD
@@ -93,6 +92,40 @@ enum Edge {
   SOURCE_HAS_SBOM
   SOURCE_HAS_SOURCE_AT
   SOURCE_IS_OCCURRENCE
+
+  CERTIFY_BAD_ARTIFACT
+  CERTIFY_BAD_PACKAGE
+  CERTIFY_BAD_SOURCE
+  CERTIFY_GOOD_ARTIFACT
+  CERTIFY_GOOD_PACKAGE
+  CERTIFY_GOOD_SOURCE
+  CERTIFY_SCORECARD_SOURCE
+  CERTIFY_VEX_STATEMENT_ARTIFACT
+  CERTIFY_VEX_STATEMENT_CVE
+  CERTIFY_VEX_STATEMENT_GHSA
+  CERTIFY_VEX_STATEMENT_OSV
+  CERTIFY_VEX_STATEMENT_PACKAGE
+  CERTIFY_VULN_CVE
+  CERTIFY_VULN_GHSA
+  CERTIFY_VULN_NO_VULN
+  CERTIFY_VULN_OSV
+  CERTIFY_VULN_PACKAGE
+  HASH_EQUAL_ARTIFACT
+  HAS_SBOM_PACKAGE
+  HAS_SBOM_SOURCE
+  HAS_SLSA_BUILT_BY
+  HAS_SLSA_MATERIALS
+  HAS_SLSA_SUBJECT
+  HAS_SOURCE_AT_PACKAGE
+  HAS_SOURCE_AT_SOURCE
+  IS_DEPENDENCY_PACKAGE
+  IS_OCCURRENCE_ARTIFACT
+  IS_OCCURRENCE_PACKAGE
+  IS_OCCURRENCE_SOURCE
+  IS_VULNERABILITY_CVE
+  IS_VULNERABILITY_GHSA
+  IS_VULNERABILITY_OSV
+  PKG_EQUAL_PACKAGE
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/path.graphql
+++ b/pkg/assembler/graphql/schema/path.graphql
@@ -52,7 +52,8 @@ Edge allows filtering path/neighbors output to only contain a subset of all
 possible GUAC verbs.
 
 Each member of the enum matches with one of the verbs. The naming scheme is
-converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+converting the CamelCase name to CAPITALS_WITH_UNDERSCORES and appending noun
+node in CAPITALS.
 
 Note that each GUAC verb is at the same time both an Edge and a Node. We need
 to return it as a Node to have it show up in the return type of the queries and
@@ -60,19 +61,38 @@ we need it to be an edge to allow filtering paths to only consider certain
 predicates.
 """
 enum Edge {
-  IS_OCCURRENCE
-  IS_DEPENDENCY
-  IS_VULNERABILITY
-  CERTIFY_VEX_STATEMENT
-  HASH_EQUAL
-  CERTIFY_BAD
-  CERTIFY_GOOD
-  PKG_EQUAL
-  CERTIFY_SCORECARD
-  CERTIFY_VULN
-  HAS_SOURCE_AT
-  HAS_SBOM
-  HAS_SLSA
+  ARTIFACT_CERTIFY_BAD
+  ARTIFACT_CERTIFY_GOOD
+  ARTIFACT_CERTIFY_VEX_STATEMENT
+  ARTIFACT_HASH_EQUAL
+  ARTIFACT_HAS_SLSA
+  ARTIFACT_IS_OCCURRENCE
+  BUILDER_HAS_SLSA
+  CVE_CERTIFY_VEX_STATEMENT
+  CVE_CERTIFY_VULN
+  CVE_IS_VULNERABILITY
+  GHSA_CERTIFY_VEX_STATEMENT
+  GHSA_CERTIFY_VULN
+  GHSA_IS_VULNERABILITY
+  NO_VULN_CERTIFY_VULN
+  OSV_CERTIFY_VEX_STATEMENT
+  OSV_CERTIFY_VULN
+  OSV_IS_VULNERABILITY
+  PACKAGE_CERTIFY_BAD
+  PACKAGE_CERTIFY_GOOD
+  PACKAGE_CERTIFY_VEX_STATEMENT
+  PACKAGE_CERTIFY_VULN
+  PACKAGE_HAS_SBOM
+  PACKAGE_HAS_SOURCE_AT
+  PACKAGE_IS_DEPENDENCY
+  PACKAGE_IS_OCCURRENCE
+  PACKAGE_PKG_EQUAL
+  SOURCE_CERTIFY_BAD
+  SOURCE_CERTIFY_GOOD
+  SOURCE_CERTIFY_SCORECARD
+  SOURCE_HAS_SBOM
+  SOURCE_HAS_SOURCE_AT
+  SOURCE_IS_OCCURRENCE
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/path.graphql
+++ b/pkg/assembler/graphql/schema/path.graphql
@@ -47,21 +47,55 @@ union Node
   | HasSBOM
   | HasSLSA
 
+"""
+Edge allows filtering path/neighbors output to only contain a subset of all
+possible GUAC verbs.
+
+Each member of the enum matches with one of the verbs. The naming scheme is
+converting the CamelCase name to CAPITALS_WITH_UNDERSCORES.
+
+Note that each GUAC verb is at the same time both an Edge and a Node. We need
+to return it as a Node to have it show up in the return type of the queries and
+we need it to be an edge to allow filtering paths to only consider certain
+predicates.
+"""
+enum Edge {
+  IS_OCCURRENCE
+  IS_DEPENDENCY
+  IS_VULNERABILITY
+  CERTIFY_VEX_STATEMENT
+  HASH_EQUAL
+  CERTIFY_BAD
+  CERTIFY_GOOD
+  PKG_EQUAL
+  CERTIFY_SCORECARD
+  CERTIFY_VULN
+  HAS_SOURCE_AT
+  HAS_SBOM
+  HAS_SLSA
+}
+
 extend type Query {
   """
   path query returns a path between subject and target, of a maximum length
 
   Since we want to uniquely identify endpoints, nodes must be specified by
   valid IDs only (instead of using filters/input spec structs).
+
+  Specifying any Edge value in `usingOnly` will make the path only contain the
+  corresponding GUAC evidence trees (GUAC verbs).
   """
-  path(subject: ID!, target: ID!, maxPathLength: Int!): [Node!]!
+  path(subject: ID!, target: ID!, maxPathLength: Int!, usingOnly: [Edge!]!): [Node!]!
 
   """
   neighbors returns all the direct neighbors of a node
 
   Similarly, the input is only specified by its ID.
+
+  Specifying any Edge value in `usingOnly` will make the neighbors list only
+  contain the corresponding GUAC evidence trees (GUAC verbs).
   """
-  neighbors(node: ID!): [Node!]!
+  neighbors(node: ID!, usingOnly: [Edge!]!): [Node!]!
 
   """
   node returns a single node, regardless of type

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -46,7 +46,7 @@ type packageQuery struct {
 }
 
 var getPackages func(ctx context.Context, client graphql.Client, filter *generated.PkgSpec) (*generated.PackagesResponse, error)
-var getNeighbors func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error)
+var getNeighbors func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 
 // NewPackageQuery initializes the packageQuery to query from the graph database
 func NewPackageQuery(client graphql.Client, daysSinceLastScan int) certifier.QueryComponents {

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -137,7 +137,7 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, response *generated.
 		for _, namespace := range pkgType.Namespaces {
 			for _, name := range namespace.Names {
 				for _, version := range name.Versions {
-					response, err := getNeighbors(ctx, p.client, version.Id)
+					response, err := getNeighbors(ctx, p.client, version.Id, []generated.Edge{})
 					if err != nil {
 						return fmt.Errorf("failed neighbors query: %w", err)
 					}

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -114,7 +114,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		name              string
 		daysSinceLastScan int
 		getPackages       func(ctx context.Context, client graphql.Client, filter *generated.PkgSpec) (*generated.PackagesResponse, error)
-		getNeighbors      func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error)
+		getNeighbors      func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 		wantPackNode      []*PackageNode
 		wantErr           bool
 	}{
@@ -126,7 +126,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil
@@ -147,7 +147,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeStamp},
 				}, nil
@@ -162,7 +162,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeStamp},
 				}, nil
@@ -181,7 +181,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeNow},
 				}, nil
@@ -196,7 +196,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeStamp, &neighborIsOccurrence},
 				}, nil
@@ -211,7 +211,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborIsOccurrence},
 				}, nil
@@ -230,7 +230,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 					Packages: []generated.PackagesPackagesPackage{testPypiPackage, testOpenSSLPackage},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil

--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -39,7 +39,7 @@ type SourceNode struct {
 }
 
 var getSources func(ctx context.Context, client graphql.Client, filter *generated.SourceSpec) (*generated.SourcesResponse, error)
-var getNeighbors func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error)
+var getNeighbors func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 
 // GetComponents get all the sources that do not have a certify scorecard attached or last scanned is more than daysSinceLastScan
 func (s sourceQuery) GetComponents(ctx context.Context, compChan chan<- interface{}) error {

--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -55,7 +55,7 @@ func (s sourceQuery) GetComponents(ctx context.Context, compChan chan<- interfac
 	for _, src := range sources {
 		for _, namespace := range src.Namespaces {
 			for _, names := range namespace.Names {
-				response, err := getNeighbors(ctx, s.client, names.Id)
+				response, err := getNeighbors(ctx, s.client, names.Id, []generated.Edge{})
 				if err != nil {
 					return fmt.Errorf("failed neighbors query: %w", err)
 				}

--- a/pkg/certifier/components/source/source_test.go
+++ b/pkg/certifier/components/source/source_test.go
@@ -139,7 +139,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		name              string
 		daysSinceLastScan int
 		getSources        func(ctx context.Context, client graphql.Client, filter *generated.SourceSpec) (*generated.SourcesResponse, error)
-		getNeighbors      func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error)
+		getNeighbors      func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 		wantSourceNode    []*SourceNode
 		wantErr           bool
 	}{
@@ -151,7 +151,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil
@@ -172,7 +172,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoCommit},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil
@@ -193,7 +193,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoCommitWithAlgo},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil
@@ -214,7 +214,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyScorecardTimeStamp},
 				}, nil
@@ -229,7 +229,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyScorecardTimeStamp},
 				}, nil
@@ -250,7 +250,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyScorecardTimeNow},
 				}, nil
@@ -265,7 +265,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag, testSourceDjangoCommit, testSourceKubeTestTag},
 				}, nil
 			},
-			getNeighbors: func(ctx context.Context, client graphql.Client, node string) (*generated.NeighborsResponse, error) {
+			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
 					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil


### PR DESCRIPTION
~~We can expand it if we want to also filter on the other neighbors, it ended up being quite generic.~~

It is now expanded to have all valid combinations of Node-Node.

~~Depends on https://github.com/guacsec/guac/pull/673.~~

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>