### PR TITLE
add isOccurrence for CDX and fix issue with passing by value

### DIFF
--- a/internal/testing/testdata/exampledata/small-deps-cyclonedx.json
+++ b/internal/testing/testdata/exampledata/small-deps-cyclonedx.json
@@ -23,6 +23,12 @@
       "name" : "getting-started",
       "version" : "1.0.0-SNAPSHOT",
       "licenses" : [ ],
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+        }
+      ],
       "purl" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
       "type" : "library",
       "bom-ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar"

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -226,10 +226,10 @@ var (
 
 	slsaStartTime, _ = time.Parse(time.RFC3339, "2020-08-19T08:38:00Z")
 	SlsaPreds        = assembler.IngestPredicates{
-		IsOccurence: []assembler.IsOccurenceIngest{
-			{Pkg: artPkg, Artifact: &art, IsOccurence: &slsaIsOccurrence},
-			{Src: mat1Src, Artifact: &mat1, IsOccurence: &slsaIsOccurrence},
-			{Pkg: mat2Pkg, Artifact: &mat2, IsOccurence: &slsaIsOccurrence},
+		IsOccurrence: []assembler.IsOccurrenceIngest{
+			{Pkg: artPkg, Artifact: &art, IsOccurrence: &slsaIsOccurrence},
+			{Src: mat1Src, Artifact: &mat1, IsOccurrence: &slsaIsOccurrence},
+			{Pkg: mat2Pkg, Artifact: &mat2, IsOccurrence: &slsaIsOccurrence},
 		},
 		HasSlsa: []assembler.HasSlsaIngest{
 			{
@@ -310,6 +310,9 @@ var (
 		Digest:    "9a4cd858d9710963848e6d5f555325dc199d1c952b01cf6e64da2c15deedbd97",
 	}
 
+	isOccurrenceJustifyTopPkg = &model.IsOccurrenceInputSpec{
+		Justification: "cdx package with checksum",
+	}
 	isDepJustifyTopPkg = &model.IsDependencyInputSpec{
 		Justification: "top-level package GUAC heuristic connecting to each file/package",
 	}
@@ -395,32 +398,32 @@ var (
 		},
 	}
 
-	SpdxOccurences = []assembler.IsOccurenceIngest{
+	SpdxOccurences = []assembler.IsOccurrenceIngest{
 		{
-			Pkg:         worldFilePack,
-			Artifact:    worldFileArtifact,
-			IsOccurence: isOccJustifyFile,
+			Pkg:          worldFilePack,
+			Artifact:     worldFileArtifact,
+			IsOccurrence: isOccJustifyFile,
 		},
 		{
-			Pkg:         rootFilePack,
-			Artifact:    rootFileArtifact,
-			IsOccurence: isOccJustifyFile,
+			Pkg:          rootFilePack,
+			Artifact:     rootFileArtifact,
+			IsOccurrence: isOccJustifyFile,
 		},
 		{
-			Pkg:         rsaPubFilePack,
-			Artifact:    rsaPubFileArtifact,
-			IsOccurence: isOccJustifyFile,
+			Pkg:          rsaPubFilePack,
+			Artifact:     rsaPubFileArtifact,
+			IsOccurrence: isOccJustifyFile,
 		},
 		{
-			Pkg:         triggersFilePack,
-			Artifact:    triggersFileArtifact,
-			IsOccurence: isOccJustifyFile,
+			Pkg:          triggersFilePack,
+			Artifact:     triggersFileArtifact,
+			IsOccurrence: isOccJustifyFile,
 		},
 	}
 
 	SpdxIngestionPredicates = assembler.IngestPredicates{
 		IsDependency: SpdxDeps,
-		IsOccurence:  SpdxOccurences,
+		IsOccurrence: SpdxOccurences,
 	}
 
 	// CycloneDX Testdata
@@ -478,8 +481,43 @@ var (
 		},
 	}
 
+	CdxQuarkusOccurrence = []assembler.IsOccurrenceIngest{
+		{
+			Pkg: cdxTopQuarkusPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		}, {
+			Pkg: cdxResteasyPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "md5",
+				Digest:    "bf39044af8c6ba66fc3beb034bc82ae8",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxResteasyPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxReactiveCommonPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+	}
+
 	CdxQuarkusIngestionPredicates = assembler.IngestPredicates{
 		IsDependency: CdxQuarkusDeps,
+		IsOccurrence: CdxQuarkusOccurrence,
 	}
 
 	cdxWebAppPackage, _ = asmhelpers.PurlToPkg("pkg:npm/web-app@1.0.0")
@@ -1168,7 +1206,7 @@ func isDependencyLess(e1, e2 assembler.IsDependencyIngest) bool {
 	return gLess(e1, e2)
 }
 
-func isOccurenceLess(e1, e2 assembler.IsOccurenceIngest) bool {
+func isOccurenceLess(e1, e2 assembler.IsOccurrenceIngest) bool {
 	return gLess(e1, e2)
 }
 

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -149,7 +149,7 @@ func (g *Graph) AppendGraph(gs ...Graph) {
 type IngestPredicates struct {
 	CertifyScorecard []CertifyScorecardIngest
 	IsDependency     []IsDependencyIngest
-	IsOccurence      []IsOccurenceIngest
+	IsOccurrence     []IsOccurrenceIngest
 	HasSlsa          []HasSlsaIngest
 	CertifyVuln      []CertifyVulnIngest
 	IsVuln           []IsVulnIngest
@@ -167,15 +167,15 @@ type IsDependencyIngest struct {
 	IsDependency *generated.IsDependencyInputSpec
 }
 
-type IsOccurenceIngest struct {
-	// Occurence describes either pkg or src
+type IsOccurrenceIngest struct {
+	// Occurrence describes either pkg or src
 	Pkg *generated.PkgInputSpec
 	Src *generated.SourceInputSpec
 
 	// Artifact is the required object of the occurence
 	Artifact *generated.ArtifactInputSpec
 
-	IsOccurence *generated.IsOccurrenceInputSpec
+	IsOccurrence *generated.IsOccurrenceInputSpec
 }
 
 type HasSlsaIngest struct {
@@ -184,7 +184,7 @@ type HasSlsaIngest struct {
 	Materials []generated.ArtifactInputSpec
 	Builder   *generated.BuilderInputSpec
 
-	// Unpon more investigation, seems like SLSA should
+	// Upon more investigation, seems like SLSA should
 	// only be applied to an artifact and linkages to pkg
 	// or src should be done via IsOccurrence
 	// Pkg      *generated.PkgInputSpec

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -40,8 +40,8 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 				return err
 			}
 
-			logger.Infof("assembling IsOccurence: %v", len(p.IsOccurence))
-			if err := ingestIsOccurrence(ctx, gqlclient, p.IsOccurence); err != nil {
+			logger.Infof("assembling IsOccurence: %v", len(p.IsOccurrence))
+			if err := ingestIsOccurrence(ctx, gqlclient, p.IsOccurrence); err != nil {
 				return err
 			}
 
@@ -89,7 +89,7 @@ func ingestIsDependency(ctx context.Context, client graphql.Client, vs []assembl
 	return nil
 }
 
-func ingestIsOccurrence(ctx context.Context, client graphql.Client, vs []assembler.IsOccurenceIngest) error {
+func ingestIsOccurrence(ctx context.Context, client graphql.Client, vs []assembler.IsOccurrenceIngest) error {
 	for _, v := range vs {
 		if v.Pkg != nil && v.Src != nil {
 			return fmt.Errorf("unable to create IsOccurrence with both Src and Pkg subject specified")
@@ -100,12 +100,12 @@ func ingestIsOccurrence(ctx context.Context, client graphql.Client, vs []assembl
 		}
 
 		if v.Src != nil {
-			_, err := model.IsOccurrenceSrc(ctx, client, *v.Src, *v.Artifact, *v.IsOccurence)
+			_, err := model.IsOccurrenceSrc(ctx, client, *v.Src, *v.Artifact, *v.IsOccurrence)
 			if err != nil {
 				return err
 			}
 		} else {
-			_, err := model.IsOccurrencePkg(ctx, client, *v.Pkg, *v.Artifact, *v.IsOccurence)
+			_, err := model.IsOccurrencePkg(ctx, client, *v.Pkg, *v.Artifact, *v.IsOccurrence)
 			if err != nil {
 				return err
 			}

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -73,9 +73,9 @@ func addMetadata(predicates *assembler.IngestPredicates, foundIdentities []Trust
 		v.IsDependency.Origin = srcInfo.Source
 	}
 
-	for _, v := range predicates.IsOccurence {
-		v.IsOccurence.Collector = srcInfo.Collector
-		v.IsOccurence.Origin = srcInfo.Source
+	for _, v := range predicates.IsOccurrence {
+		v.IsOccurrence.Collector = srcInfo.Collector
+		v.IsOccurrence.Origin = srcInfo.Source
 	}
 
 	for _, v := range predicates.HasSlsa {

--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -22,13 +22,13 @@ import (
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 )
 
-func GetIsDep(foundNode model.PkgInputSpec, relatedPackNodes []model.PkgInputSpec, relatedFileNodes []model.PkgInputSpec, justification string) (*assembler.IsDependencyIngest, error) {
+func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputSpec, relatedFileNodes []*model.PkgInputSpec, justification string) (*assembler.IsDependencyIngest, error) {
 	if len(relatedFileNodes) > 0 {
 		for _, rfileNode := range relatedFileNodes {
 			// TODO: Check is this always just expected to be one?
 			return &assembler.IsDependencyIngest{
-				Pkg:    &foundNode,
-				DepPkg: &rfileNode,
+				Pkg:    foundNode,
+				DepPkg: rfileNode,
 				IsDependency: &model.IsDependencyInputSpec{
 					Justification: justification,
 				},
@@ -37,8 +37,8 @@ func GetIsDep(foundNode model.PkgInputSpec, relatedPackNodes []model.PkgInputSpe
 	} else if len(relatedPackNodes) > 0 {
 		for _, rpackNode := range relatedPackNodes {
 			return &assembler.IsDependencyIngest{
-				Pkg:    &foundNode,
-				DepPkg: &rpackNode,
+				Pkg:    foundNode,
+				DepPkg: rpackNode,
 				IsDependency: &model.IsDependencyInputSpec{
 					Justification: justification,
 				},
@@ -49,14 +49,14 @@ func GetIsDep(foundNode model.PkgInputSpec, relatedPackNodes []model.PkgInputSpe
 	return nil, nil
 }
 
-func CreateTopLevelIsDeps(toplevel model.PkgInputSpec, packages map[string][]model.PkgInputSpec, files map[string][]model.PkgInputSpec, justification string) []assembler.IsDependencyIngest {
+func CreateTopLevelIsDeps(toplevel *model.PkgInputSpec, packages map[string][]*model.PkgInputSpec, files map[string][]*model.PkgInputSpec, justification string) []assembler.IsDependencyIngest {
 	isDeps := []assembler.IsDependencyIngest{}
 	for _, packNodes := range packages {
 		for _, packNode := range packNodes {
 			if !reflect.DeepEqual(packNode, toplevel) {
 				p := assembler.IsDependencyIngest{
-					Pkg:    &toplevel,
-					DepPkg: &packNode,
+					Pkg:    toplevel,
+					DepPkg: packNode,
 					IsDependency: &model.IsDependencyInputSpec{
 						Justification: justification,
 					},
@@ -69,8 +69,8 @@ func CreateTopLevelIsDeps(toplevel model.PkgInputSpec, packages map[string][]mod
 	for _, fileNodes := range files {
 		for _, fileNode := range fileNodes {
 			p := assembler.IsDependencyIngest{
-				Pkg:    &toplevel,
-				DepPkg: &fileNode,
+				Pkg:    toplevel,
+				DepPkg: fileNode,
 				IsDependency: &model.IsDependencyInputSpec{
 					Justification: justification,
 				},

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -15,7 +15,6 @@
 
 package cyclonedx
 
-// TODO(bulldozer): freeze test
 import (
 	"context"
 	"testing"
@@ -231,7 +230,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 						Source:    "test",
 					},
 				},
-				packagePackages:   map[string][]model.PkgInputSpec{},
+				packagePackages:   map[string][]*model.PkgInputSpec{},
 				identifierStrings: &common.IdentifierStrings{},
 			}
 			c.cdxBom = tt.cdxBom
@@ -240,7 +239,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to parse purl %v", tt.wantPurl)
 			}
-			if d := cmp.Diff(*wantPackage, c.packagePackages[tt.cdxBom.Metadata.Component.BOMRef][0]); len(d) != 0 {
+			if d := cmp.Diff(*wantPackage, *c.packagePackages[tt.cdxBom.Metadata.Component.BOMRef][0]); len(d) != 0 {
 				t.Errorf("addRootPackage failed to produce expected package for %v", tt.name)
 			}
 		})

--- a/pkg/ingestor/parser/vuln/vuln.go
+++ b/pkg/ingestor/parser/vuln/vuln.go
@@ -49,7 +49,7 @@ type parser struct {
 	vulnData *generated.VulnerabilityMetaDataInput
 	vulns    []*generated.OSVInputSpec
 	isVulns  []assembler.IsVulnIngest
-	isOccs   []assembler.IsOccurenceIngest
+	isOccs   []assembler.IsOccurrenceIngest
 }
 
 // NewVulnCertificationParser initializes the parser
@@ -89,9 +89,9 @@ func parseVulnCertifyPredicate(p []byte) (*attestation_vuln.VulnerabilityStateme
 }
 
 func parseSubject(s *attestation_vuln.VulnerabilityStatement) ([]*generated.PkgInputSpec,
-	[]assembler.IsOccurenceIngest, error) {
+	[]assembler.IsOccurrenceIngest, error) {
 	var ps []*generated.PkgInputSpec
-	var ios []assembler.IsOccurenceIngest
+	var ios []assembler.IsOccurrenceIngest
 	for _, sub := range s.StatementHeader.Subject {
 		p, err := helpers.PurlToPkg(sub.Name)
 		if err != nil {
@@ -99,13 +99,13 @@ func parseSubject(s *attestation_vuln.VulnerabilityStatement) ([]*generated.PkgI
 		}
 		ps = append(ps, p)
 		for a, d := range sub.Digest {
-			io := assembler.IsOccurenceIngest{
+			io := assembler.IsOccurrenceIngest{
 				Pkg: p,
 				Artifact: &generated.ArtifactInputSpec{
 					Algorithm: a,
 					Digest:    d,
 				},
-				IsOccurence: &generated.IsOccurrenceInputSpec{
+				IsOccurrence: &generated.IsOccurrenceInputSpec{
 					Justification: "Package digest reported to vulnerability certifier",
 				},
 			}
@@ -156,8 +156,8 @@ func parseVulns(ctx context.Context, s *attestation_vuln.VulnerabilityStatement)
 
 func (c *parser) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
 	rv := &assembler.IngestPredicates{
-		IsVuln:      c.isVulns,
-		IsOccurence: c.isOccs,
+		IsVuln:       c.isVulns,
+		IsOccurrence: c.isOccs,
 	}
 	for _, p := range c.packages {
 		for _, v := range c.vulns {


### PR DESCRIPTION
1. Fix typo on "Occurrence"
2. update test data to add hash to top-level component
3. Update tests to check for `isOccurrence` output for CDX
4. Change to pass by reference as passing by values results in values getting replaced during appending.

For example: 
```
     		{
              			Pkg: &{Type: "maven", Namespace: &"io.quarkus", Name: "quarkus-resteasy-reactive", Version: &"2.13.4.Final", ...},
              			Src: nil,
              			Artifact: &generated.ArtifactInputSpec{
            - 				Algorithm: "md5",
            + 				Algorithm: "sha3-512",
              				Digest: strings.Join({
            + 					"615e56",
              					"b",
            - 					"f39044af8c6ba66fc3beb034bc82ae8",
            + 					"dfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114",
            + 					"280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69",
              				}, ""),
              			},
              			IsOccurrence: &{Justification: "cdx package with checksum"},
              		},
```
the value should be `md5` hash but get replaced by `sha3-512` (another valid hash in the slice).

closes https://github.com/guacsec/guac/issues/632