### PR TITLE
Add end to end test

### DIFF
--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -40,3 +40,14 @@ jobs:
         env:
             DEPS_DEV_APIKEY: ${{ secrets.DEPS_DEV_APIKEY }}
         run: make deps-dev-test
+  end-to-end:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '~1.19'
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: ./internal/testing/e2e/e2e

--- a/demo/GraphQL.md
+++ b/demo/GraphQL.md
@@ -611,13 +611,8 @@ cat demo/queries.gql | gql-cli http://localhost:8080/query -o OSVQ1 | jq
 {
   "osv": [
     {
-      "id": "131389",
-      "osvIds": [
-        {
-          "id": "131683",
-          "osvId": "ghsa-jfh8-c2jp-5v3q"
-        }
-      ]
+      "id": "131666",
+      "osvId": "ghsa-jfh8-c2jp-5v3q"
     }
   ]
 }
@@ -673,13 +668,8 @@ cat demo/queries.gql | gql-cli http://localhost:8080/query -o CertifyVulnQ1 | jq
       },
       "vulnerability": {
         "__typename": "OSV",
-        "id": "131389",
-        "osvIds": [
-          {
-            "id": "131683",
-            "osvId": "ghsa-jfh8-c2jp-5v3q"
-          }
-        ]
+        "id": "131666",
+        "osvId": "ghsa-jfh8-c2jp-5v3q"
       },
       "metadata": {
         "dbUri": "",

--- a/demo/path.py
+++ b/demo/path.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 #
 # Copyright 2023 The GUAC Authors.

--- a/demo/queries.gql
+++ b/demo/queries.gql
@@ -41,7 +41,6 @@ query PkgQ3 {
   }
 }
 
-
 query PkgQ4 {
   packages(pkgSpec: { type: "oci", namespace: "docker.io/library", name: "consul" }) {
     ...allPkgTree
@@ -138,28 +137,18 @@ query GetNeighbors ($nodeId: ID!) {
 fragment allCveTree on CVE {
   id
   year
-  cveIds {
-    id
-    cveId
-  }
+  cveId
 }
 
 fragment allGHSATree on GHSA {
   id
-  ghsaIds {
-    id
-    ghsaId
-  }
+  ghsaId
 }
 
 fragment allOSVTree on OSV {
   id
-  osvIds {
-    id
-    osvId
-  }
+  osvId
 }
-
 
 fragment allCertifyVulnTree on CertifyVuln {
   id
@@ -200,7 +189,6 @@ query CertifyVulnQ1 {
     ...allCertifyVulnTree
   }
 }
-
 
 query PkgQ7 {
   packages(pkgSpec: { type: "oci", name: "python" }) {

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+#
+# Copyright 2023 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euf -o pipefail
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+GUAC_DIR=$(cd ${SCRIPT_DIR}/../../..; pwd)
+
+guac_data_hash="254d737ebc42ca32f95033e93370f5427e3fce64"
+
+echo @@@@ Installing gql Python package
+pip install gql[all]
+
+echo @@@@ Cloning guac-data
+pushd "$GUAC_DIR"
+git clone https://github.com/guacsec/guac-data.git
+pushd guac-data
+git checkout $guac_data_hash
+popd
+popd
+
+echo @@@@ Starting up graphql_playground server in background
+go run "${GUAC_DIR}/cmd/graphql_playground" &
+
+echo @@@@ Ingesting guac-data into server
+go run "${GUAC_DIR}/cmd/guacone" files "${GUAC_DIR}/guac-data/docs/"
+
+echo @@@@ Running certifiers
+go run "${GUAC_DIR}/cmd/guacone" certifier
+
+queries="${GUAC_DIR}/demo/queries.gql"
+
+echo @@@@ Running queries and validating output
+
+cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ1 | jq ' .packages |= sort ' > "${GUAC_DIR}/gotPkgQ1.json"
+diff -u "${SCRIPT_DIR}/expectPkgQ1.json" "${GUAC_DIR}/gotPkgQ1.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ2 | jq ' .packages[].namespaces |= sort ' > "${GUAC_DIR}/gotPkgQ2.json"
+diff -u "${SCRIPT_DIR}/expectPkgQ2.json" "${GUAC_DIR}/gotPkgQ2.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ3 | jq ' del(.. | .id?) | .packages[].namespaces |= sort_by(.namespace) | .packages[].namespaces[].names[].versions |= sort_by(.version) | .packages[].namespaces[].names[].versions[].qualifiers |= sort_by(.key) ' > "${GUAC_DIR}/gotPkgQ3.json"
+diff -u "${SCRIPT_DIR}/expectPkgQ3.json" "${GUAC_DIR}/gotPkgQ3.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ4 | jq ' del(.. | .id?) '> "${GUAC_DIR}/gotPkgQ4.json"
+diff -u "${SCRIPT_DIR}/expectPkgQ4.json" "${GUAC_DIR}/gotPkgQ4.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o IsDependencyQ1 | jq ' .IsDependency |= sort ' > "${GUAC_DIR}/gotIsDependencyQ1.json"
+diff -u "${SCRIPT_DIR}/expectIsDependencyQ1.json" "${GUAC_DIR}/gotIsDependencyQ1.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o IsDependencyQ2 | jq 'del(.. | .id?) | del(.. | .origin?)' > "${GUAC_DIR}/gotIsDependencyQ2.json"
+diff -u "${SCRIPT_DIR}/expectIsDependencyQ2.json" "${GUAC_DIR}/gotIsDependencyQ2.json"
+
+id1=$(cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ5 | jq -r ' .packages[0].namespaces[0].names[0].id ')
+id2=$(cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ6 | jq -r ' .packages[0].namespaces[0].names[0].id ')
+
+cat "$queries" | gql-cli http://localhost:8080/query -o PathQ1 -V subject:${id1} target:${id2} | jq 'del(.. | .id?) | del(.. | .origin?)' > "${GUAC_DIR}/gotPathQ1.json"
+diff -u "${SCRIPT_DIR}/expectPathQ1.json" "${GUAC_DIR}/gotPathQ1.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o OSVQ1 | jq 'del(.. | .id?)' > "${GUAC_DIR}/gotOSVQ1.json"
+diff -u "${SCRIPT_DIR}/expectOSVQ1.json" "${GUAC_DIR}/gotOSVQ1.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o CertifyVulnQ1 | jq 'del(.. | .id?) | del(.. | .timeScanned?)' > "${GUAC_DIR}/gotCertifyVulnQ1.json"
+diff -u "${SCRIPT_DIR}/expectCertifyVulnQ1.json" "${GUAC_DIR}/gotCertifyVulnQ1.json"
+
+id3=$(cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ7 | jq -r ' .packages[0].namespaces[0].names[0].id ')
+id4=$(cat "$queries" | gql-cli http://localhost:8080/query -o PkgQ8 | jq -r ' .packages[0].namespaces[0].names[0].id ')
+
+"${GUAC_DIR}/demo/path.py" $id3 $id4 | tail -n +2 | jq 'del(.. | .id?) | del(.. | .origin?)' > "${GUAC_DIR}/gotPathPy.json"
+diff -u "${SCRIPT_DIR}/expectPathPy.json" "${GUAC_DIR}/gotPathPy.json"
+
+# Note: graphql_playground is left running, CI will clean it up

--- a/internal/testing/e2e/expectCertifyVulnQ1.json
+++ b/internal/testing/e2e/expectCertifyVulnQ1.json
@@ -1,0 +1,38 @@
+{
+  "CertifyVuln": [
+    {
+      "package": {
+        "type": "maven",
+        "namespaces": [
+          {
+            "namespace": "org.apache.logging.log4j",
+            "names": [
+              {
+                "name": "log4j-core",
+                "versions": [
+                  {
+                    "version": "2.8.1",
+                    "qualifiers": [],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "vulnerability": {
+        "__typename": "OSV",
+        "osvId": "ghsa-jfh8-c2jp-5v3q"
+      },
+      "metadata": {
+        "dbUri": "",
+        "dbVersion": "",
+        "scannerUri": "osv.dev",
+        "scannerVersion": "0.0.14",
+        "origin": "guac",
+        "collector": "guac"
+      }
+    }
+  ]
+}

--- a/internal/testing/e2e/expectIsDependencyQ1.json
+++ b/internal/testing/e2e/expectIsDependencyQ1.json
@@ -1,0 +1,2869 @@
+{
+  "IsDependency": [
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest",
+            "names": [
+              {
+                "name": "adal"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/denverdino",
+            "names": [
+              {
+                "name": "aliyungo"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "alpine-baselayout"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "alpine-keys"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/consul",
+            "names": [
+              {
+                "name": "api"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/vault",
+            "names": [
+              {
+                "name": "api"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "google.golang.org",
+            "names": [
+              {
+                "name": "api"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "k8s.io",
+            "names": [
+              {
+                "name": "api"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "k8s.io",
+            "names": [
+              {
+                "name": "apimachinery"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "apk-tools"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest/azure",
+            "names": [
+              {
+                "name": "auth"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest",
+            "names": [
+              {
+                "name": "autorest"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/aws",
+            "names": [
+              {
+                "name": "aws-sdk-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure",
+            "names": [
+              {
+                "name": "azure-sdk-for-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "go.etcd.io",
+            "names": [
+              {
+                "name": "bbolt"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/boltdb",
+            "names": [
+              {
+                "name": "bolt"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "brotli-libs"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/google",
+            "names": [
+              {
+                "name": "btree"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "busybox"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "ca-certificates"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "ca-certificates-bundle"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/pquerna",
+            "names": [
+              {
+                "name": "cachecontrol"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/armon",
+            "names": [
+              {
+                "name": "circbuf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/circonus-labs",
+            "names": [
+              {
+                "name": "circonus-gometrics"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/circonus-labs",
+            "names": [
+              {
+                "name": "circonusllhist"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest/azure",
+            "names": [
+              {
+                "name": "cli"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "cli"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "k8s.io",
+            "names": [
+              {
+                "name": "client-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/prometheus",
+            "names": [
+              {
+                "name": "client_golang"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/prometheus",
+            "names": [
+              {
+                "name": "client_model"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/fatih",
+            "names": [
+              {
+                "name": "color"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/ryanuber",
+            "names": [
+              {
+                "name": "columnize"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/prometheus",
+            "names": [
+              {
+                "name": "common"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/posener",
+            "names": [
+              {
+                "name": "complete"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/modern-go",
+            "names": [
+              {
+                "name": "concurrent"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "consul"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "consul-awsauth"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "consul-net-rpc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "copystructure"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/coredns",
+            "names": [
+              {
+                "name": "coredns"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "crypto"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "curl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/datadog",
+            "names": [
+              {
+                "name": "datadog-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest",
+            "names": [
+              {
+                "name": "date"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/miekg",
+            "names": [
+              {
+                "name": "dns"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "dumb-init"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/pkg",
+            "names": [
+              {
+                "name": "errors"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "errwrap"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/fsnotify",
+            "names": [
+              {
+                "name": "fsnotify"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "google.golang.org",
+            "names": [
+              {
+                "name": "genproto"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/googleapis",
+            "names": [
+              {
+                "name": "gnostic"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "cloud.google.com",
+            "names": [
+              {
+                "name": "go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/cncf/xds",
+            "names": [
+              {
+                "name": "go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/json-iterator",
+            "names": [
+              {
+                "name": "go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-bexpr"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/patrickmn",
+            "names": [
+              {
+                "name": "go-cache"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-checkpoint"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-cleanhttp"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mattn",
+            "names": [
+              {
+                "name": "go-colorable"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/docker",
+            "names": [
+              {
+                "name": "go-connections"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-connlimit"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/envoyproxy",
+            "names": [
+              {
+                "name": "go-control-plane"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/pmezard",
+            "names": [
+              {
+                "name": "go-difflib"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-discover"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/ryanuber",
+            "names": [
+              {
+                "name": "go-glob"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/grpc-ecosystem",
+            "names": [
+              {
+                "name": "go-grpc-middleware"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-hclog"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "go-homedir"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-immutable-radix"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mattn",
+            "names": [
+              {
+                "name": "go-isatty"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/jmespath",
+            "names": [
+              {
+                "name": "go-jmespath"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "gopkg.in/square",
+            "names": [
+              {
+                "name": "go-jose.v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-memdb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/armon",
+            "names": [
+              {
+                "name": "go-metrics"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-msgpack"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-multierror"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/coreos",
+            "names": [
+              {
+                "name": "go-oidc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/google",
+            "names": [
+              {
+                "name": "go-querystring"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/armon",
+            "names": [
+              {
+                "name": "go-radix"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-raftchunking"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-retryablehttp"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-rootcerts"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-sockaddr"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/davecgh",
+            "names": [
+              {
+                "name": "go-spew"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/tklauser",
+            "names": [
+              {
+                "name": "go-sysconf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-syslog"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "go-testing-interface"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-uuid"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "go-version"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "go.opencensus.io"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/digitalocean",
+            "names": [
+              {
+                "name": "godo"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/google",
+            "names": [
+              {
+                "name": "gofuzz"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "golang-lru"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/matttproud",
+            "names": [
+              {
+                "name": "golang_protobuf_extensions"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/gophercloud",
+            "names": [
+              {
+                "name": "gophercloud"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/vmware",
+            "names": [
+              {
+                "name": "govmomi"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/golang",
+            "names": [
+              {
+                "name": "groupcache"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "google.golang.org",
+            "names": [
+              {
+                "name": "grpc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/nytimes",
+            "names": [
+              {
+                "name": "gziphandler"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "hashstructure"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "hcl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "hil"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/tv42",
+            "names": [
+              {
+                "name": "httpunix"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "gopkg.in",
+            "names": [
+              {
+                "name": "inf.v0"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "iptables"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "iputils"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "jq"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/form3tech-oss",
+            "names": [
+              {
+                "name": "jwt-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "k8s.io",
+            "names": [
+              {
+                "name": "klog"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libc-utils"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libc6-compat"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libcap"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libcrypto1.1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libcurl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libmnl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libnftnl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libretls"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "libssl1.1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/linode",
+            "names": [
+              {
+                "name": "linodego"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest",
+            "names": [
+              {
+                "name": "logger"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/sirupsen",
+            "names": [
+              {
+                "name": "logrus"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/pierrec",
+            "names": [
+              {
+                "name": "lz4"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "mapstructure"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "mdns"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "memberlist"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/imdario",
+            "names": [
+              {
+                "name": "mergo"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "musl"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "musl-utils"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "net"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "nghttp2-libs"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/tklauser",
+            "names": [
+              {
+                "name": "numcpus"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "oauth2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/stretchr",
+            "names": [
+              {
+                "name": "objx"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "oniguruma"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/census-instrumentation",
+            "names": [
+              {
+                "name": "opencensus-proto"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "go.opentelemetry.io/proto",
+            "names": [
+              {
+                "name": "otlp"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/packethost",
+            "names": [
+              {
+                "name": "packngo"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/beorn7",
+            "names": [
+              {
+                "name": "perks"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/spf13",
+            "names": [
+              {
+                "name": "pflag"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "pointerstructure"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/prometheus",
+            "names": [
+              {
+                "name": "procfs"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/consul",
+            "names": [
+              {
+                "name": "proto-public"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/gogo",
+            "names": [
+              {
+                "name": "protobuf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/golang",
+            "names": [
+              {
+                "name": "protobuf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "google.golang.org",
+            "names": [
+              {
+                "name": "protobuf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/envoyproxy",
+            "names": [
+              {
+                "name": "protoc-gen-validate"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "raft"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "raft-autopilot"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/modern-go",
+            "names": [
+              {
+                "name": "reflect2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh",
+            "names": [
+              {
+                "name": "reflectwalk"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "gopkg.in",
+            "names": [
+              {
+                "name": "resty.v1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/rboyer",
+            "names": [
+              {
+                "name": "safeio"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/nicolai86",
+            "names": [
+              {
+                "name": "scaleway-sdk"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "scanelf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/consul",
+            "names": [
+              {
+                "name": "sdk"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/vault",
+            "names": [
+              {
+                "name": "sdk"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/sean-",
+            "names": [
+              {
+                "name": "seed"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "serf"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/golang",
+            "names": [
+              {
+                "name": "snappy"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/softlayer",
+            "names": [
+              {
+                "name": "softlayer-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/bgentry",
+            "names": [
+              {
+                "name": "speakeasy"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "ssl_client"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "su-exec"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "sync"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "sys"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/tencentcloud",
+            "names": [
+              {
+                "name": "tencentcloud-sdk-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "term"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/stretchr",
+            "names": [
+              {
+                "name": "testify"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/kr",
+            "names": [
+              {
+                "name": "text"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "text"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "golang.org/x",
+            "names": [
+              {
+                "name": "time"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest",
+            "names": [
+              {
+                "name": "to"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest",
+            "names": [
+              {
+                "name": "tracing"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/joyent",
+            "names": [
+              {
+                "name": "triton-go"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "tzdata"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/dimchansky",
+            "names": [
+              {
+                "name": "utfbom"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "k8s.io",
+            "names": [
+              {
+                "name": "utils"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/cespare/xxhash",
+            "names": [
+              {
+                "name": "v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/googleapis/gax-go",
+            "names": [
+              {
+                "name": "v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp/raft-boltdb",
+            "names": [
+              {
+                "name": "v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/mitchellh/hashstructure",
+            "names": [
+              {
+                "name": "v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/shirou/gopsutil",
+            "names": [
+              {
+                "name": "v3"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "sigs.k8s.io/structured-merge-diff",
+            "names": [
+              {
+                "name": "v3"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/azure/go-autorest/autorest",
+            "names": [
+              {
+                "name": "validation"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "vic"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/renier",
+            "names": [
+              {
+                "name": "xmlrpc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "sigs.k8s.io",
+            "names": [
+              {
+                "name": "yaml"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "gopkg.in",
+            "names": [
+              {
+                "name": "yaml.v2"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "gopkg.in",
+            "names": [
+              {
+                "name": "yaml.v3"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/hashicorp",
+            "names": [
+              {
+                "name": "yamux"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "dependentPackage": {
+        "type": "alpine",
+        "namespaces": [
+          {
+            "namespace": "",
+            "names": [
+              {
+                "name": "zlib"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/testing/e2e/expectIsDependencyQ2.json
+++ b/internal/testing/e2e/expectIsDependencyQ2.json
@@ -1,0 +1,48 @@
+{
+  "IsDependency": [
+    {
+      "justification": "top-level package GUAC heuristic connecting to each file/package",
+      "versionRange": "",
+      "package": {
+        "type": "oci",
+        "namespaces": [
+          {
+            "namespace": "docker.io/library",
+            "names": [
+              {
+                "name": "consul",
+                "versions": [
+                  {
+                    "version": "sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c",
+                    "qualifiers": [
+                      {
+                        "key": "tag",
+                        "value": "latest"
+                      }
+                    ],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "github.com/sirupsen",
+            "names": [
+              {
+                "name": "logrus",
+                "versions": []
+              }
+            ]
+          }
+        ]
+      },
+      "collector": "FileCollector"
+    }
+  ]
+}

--- a/internal/testing/e2e/expectOSVQ1.json
+++ b/internal/testing/e2e/expectOSVQ1.json
@@ -1,0 +1,7 @@
+{
+  "osv": [
+    {
+      "osvId": "ghsa-jfh8-c2jp-5v3q"
+    }
+  ]
+}

--- a/internal/testing/e2e/expectPathPy.json
+++ b/internal/testing/e2e/expectPathPy.json
@@ -1,0 +1,88 @@
+[
+  {
+    "__typename": "Package",
+    "type": "oci",
+    "namespaces": [
+      {
+        "namespace": "docker.io/librar",
+        "names": [
+          {
+            "name": "python",
+            "versions": [
+              {
+                "version": "sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d",
+                "qualifiers": [
+                  {
+                    "key": "tag",
+                    "value": "latest"
+                  }
+                ],
+                "subpath": ""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "__typename": "IsDependency",
+    "justification": "top-level package GUAC heuristic connecting to each file/package",
+    "versionRange": "",
+    "package": {
+      "type": "oci",
+      "namespaces": [
+        {
+          "namespace": "docker.io/librar",
+          "names": [
+            {
+              "name": "python",
+              "versions": [
+                {
+                  "version": "sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d",
+                  "qualifiers": [
+                    {
+                      "key": "tag",
+                      "value": "latest"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "dependentPackage": {
+      "type": "deb",
+      "namespaces": [
+        {
+          "namespace": "debian",
+          "names": [
+            {
+              "name": "libsqlite3-dev",
+              "versions": []
+            }
+          ]
+        }
+      ]
+    },
+    "collector": "FileCollector"
+  },
+  {
+    "__typename": "Package",
+    "type": "deb",
+    "namespaces": [
+      {
+        "namespace": "debian",
+        "names": [
+          {
+            "name": "libsqlite3-dev",
+            "versions": []
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/internal/testing/e2e/expectPathQ1.json
+++ b/internal/testing/e2e/expectPathQ1.json
@@ -1,0 +1,150 @@
+{
+  "path": [
+    {
+      "__typename": "Package",
+      "type": "golang",
+      "namespaces": [
+        {
+          "namespace": "go.etcd.io/etcd/client",
+          "names": [
+            {
+              "name": "v2",
+              "versions": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "__typename": "IsDependency",
+      "justification": "top-level package GUAC heuristic connecting to each file/package",
+      "versionRange": "",
+      "package": {
+        "type": "oci",
+        "namespaces": [
+          {
+            "namespace": "docker.io/library",
+            "names": [
+              {
+                "name": "vault",
+                "versions": [
+                  {
+                    "version": "sha256:d9fdd0e93cdd325b144aed2c68d53999875c907c5a37b2d1a9456c8a45886158",
+                    "qualifiers": [
+                      {
+                        "key": "tag",
+                        "value": "latest"
+                      }
+                    ],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "go.etcd.io/etcd/client",
+            "names": [
+              {
+                "name": "v2",
+                "versions": []
+              }
+            ]
+          }
+        ]
+      },
+      "collector": "FileCollector"
+    },
+    {
+      "__typename": "Package",
+      "type": "oci",
+      "namespaces": [
+        {
+          "namespace": "docker.io/library",
+          "names": [
+            {
+              "name": "vault",
+              "versions": [
+                {
+                  "version": "sha256:d9fdd0e93cdd325b144aed2c68d53999875c907c5a37b2d1a9456c8a45886158",
+                  "qualifiers": [
+                    {
+                      "key": "tag",
+                      "value": "latest"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "__typename": "IsDependency",
+      "justification": "top-level package GUAC heuristic connecting to each file/package",
+      "versionRange": "",
+      "package": {
+        "type": "oci",
+        "namespaces": [
+          {
+            "namespace": "docker.io/library",
+            "names": [
+              {
+                "name": "vault",
+                "versions": [
+                  {
+                    "version": "sha256:d9fdd0e93cdd325b144aed2c68d53999875c907c5a37b2d1a9456c8a45886158",
+                    "qualifiers": [
+                      {
+                        "key": "tag",
+                        "value": "latest"
+                      }
+                    ],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "dependentPackage": {
+        "type": "golang",
+        "namespaces": [
+          {
+            "namespace": "go.etcd.io/etcd/api",
+            "names": [
+              {
+                "name": "v3",
+                "versions": []
+              }
+            ]
+          }
+        ]
+      },
+      "collector": "FileCollector"
+    },
+    {
+      "__typename": "Package",
+      "type": "golang",
+      "namespaces": [
+        {
+          "namespace": "go.etcd.io/etcd/api",
+          "names": [
+            {
+              "name": "v3",
+              "versions": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testing/e2e/expectPkgQ1.json
+++ b/internal/testing/e2e/expectPkgQ1.json
@@ -1,0 +1,25 @@
+{
+  "packages": [
+    {
+      "type": "alpine"
+    },
+    {
+      "type": "deb"
+    },
+    {
+      "type": "golang"
+    },
+    {
+      "type": "guac"
+    },
+    {
+      "type": "maven"
+    },
+    {
+      "type": "oci"
+    },
+    {
+      "type": "pypi"
+    }
+  ]
+}

--- a/internal/testing/e2e/expectPkgQ2.json
+++ b/internal/testing/e2e/expectPkgQ2.json
@@ -1,0 +1,18 @@
+{
+  "packages": [
+    {
+      "type": "oci",
+      "namespaces": [
+        {
+          "namespace": "docker.io/lib"
+        },
+        {
+          "namespace": "docker.io/librar"
+        },
+        {
+          "namespace": "docker.io/library"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testing/e2e/expectPkgQ3.json
+++ b/internal/testing/e2e/expectPkgQ3.json
@@ -1,0 +1,101 @@
+{
+  "packages": [
+    {
+      "type": "deb",
+      "namespaces": [
+        {
+          "namespace": "debian",
+          "names": [
+            {
+              "name": "libp11-kit0",
+              "versions": [
+                {
+                  "version": "0.23.22-1",
+                  "qualifiers": [
+                    {
+                      "key": "arch",
+                      "value": "amd64"
+                    },
+                    {
+                      "key": "distro",
+                      "value": "debian-11"
+                    },
+                    {
+                      "key": "upstream",
+                      "value": "p11-kit"
+                    }
+                  ],
+                  "subpath": ""
+                },
+                {
+                  "version": "0.23.22-1",
+                  "qualifiers": [
+                    {
+                      "key": "arch",
+                      "value": "arm64"
+                    },
+                    {
+                      "key": "distro",
+                      "value": "debian-11"
+                    },
+                    {
+                      "key": "upstream",
+                      "value": "p11-kit"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "namespace": "ubuntu",
+          "names": [
+            {
+              "name": "libp11-kit0",
+              "versions": [
+                {
+                  "version": "0.23.20-1ubuntu0.1",
+                  "qualifiers": [
+                    {
+                      "key": "arch",
+                      "value": "amd64"
+                    },
+                    {
+                      "key": "distro",
+                      "value": "ubuntu-20.04"
+                    },
+                    {
+                      "key": "upstream",
+                      "value": "p11-kit"
+                    }
+                  ],
+                  "subpath": ""
+                },
+                {
+                  "version": "0.24.0-6build1",
+                  "qualifiers": [
+                    {
+                      "key": "arch",
+                      "value": "amd64"
+                    },
+                    {
+                      "key": "distro",
+                      "value": "ubuntu-22.04"
+                    },
+                    {
+                      "key": "upstream",
+                      "value": "p11-kit"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testing/e2e/expectPkgQ4.json
+++ b/internal/testing/e2e/expectPkgQ4.json
@@ -1,0 +1,29 @@
+{
+  "packages": [
+    {
+      "type": "oci",
+      "namespaces": [
+        {
+          "namespace": "docker.io/library",
+          "names": [
+            {
+              "name": "consul",
+              "versions": [
+                {
+                  "version": "sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c",
+                  "qualifiers": [
+                    {
+                      "key": "tag",
+                      "value": "latest"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds test to postmerge GHA workflow. Test sets up graphql_playground, ingests all of guac-data, then runs the certifiers. Next, all the queries from demo/queries.gql are run and compared against expected output.