### PR TITLE
Add markdown format check to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,8 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check format
         run: make fmt
+      - name: Check markdown format
+        run: make format
       - name: Check that all generated code is up to date
         run: make generated_up_to_date
   lint:


### PR DESCRIPTION
Maybe `make format` should be a part of `make fmt` or vice versa.