### PR TITLE
Update linter config. Add type assertion check.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,15 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check format
         run: make fmt
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.2.0
       - name: Check that all generated code is up to date
         run: make generated_up_to_date
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag=v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.2.0
+        with:
+          only-new-issues: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 2m
+  timeout: 3m
   skip-files:
     - ".*\\.pb\\.go$"
     - "pkg/assembler/generated/.*"
@@ -7,7 +7,4 @@ run:
 linters:
   enable:
     - wrapcheck
-issues:
-  # Exclude previously existing issues from the report
-  new: true
-  new-from-rev: HEAD
+    - forcetypeassert


### PR DESCRIPTION
Move to it's own job, I think this was causing caching issues. Remove unecessary exclusion filters, these are unintuitive. Use setting on GHA 'only-new-issues' which is for the PR case.