### PR TITLE
change certifier name to osv and add polling and interval to cli

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -67,6 +67,10 @@ type options struct {
 	subject       string
 	// if type is package, true if attestation is at pkgName (for all versions) or false for a specific version
 	pkgName bool
+
+	// osv/scorecard certifier
+	poll     bool
+	interval int
 }
 
 var exampleCmd = &cobra.Command{

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -125,8 +125,6 @@ var osvCmd = &cobra.Command{
 			logger.Errorf("certifier ended with error: %v", err)
 			return false
 		}
-		fmt.Print(opts.interval)
-		fmt.Print(opts.poll)
 
 		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler, opts.poll, time.Minute*time.Duration(opts.interval)); err != nil {
 			logger.Fatal(err)

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -33,19 +33,21 @@ import (
 	"github.com/spf13/viper"
 )
 
-var certifierCmd = &cobra.Command{
-	Use:   "certifier",
-	Short: "certifies packages in GUAC graph, this command talks directly to the graphQL endpoint",
+var osvCmd = &cobra.Command{
+	Use:   "osv [flags]",
+	Short: "runs the osv certifier",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
 
-		opts, err := validateCertifierFlags(
+		opts, err := validateOSVFlags(
 			viper.GetString("gdbuser"),
 			viper.GetString("gdbpass"),
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
 			viper.GetString("gql-endpoint"),
+			viper.GetBool("poll"),
+			viper.GetInt("interval"),
 		)
 
 		if err != nil {
@@ -123,8 +125,10 @@ var certifierCmd = &cobra.Command{
 			logger.Errorf("certifier ended with error: %v", err)
 			return false
 		}
+		fmt.Print(opts.interval)
+		fmt.Print(opts.poll)
 
-		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler, time.Minute*5); err != nil {
+		if err := certify.Certify(ctx, packageQueryFunc(), emit, errHandler, opts.poll, time.Minute*time.Duration(opts.interval)); err != nil {
 			logger.Fatal(err)
 		}
 		if gotErr {
@@ -135,13 +139,15 @@ var certifierCmd = &cobra.Command{
 	},
 }
 
-func validateCertifierFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint string) (options, error) {
+func validateOSVFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint string, poll bool, interval int) (options, error) {
 	var opts options
 	opts.user = user
 	opts.pass = pass
 	opts.dbAddr = dbAddr
 	opts.realm = realm
 	opts.graphqlEndpoint = graphqlEndpoint
+	opts.poll = poll
+	opts.interval = interval
 
 	return opts, nil
 }
@@ -154,5 +160,5 @@ func getPackageQuery(client graphql.Client) (func() certifier.QueryComponents, e
 }
 
 func init() {
-	rootCmd.AddCommand(certifierCmd)
+	rootCmd.AddCommand(osvCmd)
 }

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -47,6 +47,10 @@ var flags = struct {
 
 	// graphQL client flags
 	graphqlEndpoint string
+
+	// run as poll certifier
+	poll     bool
+	interval int
 }{}
 
 var cfgFile string
@@ -73,10 +77,15 @@ func init() {
 	// graphql client flags
 	persistentFlags.StringVar(&flags.graphqlEndpoint, "gql-endpoint", "http://localhost:8080/query", "endpoint used to connect to graphQL server")
 
+	// certifier flags
+	persistentFlags.BoolVarP(&flags.poll, "poll", "p", true, "sets the certifier to polling mode")
+	persistentFlags.IntVarP(&flags.interval, "interval", "i", 5, "if polling set interval in minutes")
+
 	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm",
 		"verifier-keyPath", "verifier-keyID",
 		"csub-addr", "csub-listen-port",
 		"gql-backend", "gql-port", "gql-debug", "gql-endpoint",
+		"poll", "interval",
 	}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -36,8 +36,8 @@ import (
 )
 
 var scorecardCmd = &cobra.Command{
-	Use:   "scorecard",
-	Short: "Gets scorecard data from GUAC graph",
+	Use:   "scorecard [flags]",
+	Short: "runs the scorecard certifier",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
@@ -48,6 +48,8 @@ var scorecardCmd = &cobra.Command{
 			viper.GetString("gdbaddr"),
 			viper.GetString("realm"),
 			viper.GetString("gql-endpoint"),
+			viper.GetBool("poll"),
+			viper.GetInt("interval"),
 		)
 
 		if err != nil {
@@ -149,7 +151,7 @@ var scorecardCmd = &cobra.Command{
 			return false
 		}
 
-		if err := certify.Certify(ctx, query, emit, errHandler, time.Minute*5); err != nil {
+		if err := certify.Certify(ctx, query, emit, errHandler, opts.poll, time.Minute*time.Duration(opts.interval)); err != nil {
 			logger.Fatal(err)
 		}
 		if gotErr {
@@ -160,13 +162,15 @@ var scorecardCmd = &cobra.Command{
 	},
 }
 
-func validateScorecardFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint string) (options, error) {
+func validateScorecardFlags(user string, pass string, dbAddr string, realm string, graphqlEndpoint string, poll bool, interval int) (options, error) {
 	var opts options
 	opts.user = user
 	opts.pass = pass
 	opts.dbAddr = dbAddr
 	opts.realm = realm
 	opts.graphqlEndpoint = graphqlEndpoint
+	opts.poll = poll
+	opts.interval = interval
 
 	return opts, nil
 }

--- a/cmd/pubsub_test/cmd/files.go
+++ b/cmd/pubsub_test/cmd/files.go
@@ -47,6 +47,10 @@ type options struct {
 	path string
 	// nats
 	natsAddr string
+
+	// osv/scorecard certifier
+	poll     bool
+	interval int
 }
 
 var filesCmd = &cobra.Command{

--- a/cmd/pubsub_test/cmd/root.go
+++ b/cmd/pubsub_test/cmd/root.go
@@ -37,6 +37,10 @@ var flags = struct {
 
 	// nats
 	natsAddr string
+
+	// run as poll certifier
+	poll     bool
+	interval int
 }{}
 
 func init() {
@@ -47,7 +51,11 @@ func init() {
 	persistentFlags.StringVar(&flags.gdbpass, "gdbpass", "", "neo4j password credential to connect to graph db")
 	persistentFlags.StringVar(&flags.realm, "realm", "neo4j", "realm to connect to graph db")
 	persistentFlags.StringVar(&flags.natsAddr, "natsaddr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
-	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "natsaddr"}
+	// certifier flags
+	persistentFlags.BoolVarP(&flags.poll, "poll", "p", true, "sets the certifier to polling mode")
+	persistentFlags.IntVarP(&flags.interval, "interval", "i", 5, "if polling set interval in minutes")
+
+	flagNames := []string{"gdbaddr", "gdbuser", "gdbpass", "realm", "natsaddr", "poll", "interval"}
 	for _, name := range flagNames {
 		if flag := persistentFlags.Lookup(name); flag != nil {
 			if err := viper.BindPFlag(name, flag); err != nil {

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -39,8 +39,8 @@ go run "${GUAC_DIR}/cmd/graphql_playground" &
 echo @@@@ Ingesting guac-data into server
 go run "${GUAC_DIR}/cmd/guacone" files "${GUAC_DIR}/guac-data/docs/"
 
-echo @@@@ Running certifiers
-go run "${GUAC_DIR}/cmd/guacone" certifier
+echo @@@@ Running osv certifier
+go run "${GUAC_DIR}/cmd/guacone" osv -p=false
 
 queries="${GUAC_DIR}/demo/queries.gql"
 

--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -37,7 +37,7 @@ func PurlToPkg(purlUri string) (*model.PkgInputSpec, error) {
 }
 
 func PkgToPurl(purlType, namespace, name, version, subpath string, qualifiersList []string) string {
-	collectedQualifiers := []purl.Qualifier{}
+	collectedQualifiers := purl.Qualifiers{}
 	for i := range qualifiersList {
 		if i%2 == 0 {
 			qualifier := purl.Qualifier{
@@ -47,6 +47,14 @@ func PkgToPurl(purlType, namespace, name, version, subpath string, qualifiersLis
 			collectedQualifiers = append(collectedQualifiers, qualifier)
 		}
 	}
+
+	if purlType == purl.TypeOCI || purlType == purl.TypeDocker {
+		if namespace != "" {
+			collectedQualifiers = append(collectedQualifiers, purl.Qualifier{Key: "repository_url", Value: namespace})
+			namespace = ""
+		}
+	}
+
 	pkg := purl.NewPackageURL(purlType, namespace, name, version, collectedQualifiers, subpath)
 	return pkg.ToString()
 }

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -88,6 +88,12 @@ func TestPurlConvert(t *testing.T) {
 			purlUri:  "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io",
 			expected: pkg("docker", "gcr.io/customer", "dockerimage", "sha256:244fd47e07d10", "", map[string]string{}),
 		}, {
+			purlUri:  "pkg:oci/docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest&repository_url=docker.io%2Flibrary",
+			expected: pkg("oci", "docker.io/library", "alpine", "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870", "", map[string]string{"tag": "latest"}),
+		}, {
+			purlUri:  "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&tag=latest&repository_url=docker.io%2Flibrary",
+			expected: pkg("oci", "docker.io/library", "debian", "sha256:244fd47e07d10", "", map[string]string{"arch": "amd64", "tag": "latest"}),
+		}, {
 			purlUri:  "pkg:docker/smartentry/debian@dc437cc87d10",
 			expected: pkg("docker", "smartentry", "debian", "dc437cc87d10", "", map[string]string{}),
 		}, {
@@ -304,7 +310,7 @@ func TestPkgToPurl(t *testing.T) {
 			// use tags and potentially indicate truncated hashes.
 
 			//expectedPurlUri: "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io",
-			expectedPurlUri: "pkg:docker/gcr.io/customer/dockerimage@sha256:244fd47e07d10",
+			expectedPurlUri: "pkg:docker/dockerimage@sha256:244fd47e07d10?repository_url=gcr.io%2Fcustomer",
 			pkgType:         "docker",
 			namespace:       "gcr.io/customer",
 			name:            "dockerimage",
@@ -312,7 +318,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{},
 		}, {
-			expectedPurlUri: "pkg:docker/smartentry/debian@dc437cc87d10",
+			expectedPurlUri: "pkg:docker/debian@dc437cc87d10?repository_url=smartentry",
 			pkgType:         "docker",
 			namespace:       "smartentry",
 			name:            "debian",
@@ -453,7 +459,7 @@ func TestPkgToPurl(t *testing.T) {
 			//TODO (Issue #635): similar issue to above.
 
 			//expectedPurlUri: "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io/library/debian&arch=amd64&tag=latest",
-			expectedPurlUri: "pkg:oci/docker.io/library/debian@sha256:244fd47e07d10?arch=amd64&tag=latest",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&tag=latest&repository_url=docker.io%2Flibrary",
 			pkgType:         "oci",
 			namespace:       "docker.io/library",
 			name:            "debian",
@@ -461,7 +467,7 @@ func TestPkgToPurl(t *testing.T) {
 			subpath:         "",
 			qualifiers:      []string{"arch", "amd64", "tag", "latest"},
 		}, {
-			expectedPurlUri: "pkg:oci/ghcr.io/debian@sha256:244fd47e07d10?tag=bullseye",
+			expectedPurlUri: "pkg:oci/debian@sha256:244fd47e07d10?tag=bullseye&repository_url=ghcr.io",
 			pkgType:         "oci",
 			namespace:       "ghcr.io",
 			name:            "debian",

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -92,9 +92,10 @@ func (p *packageQuery) GetComponents(ctx context.Context, compChan chan<- interf
 			}
 			ticker.Reset(tickInterval)
 		case d := <-nodeChan:
-			if len(packNodes) < 1000 {
+			if len(packNodes) < 999 {
 				packNodes = append(packNodes, d)
 			} else {
+				packNodes = append(packNodes, d)
 				compChan <- packNodes
 				packNodes = []*PackageNode{}
 				ticker.Reset(tickInterval)
@@ -111,9 +112,10 @@ func (p *packageQuery) GetComponents(ctx context.Context, compChan chan<- interf
 
 	for len(nodeChan) > 0 {
 		d := <-nodeChan
-		if len(packNodes) < 1000 {
+		if len(packNodes) < 999 {
 			packNodes = append(packNodes, d)
 		} else {
+			packNodes = append(packNodes, d)
 			compChan <- packNodes
 			packNodes = []*PackageNode{}
 		}


### PR DESCRIPTION
1. Add poll and interval to cli
2. change from "certifier" to "osv"
3. `go run ./cmd/guacone osv -p=false` to not poll
4. handle the special case for oci and docker images from package to purl conversion

Fixes e2e osv certifier never stopping.

closes https://github.com/guacsec/guac/issues/688