### PR TITLE
Improve purl handling in cdx and spdx parsers

### DIFF
--- a/demo/GraphQL.md
+++ b/demo/GraphQL.md
@@ -126,9 +126,6 @@ We receive:
 {
   "packages": [
     {
-      "type": "oci"
-    },
-    {
       "type": "alpine"
     },
     {
@@ -160,7 +157,7 @@ Type. The query looks like this:
 
 ```
 {
-  packages(pkgSpec: { type: "oci" }) {
+  packages(pkgSpec: { type: "deb" }) {
     type
     namespaces {
       namespace
@@ -179,22 +176,21 @@ Output:
 
 ```json
 {
-  "packages": [
-    {
-      "type": "oci",
-      "namespaces": [
-        {
-          "namespace": "docker.io/library"
-        },
-        {
-          "namespace": "docker.io/librar"
-        },
-        {
-          "namespace": "docker.io/lib"
-        }
-      ]
-    }
-  ]
+  "data": {
+    "packages": [
+      {
+        "type": "deb",
+        "namespaces": [
+          {
+            "namespace": "ubuntu"
+          },
+          {
+            "namespace": "debian"
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/demo/queries.gql
+++ b/demo/queries.gql
@@ -27,7 +27,7 @@ query PkgQ1 {
 }
 
 query PkgQ2 {
-  packages(pkgSpec: { type: "oci" }) {
+  packages(pkgSpec: { type: "guac" }) {
     type
     namespaces {
       namespace

--- a/demo/queries.gql
+++ b/demo/queries.gql
@@ -191,7 +191,7 @@ query CertifyVulnQ1 {
 }
 
 query PkgQ7 {
-  packages(pkgSpec: { type: "oci", name: "python" }) {
+  packages(pkgSpec: { type: "guac", name: "python" }) {
     type
     namespaces {
       namespace

--- a/demo/queries.gql
+++ b/demo/queries.gql
@@ -27,7 +27,7 @@ query PkgQ1 {
 }
 
 query PkgQ2 {
-  packages(pkgSpec: { type: "guac" }) {
+  packages(pkgSpec: { type: "deb" }) {
     type
     namespaces {
       namespace
@@ -42,7 +42,7 @@ query PkgQ3 {
 }
 
 query PkgQ4 {
-  packages(pkgSpec: { type: "oci", namespace: "docker.io/library", name: "consul" }) {
+  packages(pkgSpec: { type: "guac", namespace: "cdx/docker.io/library", name: "consul" }) {
     ...allPkgTree
   }
 }
@@ -62,7 +62,7 @@ fragment allIsDependencyTree on IsDependency {
 }
 
 query IsDependencyQ1 {
-  IsDependency(isDependencySpec: { package: { type: "oci", namespace: "docker.io/library", name: "consul" }}) {
+  IsDependency(isDependencySpec: { package: { type: "guac", namespace: "cdx/docker.io/library", name: "consul" }}) {
     dependentPackage {
       type
       namespaces {
@@ -77,7 +77,7 @@ query IsDependencyQ1 {
 
 query IsDependencyQ2 {
   IsDependency(isDependencySpec: {
-    package: { type: "oci", namespace: "docker.io/library", name: "consul" }
+    package: { type: "guac", namespace: "cdx/docker.io/library", name: "consul" }
     dependentPackage: { type: "golang", namespace: "github.com/sirupsen", name: "logrus" }
   }) {
     ...allIsDependencyTree

--- a/internal/testing/e2e/expectIsDependencyQ2.json
+++ b/internal/testing/e2e/expectIsDependencyQ2.json
@@ -7,7 +7,7 @@
         "type": "guac",
         "namespaces": [
           {
-            "namespace": "docker.io/library",
+            "namespace": "cdx/docker.io/library",
             "names": [
               {
                 "name": "consul",

--- a/internal/testing/e2e/expectIsDependencyQ2.json
+++ b/internal/testing/e2e/expectIsDependencyQ2.json
@@ -4,7 +4,7 @@
       "justification": "top-level package GUAC heuristic connecting to each file/package",
       "versionRange": "v1.4.2",
       "package": {
-        "type": "oci",
+        "type": "guac",
         "namespaces": [
           {
             "namespace": "docker.io/library",

--- a/internal/testing/e2e/expectPathPy.json
+++ b/internal/testing/e2e/expectPathPy.json
@@ -1,10 +1,10 @@
 [
   {
     "__typename": "Package",
-    "type": "oci",
+    "type": "guac",
     "namespaces": [
       {
-        "namespace": "docker.io/librar",
+        "namespace": "cdx/docker.io/library",
         "names": [
           {
             "name": "python",
@@ -33,7 +33,7 @@
       "type": "guac",
       "namespaces": [
         {
-          "namespace": "docker.io/librar",
+          "namespace": "cdx/docker.io/library",
           "names": [
             {
               "name": "python",

--- a/internal/testing/e2e/expectPathPy.json
+++ b/internal/testing/e2e/expectPathPy.json
@@ -30,7 +30,7 @@
     "justification": "top-level package GUAC heuristic connecting to each file/package",
     "versionRange": "3.34.1-3",
     "package": {
-      "type": "oci",
+      "type": "guac",
       "namespaces": [
         {
           "namespace": "docker.io/librar",

--- a/internal/testing/e2e/expectPkgQ1.json
+++ b/internal/testing/e2e/expectPkgQ1.json
@@ -16,9 +16,6 @@
       "type": "maven"
     },
     {
-      "type": "oci"
-    },
-    {
       "type": "pypi"
     }
   ]

--- a/internal/testing/e2e/expectPkgQ2.json
+++ b/internal/testing/e2e/expectPkgQ2.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "type": "oci",
+      "type": "guac",
       "namespaces": [
         {
           "namespace": "docker.io/lib"

--- a/internal/testing/e2e/expectPkgQ2.json
+++ b/internal/testing/e2e/expectPkgQ2.json
@@ -1,16 +1,13 @@
 {
   "packages": [
     {
-      "type": "guac",
+      "type": "deb",
       "namespaces": [
         {
-          "namespace": "docker.io/lib"
+          "namespace": "debian"
         },
         {
-          "namespace": "docker.io/librar"
-        },
-        {
-          "namespace": "docker.io/library"
+          "namespace": "ubuntu"
         }
       ]
     }

--- a/internal/testing/e2e/expectPkgQ4.json
+++ b/internal/testing/e2e/expectPkgQ4.json
@@ -1,7 +1,7 @@
 {
   "packages": [
     {
-      "type": "oci",
+      "type": "guac",
       "namespaces": [
         {
           "namespace": "docker.io/library",

--- a/internal/testing/e2e/expectPkgQ4.json
+++ b/internal/testing/e2e/expectPkgQ4.json
@@ -4,7 +4,7 @@
       "type": "guac",
       "namespaces": [
         {
-          "namespace": "docker.io/library",
+          "namespace": "cdx/docker.io/library",
           "names": [
             {
               "name": "consul",

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -457,7 +457,7 @@ var (
 	}
 
 	// CycloneDX Testdata
-	cdxTopLevelPack, _ = asmhelpers.PurlToPkg("pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot")
+	cdxTopLevelPack, _ = asmhelpers.PurlToPkg("pkg:guac/cdx/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=nonroot")
 
 	cdxTzdataPack, _ = asmhelpers.PurlToPkg("pkg:deb/debian/tzdata@2021a-1+deb11u6?arch=all&distro=debian-11")
 

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -457,7 +457,7 @@ var (
 	}
 
 	// CycloneDX Testdata
-	cdxTopLevelPack, _ = asmhelpers.PurlToPkg("pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot")
+	cdxTopLevelPack, _ = asmhelpers.PurlToPkg("pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot")
 
 	cdxTzdataPack, _ = asmhelpers.PurlToPkg("pkg:deb/debian/tzdata@2021a-1+deb11u6?arch=all&distro=debian-11")
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -76,15 +76,7 @@ func (c *cyclonedxParser) getTopLevelPackage(cdxBom *cdx.BOM) error {
 		purl := cdxBom.Metadata.Component.PackageURL
 		if cdxBom.Metadata.Component.PackageURL == "" {
 			if cdxBom.Metadata.Component.Type == cdx.ComponentTypeContainer {
-				//TODO(dejanb): Change prefix to pkg:guac/cdx and align it with spdx implementation
 				splitImage := strings.Split(cdxBom.Metadata.Component.Name, "/")
-
-				const (
-					ociPrefix        = "pkg:oci/"
-					repositoryURLKey = "?repository_url="
-					tagKey           = "&tag="
-				)
-
 				splitTag := strings.Split(splitImage[len(splitImage)-1], ":")
 				var repositoryURL string
 				var tag string
@@ -102,13 +94,14 @@ func (c *cyclonedxParser) getTopLevelPackage(cdxBom *cdx.BOM) error {
 					tag = splitTag[1]
 				}
 
-				purl = fmt.Sprintf("%s%s@%s%s%s%s%s", ociPrefix, splitTag[0],
-					cdxBom.Metadata.Component.Version, repositoryURLKey, repositoryURL, tagKey, tag)
+				purl = "pkg:/guac/cdx/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
+					"?repository_url=" + repositoryURL + "&tag=" + tag
 			} else if cdxBom.Metadata.Component.Type == cdx.ComponentTypeFile {
 				// example: file type ("/home/work/test/build/webserver/")
 				purl = "pkg:guac/file/" + cdxBom.Metadata.Component.Name + "&checksum=" + cdxBom.Metadata.Component.Version
 			}
 		}
+
 		topPackage, err := asmhelpers.PurlToPkg(purl)
 		if err != nil {
 			return err

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -94,8 +94,7 @@ func (c *cyclonedxParser) getTopLevelPackage(cdxBom *cdx.BOM) error {
 					tag = splitTag[1]
 				}
 
-				purl = "pkg:/guac/cdx/" + splitTag[0] + "@" + cdxBom.Metadata.Component.Version +
-					"?repository_url=" + repositoryURL + "&tag=" + tag
+				purl = "pkg:guac/cdx/" + repositoryURL + "@" + cdxBom.Metadata.Component.Version + "?tag=" + tag
 			} else if cdxBom.Metadata.Component.Type == cdx.ComponentTypeFile {
 				// example: file type ("/home/work/test/build/webserver/")
 				purl = "pkg:guac/file/" + cdxBom.Metadata.Component.Name + "&checksum=" + cdxBom.Metadata.Component.Version

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -143,7 +143,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+		wantPurl: "pkg:guac/cdx/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=nonroot",
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -156,7 +156,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=",
+		wantPurl: "pkg:guac/cdx/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=",
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified, version not specified",
 		cdxBom: &cdx.BOM{
@@ -168,7 +168,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:guac/cdx/static@?repository_url=gcr.io/distroless/static&tag=",
+		wantPurl: "pkg:guac/cdx/gcr.io/distroless/static@?tag=",
 	}, {
 		name: "library/debian:latest - purl not provided, assume docker.io",
 		cdxBom: &cdx.BOM{
@@ -181,7 +181,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:guac/cdx/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=latest",
+		wantPurl: "pkg:guac/cdx/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest",
 	}, {
 		name: "library/debian - purl not provided, assume docker.io, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -194,7 +194,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:guac/cdx/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=",
+		wantPurl: "pkg:guac/cdx/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=",
 	}, {
 		name: "file type - purl nor provided, version provided",
 		cdxBom: &cdx.BOM{
@@ -239,7 +239,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			}
 			wantPackage, err := asmhelpers.PurlToPkg(tt.wantPurl)
 			if err != nil {
-				t.Errorf("Failed to parse purl %v", tt.wantPurl)
+				t.Errorf("Failed to parse purl %v %v", tt.wantPurl, err)
 			}
 			if d := cmp.Diff(*wantPackage, *c.packagePackages[tt.cdxBom.Metadata.Component.BOMRef][0]); len(d) != 0 {
 				t.Errorf("addRootPackage failed to produce expected package for %v", tt.name)

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -143,7 +143,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+		wantPurl: "pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -156,7 +156,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=",
+		wantPurl: "pkg:guac/cdx/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=",
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified, version not specified",
 		cdxBom: &cdx.BOM{
@@ -168,7 +168,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:oci/static@?repository_url=gcr.io/distroless/static&tag=",
+		wantPurl: "pkg:guac/cdx/static@?repository_url=gcr.io/distroless/static&tag=",
 	}, {
 		name: "library/debian:latest - purl not provided, assume docker.io",
 		cdxBom: &cdx.BOM{
@@ -181,7 +181,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=latest",
+		wantPurl: "pkg:guac/cdx/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=latest",
 	}, {
 		name: "library/debian - purl not provided, assume docker.io, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -194,7 +194,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			},
 		},
 		wantTag:  "container",
-		wantPurl: "pkg:oci/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=",
+		wantPurl: "pkg:guac/cdx/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?repository_url=library/debian&tag=",
 	}, {
 		name: "file type - purl nor provided, version provided",
 		cdxBom: &cdx.BOM{
@@ -243,6 +243,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 			}
 			if d := cmp.Diff(*wantPackage, *c.packagePackages[tt.cdxBom.Metadata.Component.BOMRef][0]); len(d) != 0 {
 				t.Errorf("addRootPackage failed to produce expected package for %v", tt.name)
+				t.Errorf("spdx.GetPredicate mismatch values (+got, -expected): %s", d)
 			}
 		})
 	}

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -74,6 +74,9 @@ func (s *spdxParser) getTopLevelPackage() error {
 	// TODO: Add CertifyPkg to make a connection from GUAC purl to OCI purl guessed
 	// oci purl: pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
 
+	// TODO (dejanb): do a quick check for SPDX to see if there are any "DESCRIBES" relationships
+	// from the document and omit this top level heuristic package otherwise.
+
 	// Currently create TopLevel package as well in some cases where we guess that the SPDX document
 	// may not encode it
 	var purl string = "pkg:guac/spdx/" + s.spdxDoc.DocumentName

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -73,16 +73,10 @@ func (s *spdxParser) Parse(ctx context.Context, doc *processor.Document) error {
 func (s *spdxParser) getTopLevelPackage() error {
 	// TODO: Add CertifyPkg to make a connection from GUAC purl to OCI purl guessed
 	// oci purl: pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
-	splitImage := strings.Split(s.spdxDoc.DocumentName, "/")
 
 	// Currently create TopLevel package as well in some cases where we guess that the SPDX document
 	// may not encode it
-	var purl string
-	if len(splitImage) == 3 {
-		purl = "pkg:guac/spdx/" + s.spdxDoc.DocumentName
-	} else if len(splitImage) == 2 {
-		purl = "pkg:guac/spdx/" + s.spdxDoc.DocumentName
-	}
+	var purl string = "pkg:guac/spdx/" + s.spdxDoc.DocumentName
 
 	if purl != "" {
 		topPackage, err := asmhelpers.PurlToPkg(purl)


### PR DESCRIPTION
This PR fixes TODO left to use 'guac/cdx' prefix instead of the `oci` one for the CyclonDX parser. I also made some small changes to the spdx one. I tried to see if there could any further alignment between two, but failed to see it.