### PR TITLE
add release workflow to build and publish container image to ghcr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # tag=v3.2.1
         with:
           go-version: '1.19'
-      - uses: actions/cache@v3
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # tag=v3.2.1
         with:
           go-version: '1.19'
-      - uses: actions/cache@v3
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+#
+# Copyright 2022 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: release-guac-image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  packages: write # To publish container images to GHCR
+
+jobs:
+  build-image-on-release:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag=v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${GITHUB_WORKFLOW}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: setup pack 
+        uses: buildpacks/github-actions/setup-pack@7fc3d673350db0fff960cc94a3b9b80e5b663ae2 # v5.0.0
+      - name: Build and publish image
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          pack build ${IMAGE}:${GITHUB_REF_NAME} --builder ${BUILDER} --buildpack ${BUILDPACK} --publish
+        shell: bash
+        env:
+          IMAGE: ghcr.io/guacsec/guac
+          BUILDER: paketobuildpacks/builder:base
+          BUILDPACK: paketo-buildpacks/go
+          BP_GO_TARGETS: "./cmd/collector:./cmd/guacone:./cmd/ingest:./cmd/graphql_playground"


### PR DESCRIPTION
The release workflow will be triggered as a release is published. Release tag will be used as image tag.