### PR TITLE
query purl to find all transitive vulnerabilities

### DIFF
--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -113,7 +113,7 @@ var queryVulnCmd = &cobra.Command{
 
 			osvResponse, err := model.OSVs(ctx, gqlclient, &model.OSVSpec{OsvId: &opts.vulnerabilityID})
 			if err != nil {
-				logger.Debugf("error querying for osvs: %v", err)
+				logger.Fatalf("error querying for osvs: %v", err)
 			}
 
 			if len(osvResponse.Osv) == 0 {
@@ -123,7 +123,7 @@ var queryVulnCmd = &cobra.Command{
 						logger.Fatalf("error querying for cves: %v", err)
 					}
 					if len(cveResponse.Cve) == 0 {
-						logger.Fatalf("error failed to find CVE or OSV matching vulnerability ID")
+						logger.Debugf("error failed to find CVE or OSV matching vulnerability ID")
 					}
 				} else if strings.HasPrefix(opts.vulnerabilityID, "ghsa") {
 					ghsaResponse, err = model.GHSAs(ctx, gqlclient, &model.GHSASpec{GhsaId: &opts.vulnerabilityID})
@@ -131,10 +131,10 @@ var queryVulnCmd = &cobra.Command{
 						logger.Fatalf("error querying for ghsas: %v", err)
 					}
 					if len(ghsaResponse.Ghsa) == 0 {
-						logger.Fatalf("error failed to find CVE or OSV matching vulnerability ID")
+						logger.Debugf("error failed to find CVE or OSV matching vulnerability ID")
 					}
 				} else {
-					logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
+					logger.Debugf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
 				}
 			}
 
@@ -155,10 +155,14 @@ var queryVulnCmd = &cobra.Command{
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
 			} else {
-				logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
+				logger.Debugf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
 			}
-			logger.Infof("found path %v", strings.Join(path, `,`))
-			logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+			if len(path) > 0 {
+				logger.Infof("found path %v", strings.Join(path, `,`))
+				logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+			} else {
+				logger.Infof("No path to vulnerability ID found!")
+			}
 		} else {
 			var path []string
 			vulnPath, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
@@ -169,15 +173,20 @@ var queryVulnCmd = &cobra.Command{
 			if err != nil {
 				logger.Fatalf("error searching dependency packages match: %v", err)
 			}
-			path = append(path, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
-				pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
-				pkgResponse.Packages[0].Id)
+
 			path = append(path, vulnPath...)
 			path = append(path, depVulnPath...)
-			logger.Infof("found path %v", strings.Join(path, `,`))
-			logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
-		}
 
+			if len(path) > 0 {
+				path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
+					pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
+					pkgResponse.Packages[0].Id}, path...)
+				logger.Infof("found path %v", strings.Join(path, `,`))
+				logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+			} else {
+				logger.Infof("No path to vulnerabilities found!")
+			}
+		}
 	},
 }
 

--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -32,6 +32,8 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+const guacType string = "guac"
+
 var queryFlags = struct {
 	purl            string
 	vulnerabilityID string
@@ -155,7 +157,7 @@ var queryVulnCmd = &cobra.Command{
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
 			} else {
-				logger.Debugf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
+				logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
 			}
 			if len(path) > 0 {
 				logger.Infof("found path %v", strings.Join(path, `,`))
@@ -165,9 +167,12 @@ var queryVulnCmd = &cobra.Command{
 			}
 		} else {
 			var path []string
-			vulnPath, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
-			if err != nil {
-				logger.Fatalf("error querying neighbor: %v", err)
+			var vulnPath []string
+			if pkgResponse.Packages[0].Type != guacType {
+				vulnPath, err = queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
+				if err != nil {
+					logger.Fatalf("error querying neighbor: %v", err)
+				}
 			}
 			depVulnPath, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
 			if err != nil {
@@ -192,12 +197,14 @@ var queryVulnCmd = &cobra.Command{
 
 func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, error) {
 	path := []string{}
-	certifyVulns, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
+	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
 	if err != nil {
 		return nil, fmt.Errorf("error querying neighbor for vulnerability: %v", err)
 	}
-	for _, certifyVuln := range certifyVulns.Neighbors {
-		if certifyVuln, ok := certifyVuln.(*model.NeighborsNeighborsCertifyVuln); ok {
+	certifyVulnFound := false
+	for _, neighbor := range pkgVersionNeighborResponse.Neighbors {
+		if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
+			certifyVulnFound = true
 			if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityOSV); ok {
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
@@ -215,6 +222,9 @@ func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client
 					certifyVuln.Package.Id}...)
 			}
 		}
+	}
+	if !certifyVulnFound {
+		return nil, fmt.Errorf("error certify vulnerability node not found, incomplete data. Please ensure certifier has run")
 	}
 	return path, nil
 }
@@ -241,13 +251,13 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 			break
 		}
 
-		isDependencyResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{model.EdgePackageIsDependency})
+		isDependencyNeighborResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{model.EdgePackageIsDependency})
 		if err != nil {
 			return nil, fmt.Errorf("failed getting package parent:%v", err)
 		}
-		for _, isDependencyResponse := range isDependencyResponses.Neighbors {
-			if isDependency, ok := isDependencyResponse.(*model.NeighborsNeighborsIsDependency); ok {
-				if isDependency.DependentPackage.Type == "guac" {
+		for _, neighbor := range isDependencyNeighborResponses.Neighbors {
+			if isDependency, ok := neighbor.(*model.NeighborsNeighborsIsDependency); ok {
+				if isDependency.DependentPackage.Type == guacType {
 					continue
 				}
 				depPkgFilter := &model.PkgSpec{
@@ -300,12 +310,14 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 
 func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth int) ([]string, error) {
 	path := []string{}
-	certifyVulns, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
+	vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
 	if err != nil {
 		return nil, fmt.Errorf("error querying neighbor for vulnerability: %v", err)
 	}
-	for _, certifyVuln := range certifyVulns.Neighbors {
-		if certifyVuln, ok := certifyVuln.(*model.NeighborsNeighborsCertifyVuln); ok {
+	certifyVulnFound := false
+	for _, neighbor := range vulnNodeNeighborResponse.Neighbors {
+		if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
+			certifyVulnFound = true
 			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
 			if err != nil {
 				return nil, fmt.Errorf("error searching dependency packages match: %v", err)
@@ -315,6 +327,9 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 				certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 				certifyVuln.Package.Id}, pkgPath...)
 		}
+	}
+	if !certifyVulnFound {
+		return nil, fmt.Errorf("error certify vulnerability node not found, incomplete data. Please ensure certifier has run")
 	}
 	return path, nil
 }
@@ -347,22 +362,22 @@ func searchDependencyPackagesReverse(ctx context.Context, gqlclient graphql.Clie
 			break
 		}
 
-		pkgNameResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{})
+		pkgNameNeighborResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{})
 		if err != nil {
 			return nil, fmt.Errorf("failed getting package parent:%v", err)
 		}
 
-		for _, pkgNameResponse := range pkgNameResponses.Neighbors {
-			if pkgName, ok := pkgNameResponse.(*model.NeighborsNeighborsPackage); ok {
+		for _, neighbor := range pkgNameNeighborResponses.Neighbors {
+			if pkgName, ok := neighbor.(*model.NeighborsNeighborsPackage); ok {
 				if len(pkgName.Namespaces) == 0 {
 					continue
 				}
-				isDependencyResponses, err := model.Neighbors(ctx, gqlclient, pkgName.Namespaces[0].Names[0].Id, []model.Edge{model.EdgePackageIsDependency})
+				isDependencyNeighborResponses, err := model.Neighbors(ctx, gqlclient, pkgName.Namespaces[0].Names[0].Id, []model.Edge{model.EdgePackageIsDependency})
 				if err != nil {
 					return nil, fmt.Errorf("failed getting package parent:%v", err)
 				}
-				for _, isDependencyResponse := range isDependencyResponses.Neighbors {
-					if isDependency, ok := isDependencyResponse.(*model.NeighborsNeighborsIsDependency); ok {
+				for _, neighbor := range isDependencyNeighborResponses.Neighbors {
+					if isDependency, ok := neighbor.(*model.NeighborsNeighborsIsDependency); ok {
 						path = append(path, isDependency.Id, isDependency.Package.Namespaces[0].Names[0].Versions[0].Id,
 							isDependency.Package.Namespaces[0].Names[0].Id, isDependency.Package.Namespaces[0].Id,
 							isDependency.Package.Id)

--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/logging"
@@ -105,64 +106,190 @@ var queryVulnCmd = &cobra.Command{
 		if len(pkgResponse.Packages) != 1 {
 			logger.Fatalf("error too many packages matching purl found")
 		}
-		cveResponse := &model.CVEsResponse{}
-		ghsaResponse := &model.GHSAsResponse{}
 
-		osvResponse, err := model.OSVs(ctx, gqlclient, &model.OSVSpec{OsvId: &opts.vulnerabilityID})
-		if err != nil {
-			logger.Debugf("error querying for osvs: %v", err)
-		}
-		if osvResponse != nil && len(osvResponse.Osv) != 1 {
-			logger.Fatalf("error too many OSVs matching ID found")
-		}
+		if opts.vulnerabilityID != "" {
+			cveResponse := &model.CVEsResponse{}
+			ghsaResponse := &model.GHSAsResponse{}
 
-		if osvResponse == nil {
-			if strings.HasPrefix(opts.vulnerabilityID, "cve") {
-				cveResponse, err = model.CVEs(ctx, gqlclient, &model.CVESpec{CveId: &opts.vulnerabilityID})
+			osvResponse, err := model.OSVs(ctx, gqlclient, &model.OSVSpec{OsvId: &opts.vulnerabilityID})
+			if err != nil {
+				logger.Debugf("error querying for osvs: %v", err)
+			}
+
+			if len(osvResponse.Osv) == 0 {
+				if strings.HasPrefix(opts.vulnerabilityID, "cve") {
+					cveResponse, err = model.CVEs(ctx, gqlclient, &model.CVESpec{CveId: &opts.vulnerabilityID})
+					if err != nil {
+						logger.Fatalf("error querying for cves: %v", err)
+					}
+					if len(cveResponse.Cve) == 0 {
+						logger.Fatalf("error failed to find CVE or OSV matching vulnerability ID")
+					}
+				} else if strings.HasPrefix(opts.vulnerabilityID, "ghsa") {
+					ghsaResponse, err = model.GHSAs(ctx, gqlclient, &model.GHSASpec{GhsaId: &opts.vulnerabilityID})
+					if err != nil {
+						logger.Fatalf("error querying for ghsas: %v", err)
+					}
+					if len(ghsaResponse.Ghsa) == 0 {
+						logger.Fatalf("error failed to find CVE or OSV matching vulnerability ID")
+					}
+				} else {
+					logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
+				}
+			}
+
+			var path []string
+			if len(osvResponse.Osv) > 0 {
+				path, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, osvResponse.Osv[0].Id, model.EdgeOsvCertifyVuln, opts.depth)
 				if err != nil {
-					logger.Fatalf("error querying for cves: %v", err)
+					logger.Fatalf("error querying neighbor: %v", err)
 				}
-				if len(cveResponse.Cve) != 1 {
-					logger.Fatalf("error too many CVEs matching ID found")
-				}
-			} else if strings.HasPrefix(opts.vulnerabilityID, "ghsa") {
-				ghsaResponse, err = model.GHSAs(ctx, gqlclient, &model.GHSASpec{GhsaId: &opts.vulnerabilityID})
+			} else if len(cveResponse.Cve) > 0 {
+				path, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, cveResponse.Cve[0].Id, model.EdgeCveCertifyVuln, opts.depth)
 				if err != nil {
-					logger.Fatalf("error querying for ghsas: %v", err)
+					logger.Fatalf("error querying neighbor: %v", err)
 				}
-				if len(ghsaResponse.Ghsa) != 1 {
-					logger.Fatalf("error too many GHSAs matching ID found")
+			} else if len(ghsaResponse.Ghsa) > 0 {
+				path, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, ghsaResponse.Ghsa[0].Id, model.EdgeGhsaCertifyVuln, opts.depth)
+				if err != nil {
+					logger.Fatalf("error querying neighbor: %v", err)
 				}
 			} else {
 				logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
 			}
+			logger.Infof("found path %v", strings.Join(path, `,`))
+			logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+		} else {
+			var path []string
+			vulnPath, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
+			if err != nil {
+				logger.Fatalf("error querying neighbor: %v", err)
+			}
+			depVulnPath, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
+			if err != nil {
+				logger.Fatalf("error searching dependency packages match: %v", err)
+			}
+			path = append(path, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
+				pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
+				pkgResponse.Packages[0].Id)
+			path = append(path, vulnPath...)
+			path = append(path, depVulnPath...)
+			logger.Infof("found path %v", strings.Join(path, `,`))
+			logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
 		}
 
-		var path []string
-		if osvResponse != nil {
-			path, err = queryCertifyVulnsNeighbors(ctx, gqlclient, pkgResponse, osvResponse.Osv[0].Id, model.EdgeOsvCertifyVuln, opts.depth)
-			if err != nil {
-				logger.Fatalf("error querying neighbor: %v", err)
-			}
-		} else if cveResponse != nil {
-			path, err = queryCertifyVulnsNeighbors(ctx, gqlclient, pkgResponse, cveResponse.Cve[0].Id, model.EdgeCveCertifyVuln, opts.depth)
-			if err != nil {
-				logger.Fatalf("error querying neighbor: %v", err)
-			}
-		} else if ghsaResponse != nil {
-			path, err = queryCertifyVulnsNeighbors(ctx, gqlclient, pkgResponse, ghsaResponse.Ghsa[0].Id, model.EdgeGhsaCertifyVuln, opts.depth)
-			if err != nil {
-				logger.Fatalf("error querying neighbor: %v", err)
-			}
-		} else {
-			logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
-		}
-		logger.Infof("found path %v", strings.Join(path, `,`))
-		logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
 	},
 }
 
-func queryCertifyVulnsNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth int) ([]string, error) {
+func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, error) {
+	path := []string{}
+	certifyVulns, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
+	if err != nil {
+		return nil, fmt.Errorf("error querying neighbor for vulnerability: %v", err)
+	}
+	for _, certifyVuln := range certifyVulns.Neighbors {
+		if certifyVuln, ok := certifyVuln.(*model.NeighborsNeighborsCertifyVuln); ok {
+			if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityOSV); ok {
+				path = append(path, []string{vuln.Id, certifyVuln.Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
+					certifyVuln.Package.Id}...)
+			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityCVE); ok {
+				path = append(path, []string{vuln.Id, certifyVuln.Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
+					certifyVuln.Package.Id}...)
+			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityGHSA); ok {
+				path = append(path, []string{vuln.Id, certifyVuln.Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
+					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
+					certifyVuln.Package.Id}...)
+			}
+		}
+	}
+	return path, nil
+}
+
+func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, error) {
+	path := []string{}
+	queue := make([]string, 0) // the queue of nodes in bfs
+	type dfsNode struct {
+		expanded bool // true once all node neighbors are added to queue
+		parent   string
+		depth    int
+	}
+	nodeMap := map[string]dfsNode{}
+
+	nodeMap[topPkgID] = dfsNode{}
+	queue = append(queue, topPkgID)
+
+	for len(queue) > 0 {
+		now := queue[0]
+		queue = queue[1:]
+		nowNode := nodeMap[now]
+
+		if maxLength != 0 && nowNode.depth >= maxLength {
+			break
+		}
+
+		isDependencyResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{model.EdgePackageIsDependency})
+		if err != nil {
+			return nil, fmt.Errorf("failed getting package parent:%v", err)
+		}
+		for _, isDependencyResponse := range isDependencyResponses.Neighbors {
+			if isDependency, ok := isDependencyResponse.(*model.NeighborsNeighborsIsDependency); ok {
+				if isDependency.DependentPackage.Type == "guac" {
+					continue
+				}
+				depPkgFilter := &model.PkgSpec{
+					Type:      &isDependency.DependentPackage.Type,
+					Namespace: &isDependency.DependentPackage.Namespaces[0].Namespace,
+					Name:      &isDependency.DependentPackage.Namespaces[0].Names[0].Name,
+					Version:   ptrfrom.String(isDependency.VersionRange),
+				}
+
+				depPkgResponse, err := model.Packages(ctx, gqlclient, depPkgFilter)
+				if err != nil {
+					return nil, fmt.Errorf("error querying for dependent package: %v", err)
+				}
+				if len(depPkgResponse.Packages) != 1 {
+					return nil, fmt.Errorf("error too many dependent packages matching purl found")
+				}
+				for _, depPkgVersion := range depPkgResponse.Packages[0].Namespaces[0].Names[0].Versions {
+					vulnPath, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, depPkgVersion.Id, model.EdgePackageCertifyVuln)
+					if err != nil {
+						return nil, fmt.Errorf("error querying neighbor: %v", err)
+					}
+					if len(vulnPath) > 0 {
+						path = append(path, isDependency.Id, depPkgVersion.Id,
+							depPkgResponse.Packages[0].Namespaces[0].Names[0].Id, depPkgResponse.Packages[0].Namespaces[0].Id,
+							depPkgResponse.Packages[0].Id)
+						path = append(path, vulnPath...)
+					}
+
+					dfsN, seen := nodeMap[depPkgVersion.Id]
+					if !seen {
+						dfsN = dfsNode{
+							parent: now,
+							depth:  nowNode.depth + 1,
+						}
+						nodeMap[depPkgVersion.Id] = dfsN
+					}
+					if !dfsN.expanded {
+						queue = append(queue, depPkgVersion.Id)
+					}
+				}
+			}
+		}
+
+		nowNode.expanded = true
+		nodeMap[now] = nowNode
+	}
+
+	return path, nil
+}
+
+func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth int) ([]string, error) {
 	path := []string{}
 	certifyVulns, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
 	if err != nil {
@@ -170,7 +297,7 @@ func queryCertifyVulnsNeighbors(ctx context.Context, gqlclient graphql.Client, t
 	}
 	for _, certifyVuln := range certifyVulns.Neighbors {
 		if certifyVuln, ok := certifyVuln.(*model.NeighborsNeighborsCertifyVuln); ok {
-			pkgPath, err := searchDependencyPackages(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
+			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
 			if err != nil {
 				return nil, fmt.Errorf("error searching dependency packages match: %v", err)
 			}
@@ -183,7 +310,7 @@ func queryCertifyVulnsNeighbors(ctx context.Context, gqlclient graphql.Client, t
 	return path, nil
 }
 
-func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, searchPkgID string, maxLength int) ([]string, error) {
+func searchDependencyPackagesReverse(ctx context.Context, gqlclient graphql.Client, topPkgID string, searchPkgID string, maxLength int) ([]string, error) {
 	path := []string{}
 	queue := make([]string, 0) // the queue of nodes in bfs
 	type dfsNode struct {


### PR DESCRIPTION
Update vulnerability CLI to return all vulnerabilities path (transitive) for a given purl