### PR TITLE
fix issue with dependent package purl on deps.dev and remove duplicates for vulnerability and hasSourceAt

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -964,8 +964,7 @@ var (
 		   "tag":null,
 		   "type":"git"
 		},
-		"UpdateTime":"2022-11-21T17:45:50.52Z",
-		"Vulnerabilities":null
+		"UpdateTime":"2022-11-21T17:45:50.52Z"
 	 }`
 
 	CollectedForeignTypes = `{
@@ -1057,8 +1056,7 @@ var (
 				 "tag":null,
 				 "type":"git"
 			  },
-			  "UpdateTime":"2022-11-21T17:45:50.52Z",
-			  "Vulnerabilities":null
+			  "UpdateTime":"2022-11-21T17:45:50.52Z"
 		   }
 		],
 		"Scorecard":{
@@ -1130,8 +1128,7 @@ var (
 		   "tag":null,
 		   "type":"git"
 		},
-		"UpdateTime":"2022-11-21T17:45:50.52Z",
-		"Vulnerabilities":null
+		"UpdateTime":"2022-11-21T17:45:50.52Z"
 	 }`
 	CollectedYargsParser = `{
 		"CurrentPackage":{
@@ -1161,8 +1158,7 @@ var (
 				 "tag":null,
 				 "type":"git"
 			  },
-			  "UpdateTime":"2022-11-21T17:45:50.52Z",
-			  "Vulnerabilities":null
+			  "UpdateTime":"2022-11-21T17:45:50.52Z"
 		   }
 		],
 		"Scorecard":null,
@@ -1173,12 +1169,7 @@ var (
 		   "tag":null,
 		   "type":"git"
 		},
-		"UpdateTime":"2022-11-21T17:45:50.52Z",
-		"Vulnerabilities":[
-		   {
-			  "osvId":"GHSA-p9pc-299p-vxgp"
-		   }
-		]
+		"UpdateTime":"2022-11-21T17:45:50.52Z"
 	 }`
 )
 

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -982,9 +982,7 @@ var (
 			  "CurrentPackage":{
 				 "name":"foreign-types-shared",
 				 "namespace":"",
-				 "qualifiers":[
-					
-				 ],
+				 "qualifiers":null,
 				 "subpath":"",
 				 "type":"cargo",
 				 "version":"0.1.1"
@@ -1135,56 +1133,53 @@ var (
 		"UpdateTime":"2022-11-21T17:45:50.52Z",
 		"Vulnerabilities":null
 	 }`
-	CollectedYargsParser = `
- {
-	 "CurrentPackage":{
-		"type":"npm",
-		"namespace":"",
-		"name":"yargs-parser",
-		"version":"4.2.1",
-		"qualifiers":null,
-		"subpath":""
-	 },
-	 "Source":{
-		"type":"git",
-		"namespace":"github.com/yargs",
-		"name":"yargs-parser.git",
-		"tag":null,
-		"commit":null
-	 },
-	 "Vulnerabilities":[
-		{
-		   "osvId":"GHSA-p9pc-299p-vxgp"
-		}
-	 ],
-	 "Scorecard":null,
-	 "DepPackages":[
-		{
-		   "CurrentPackage":{
-			  "type":"npm",
-			  "namespace":"",
-			  "name":"camelcase",
-			  "version":"3.0.0",
-			  "qualifiers":[
-				 
-			  ],
-			  "subpath":""
-		   },
-		   "Source":{
-			  "type":"git",
-			  "namespace":"github.com/sindresorhus",
-			  "name":"camelcase.git",
-			  "tag":null,
-			  "commit":null
-		   },
-		   "Vulnerabilities":null,
-		   "Scorecard":null,
-		   "DepPackages":null,
-		   "UpdateTime":"2022-11-21T17:45:50.52Z"
-		}
-	 ],
-	 "UpdateTime":"2022-11-21T17:45:50.52Z"
-  }`
+	CollectedYargsParser = `{
+		"CurrentPackage":{
+		   "name":"yargs-parser",
+		   "namespace":"",
+		   "qualifiers":null,
+		   "subpath":"",
+		   "type":"npm",
+		   "version":"4.2.1"
+		},
+		"DepPackages":[
+		   {
+			  "CurrentPackage":{
+				 "name":"camelcase",
+				 "namespace":"",
+				 "qualifiers":null,
+				 "subpath":"",
+				 "type":"npm",
+				 "version":"3.0.0"
+			  },
+			  "DepPackages":null,
+			  "Scorecard":null,
+			  "Source":{
+				 "commit":null,
+				 "name":"camelcase.git",
+				 "namespace":"github.com/sindresorhus",
+				 "tag":null,
+				 "type":"git"
+			  },
+			  "UpdateTime":"2022-11-21T17:45:50.52Z",
+			  "Vulnerabilities":null
+		   }
+		],
+		"Scorecard":null,
+		"Source":{
+		   "commit":null,
+		   "name":"yargs-parser.git",
+		   "namespace":"github.com/yargs",
+		   "tag":null,
+		   "type":"git"
+		},
+		"UpdateTime":"2022-11-21T17:45:50.52Z",
+		"Vulnerabilities":[
+		   {
+			  "osvId":"GHSA-p9pc-299p-vxgp"
+		   }
+		]
+	 }`
 )
 
 func GuacNodeSliceEqual(slice1, slice2 []assembler.GuacNode) bool {

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -137,7 +137,7 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, response *generated.
 		for _, namespace := range pkgType.Namespaces {
 			for _, name := range namespace.Names {
 				for _, version := range name.Versions {
-					response, err := getNeighbors(ctx, p.client, version.Id, []generated.Edge{})
+					response, err := getNeighbors(ctx, p.client, version.Id, []generated.Edge{generated.EdgePackageCertifyVuln, generated.EdgePackageIsOccurrence})
 					if err != nil {
 						return fmt.Errorf("failed neighbors query: %w", err)
 					}

--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -55,7 +55,7 @@ func (s sourceQuery) GetComponents(ctx context.Context, compChan chan<- interfac
 	for _, src := range sources {
 		for _, namespace := range src.Namespaces {
 			for _, names := range namespace.Names {
-				response, err := getNeighbors(ctx, s.client, names.Id, []generated.Edge{})
+				response, err := getNeighbors(ctx, s.client, names.Id, []generated.Edge{generated.EdgeSourceCertifyScorecard})
 				if err != nil {
 					return fmt.Errorf("failed neighbors query: %w", err)
 				}

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -185,16 +185,14 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 		}
 
 		purl := "pkg:" + pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
-
 		depPackageInput, err := helpers.PurlToPkg(purl)
 		if err != nil {
-			logger.Debugf("failed to get dependency purl", err)
+			logger.Infof("unable to parse purl: %v", purl)
 			continue
 		}
 
 		// check if dependent package purl has already been queried. If found, append to the list of dependent packages for top level package
-		if foundDepVal, ok := d.checkedPurls[helpers.PkgToPurl(depPackageInput.Type, *depPackageInput.Namespace, depPackageInput.Name,
-			*depPackageInput.Version, *depPackageInput.Subpath, []string{})]; ok {
+		if foundDepVal, ok := d.checkedPurls[purl]; ok {
 
 			logger.Debugf("dependant package purl %s already queried: %s", purl)
 			component.DepPackages = append(component.DepPackages, foundDepVal)

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -41,12 +41,11 @@ const (
 )
 
 type PackageComponent struct {
-	CurrentPackage  *model.PkgInputSpec
-	Source          *model.SourceInputSpec
-	Vulnerabilities []*model.OSVInputSpec
-	Scorecard       *model.ScorecardInputSpec
-	DepPackages     []*PackageComponent
-	UpdateTime      time.Time
+	CurrentPackage *model.PkgInputSpec
+	Source         *model.SourceInputSpec
+	Scorecard      *model.ScorecardInputSpec
+	DepPackages    []*PackageComponent
+	UpdateTime     time.Time
 }
 
 type depsCollector struct {
@@ -55,6 +54,7 @@ type depsCollector struct {
 	poll              bool
 	interval          time.Duration
 	checkedPurls      map[string]*PackageComponent
+	ingestedSource    map[string]*model.SourceInputSpec
 }
 
 func NewDepsCollector(ctx context.Context, collectDataSource datasource.CollectSource, poll bool, interval time.Duration) (*depsCollector, error) {
@@ -80,6 +80,7 @@ func NewDepsCollector(ctx context.Context, collectDataSource datasource.CollectS
 		poll:              poll,
 		interval:          interval,
 		checkedPurls:      map[string]*PackageComponent{},
+		ingestedSource:    map[string]*model.SourceInputSpec{},
 	}, nil
 }
 
@@ -129,7 +130,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 
 	// check if top level purl has already been queried
 	if _, ok := d.checkedPurls[purl]; ok {
-		logger.Debugf("purl %s already queried: %s", purl)
+		logger.Infof("purl %s already queried: %s", purl)
 		return nil
 	}
 
@@ -175,6 +176,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 		if i == 0 {
 			continue
 		}
+
 		depComponent := &PackageComponent{}
 
 		pkgtype := ""
@@ -184,17 +186,21 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 			pkgtype = strings.ToLower(node.VersionKey.System.String())
 		}
 
-		purl := "pkg:" + pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
-		depPackageInput, err := helpers.PurlToPkg(purl)
+		depPurl := "pkg:" + pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
+		depPackageInput, err := helpers.PurlToPkg(depPurl)
 		if err != nil {
-			logger.Infof("unable to parse purl: %v", purl)
+			logger.Infof("unable to parse purl: %v", depPurl)
 			continue
 		}
 
 		// check if dependent package purl has already been queried. If found, append to the list of dependent packages for top level package
-		if foundDepVal, ok := d.checkedPurls[purl]; ok {
-
-			logger.Debugf("dependant package purl %s already queried: %s", purl)
+		if foundDepVal, ok := d.checkedPurls[depPurl]; ok {
+			// if found, return the source as nothing as it has already been ingested once
+			foundDepVal.Source = nil
+			for _, foundDep := range foundDepVal.DepPackages {
+				foundDep.Source = nil
+			}
+			logger.Debugf("dependant package purl %s already queried: %s", depPurl)
 			component.DepPackages = append(component.DepPackages, foundDepVal)
 			continue
 		}
@@ -203,7 +209,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 
 		err = d.collectAdditionalMetadata(ctx, depPackageInput.Type, depPackageInput.Namespace, depPackageInput.Name, depPackageInput.Version, depComponent)
 		if err != nil {
-			logger.Debugf("failed to get additional metadata for package: %s, err: %w", purl, err)
+			logger.Debugf("failed to get additional metadata for package: %s, err: %w", depPurl, err)
 		}
 		component.DepPackages = append(component.DepPackages, depComponent)
 	}
@@ -232,6 +238,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 }
 
 func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType string, namespace *string, name string, version *string, pkgComponent *PackageComponent) error {
+	logger := logging.FromContext(ctx)
 
 	versionKey, err := getVersionKey(pkgType, namespace, name, version)
 	if err != nil {
@@ -250,9 +257,18 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 		if link.Label == sourceRepo {
 			src, err := helpers.VcsToSrc(link.Url)
 			if err != nil {
+				logger.Debugf("unable to parse source url: %v", link.Url)
 				continue
 			}
-			pkgComponent.Source = src
+
+			// check if source has already been ingest for this package (without version), if not add source to be ingest for hasSourceAt
+			// HasSourceAt is done at the pkgName level for all entries from deps.dev as it does not specify a tag or commit for each version
+			// of the package being ingested
+			purlWithoutVersion := "pkg:" + pkgType + "/" + strings.TrimSuffix(*namespace, "/") + "/" + name
+			if _, ok := d.ingestedSource[purlWithoutVersion]; !ok {
+				pkgComponent.Source = src
+				d.ingestedSource[purlWithoutVersion] = src
+			}
 
 			projectReq := &pb.GetProjectRequest{
 				ProjectKey: &pb.ProjectKey{
@@ -262,6 +278,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 
 			project, err := d.client.GetProject(ctx, projectReq)
 			if err != nil {
+				logger.Debugf("unable to get project for: %v", projectReq.ProjectKey.Id)
 				continue
 			}
 			if project.Scorecard != nil {
@@ -283,14 +300,6 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 		}
 	}
 
-	vulnerabilities := []*model.OSVInputSpec{}
-	for _, vuln := range versionResponse.AdvisoryKeys {
-		osv := model.OSVInputSpec{
-			OsvId: vuln.Id,
-		}
-		vulnerabilities = append(vulnerabilities, &osv)
-	}
-	pkgComponent.Vulnerabilities = append(pkgComponent.Vulnerabilities, vulnerabilities...)
 	// add time when data was obtained
 	pkgComponent.UpdateTime = time.Now().UTC()
 

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -184,7 +184,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 			pkgtype = strings.ToLower(node.VersionKey.System.String())
 		}
 
-		purl := pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
+		purl := "pkg:" + pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
 
 		depPackageInput, err := helpers.PurlToPkg(purl)
 		if err != nil {

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
@@ -184,13 +183,13 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 		} else {
 			pkgtype = strings.ToLower(node.VersionKey.System.String())
 		}
-		depPackageInput := &model.PkgInputSpec{
-			Type:       pkgtype,
-			Namespace:  ptrfrom.String(""),
-			Name:       node.VersionKey.Name,
-			Version:    &node.VersionKey.Version,
-			Qualifiers: []model.PackageQualifierInputSpec{},
-			Subpath:    ptrfrom.String(""),
+
+		purl := pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
+
+		depPackageInput, err := helpers.PurlToPkg(purl)
+		if err != nil {
+			logger.Debugf("failed to get dependency purl", err)
+			continue
 		}
 
 		// check if dependent package purl has already been queried. If found, append to the list of dependent packages for top level package

--- a/pkg/ingestor/parser/deps_dev/deps_dev.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/guacsec/guac/pkg/assembler"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
-	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/handler/collector/deps_dev"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
@@ -139,7 +138,10 @@ func (d *depsDevParser) GetIdentities(ctx context.Context) []common.TrustInforma
 
 func (d *depsDevParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
 	idstrings := &common.IdentifierStrings{}
-	for _, depComp := range d.packComponent.DepPackages {
+	// TODO (pxp928): currently commented out based on issue https://github.com/guacsec/guac/issues/769
+	// this will be uncommented once that work is complete such that deps.dev collector does not keep spinning.
+	// TODO (pxp928): Unit test will also need to be fixed
+	/* 	for _, depComp := range d.packComponent.DepPackages {
 		pkg := depComp.CurrentPackage
 		qualifiers := []string{}
 		for _, v := range pkg.Qualifiers {
@@ -148,6 +150,6 @@ func (d *depsDevParser) GetIdentifiers(ctx context.Context) (*common.IdentifierS
 		purl := helpers.PkgToPurl(pkg.Type, *pkg.Namespace, pkg.Name, *pkg.Version, *pkg.Subpath, qualifiers)
 
 		idstrings.PurlStrings = append(idstrings.PurlStrings, purl)
-	}
+	} */
 	return idstrings, nil
 }

--- a/pkg/ingestor/parser/deps_dev/deps_dev.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev.go
@@ -182,5 +182,16 @@ func (d *depsDevParser) GetIdentities(ctx context.Context) []common.TrustInforma
 }
 
 func (d *depsDevParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	idstrings := &common.IdentifierStrings{}
+	for _, depComp := range d.packComponent.DepPackages {
+		pkg := depComp.CurrentPackage
+		qualifiers := []string{}
+		for _, v := range pkg.Qualifiers {
+			qualifiers = append(qualifiers, v.Key, v.Value)
+		}
+		purl := helpers.PkgToPurl(pkg.Type, *pkg.Namespace, pkg.Name, *pkg.Version, *pkg.Subpath, qualifiers)
+
+		idstrings.PurlStrings = append(idstrings.PurlStrings, purl)
+	}
+	return idstrings, nil
 }

--- a/pkg/ingestor/parser/deps_dev/deps_dev_test.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev_test.go
@@ -233,44 +233,6 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					},
 				},
 			},
-			CertifyVuln: []assembler.CertifyVulnIngest{
-				{
-					Pkg: &model.PkgInputSpec{
-						Type:      "npm",
-						Namespace: ptrfrom.String(""),
-						Name:      "yargs-parser",
-						Version:   ptrfrom.String("4.2.1"),
-						Subpath:   ptrfrom.String(""),
-					},
-					OSV: &model.OSVInputSpec{
-						OsvId: "GHSA-p9pc-299p-vxgp",
-					},
-					VulnData: &model.VulnerabilityMetaDataInput{
-						TimeScanned:    tm.UTC(),
-						DbUri:          "",
-						DbVersion:      "",
-						ScannerUri:     "osv.dev",
-						ScannerVersion: "",
-						Origin:         "",
-						Collector:      "",
-					},
-				},
-			},
-			IsVuln: []assembler.IsVulnIngest{
-				{
-					OSV: &model.OSVInputSpec{
-						OsvId: "GHSA-p9pc-299p-vxgp",
-					},
-					GHSA: &model.GHSAInputSpec{
-						GhsaId: "GHSA-p9pc-299p-vxgp",
-					},
-					IsVuln: &model.IsVulnerabilityInputSpec{
-						Justification: "decoded OSV data collected via deps.dev",
-						Origin:        "",
-						Collector:     "",
-					},
-				},
-			},
 			HasSourceAt: []assembler.HasSourceAtIngest{
 				{
 					Pkg: &model.PkgInputSpec{

--- a/pkg/ingestor/parser/deps_dev/deps_dev_test.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev_test.go
@@ -298,50 +298,52 @@ func Test_depsDevParser_Parse(t *testing.T) {
 	}
 }
 
-func Test_depsDevParser_GetIdentifiers(t *testing.T) {
-	ctx := logging.WithLogger(context.Background())
+// TODO (pxp928): Unit test will also need to be fixed after issue https://github.com/guacsec/guac/issues/769 is resolved
 
-	tests := []struct {
-		name            string
-		doc             *processor.Document
-		wantIdentifiers *common.IdentifierStrings
-		wantErr         bool
-	}{{
-		name: "package foreign-types",
-		doc: &processor.Document{
-			Blob:              []byte(testdata.CollectedForeignTypes),
-			Type:              processor.DocumentDepsDev,
-			Format:            processor.FormatJSON,
-			SourceInformation: processor.SourceInformation{},
-		},
-		wantIdentifiers: &common.IdentifierStrings{
-			PurlStrings: []string{"pkg:cargo/foreign-types-shared@0.1.1"}},
-		wantErr: false,
-	}, {
-		name: "package yargs-parser",
-		doc: &processor.Document{
-			Blob:              []byte(testdata.CollectedYargsParser),
-			Type:              processor.DocumentDepsDev,
-			Format:            processor.FormatJSON,
-			SourceInformation: processor.SourceInformation{},
-		},
-		wantIdentifiers: &common.IdentifierStrings{
-			PurlStrings: []string{"pkg:npm/camelcase@3.0.0"}},
-		wantErr: false,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := NewDepsDevParser()
-			if err := d.Parse(ctx, tt.doc); (err != nil) != tt.wantErr {
-				t.Errorf("deps.dev.Parse() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			identifiers, err := d.GetIdentifiers(ctx)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("deps.dev.GetIdentifiers() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if d := cmp.Diff(tt.wantIdentifiers, identifiers); len(d) != 0 {
-				t.Errorf("deps.dev.GetPredicate mismatch values (+got, -expected): %s", d)
-			}
-		})
-	}
-}
+// func Test_depsDevParser_GetIdentifiers(t *testing.T) {
+// 	ctx := logging.WithLogger(context.Background())
+
+// 	tests := []struct {
+// 		name            string
+// 		doc             *processor.Document
+// 		wantIdentifiers *common.IdentifierStrings
+// 		wantErr         bool
+// 	}{{
+// 		name: "package foreign-types",
+// 		doc: &processor.Document{
+// 			Blob:              []byte(testdata.CollectedForeignTypes),
+// 			Type:              processor.DocumentDepsDev,
+// 			Format:            processor.FormatJSON,
+// 			SourceInformation: processor.SourceInformation{},
+// 		},
+// 		wantIdentifiers: &common.IdentifierStrings{
+// 			PurlStrings: []string{"pkg:cargo/foreign-types-shared@0.1.1"}},
+// 		wantErr: false,
+// 	}, {
+// 		name: "package yargs-parser",
+// 		doc: &processor.Document{
+// 			Blob:              []byte(testdata.CollectedYargsParser),
+// 			Type:              processor.DocumentDepsDev,
+// 			Format:            processor.FormatJSON,
+// 			SourceInformation: processor.SourceInformation{},
+// 		},
+// 		wantIdentifiers: &common.IdentifierStrings{
+// 			PurlStrings: []string{"pkg:npm/camelcase@3.0.0"}},
+// 		wantErr: false,
+// 	}}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			d := NewDepsDevParser()
+// 			if err := d.Parse(ctx, tt.doc); (err != nil) != tt.wantErr {
+// 				t.Errorf("deps.dev.Parse() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+// 			identifiers, err := d.GetIdentifiers(ctx)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("deps.dev.GetIdentifiers() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+// 			if d := cmp.Diff(tt.wantIdentifiers, identifiers); len(d) != 0 {
+// 				t.Errorf("deps.dev.GetPredicate mismatch values (+got, -expected): %s", d)
+// 			}
+// 		})
+// 	}
+// }


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

- Also adds edge filters to certifier queries
- remove vulnerability collection from deps.dev as it ends up with duplicate data from the osv certifier
- check if a source has already been ingested for a purl. If it has, do not re-ingest as it duplicates "hasSourceAt" (different timestamps)