### PR TITLE
Cleaned up guacone CLI opts. Categorized collectors and certifiers.

### DIFF
--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -44,7 +44,7 @@ var filesCmd = &cobra.Command{
 	Short: "take a folder of files and create a GUAC graph utilizing Nats pubsub",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		opts, err := validateFlags(
+		opts, err := validateFilesFlags(
 			viper.GetString("natsaddr"),
 			viper.GetBool("poll"),
 			args)
@@ -67,7 +67,7 @@ var filesCmd = &cobra.Command{
 	},
 }
 
-func validateFlags(natsAddr string, poll bool, args []string) (filesOptions, error) {
+func validateFilesFlags(natsAddr string, poll bool, args []string) (filesOptions, error) {
 	var opts filesOptions
 
 	opts.natsAddr = natsAddr

--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -58,7 +58,7 @@ var filesCmd = &cobra.Command{
 		logger := logging.FromContext(ctx)
 
 		// Register collector
-		fileCollector := file.NewFileCollector(ctx, opts.path, opts.poll, time.Second)
+		fileCollector := file.NewFileCollector(ctx, opts.path, opts.poll, 30*time.Second)
 		err = collector.RegisterDocumentCollector(fileCollector, file.FileCollector)
 		if err != nil {
 			logger.Errorf("unable to register file collector: %v", err)

--- a/cmd/guaccsub/cmd/root.go
+++ b/cmd/guaccsub/cmd/root.go
@@ -20,29 +20,25 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/collectsub/server"
 	"github.com/guacsec/guac/pkg/logging"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-var flags = struct {
-	port int
-}{}
 
 var rootCmd = &cobra.Command{
 	Use:   "guaccsub",
 	Short: "GUAC collect subscriber service for GUAC collectors",
 	Run: func(cmd *cobra.Command, args []string) {
-		flags.port = viper.GetInt("csub-listen-port")
+		port := viper.GetInt("csub-listen-port")
 
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
 
 		// Start csub listening server
-		csubServer, err := server.NewServer(flags.port)
+		csubServer, err := server.NewServer(port)
 		if err != nil {
 			logger.Fatalf("unable to create csub server: %v", err)
 		}
@@ -53,49 +49,18 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-var cfgFile string
-
 func init() {
-	cobra.OnInitialize(initConfig)
-	cmdFlags := rootCmd.Flags()
+	cobra.OnInitialize(cli.InitConfig)
 
-	cmdFlags.IntVar(&flags.port, "csub-listen-port", 2782, "port to listen to on collect-sub service")
-
-	flagNames := []string{"csub-listen-port"}
-	for _, name := range flagNames {
-		if flag := cmdFlags.Lookup(name); flag != nil {
-			if err := viper.BindPFlag(name, flag); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to bind flag: %v", err)
-				os.Exit(1)
-			}
-		}
+	set, err := cli.BuildFlags([]string{"csub-listen-port"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
 	}
-}
-
-func initConfig() {
-	ctx := logging.WithLogger(context.Background())
-	logger := logging.FromContext(ctx)
-
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to get user home directory: %v\n", err)
-			os.Exit(1)
-		}
-
-		viper.AddConfigPath(home)
-		viper.AddConfigPath(".")
-		viper.SetConfigName("guac")
-		viper.SetConfigType("yaml")
-	}
-
-	viper.AutomaticEnv()
-	viper.SetEnvPrefix("guac")
-
-	if err := viper.ReadInConfig(); err == nil {
-		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
+	rootCmd.Flags().AddFlagSet(set)
+	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/guacone/cmd/certifier.go
+++ b/cmd/guacone/cmd/certifier.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The GUAC Authors.
+// Copyright 2023 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,37 +20,26 @@ import (
 	"os"
 
 	"github.com/guacsec/guac/pkg/cli"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-func init() {
-	cobra.OnInitialize(cli.InitConfig)
+var certifierCmd = &cobra.Command{
+	Use:   "certifier",
+	Short: "Runs the certifier command aginst GraphQL",
+}
 
-	set, err := cli.BuildFlags([]string{"natsaddr", "csub-addr", "gql-endpoint"})
+func init() {
+	set, err := cli.BuildFlags([]string{"poll", "interval"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)
 	}
-	rootCmd.Flags().AddFlagSet(set)
-	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
+	certifierCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(certifierCmd.PersistentFlags()); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
 		os.Exit(1)
 	}
-}
 
-var rootCmd = &cobra.Command{
-	Use:   "guacingest",
-	Short: "starts the GUAC processor, ingestor and assembler process",
-	Run: func(cmd *cobra.Command, args []string) {
-		ingest(cmd, args)
-	},
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	rootCmd.AddCommand(certifierCmd)
 }

--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -24,17 +24,23 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var certifyFlags = struct {
-	justification string
-	subjectType   string
+type certifyOptions struct {
+	// gql endpoint
+	graphqlEndpoint string
+	// // certifyBad/certifyGood
 	good          bool
-	pkgName       bool
-}{}
+	certifyType   string
+	justification string
+	subject       string
+	// // if type is package, true if attestation is at pkgName (for all versions) or false for a specific version
+	pkgName bool
+}
 
 var certifyCmd = &cobra.Command{
 	Use:              "certify [flags] purl / source (<vcs_tool>+<transport>) / artifact (algorithm:digest)",
@@ -59,7 +65,7 @@ var certifyCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		assemblerFunc, err := getAssembler(ctx, opts)
+		assemblerFunc, err := getAssembler(ctx, opts.graphqlEndpoint)
 		if err != nil {
 			logger.Fatalf("error: %v", err)
 		}
@@ -147,8 +153,8 @@ var certifyCmd = &cobra.Command{
 	},
 }
 
-func validateCertifyFlags(graphqlEndpoint, certifyType, justification string, good, pkgName bool, args []string) (options, error) {
-	var opts options
+func validateCertifyFlags(graphqlEndpoint, certifyType, justification string, good, pkgName bool, args []string) (certifyOptions, error) {
+	var opts certifyOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.good = good
 	opts.pkgName = pkgName
@@ -170,19 +176,16 @@ func validateCertifyFlags(graphqlEndpoint, certifyType, justification string, go
 }
 
 func init() {
-	localFlags := certifyCmd.Flags()
-	localFlags.BoolVarP(&certifyFlags.good, "good", "g", true, "set true if certifyGood or false for certifyBad")
-	localFlags.StringVarP(&certifyFlags.subjectType, "type", "t", "", "package, source or artifact that is being certified")
-	localFlags.StringVarP(&certifyFlags.justification, "justification", "j", "", "justification for the certification (either good or bad)")
-	localFlags.BoolVarP(&certifyFlags.pkgName, "pkgName", "n", false, "if type is package, true if attestation is at pkgName (for all versions) or false for a specific version")
-	flagNames := []string{"good", "type", "justification", "pkgName"}
-	for _, name := range flagNames {
-		if flag := localFlags.Lookup(name); flag != nil {
-			if err := viper.BindPFlag(name, flag); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to bind flag: %v", err)
-				os.Exit(1)
-			}
-		}
+	set, err := cli.BuildFlags([]string{"good", "type", "justification", "pkgName"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
 	}
+	certifyCmd.Flags().AddFlagSet(set)
+	if err := viper.BindPFlags(certifyCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+
 	rootCmd.AddCommand(certifyCmd)
 }

--- a/cmd/guacone/cmd/collect.go
+++ b/cmd/guacone/cmd/collect.go
@@ -1,0 +1,27 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+var collectCmd = &cobra.Command{
+	Use:   "collect",
+	Short: "Runs the collector against GraphQL",
+}
+
+func init() {
+	rootCmd.AddCommand(collectCmd)
+}

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/collectsub"
 	"github.com/guacsec/guac/pkg/collectsub/collectsub/input"
@@ -177,6 +178,17 @@ var csubGetCollectEntriesCmd = &cobra.Command{
 }
 
 func init() {
+	set, err := cli.BuildFlags([]string{"csub-addr"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	csubClientCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(csubClientCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+
 	rootCmd.AddCommand(csubClientCmd)
 	csubClientCmd.AddCommand(csubAddCollectEntriesCmd)
 	csubClientCmd.AddCommand(csubGetCollectEntriesCmd)

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -29,7 +29,13 @@ import (
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+type ociOptions struct {
+	graphqlEndpoint string
+	dataSource      datasource.CollectSource
+}
 
 var ociCmd = &cobra.Command{
 	Use:   "image [flags] image_path1 image_path2...",
@@ -64,7 +70,7 @@ var ociCmd = &cobra.Command{
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
 		}
-		assemblerFunc, err := getAssembler(ctx, opts)
+		assemblerFunc, err := getAssembler(ctx, opts.graphqlEndpoint)
 		if err != nil {
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
@@ -121,8 +127,9 @@ var ociCmd = &cobra.Command{
 	},
 }
 
-func validateOCIFlags(args []string) (options, error) {
-	var opts options
+func validateOCIFlags(args []string) (ociOptions, error) {
+	var opts ociOptions
+	opts.graphqlEndpoint = viper.GetString("gql-endpoint")
 
 	if len(args) < 1 {
 		return opts, fmt.Errorf("expected positional argument for image_path")
@@ -149,5 +156,5 @@ func validateOCIFlags(args []string) (options, error) {
 }
 
 func init() {
-	rootCmd.AddCommand(ociCmd)
+	collectCmd.AddCommand(ociCmd)
 }

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -33,6 +33,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+type osvOptions struct {
+	graphqlEndpoint string
+	poll            bool
+	interval        int
+}
+
 var osvCmd = &cobra.Command{
 	Use:   "osv [flags]",
 	Short: "runs the osv certifier",
@@ -70,7 +76,7 @@ var osvCmd = &cobra.Command{
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
 		}
-		assemblerFunc, err := getAssembler(ctx, opts)
+		assemblerFunc, err := getAssembler(ctx, opts.graphqlEndpoint)
 		if err != nil {
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
@@ -133,8 +139,8 @@ var osvCmd = &cobra.Command{
 	},
 }
 
-func validateOSVFlags(graphqlEndpoint string, poll bool, interval int) (options, error) {
-	var opts options
+func validateOSVFlags(graphqlEndpoint string, poll bool, interval int) (osvOptions, error) {
+	var opts osvOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.poll = poll
 	opts.interval = interval
@@ -150,5 +156,5 @@ func getPackageQuery(client graphql.Client) (func() certifier.QueryComponents, e
 }
 
 func init() {
-	rootCmd.AddCommand(osvCmd)
+	certifierCmd.AddCommand(osvCmd)
 }

--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -26,6 +26,7 @@ import (
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -33,13 +34,6 @@ import (
 )
 
 const guacType string = "guac"
-
-var queryFlags = struct {
-	purl            string
-	vulnerabilityID string
-	depth           int
-	pathsToReturn   int
-}{}
 
 type queryOptions struct {
 	// gql endpoint
@@ -428,19 +422,16 @@ func validateQueryVulnFlags(graphqlEndpoint, purl, vulnID string, depth, path in
 }
 
 func init() {
-	localFlags := queryVulnCmd.Flags()
-	localFlags.StringVar(&queryFlags.purl, "purl", "", "package purl to check")
-	localFlags.StringVar(&queryFlags.vulnerabilityID, "vulnerabilityID", "", "CVE, GHSA or OSV ID to check")
-	localFlags.IntVar(&queryFlags.depth, "depth", 0, "depth to check, 0 has no limit")
-	localFlags.IntVar(&queryFlags.pathsToReturn, "path", 0, "number of paths to return, 0 means all paths")
-	flagNames := []string{"purl", "vulnerabilityID", "depth", "path"}
-	for _, name := range flagNames {
-		if flag := localFlags.Lookup(name); flag != nil {
-			if err := viper.BindPFlag(name, flag); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to bind flag: %v", err)
-				os.Exit(1)
-			}
-		}
+	set, err := cli.BuildFlags([]string{"purl", "vulnerabilityID", "depth", "path"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
 	}
+	queryVulnCmd.Flags().AddFlagSet(set)
+	if err := viper.BindPFlags(queryVulnCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+
 	rootCmd.AddCommand(queryVulnCmd)
 }

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -35,6 +35,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+type scorecardOptions struct {
+	graphqlEndpoint string
+	poll            bool
+	interval        int
+}
+
 var scorecardCmd = &cobra.Command{
 	Use:   "scorecard [flags]",
 	Short: "runs the scorecard certifier",
@@ -101,7 +107,7 @@ var scorecardCmd = &cobra.Command{
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
 		}
-		assemblerFunc, err := getAssembler(ctx, opts)
+		assemblerFunc, err := getAssembler(ctx, opts.graphqlEndpoint)
 		if err != nil {
 			logger.Errorf("error: %v", err)
 			os.Exit(1)
@@ -158,8 +164,8 @@ var scorecardCmd = &cobra.Command{
 	},
 }
 
-func validateScorecardFlags(graphqlEndpoint string, poll bool, interval int) (options, error) {
-	var opts options
+func validateScorecardFlags(graphqlEndpoint string, poll bool, interval int) (scorecardOptions, error) {
+	var opts scorecardOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.poll = poll
 	opts.interval = interval
@@ -168,5 +174,5 @@ func validateScorecardFlags(graphqlEndpoint string, poll bool, interval int) (op
 }
 
 func init() {
-	rootCmd.AddCommand(scorecardCmd)
+	certifierCmd.AddCommand(scorecardCmd)
 }

--- a/demo/GraphQL.md
+++ b/demo/GraphQL.md
@@ -61,7 +61,7 @@ GUAC graph.
 In your original window, run:
 
 ```bash
-bin/guacone files ../guac-data/docs/
+bin/guacone collect files ../guac-data/docs/
 ```
 
 This can take a minute or two. This dataset consists of a set of document types:
@@ -611,7 +611,7 @@ them. The OSV certifier will search for OSV vulnerability information. To run
 the OSV certifiers, run:
 
 ```bash
-bin/guacone osv --poll=false
+bin/guacone certifier osv --poll=false
 ```
 
 The certifier will take a few minutes to run. A vulnerability "noun" node may be

--- a/demo/bad_packages.md
+++ b/demo/bad_packages.md
@@ -32,7 +32,7 @@ For this demo, we will simulate ingesting an organization's software catalog. To
 do this, we will ingest a collection of SBOMs.
 
 ```bash
-bin/guacone files ../guac-data/docs/
+bin/guacone collect files ../guac-data/docs/
 ```
 
 This will ingest a collection of SBOMs and SLSA attestations into GUAC.

--- a/demo/query_vuln.md
+++ b/demo/query_vuln.md
@@ -52,7 +52,7 @@ In your terminal window, run:
 
 ```bash
 pushd ../guac-data/docs/spdx/spdx_vuln.json
-docker run --rm -v $PWD:/data --network guac_default local-organic-guac:latest /opt/guac/guacone files /data --gql-endpoint http://guac-graphql:8080/query
+docker run --rm -v $PWD:/data --network guac_default local-organic-guac:latest /opt/guac/guacone collect files /data --gql-endpoint http://guac-graphql:8080/query
 popd
 ```
 
@@ -93,7 +93,7 @@ them.
 wait for the OSV certifier to re-scan or force it to run manually via:
 
 ```bash
-docker run --rm --network guac_default local-organic-guac:latest /opt/guac/guacone osv -p=false --gql-endpoint http://guac-graphql:8080/query
+docker run --rm --network guac_default local-organic-guac:latest /opt/guac/guacone certifier osv -p=false --gql-endpoint http://guac-graphql:8080/query
 ```
 
 Once the OSV certifier has completed running and you will see the following
@@ -142,7 +142,7 @@ five minute interval to keep re-scanning for any new packages in GUAC). To force
 the scan to occur immediately please run:
 
 ```bash
-docker run --rm --network guac_default local-organic-guac:latest /opt/guac/guacone osv -p=false --gql-endpoint http://guac-graphql:8080/query
+docker run --rm --network guac_default local-organic-guac:latest /opt/guac/guacone certifier osv -p=false --gql-endpoint http://guac-graphql:8080/query
 ```
 
 Successful output will show the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - ./container_files/guac:/guac
   osv-certifier:
     image: "local-organic-guac"
-    command: "/opt/guac/guacone osv --poll --interval 5"
+    command: "/opt/guac/guacone certifier osv --poll --interval 5"
     working_dir: /guac
     restart: on-failure
     depends_on:

--- a/docs/Compose.md
+++ b/docs/Compose.md
@@ -179,13 +179,13 @@ containers used, the unclean state can cause issues.
 
 ## Start Ingesting Data
 
-Now you can run the `guacone files` ingestion command to load data into your
-GUAC deployment. For example we can ingest the sample `guac-data` data. However,
-you may ingest what you wish to here instead.
+Now you can run the `guacone collect files` ingestion command to load data into
+your GUAC deployment. For example we can ingest the sample `guac-data` data.
+However, you may ingest what you wish to here instead.
 
 ```bash
 pushd ../guac-data/docs
-docker run --rm -v $PWD:/data --network guac_default local-organic-guac:latest /opt/guac/guacone files /data --gql-endpoint http://guac-graphql:8080/query
+docker run --rm -v $PWD:/data --network guac_default local-organic-guac:latest /opt/guac/guacone collect files /data --gql-endpoint http://guac-graphql:8080/query
 popd
 ```
 
@@ -205,7 +205,7 @@ them natively.
 
 ```bash
 make build
-./bin/guacone files ../guac-data/docs
+./bin/guacone collect files ../guac-data/docs
 ```
 
 ## Query GraphQL Endpoint

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -37,10 +37,10 @@ echo @@@@ Starting up guac server in background
 go run "${GUAC_DIR}/cmd/guacgql" &
 
 echo @@@@ Ingesting guac-data into server
-go run "${GUAC_DIR}/cmd/guacone" files "${GUAC_DIR}/guac-data/docs/"
+go run "${GUAC_DIR}/cmd/guacone" collect files "${GUAC_DIR}/guac-data/docs/"
 
 echo @@@@ Running osv certifier
-go run "${GUAC_DIR}/cmd/guacone" osv -p=false
+go run "${GUAC_DIR}/cmd/guacone" certifier osv -p=false
 
 queries="${GUAC_DIR}/demo/queries.gql"
 

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -1,0 +1,55 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/guacsec/guac/pkg/logging"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+func InitConfig() {
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get user home directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	viper.AddConfigPath(home)
+	viper.AddConfigPath(".")
+	viper.SetConfigName("guac")
+	viper.SetConfigType("yaml")
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("guac")
+	// The following line is needed to replace - with _ in env variables
+	// e.g. GUAC_DB_ADDR will be read as GUAC_gdbaddr
+	// The POSIX standard does not allow - in env variables
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	if err := viper.ReadInConfig(); err == nil {
+		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
+	}
+}

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -1,0 +1,83 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+var flagStore = make(map[string]*pflag.Flag)
+
+var NotFound = errors.New("Flag not found")
+
+func init() {
+	set := &pflag.FlagSet{}
+
+	// Set of all flags used across GUAC clis and subcommands. Use consistant
+	// names for config file.
+	set.String("natsaddr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
+	set.String("csub-addr", "localhost:2782", "address to connect to collect-sub service")
+	set.Bool("use-csub", true, "use collectsub server for datasource")
+
+	set.Int("csub-listen-port", 2782, "port to listen to on collect-sub service")
+
+	set.String("gql-backend", "inmem", "backend used for graphql api server: [neo4j | inmem]")
+	set.Int("gql-port", 8080, "port used for graphql api server")
+	set.Bool("gql-debug", false, "debug flag which enables the graphQL playground")
+	set.Bool("gql-testdata", false, "Populate backend with test data")
+
+	set.String("gdbaddr", "neo4j://localhost:7687", "address to neo4j db")
+	set.String("gdbuser", "", "neo4j user credential to connect to graph db")
+	set.String("gdbpass", "", "neo4j password credential to connect to graph db")
+	set.String("realm", "neo4j", "realm to connect to graph db")
+
+	set.String("gql-endpoint", "http://localhost:8080/query", "endpoint used to connect to graphQL server")
+
+	set.String("verifier-keyPath", "", "path to pem file to verify dsse")
+	set.String("verifier-keyID", "", "ID of the key to be stored")
+
+	set.BoolP("poll", "p", true, "sets the collector or certifier to polling mode")
+	set.IntP("interval", "i", 5, "if polling set interval in minutes")
+
+	set.BoolP("good", "g", true, "set true if certifyGood or false for certifyBad")
+	set.StringP("type", "t", "", "package, source or artifact that is being certified")
+	set.StringP("justification", "j", "", "justification for the certification (either good or bad)")
+	set.BoolP("pkgName", "n", false, "if type is package, true if attestation is at pkgName (for all versions) or false for a specific version")
+
+	set.String("purl", "", "package purl to check")
+	set.String("vulnerabilityID", "", "CVE, GHSA or OSV ID to check")
+	set.Int("depth", 0, "depth to check, 0 has no limit")
+	set.Int("path", 0, "number of paths to return, 0 means all paths")
+
+	set.VisitAll(func(f *pflag.Flag) {
+		flagStore[f.Name] = f
+	})
+}
+
+func BuildFlags(names []string) (*pflag.FlagSet, error) {
+	rv := &pflag.FlagSet{}
+	for _, n := range names {
+		f, ok := flagStore[n]
+		if !ok {
+			return nil, fmt.Errorf("%w : %s", NotFound, n)
+		}
+		rv.AddFlag(f)
+	}
+	return rv, nil
+}


### PR DESCRIPTION
`pkg/cli/store.go` contains a "FlagStore". All CLI flags are defined here, and the commands build from there by flag name. Commands don't need a "flag" struct, they always just pull from viper with `viper.GetType("name")`

 `pkg/cli/init.go` contains the Config file initialization routine that all commands had duplicated before. We can add more duplication to `pkg/cli` that we find.

`guacone`'s `files` and `image` are moved under `guacone collect`.

`guacone`'s `osv` and `scorecard` are moved under `guacone certifier` and share the `interval` and `poll` options there.

The only top-level `guacone` flag is `gql-endpoint`. The others are underneath the sub command they are for.

**TODO**
I didn't change any flag names, as to not change any existing `guac.yaml` files. We should go over these and think about changing them. Some are `camelCase` and others `dash-case`. Some are "namespaced" (ex: `gql-backend`, `gql-port`) which makes them nicer to group up in the `guac.yaml` and help identify them there without the context of which command they are for.

Also, `poll` default is still true. I want it to be true for `guaccollect` and false for `guacone collect`. Therefore we need different names. I'll think about this and change it soon.