### PR TITLE
update hasSBOM schema to include fields from ResourceDescriptor

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -196,10 +196,11 @@ func ingestDependency(ctx context.Context, client graphql.Client) {
 			Name:      "openssl",
 		},
 		dependency: model.IsDependencyInputSpec{
-			VersionRange:  "3.0.3",
-			Justification: "deb: part of SBOM - openssl",
-			Origin:        "Demo ingestion",
-			Collector:     "Demo ingestion",
+			VersionRange:   "3.0.3",
+			DependencyType: model.DependencyTypeDirect,
+			Justification:  "deb: part of SBOM - openssl",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
 		},
 	}, {
 		name: "docker: part of SBOM - openssl",
@@ -214,10 +215,11 @@ func ingestDependency(ctx context.Context, client graphql.Client) {
 			Name:      "openssl",
 		},
 		dependency: model.IsDependencyInputSpec{
-			VersionRange:  "3.0.3",
-			Justification: "docker: part of SBOM - openssl",
-			Origin:        "Demo ingestion",
-			Collector:     "Demo ingestion",
+			VersionRange:   "3.0.3",
+			DependencyType: model.DependencyTypeIndirect,
+			Justification:  "docker: part of SBOM - openssl",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
 		},
 	}, {
 		name: "deb: part of SBOM - openssl (duplicate)",
@@ -236,10 +238,11 @@ func ingestDependency(ctx context.Context, client graphql.Client) {
 			Name:      "openssl",
 		},
 		dependency: model.IsDependencyInputSpec{
-			VersionRange:  "3.0.3",
-			Justification: "deb: part of SBOM - openssl",
-			Origin:        "Demo ingestion",
-			Collector:     "Demo ingestion",
+			VersionRange:   "3.0.3",
+			DependencyType: model.DependencyTypeDirect,
+			Justification:  "deb: part of SBOM - openssl",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
 		},
 	}}
 	for _, ingest := range ingestDependencies {
@@ -1046,7 +1049,16 @@ func ingestHasSBOM(ctx context.Context, client graphql.Client) {
 			Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
 		},
 		hasSBOM: model.HasSBOMInputSpec{
-			Uri:       "uri:location of package SBOM",
+			Uri:              "uri:location of package SBOM",
+			Algorithm:        "sha256",
+			Digest:           "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+			DownloadLocation: "uri: download location of the SBOM",
+			Annotations: []model.AnnotationInputSpec{
+				{
+					Key:   "scorecard",
+					Value: "7",
+				},
+			},
 			Origin:    "Demo ingestion",
 			Collector: "Demo ingestion",
 		},
@@ -1059,8 +1071,61 @@ func ingestHasSBOM(ctx context.Context, client graphql.Client) {
 			Tag:       &sourceTag,
 		},
 		hasSBOM: model.HasSBOMInputSpec{
-			//Annotation: "this SBOM has a score of 10",
-			Uri:       "uri:location of source SBOM",
+			Uri:              "uri:location of source SBOM",
+			Algorithm:        "sha1",
+			Digest:           "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+			DownloadLocation: "uri: download location of the SBOM",
+			Annotations: []model.AnnotationInputSpec{
+				{
+					Key:   "scorecard",
+					Value: "10",
+				},
+			},
+			Origin:    "Demo ingestion",
+			Collector: "Demo ingestion",
+		},
+	}, {
+		name: "uri:location of package SBOM (duplicate)",
+		pkg: &model.PkgInputSpec{
+			Type:       "conan",
+			Namespace:  &opensslNs,
+			Name:       "openssl",
+			Version:    &opensslVersion,
+			Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+		},
+		hasSBOM: model.HasSBOMInputSpec{
+			Uri:              "uri:location of package SBOM",
+			Algorithm:        "sha256",
+			Digest:           "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+			DownloadLocation: "uri: download location of the SBOM",
+			Annotations: []model.AnnotationInputSpec{
+				{
+					Key:   "scorecard",
+					Value: "7",
+				},
+			},
+			Origin:    "Demo ingestion",
+			Collector: "Demo ingestion",
+		},
+	}, {
+		name: "uri:location of source SBOM (duplicate)",
+		source: &model.SourceInputSpec{
+			Type:      "git",
+			Namespace: "github",
+			Name:      "github.com/guacsec/guac",
+			Tag:       &sourceTag,
+		},
+		hasSBOM: model.HasSBOMInputSpec{
+			Uri:              "uri:location of source SBOM",
+			Algorithm:        "sha1",
+			Digest:           "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+			DownloadLocation: "uri: download location of the SBOM",
+			Annotations: []model.AnnotationInputSpec{
+				{
+					Key:   "scorecard",
+					Value: "10",
+				},
+			},
 			Origin:    "Demo ingestion",
 			Collector: "Demo ingestion",
 		},
@@ -1579,10 +1644,11 @@ func ingestReachabilityTestData(ctx context.Context, client graphql.Client) {
 			Name:      "openssl",
 		},
 		dependency: model.IsDependencyInputSpec{
-			VersionRange:  "3.0.3",
-			Justification: "deb: part of SBOM - openssl",
-			Origin:        "Demo ingestion",
-			Collector:     "Demo ingestion",
+			VersionRange:   "3.0.3",
+			DependencyType: model.DependencyTypeDirect,
+			Justification:  "deb: part of SBOM - openssl",
+			Origin:         "Demo ingestion",
+			Collector:      "Demo ingestion",
 		},
 		depPkgWithVersion: model.PkgInputSpec{
 			Type:      "conan",

--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -1059,10 +1059,10 @@ func ingestHasSBOM(ctx context.Context, client graphql.Client) {
 			Tag:       &sourceTag,
 		},
 		hasSBOM: model.HasSBOMInputSpec{
-			Annotation: "this SBOM has a score of 10",
-			Uri:        "uri:location of source SBOM",
-			Origin:     "Demo ingestion",
-			Collector:  "Demo ingestion",
+			//Annotation: "this SBOM has a score of 10",
+			Uri:       "uri:location of source SBOM",
+			Origin:    "Demo ingestion",
+			Collector: "Demo ingestion",
 		},
 	}}
 	for _, ingest := range ingestHasSBOM {

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -17,6 +17,7 @@ package inmem
 
 import (
 	"context"
+	"reflect"
 	"strconv"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -27,12 +28,16 @@ import (
 
 type hasSBOMList []*hasSBOMStruct
 type hasSBOMStruct struct {
-	id        uint32
-	pkg       uint32
-	src       uint32
-	uri       string
-	origin    string
-	collector string
+	id               uint32
+	pkg              uint32
+	src              uint32
+	uri              string
+	algorithm        string
+	digest           string
+	downloadLocation string
+	annotations      map[string]string
+	origin           string
+	collector        string
 }
 
 func (n *hasSBOMStruct) ID() uint32 { return n.id }
@@ -140,6 +145,10 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 		if h.pkg == packageID &&
 			h.src == sourceID &&
 			h.uri == input.URI &&
+			h.algorithm == input.Algorithm &&
+			h.digest == input.Digest &&
+			h.downloadLocation == input.DownloadLocation &&
+			reflect.DeepEqual(h.annotations, getAnnotationsFromInput(input.Annotations)) &&
 			h.origin == input.Origin &&
 			h.collector == input.Collector {
 			return c.convHasSBOM(h)
@@ -154,12 +163,16 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 	}
 
 	h := &hasSBOMStruct{
-		id:        c.getNextID(),
-		pkg:       packageID,
-		src:       sourceID,
-		uri:       input.URI,
-		origin:    input.Origin,
-		collector: input.Collector,
+		id:               c.getNextID(),
+		pkg:              packageID,
+		src:              sourceID,
+		uri:              input.URI,
+		algorithm:        input.Algorithm,
+		digest:           input.Digest,
+		downloadLocation: input.DownloadLocation,
+		annotations:      getAnnotationsFromInput(input.Annotations),
+		origin:           input.Origin,
+		collector:        input.Collector,
 	}
 	c.index[h.id] = h
 	c.hasSBOMs = append(c.hasSBOMs, h)
@@ -173,10 +186,14 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 
 func (c *demoClient) convHasSBOM(in *hasSBOMStruct) (*model.HasSbom, error) {
 	out := &model.HasSbom{
-		ID:        nodeID(in.id),
-		URI:       in.uri,
-		Origin:    in.origin,
-		Collector: in.collector,
+		ID:               nodeID(in.id),
+		URI:              in.uri,
+		Algorithm:        in.algorithm,
+		Digest:           in.digest,
+		DownloadLocation: in.downloadLocation,
+		Annotations:      getCollectedHasSBOMAnnotations(in.annotations),
+		Origin:           in.origin,
+		Collector:        in.collector,
 	}
 	if in.pkg != 0 {
 		p, err := c.buildPackageResponse(in.pkg, nil)
@@ -274,6 +291,10 @@ func (c *demoClient) addHasSBOMIfMatch(out []*model.HasSbom,
 	filter *model.HasSBOMSpec, link *hasSBOMStruct) (
 	[]*model.HasSbom, error) {
 	if noMatch(filter.URI, link.uri) ||
+		noMatch(filter.Algorithm, link.algorithm) ||
+		noMatch(filter.Digest, link.digest) ||
+		noMatch(filter.DownloadLocation, link.downloadLocation) ||
+		noMatchAnnotations(filter.Annotations, link.annotations) ||
 		noMatch(filter.Origin, link.origin) ||
 		noMatch(filter.Collector, link.collector) {
 		return out, nil
@@ -308,4 +329,46 @@ func (c *demoClient) addHasSBOMIfMatch(out []*model.HasSbom,
 		return nil, err
 	}
 	return append(out, sb), nil
+}
+
+func getCollectedHasSBOMAnnotations(annotationMap map[string]string) []*model.Annotation {
+	annotations := []*model.Annotation{}
+	for key, val := range annotationMap {
+		annotation := &model.Annotation{
+			Key:   key,
+			Value: val,
+		}
+		annotations = append(annotations, annotation)
+
+	}
+	return annotations
+}
+
+func getAnnotationsFromInput(annotationInput []*model.AnnotationInputSpec) map[string]string {
+	annotationMap := map[string]string{}
+	if annotationInput == nil {
+		return annotationMap
+	}
+	for _, kv := range annotationInput {
+		annotationMap[kv.Key] = kv.Value
+	}
+	return annotationMap
+}
+
+func getAnnotationsFromFilter(annotationFilter []*model.AnnotationSpec) map[string]string {
+	annotationMap := map[string]string{}
+	if annotationFilter == nil {
+		return annotationMap
+	}
+	for _, kv := range annotationFilter {
+		annotationMap[kv.Key] = kv.Value
+	}
+	return annotationMap
+}
+
+func noMatchAnnotations(annotationFilter []*model.AnnotationSpec, v map[string]string) bool {
+	if annotationFilter == nil && len(annotationFilter) > 0 {
+		return !reflect.DeepEqual(v, getAnnotationsFromFilter(annotationFilter))
+	}
+	return false
 }

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -27,13 +27,12 @@ import (
 
 type hasSBOMList []*hasSBOMStruct
 type hasSBOMStruct struct {
-	id         uint32
-	pkg        uint32
-	src        uint32
-	uri        string
-	annotation string
-	origin     string
-	collector  string
+	id        uint32
+	pkg       uint32
+	src       uint32
+	uri       string
+	origin    string
+	collector string
 }
 
 func (n *hasSBOMStruct) ID() uint32 { return n.id }
@@ -141,7 +140,6 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 		if h.pkg == packageID &&
 			h.src == sourceID &&
 			h.uri == input.URI &&
-			h.annotation == input.Annotation &&
 			h.origin == input.Origin &&
 			h.collector == input.Collector {
 			return c.convHasSBOM(h)
@@ -156,13 +154,12 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 	}
 
 	h := &hasSBOMStruct{
-		id:         c.getNextID(),
-		pkg:        packageID,
-		src:        sourceID,
-		uri:        input.URI,
-		annotation: input.Annotation,
-		origin:     input.Origin,
-		collector:  input.Collector,
+		id:        c.getNextID(),
+		pkg:       packageID,
+		src:       sourceID,
+		uri:       input.URI,
+		origin:    input.Origin,
+		collector: input.Collector,
 	}
 	c.index[h.id] = h
 	c.hasSBOMs = append(c.hasSBOMs, h)
@@ -176,11 +173,10 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrS
 
 func (c *demoClient) convHasSBOM(in *hasSBOMStruct) (*model.HasSbom, error) {
 	out := &model.HasSbom{
-		ID:         nodeID(in.id),
-		URI:        in.uri,
-		Annotation: in.annotation,
-		Origin:     in.origin,
-		Collector:  in.collector,
+		ID:        nodeID(in.id),
+		URI:       in.uri,
+		Origin:    in.origin,
+		Collector: in.collector,
 	}
 	if in.pkg != 0 {
 		p, err := c.buildPackageResponse(in.pkg, nil)
@@ -278,7 +274,6 @@ func (c *demoClient) addHasSBOMIfMatch(out []*model.HasSbom,
 	filter *model.HasSBOMSpec, link *hasSBOMStruct) (
 	[]*model.HasSbom, error) {
 	if noMatch(filter.URI, link.uri) ||
-		noMatch(filter.Annotation, link.annotation) ||
 		noMatch(filter.Origin, link.origin) ||
 		noMatch(filter.Collector, link.collector) {
 		return out, nil

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	uri        string = "uri"
-	annotation string = "annotation"
+	uri string = "uri"
 )
 
 func (c *neo4jClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpec) ([]*model.HasSbom, error) {
@@ -91,7 +90,7 @@ func (c *neo4jClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpe
 						return nil, gqlerror.Errorf("hasSBOM Node not found in neo4j")
 					}
 
-					hasSBOM := generateModelHasSBOM(pkg, hasSBOMNode.Props[uri].(string), hasSBOMNode.Props[annotation].(string), hasSBOMNode.Props[origin].(string), hasSBOMNode.Props[collector].(string))
+					hasSBOM := generateModelHasSBOM(pkg, hasSBOMNode.Props[uri].(string), hasSBOMNode.Props[origin].(string), hasSBOMNode.Props[collector].(string))
 
 					collectedHasSBOM = append(collectedHasSBOM, hasSBOM)
 				}
@@ -149,7 +148,7 @@ func (c *neo4jClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpe
 						return nil, gqlerror.Errorf("hasSBOM Node not found in neo4j")
 					}
 
-					hasSBOM := generateModelHasSBOM(src, hasSBOMNode.Props[uri].(string), hasSBOMNode.Props[annotation].(string), hasSBOMNode.Props[origin].(string), hasSBOMNode.Props[collector].(string))
+					hasSBOM := generateModelHasSBOM(src, hasSBOMNode.Props[uri].(string), hasSBOMNode.Props[origin].(string), hasSBOMNode.Props[collector].(string))
 
 					collectedHasSBOM = append(collectedHasSBOM, hasSBOM)
 				}
@@ -174,11 +173,6 @@ func setHasSBOMValues(sb *strings.Builder, hasSBOMSpec *model.HasSBOMSpec, first
 		*firstMatch = false
 		queryValues[uri] = hasSBOMSpec.URI
 	}
-	if hasSBOMSpec.Annotation != nil {
-		matchProperties(sb, *firstMatch, "hasSBOM", annotation, "$"+annotation)
-		*firstMatch = false
-		queryValues[annotation] = hasSBOMSpec.Annotation
-	}
 	if hasSBOMSpec.Origin != nil {
 		matchProperties(sb, *firstMatch, "hasSBOM", origin, "$"+origin)
 		*firstMatch = false
@@ -191,13 +185,12 @@ func setHasSBOMValues(sb *strings.Builder, hasSBOMSpec *model.HasSBOMSpec, first
 	}
 }
 
-func generateModelHasSBOM(subject model.PackageOrSource, uri, annotation, origin, collector string) *model.HasSbom {
+func generateModelHasSBOM(subject model.PackageOrSource, uri, origin, collector string) *model.HasSbom {
 	hasSBOM := model.HasSbom{
-		Subject:    subject,
-		URI:        uri,
-		Annotation: annotation,
-		Origin:     origin,
-		Collector:  collector,
+		Subject:   subject,
+		URI:       uri,
+		Origin:    origin,
+		Collector: collector,
 	}
 	return &hasSBOM
 }

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -30,6 +30,7 @@ const (
 	uri string = "uri"
 )
 
+// TODO: noe4j backend does not match the schema. This needs updating before use!
 func (c *neo4jClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpec) ([]*model.HasSbom, error) {
 
 	// TODO: Fix validation

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1528,16 +1528,16 @@ func (v *AllSourceTreeNamespacesSourceNamespaceNamesSourceName) GetTag() *string
 func (v *AllSourceTreeNamespacesSourceNamespaceNamesSourceName) GetCommit() *string { return v.Commit }
 
 // AnnotationsSpec is the same as Annotations, but usable as mutation input.
-type AnnotationsInputSpec struct {
+type AnnotationInputSpec struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-// GetKey returns AnnotationsInputSpec.Key, and is useful for accessing the field via an interface.
-func (v *AnnotationsInputSpec) GetKey() string { return v.Key }
+// GetKey returns AnnotationInputSpec.Key, and is useful for accessing the field via an interface.
+func (v *AnnotationInputSpec) GetKey() string { return v.Key }
 
-// GetValue returns AnnotationsInputSpec.Value, and is useful for accessing the field via an interface.
-func (v *AnnotationsInputSpec) GetValue() string { return v.Value }
+// GetValue returns AnnotationInputSpec.Value, and is useful for accessing the field via an interface.
+func (v *AnnotationInputSpec) GetValue() string { return v.Value }
 
 // ArtifactInputSpec is the same as Artifact, but used as mutation input.
 //
@@ -4044,13 +4044,13 @@ func (v *GHSAsResponse) GetGhsa() []GHSAsGhsaGHSA { return v.Ghsa }
 //
 // All fields are required.
 type HasSBOMInputSpec struct {
-	Uri              string                 `json:"uri"`
-	Algorithm        string                 `json:"algorithm"`
-	Digest           string                 `json:"digest"`
-	DownloadLocation string                 `json:"downloadLocation"`
-	Annotations      []AnnotationsInputSpec `json:"annotations"`
-	Origin           string                 `json:"origin"`
-	Collector        string                 `json:"collector"`
+	Uri              string                `json:"uri"`
+	Algorithm        string                `json:"algorithm"`
+	Digest           string                `json:"digest"`
+	DownloadLocation string                `json:"downloadLocation"`
+	Annotations      []AnnotationInputSpec `json:"annotations"`
+	Origin           string                `json:"origin"`
+	Collector        string                `json:"collector"`
 }
 
 // GetUri returns HasSBOMInputSpec.Uri, and is useful for accessing the field via an interface.
@@ -4066,7 +4066,7 @@ func (v *HasSBOMInputSpec) GetDigest() string { return v.Digest }
 func (v *HasSBOMInputSpec) GetDownloadLocation() string { return v.DownloadLocation }
 
 // GetAnnotations returns HasSBOMInputSpec.Annotations, and is useful for accessing the field via an interface.
-func (v *HasSBOMInputSpec) GetAnnotations() []AnnotationsInputSpec { return v.Annotations }
+func (v *HasSBOMInputSpec) GetAnnotations() []AnnotationInputSpec { return v.Annotations }
 
 // GetOrigin returns HasSBOMInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
@@ -4116,7 +4116,7 @@ func (v *HasSBOMPkgIngestHasSBOM) GetDownloadLocation() string {
 }
 
 // GetAnnotations returns HasSBOMPkgIngestHasSBOM.Annotations, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+func (v *HasSBOMPkgIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation {
 	return v.allHasSBOMTree.Annotations
 }
 
@@ -4164,7 +4164,7 @@ type __premarshalHasSBOMPkgIngestHasSBOM struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -4341,7 +4341,7 @@ func (v *HasSBOMSrcIngestHasSBOM) GetDownloadLocation() string {
 }
 
 // GetAnnotations returns HasSBOMSrcIngestHasSBOM.Annotations, and is useful for accessing the field via an interface.
-func (v *HasSBOMSrcIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+func (v *HasSBOMSrcIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation {
 	return v.allHasSBOMTree.Annotations
 }
 
@@ -4389,7 +4389,7 @@ type __premarshalHasSBOMSrcIngestHasSBOM struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -7482,7 +7482,7 @@ func (v *NeighborsNeighborsHasSBOM) GetDownloadLocation() string {
 }
 
 // GetAnnotations returns NeighborsNeighborsHasSBOM.Annotations, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+func (v *NeighborsNeighborsHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation {
 	return v.allHasSBOMTree.Annotations
 }
 
@@ -7532,7 +7532,7 @@ type __premarshalNeighborsNeighborsHasSBOM struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -10350,7 +10350,7 @@ func (v *NodeNodeHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
 func (v *NodeNodeHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
 
 // GetAnnotations returns NodeNodeHasSBOM.Annotations, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+func (v *NodeNodeHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation {
 	return v.allHasSBOMTree.Annotations
 }
 
@@ -10400,7 +10400,7 @@ type __premarshalNodeNodeHasSBOM struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -12594,7 +12594,7 @@ func (v *PathPathHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
 func (v *PathPathHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
 
 // GetAnnotations returns PathPathHasSBOM.Annotations, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+func (v *PathPathHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation {
 	return v.allHasSBOMTree.Annotations
 }
 
@@ -12644,7 +12644,7 @@ type __premarshalPathPathHasSBOM struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -19490,15 +19490,15 @@ func (v *allCertifyVEXStatementVulnerabilityOSV) __premarshalJSON() (*__premarsh
 //
 // Note: Only package object or source object can be defined. Not both.
 type allHasSBOMTree struct {
-	Id               string                               `json:"id"`
-	Subject          allHasSBOMTreeSubjectPackageOrSource `json:"-"`
-	Uri              string                               `json:"uri"`
-	Algorithm        string                               `json:"algorithm"`
-	Digest           string                               `json:"digest"`
-	DownloadLocation string                               `json:"downloadLocation"`
-	Annotations      []allHasSBOMTreeAnnotations          `json:"annotations"`
-	Origin           string                               `json:"origin"`
-	Collector        string                               `json:"collector"`
+	Id               string                                `json:"id"`
+	Subject          allHasSBOMTreeSubjectPackageOrSource  `json:"-"`
+	Uri              string                                `json:"uri"`
+	Algorithm        string                                `json:"algorithm"`
+	Digest           string                                `json:"digest"`
+	DownloadLocation string                                `json:"downloadLocation"`
+	Annotations      []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
+	Origin           string                                `json:"origin"`
+	Collector        string                                `json:"collector"`
 }
 
 // GetId returns allHasSBOMTree.Id, and is useful for accessing the field via an interface.
@@ -19520,7 +19520,7 @@ func (v *allHasSBOMTree) GetDigest() string { return v.Digest }
 func (v *allHasSBOMTree) GetDownloadLocation() string { return v.DownloadLocation }
 
 // GetAnnotations returns allHasSBOMTree.Annotations, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetAnnotations() []allHasSBOMTreeAnnotations { return v.Annotations }
+func (v *allHasSBOMTree) GetAnnotations() []allHasSBOMTreeAnnotationsAnnotation { return v.Annotations }
 
 // GetOrigin returns allHasSBOMTree.Origin, and is useful for accessing the field via an interface.
 func (v *allHasSBOMTree) GetOrigin() string { return v.Origin }
@@ -19574,7 +19574,7 @@ type __premarshalallHasSBOMTree struct {
 
 	DownloadLocation string `json:"downloadLocation"`
 
-	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
+	Annotations []allHasSBOMTreeAnnotationsAnnotation `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -19615,20 +19615,20 @@ func (v *allHasSBOMTree) __premarshalJSON() (*__premarshalallHasSBOMTree, error)
 	return &retval, nil
 }
 
-// allHasSBOMTreeAnnotations includes the requested fields of the GraphQL type Annotations.
+// allHasSBOMTreeAnnotationsAnnotation includes the requested fields of the GraphQL type Annotation.
 // The GraphQL type's documentation follows.
 //
-// Annotations are key-value pairs to provide additional information or metadata about SBOM
-type allHasSBOMTreeAnnotations struct {
+// Annotation are key-value pairs to provide additional information or metadata about SBOM
+type allHasSBOMTreeAnnotationsAnnotation struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-// GetKey returns allHasSBOMTreeAnnotations.Key, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeAnnotations) GetKey() string { return v.Key }
+// GetKey returns allHasSBOMTreeAnnotationsAnnotation.Key, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTreeAnnotationsAnnotation) GetKey() string { return v.Key }
 
-// GetValue returns allHasSBOMTreeAnnotations.Value, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeAnnotations) GetValue() string { return v.Value }
+// GetValue returns allHasSBOMTreeAnnotationsAnnotation.Value, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTreeAnnotationsAnnotation) GetValue() string { return v.Value }
 
 // allHasSBOMTreeSubjectPackage includes the requested fields of the GraphQL type Package.
 // The GraphQL type's documentation follows.

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1527,6 +1527,18 @@ func (v *AllSourceTreeNamespacesSourceNamespaceNamesSourceName) GetTag() *string
 // GetCommit returns AllSourceTreeNamespacesSourceNamespaceNamesSourceName.Commit, and is useful for accessing the field via an interface.
 func (v *AllSourceTreeNamespacesSourceNamespaceNamesSourceName) GetCommit() *string { return v.Commit }
 
+// AnnotationsSpec is the same as Annotations, but usable as mutation input.
+type AnnotationsInputSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns AnnotationsInputSpec.Key, and is useful for accessing the field via an interface.
+func (v *AnnotationsInputSpec) GetKey() string { return v.Key }
+
+// GetValue returns AnnotationsInputSpec.Value, and is useful for accessing the field via an interface.
+func (v *AnnotationsInputSpec) GetValue() string { return v.Value }
+
 // ArtifactInputSpec is the same as Artifact, but used as mutation input.
 //
 // Both arguments will be canonicalized to lowercase.
@@ -4032,17 +4044,29 @@ func (v *GHSAsResponse) GetGhsa() []GHSAsGhsaGHSA { return v.Ghsa }
 //
 // All fields are required.
 type HasSBOMInputSpec struct {
-	Uri        string `json:"uri"`
-	Annotation string `json:"annotation"`
-	Origin     string `json:"origin"`
-	Collector  string `json:"collector"`
+	Uri              string                 `json:"uri"`
+	Algorithm        string                 `json:"algorithm"`
+	Digest           string                 `json:"digest"`
+	DownloadLocation string                 `json:"downloadLocation"`
+	Annotations      []AnnotationsInputSpec `json:"annotations"`
+	Origin           string                 `json:"origin"`
+	Collector        string                 `json:"collector"`
 }
 
 // GetUri returns HasSBOMInputSpec.Uri, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetUri() string { return v.Uri }
 
-// GetAnnotation returns HasSBOMInputSpec.Annotation, and is useful for accessing the field via an interface.
-func (v *HasSBOMInputSpec) GetAnnotation() string { return v.Annotation }
+// GetAlgorithm returns HasSBOMInputSpec.Algorithm, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetAlgorithm() string { return v.Algorithm }
+
+// GetDigest returns HasSBOMInputSpec.Digest, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetDigest() string { return v.Digest }
+
+// GetDownloadLocation returns HasSBOMInputSpec.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetDownloadLocation() string { return v.DownloadLocation }
+
+// GetAnnotations returns HasSBOMInputSpec.Annotations, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetAnnotations() []AnnotationsInputSpec { return v.Annotations }
 
 // GetOrigin returns HasSBOMInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
@@ -4057,6 +4081,10 @@ func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
@@ -4068,15 +4096,28 @@ type HasSBOMPkgIngestHasSBOM struct {
 // GetId returns HasSBOMPkgIngestHasSBOM.Id, and is useful for accessing the field via an interface.
 func (v *HasSBOMPkgIngestHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
 
-// GetUri returns HasSBOMPkgIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
-
-// GetAnnotation returns HasSBOMPkgIngestHasSBOM.Annotation, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetAnnotation() string { return v.allHasSBOMTree.Annotation }
-
 // GetSubject returns HasSBOMPkgIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
 func (v *HasSBOMPkgIngestHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrSource {
 	return v.allHasSBOMTree.Subject
+}
+
+// GetUri returns HasSBOMPkgIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *HasSBOMPkgIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+
+// GetAlgorithm returns HasSBOMPkgIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *HasSBOMPkgIngestHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+
+// GetDigest returns HasSBOMPkgIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *HasSBOMPkgIngestHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+
+// GetDownloadLocation returns HasSBOMPkgIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *HasSBOMPkgIngestHasSBOM) GetDownloadLocation() string {
+	return v.allHasSBOMTree.DownloadLocation
+}
+
+// GetAnnotations returns HasSBOMPkgIngestHasSBOM.Annotations, and is useful for accessing the field via an interface.
+func (v *HasSBOMPkgIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+	return v.allHasSBOMTree.Annotations
 }
 
 // GetOrigin returns HasSBOMPkgIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
@@ -4113,11 +4154,17 @@ func (v *HasSBOMPkgIngestHasSBOM) UnmarshalJSON(b []byte) error {
 type __premarshalHasSBOMPkgIngestHasSBOM struct {
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -4136,8 +4183,6 @@ func (v *HasSBOMPkgIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMPkgIng
 	var retval __premarshalHasSBOMPkgIngestHasSBOM
 
 	retval.Id = v.allHasSBOMTree.Id
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Annotation = v.allHasSBOMTree.Annotation
 	{
 
 		dst := &retval.Subject
@@ -4150,6 +4195,11 @@ func (v *HasSBOMPkgIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMPkgIng
 				"Unable to marshal HasSBOMPkgIngestHasSBOM.allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.allHasSBOMTree.Uri
+	retval.Algorithm = v.allHasSBOMTree.Algorithm
+	retval.Digest = v.allHasSBOMTree.Digest
+	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
+	retval.Annotations = v.allHasSBOMTree.Annotations
 	retval.Origin = v.allHasSBOMTree.Origin
 	retval.Collector = v.allHasSBOMTree.Collector
 	return &retval, nil
@@ -4256,6 +4306,10 @@ func (v *HasSBOMPkgResponse) GetIngestHasSBOM() HasSBOMPkgIngestHasSBOM { return
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
@@ -4267,15 +4321,28 @@ type HasSBOMSrcIngestHasSBOM struct {
 // GetId returns HasSBOMSrcIngestHasSBOM.Id, and is useful for accessing the field via an interface.
 func (v *HasSBOMSrcIngestHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
 
-// GetUri returns HasSBOMSrcIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMSrcIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
-
-// GetAnnotation returns HasSBOMSrcIngestHasSBOM.Annotation, and is useful for accessing the field via an interface.
-func (v *HasSBOMSrcIngestHasSBOM) GetAnnotation() string { return v.allHasSBOMTree.Annotation }
-
 // GetSubject returns HasSBOMSrcIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
 func (v *HasSBOMSrcIngestHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrSource {
 	return v.allHasSBOMTree.Subject
+}
+
+// GetUri returns HasSBOMSrcIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *HasSBOMSrcIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+
+// GetAlgorithm returns HasSBOMSrcIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *HasSBOMSrcIngestHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+
+// GetDigest returns HasSBOMSrcIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *HasSBOMSrcIngestHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+
+// GetDownloadLocation returns HasSBOMSrcIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *HasSBOMSrcIngestHasSBOM) GetDownloadLocation() string {
+	return v.allHasSBOMTree.DownloadLocation
+}
+
+// GetAnnotations returns HasSBOMSrcIngestHasSBOM.Annotations, and is useful for accessing the field via an interface.
+func (v *HasSBOMSrcIngestHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+	return v.allHasSBOMTree.Annotations
 }
 
 // GetOrigin returns HasSBOMSrcIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
@@ -4312,11 +4379,17 @@ func (v *HasSBOMSrcIngestHasSBOM) UnmarshalJSON(b []byte) error {
 type __premarshalHasSBOMSrcIngestHasSBOM struct {
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -4335,8 +4408,6 @@ func (v *HasSBOMSrcIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMSrcIng
 	var retval __premarshalHasSBOMSrcIngestHasSBOM
 
 	retval.Id = v.allHasSBOMTree.Id
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Annotation = v.allHasSBOMTree.Annotation
 	{
 
 		dst := &retval.Subject
@@ -4349,6 +4420,11 @@ func (v *HasSBOMSrcIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMSrcIng
 				"Unable to marshal HasSBOMSrcIngestHasSBOM.allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.allHasSBOMTree.Uri
+	retval.Algorithm = v.allHasSBOMTree.Algorithm
+	retval.Digest = v.allHasSBOMTree.Digest
+	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
+	retval.Annotations = v.allHasSBOMTree.Annotations
 	retval.Origin = v.allHasSBOMTree.Origin
 	retval.Collector = v.allHasSBOMTree.Collector
 	return &retval, nil
@@ -7367,6 +7443,10 @@ func (v *NeighborsNeighborsGHSA) __premarshalJSON() (*__premarshalNeighborsNeigh
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
@@ -7382,15 +7462,28 @@ func (v *NeighborsNeighborsHasSBOM) GetTypename() *string { return v.Typename }
 // GetId returns NeighborsNeighborsHasSBOM.Id, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
 
-// GetUri returns NeighborsNeighborsHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
-
-// GetAnnotation returns NeighborsNeighborsHasSBOM.Annotation, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetAnnotation() string { return v.allHasSBOMTree.Annotation }
-
 // GetSubject returns NeighborsNeighborsHasSBOM.Subject, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrSource {
 	return v.allHasSBOMTree.Subject
+}
+
+// GetUri returns NeighborsNeighborsHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+
+// GetAlgorithm returns NeighborsNeighborsHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+
+// GetDigest returns NeighborsNeighborsHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+
+// GetDownloadLocation returns NeighborsNeighborsHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasSBOM) GetDownloadLocation() string {
+	return v.allHasSBOMTree.DownloadLocation
+}
+
+// GetAnnotations returns NeighborsNeighborsHasSBOM.Annotations, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+	return v.allHasSBOMTree.Annotations
 }
 
 // GetOrigin returns NeighborsNeighborsHasSBOM.Origin, and is useful for accessing the field via an interface.
@@ -7429,11 +7522,17 @@ type __premarshalNeighborsNeighborsHasSBOM struct {
 
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -7453,8 +7552,6 @@ func (v *NeighborsNeighborsHasSBOM) __premarshalJSON() (*__premarshalNeighborsNe
 
 	retval.Typename = v.Typename
 	retval.Id = v.allHasSBOMTree.Id
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Annotation = v.allHasSBOMTree.Annotation
 	{
 
 		dst := &retval.Subject
@@ -7467,6 +7564,11 @@ func (v *NeighborsNeighborsHasSBOM) __premarshalJSON() (*__premarshalNeighborsNe
 				"Unable to marshal NeighborsNeighborsHasSBOM.allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.allHasSBOMTree.Uri
+	retval.Algorithm = v.allHasSBOMTree.Algorithm
+	retval.Digest = v.allHasSBOMTree.Digest
+	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
+	retval.Annotations = v.allHasSBOMTree.Annotations
 	retval.Origin = v.allHasSBOMTree.Origin
 	retval.Collector = v.allHasSBOMTree.Collector
 	return &retval, nil
@@ -10211,6 +10313,10 @@ func (v *NodeNodeGHSA) __premarshalJSON() (*__premarshalNodeNodeGHSA, error) {
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
@@ -10226,15 +10332,26 @@ func (v *NodeNodeHasSBOM) GetTypename() *string { return v.Typename }
 // GetId returns NodeNodeHasSBOM.Id, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
 
-// GetUri returns NodeNodeHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
-
-// GetAnnotation returns NodeNodeHasSBOM.Annotation, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetAnnotation() string { return v.allHasSBOMTree.Annotation }
-
 // GetSubject returns NodeNodeHasSBOM.Subject, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrSource {
 	return v.allHasSBOMTree.Subject
+}
+
+// GetUri returns NodeNodeHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+
+// GetAlgorithm returns NodeNodeHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+
+// GetDigest returns NodeNodeHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+
+// GetDownloadLocation returns NodeNodeHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
+
+// GetAnnotations returns NodeNodeHasSBOM.Annotations, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+	return v.allHasSBOMTree.Annotations
 }
 
 // GetOrigin returns NodeNodeHasSBOM.Origin, and is useful for accessing the field via an interface.
@@ -10273,11 +10390,17 @@ type __premarshalNodeNodeHasSBOM struct {
 
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -10297,8 +10420,6 @@ func (v *NodeNodeHasSBOM) __premarshalJSON() (*__premarshalNodeNodeHasSBOM, erro
 
 	retval.Typename = v.Typename
 	retval.Id = v.allHasSBOMTree.Id
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Annotation = v.allHasSBOMTree.Annotation
 	{
 
 		dst := &retval.Subject
@@ -10311,6 +10432,11 @@ func (v *NodeNodeHasSBOM) __premarshalJSON() (*__premarshalNodeNodeHasSBOM, erro
 				"Unable to marshal NodeNodeHasSBOM.allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.allHasSBOMTree.Uri
+	retval.Algorithm = v.allHasSBOMTree.Algorithm
+	retval.Digest = v.allHasSBOMTree.Digest
+	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
+	retval.Annotations = v.allHasSBOMTree.Annotations
 	retval.Origin = v.allHasSBOMTree.Origin
 	retval.Collector = v.allHasSBOMTree.Collector
 	return &retval, nil
@@ -12431,6 +12557,10 @@ func (v *PathPathGHSA) __premarshalJSON() (*__premarshalPathPathGHSA, error) {
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
@@ -12446,15 +12576,26 @@ func (v *PathPathHasSBOM) GetTypename() *string { return v.Typename }
 // GetId returns PathPathHasSBOM.Id, and is useful for accessing the field via an interface.
 func (v *PathPathHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
 
-// GetUri returns PathPathHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
-
-// GetAnnotation returns PathPathHasSBOM.Annotation, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetAnnotation() string { return v.allHasSBOMTree.Annotation }
-
 // GetSubject returns PathPathHasSBOM.Subject, and is useful for accessing the field via an interface.
 func (v *PathPathHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrSource {
 	return v.allHasSBOMTree.Subject
+}
+
+// GetUri returns PathPathHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *PathPathHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+
+// GetAlgorithm returns PathPathHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *PathPathHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+
+// GetDigest returns PathPathHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *PathPathHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+
+// GetDownloadLocation returns PathPathHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *PathPathHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
+
+// GetAnnotations returns PathPathHasSBOM.Annotations, and is useful for accessing the field via an interface.
+func (v *PathPathHasSBOM) GetAnnotations() []allHasSBOMTreeAnnotations {
+	return v.allHasSBOMTree.Annotations
 }
 
 // GetOrigin returns PathPathHasSBOM.Origin, and is useful for accessing the field via an interface.
@@ -12493,11 +12634,17 @@ type __premarshalPathPathHasSBOM struct {
 
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -12517,8 +12664,6 @@ func (v *PathPathHasSBOM) __premarshalJSON() (*__premarshalPathPathHasSBOM, erro
 
 	retval.Typename = v.Typename
 	retval.Id = v.allHasSBOMTree.Id
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Annotation = v.allHasSBOMTree.Annotation
 	{
 
 		dst := &retval.Subject
@@ -12531,6 +12676,11 @@ func (v *PathPathHasSBOM) __premarshalJSON() (*__premarshalPathPathHasSBOM, erro
 				"Unable to marshal PathPathHasSBOM.allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.allHasSBOMTree.Uri
+	retval.Algorithm = v.allHasSBOMTree.Algorithm
+	retval.Digest = v.allHasSBOMTree.Digest
+	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
+	retval.Annotations = v.allHasSBOMTree.Annotations
 	retval.Origin = v.allHasSBOMTree.Origin
 	retval.Collector = v.allHasSBOMTree.Collector
 	return &retval, nil
@@ -19331,30 +19481,46 @@ func (v *allCertifyVEXStatementVulnerabilityOSV) __premarshalJSON() (*__premarsh
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
 // Note: Only package object or source object can be defined. Not both.
 type allHasSBOMTree struct {
-	Id         string                               `json:"id"`
-	Uri        string                               `json:"uri"`
-	Annotation string                               `json:"annotation"`
-	Subject    allHasSBOMTreeSubjectPackageOrSource `json:"-"`
-	Origin     string                               `json:"origin"`
-	Collector  string                               `json:"collector"`
+	Id               string                               `json:"id"`
+	Subject          allHasSBOMTreeSubjectPackageOrSource `json:"-"`
+	Uri              string                               `json:"uri"`
+	Algorithm        string                               `json:"algorithm"`
+	Digest           string                               `json:"digest"`
+	DownloadLocation string                               `json:"downloadLocation"`
+	Annotations      []allHasSBOMTreeAnnotations          `json:"annotations"`
+	Origin           string                               `json:"origin"`
+	Collector        string                               `json:"collector"`
 }
 
 // GetId returns allHasSBOMTree.Id, and is useful for accessing the field via an interface.
 func (v *allHasSBOMTree) GetId() string { return v.Id }
 
+// GetSubject returns allHasSBOMTree.Subject, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTree) GetSubject() allHasSBOMTreeSubjectPackageOrSource { return v.Subject }
+
 // GetUri returns allHasSBOMTree.Uri, and is useful for accessing the field via an interface.
 func (v *allHasSBOMTree) GetUri() string { return v.Uri }
 
-// GetAnnotation returns allHasSBOMTree.Annotation, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetAnnotation() string { return v.Annotation }
+// GetAlgorithm returns allHasSBOMTree.Algorithm, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTree) GetAlgorithm() string { return v.Algorithm }
 
-// GetSubject returns allHasSBOMTree.Subject, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetSubject() allHasSBOMTreeSubjectPackageOrSource { return v.Subject }
+// GetDigest returns allHasSBOMTree.Digest, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTree) GetDigest() string { return v.Digest }
+
+// GetDownloadLocation returns allHasSBOMTree.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTree) GetDownloadLocation() string { return v.DownloadLocation }
+
+// GetAnnotations returns allHasSBOMTree.Annotations, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTree) GetAnnotations() []allHasSBOMTreeAnnotations { return v.Annotations }
 
 // GetOrigin returns allHasSBOMTree.Origin, and is useful for accessing the field via an interface.
 func (v *allHasSBOMTree) GetOrigin() string { return v.Origin }
@@ -19398,11 +19564,17 @@ func (v *allHasSBOMTree) UnmarshalJSON(b []byte) error {
 type __premarshalallHasSBOMTree struct {
 	Id string `json:"id"`
 
+	Subject json.RawMessage `json:"subject"`
+
 	Uri string `json:"uri"`
 
-	Annotation string `json:"annotation"`
+	Algorithm string `json:"algorithm"`
 
-	Subject json.RawMessage `json:"subject"`
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Annotations []allHasSBOMTreeAnnotations `json:"annotations"`
 
 	Origin string `json:"origin"`
 
@@ -19421,8 +19593,6 @@ func (v *allHasSBOMTree) __premarshalJSON() (*__premarshalallHasSBOMTree, error)
 	var retval __premarshalallHasSBOMTree
 
 	retval.Id = v.Id
-	retval.Uri = v.Uri
-	retval.Annotation = v.Annotation
 	{
 
 		dst := &retval.Subject
@@ -19435,10 +19605,30 @@ func (v *allHasSBOMTree) __premarshalJSON() (*__premarshalallHasSBOMTree, error)
 				"Unable to marshal allHasSBOMTree.Subject: %w", err)
 		}
 	}
+	retval.Uri = v.Uri
+	retval.Algorithm = v.Algorithm
+	retval.Digest = v.Digest
+	retval.DownloadLocation = v.DownloadLocation
+	retval.Annotations = v.Annotations
 	retval.Origin = v.Origin
 	retval.Collector = v.Collector
 	return &retval, nil
 }
+
+// allHasSBOMTreeAnnotations includes the requested fields of the GraphQL type Annotations.
+// The GraphQL type's documentation follows.
+//
+// Annotations are key-value pairs to provide additional information or metadata about SBOM
+type allHasSBOMTreeAnnotations struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns allHasSBOMTreeAnnotations.Key, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTreeAnnotations) GetKey() string { return v.Key }
+
+// GetValue returns allHasSBOMTreeAnnotations.Value, and is useful for accessing the field via an interface.
+func (v *allHasSBOMTreeAnnotations) GetValue() string { return v.Value }
 
 // allHasSBOMTreeSubjectPackage includes the requested fields of the GraphQL type Package.
 // The GraphQL type's documentation follows.
@@ -22133,8 +22323,6 @@ fragment AllPkgTree on Package {
 }
 fragment allHasSBOMTree on HasSBOM {
 	id
-	uri
-	annotation
 	subject {
 		__typename
 		... on Package {
@@ -22143,6 +22331,14 @@ fragment allHasSBOMTree on HasSBOM {
 		... on Source {
 			... AllSourceTree
 		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	annotations {
+		key
+		value
 	}
 	origin
 	collector
@@ -22214,8 +22410,6 @@ fragment AllSourceTree on Source {
 }
 fragment allHasSBOMTree on HasSBOM {
 	id
-	uri
-	annotation
 	subject {
 		__typename
 		... on Package {
@@ -22224,6 +22418,14 @@ fragment allHasSBOMTree on HasSBOM {
 		... on Source {
 			... AllSourceTree
 		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	annotations {
+		key
+		value
 	}
 	origin
 	collector
@@ -23107,8 +23309,6 @@ fragment allHashEqualTree on HashEqual {
 }
 fragment allHasSBOMTree on HasSBOM {
 	id
-	uri
-	annotation
 	subject {
 		__typename
 		... on Package {
@@ -23117,6 +23317,14 @@ fragment allHasSBOMTree on HasSBOM {
 		... on Source {
 			... AllSourceTree
 		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	annotations {
+		key
+		value
 	}
 	origin
 	collector
@@ -23499,8 +23707,6 @@ fragment allHashEqualTree on HashEqual {
 }
 fragment allHasSBOMTree on HasSBOM {
 	id
-	uri
-	annotation
 	subject {
 		__typename
 		... on Package {
@@ -23509,6 +23715,14 @@ fragment allHasSBOMTree on HasSBOM {
 		... on Source {
 			... AllSourceTree
 		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	annotations {
+		key
+		value
 	}
 	origin
 	collector
@@ -23982,8 +24196,6 @@ fragment allHashEqualTree on HashEqual {
 }
 fragment allHasSBOMTree on HasSBOM {
 	id
-	uri
-	annotation
 	subject {
 		__typename
 		... on Package {
@@ -23992,6 +24204,14 @@ fragment allHasSBOMTree on HasSBOM {
 		... on Source {
 			... AllSourceTree
 		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	annotations {
+		key
+		value
 	}
 	origin
 	collector

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -211,8 +211,6 @@ fragment allHashEqualTree on HashEqual {
 
 fragment allHasSBOMTree on HasSBOM {
   id
-  uri
-  annotation
   subject {
     __typename
     ... on Package {
@@ -222,6 +220,14 @@ fragment allHasSBOMTree on HasSBOM {
       ...AllSourceTree
       }
   }
+  uri
+  algorithm
+  digest
+  downloadLocation
+  annotations {
+      key
+      value
+    }
   origin
   collector
 }

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -227,7 +227,7 @@ fragment allHasSBOMTree on HasSBOM {
   annotations {
       key
       value
-    }
+  }
   origin
   collector
 }

--- a/pkg/assembler/graphql/examples/has_sbom.gql
+++ b/pkg/assembler/graphql/examples/has_sbom.gql
@@ -1,7 +1,5 @@
 fragment allHasSBOMTree on HasSBOM {
   id
-  uri
-  annotation
   subject {
     __typename
     ... on Package {
@@ -39,6 +37,14 @@ fragment allHasSBOMTree on HasSBOM {
         }
       }
     }
+  }
+  uri
+  algorithm
+  digest
+  downloadLocation
+  annotations {
+      key
+      value
   }
   origin
   collector

--- a/pkg/assembler/graphql/examples/is_dependency.gql
+++ b/pkg/assembler/graphql/examples/is_dependency.gql
@@ -43,6 +43,7 @@ dependentPackage {
       }
     }
   }
+dependencyType  
 versionRange
 origin
 collector

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -1788,8 +1788,14 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSBOM(ctx context.Cont
 				return ec.fieldContext_HasSBOM_subject(ctx, field)
 			case "uri":
 				return ec.fieldContext_HasSBOM_uri(ctx, field)
-			case "annotation":
-				return ec.fieldContext_HasSBOM_annotation(ctx, field)
+			case "algorithm":
+				return ec.fieldContext_HasSBOM_algorithm(ctx, field)
+			case "digest":
+				return ec.fieldContext_HasSBOM_digest(ctx, field)
+			case "downloadLocation":
+				return ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
+			case "annotations":
+				return ec.fieldContext_HasSBOM_annotations(ctx, field)
 			case "origin":
 				return ec.fieldContext_HasSBOM_origin(ctx, field)
 			case "collector":
@@ -3173,8 +3179,14 @@ func (ec *executionContext) fieldContext_Query_HasSBOM(ctx context.Context, fiel
 				return ec.fieldContext_HasSBOM_subject(ctx, field)
 			case "uri":
 				return ec.fieldContext_HasSBOM_uri(ctx, field)
-			case "annotation":
-				return ec.fieldContext_HasSBOM_annotation(ctx, field)
+			case "algorithm":
+				return ec.fieldContext_HasSBOM_algorithm(ctx, field)
+			case "digest":
+				return ec.fieldContext_HasSBOM_digest(ctx, field)
+			case "downloadLocation":
+				return ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
+			case "annotations":
+				return ec.fieldContext_HasSBOM_annotations(ctx, field)
 			case "origin":
 				return ec.fieldContext_HasSBOM_origin(ctx, field)
 			case "collector":

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -5,6 +5,7 @@ package generated
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -26,6 +27,94 @@ import (
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _Annotations_key(ctx context.Context, field graphql.CollectedField, obj *model.Annotations) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Annotations_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Annotations_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Annotations",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Annotations_value(ctx context.Context, field graphql.CollectedField, obj *model.Annotations) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Annotations_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Annotations_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Annotations",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _HasSBOM_id(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HasSBOM_id(ctx, field)
@@ -159,8 +248,8 @@ func (ec *executionContext) fieldContext_HasSBOM_uri(ctx context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSBOM_annotation(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSBOM_annotation(ctx, field)
+func (ec *executionContext) _HasSBOM_algorithm(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_algorithm(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -173,7 +262,7 @@ func (ec *executionContext) _HasSBOM_annotation(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Annotation, nil
+		return obj.Algorithm, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -190,7 +279,7 @@ func (ec *executionContext) _HasSBOM_annotation(ctx context.Context, field graph
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSBOM_annotation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_HasSBOM_algorithm(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HasSBOM",
 		Field:      field,
@@ -198,6 +287,144 @@ func (ec *executionContext) fieldContext_HasSBOM_annotation(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HasSBOM_digest(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_digest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Digest, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSBOM_digest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSBOM",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HasSBOM_downloadLocation(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DownloadLocation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSBOM_downloadLocation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSBOM",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HasSBOM_annotations(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_annotations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Annotations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Annotations)
+	fc.Result = res
+	return ec.marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSBOM_annotations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSBOM",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_Annotations_key(ctx, field)
+			case "value":
+				return ec.fieldContext_Annotations_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Annotations", field.Name)
 		},
 	}
 	return fc, nil
@@ -295,6 +522,78 @@ func (ec *executionContext) fieldContext_HasSBOM_collector(ctx context.Context, 
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputAnnotationsInputSpec(ctx context.Context, obj interface{}) (model.AnnotationsInputSpec, error) {
+	var it model.AnnotationsInputSpec
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "value":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			it.Value, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputAnnotationsSpec(ctx context.Context, obj interface{}) (model.AnnotationsSpec, error) {
+	var it model.AnnotationsSpec
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "value":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			it.Value, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, obj interface{}) (model.HasSBOMInputSpec, error) {
 	var it model.HasSBOMInputSpec
 	asMap := map[string]interface{}{}
@@ -302,7 +601,7 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"uri", "annotation", "origin", "collector"}
+	fieldsInOrder := [...]string{"uri", "algorithm", "digest", "downloadLocation", "annotations", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -317,11 +616,35 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
-		case "annotation":
+		case "algorithm":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotation"))
-			it.Annotation, err = ec.unmarshalNString2string(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("algorithm"))
+			it.Algorithm, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "digest":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("digest"))
+			it.Digest, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "downloadLocation":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("downloadLocation"))
+			it.DownloadLocation, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "annotations":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotations"))
+			it.Annotations, err = ec.unmarshalNAnnotationsInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -354,7 +677,11 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "uri", "annotation", "origin", "collector"}
+	if _, present := asMap["annotations"]; !present {
+		asMap["annotations"] = []interface{}{}
+	}
+
+	fieldsInOrder := [...]string{"id", "subject", "uri", "algorithm", "digest", "downloadLocation", "annotations", "origin", "collector"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -385,11 +712,35 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 			if err != nil {
 				return it, err
 			}
-		case "annotation":
+		case "algorithm":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotation"))
-			it.Annotation, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("algorithm"))
+			it.Algorithm, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "digest":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("digest"))
+			it.Digest, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "downloadLocation":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("downloadLocation"))
+			it.DownloadLocation, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "annotations":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotations"))
+			it.Annotations, err = ec.unmarshalOAnnotationsSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -423,6 +774,41 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 
 // region    **************************** object.gotpl ****************************
 
+var annotationsImplementors = []string{"Annotations"}
+
+func (ec *executionContext) _Annotations(ctx context.Context, sel ast.SelectionSet, obj *model.Annotations) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, annotationsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Annotations")
+		case "key":
+
+			out.Values[i] = ec._Annotations_key(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "value":
+
+			out.Values[i] = ec._Annotations_value(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var hasSBOMImplementors = []string{"HasSBOM", "Node"}
 
 func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, obj *model.HasSbom) graphql.Marshaler {
@@ -454,9 +840,30 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "annotation":
+		case "algorithm":
 
-			out.Values[i] = ec._HasSBOM_annotation(ctx, field, obj)
+			out.Values[i] = ec._HasSBOM_algorithm(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "digest":
+
+			out.Values[i] = ec._HasSBOM_digest(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "downloadLocation":
+
+			out.Values[i] = ec._HasSBOM_downloadLocation(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "annotations":
+
+			out.Values[i] = ec._HasSBOM_annotations(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -489,6 +896,87 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
+
+func (ec *executionContext) marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Annotations) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAnnotations2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotations(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNAnnotations2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotations(ctx context.Context, sel ast.SelectionSet, v *model.Annotations) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Annotations(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNAnnotationsInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationsInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.AnnotationsInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNAnnotationsInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNAnnotationsInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpec(ctx context.Context, v interface{}) (*model.AnnotationsInputSpec, error) {
+	res, err := ec.unmarshalInputAnnotationsInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNAnnotationsSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpec(ctx context.Context, v interface{}) (*model.AnnotationsSpec, error) {
+	res, err := ec.unmarshalInputAnnotationsSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
 
 func (ec *executionContext) marshalNHasSBOM2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSbom(ctx context.Context, sel ast.SelectionSet, v model.HasSbom) graphql.Marshaler {
 	return ec._HasSBOM(ctx, sel, &v)
@@ -551,6 +1039,26 @@ func (ec *executionContext) marshalNHasSBOM2ᚖgithubᚗcomᚋguacsecᚋguacᚋp
 func (ec *executionContext) unmarshalNHasSBOMInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSBOMInputSpec(ctx context.Context, v interface{}) (model.HasSBOMInputSpec, error) {
 	res, err := ec.unmarshalInputHasSBOMInputSpec(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOAnnotationsSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationsSpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.AnnotationsSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNAnnotationsSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOHasSBOMSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSBOMSpec(ctx context.Context, v interface{}) (*model.HasSBOMSpec, error) {

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -28,8 +28,8 @@ import (
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _Annotations_key(ctx context.Context, field graphql.CollectedField, obj *model.Annotations) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Annotations_key(ctx, field)
+func (ec *executionContext) _Annotation_key(ctx context.Context, field graphql.CollectedField, obj *model.Annotation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Annotation_key(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -59,9 +59,9 @@ func (ec *executionContext) _Annotations_key(ctx context.Context, field graphql.
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Annotations_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Annotation_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "Annotations",
+		Object:     "Annotation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -72,8 +72,8 @@ func (ec *executionContext) fieldContext_Annotations_key(ctx context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Annotations_value(ctx context.Context, field graphql.CollectedField, obj *model.Annotations) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Annotations_value(ctx, field)
+func (ec *executionContext) _Annotation_value(ctx context.Context, field graphql.CollectedField, obj *model.Annotation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Annotation_value(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -103,9 +103,9 @@ func (ec *executionContext) _Annotations_value(ctx context.Context, field graphq
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Annotations_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Annotation_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "Annotations",
+		Object:     "Annotation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -406,9 +406,9 @@ func (ec *executionContext) _HasSBOM_annotations(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Annotations)
+	res := resTmp.([]*model.Annotation)
 	fc.Result = res
-	return ec.marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsᚄ(ctx, field.Selections, res)
+	return ec.marshalNAnnotation2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSBOM_annotations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -420,11 +420,11 @@ func (ec *executionContext) fieldContext_HasSBOM_annotations(ctx context.Context
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "key":
-				return ec.fieldContext_Annotations_key(ctx, field)
+				return ec.fieldContext_Annotation_key(ctx, field)
 			case "value":
-				return ec.fieldContext_Annotations_value(ctx, field)
+				return ec.fieldContext_Annotation_value(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Annotations", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type Annotation", field.Name)
 		},
 	}
 	return fc, nil
@@ -522,8 +522,8 @@ func (ec *executionContext) fieldContext_HasSBOM_collector(ctx context.Context, 
 
 // region    **************************** input.gotpl *****************************
 
-func (ec *executionContext) unmarshalInputAnnotationsInputSpec(ctx context.Context, obj interface{}) (model.AnnotationsInputSpec, error) {
-	var it model.AnnotationsInputSpec
+func (ec *executionContext) unmarshalInputAnnotationInputSpec(ctx context.Context, obj interface{}) (model.AnnotationInputSpec, error) {
+	var it model.AnnotationInputSpec
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -558,8 +558,8 @@ func (ec *executionContext) unmarshalInputAnnotationsInputSpec(ctx context.Conte
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputAnnotationsSpec(ctx context.Context, obj interface{}) (model.AnnotationsSpec, error) {
-	var it model.AnnotationsSpec
+func (ec *executionContext) unmarshalInputAnnotationSpec(ctx context.Context, obj interface{}) (model.AnnotationSpec, error) {
+	var it model.AnnotationSpec
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -644,7 +644,7 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotations"))
-			it.Annotations, err = ec.unmarshalNAnnotationsInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpecᚄ(ctx, v)
+			it.Annotations, err = ec.unmarshalNAnnotationInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationInputSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -740,7 +740,7 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("annotations"))
-			it.Annotations, err = ec.unmarshalOAnnotationsSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpecᚄ(ctx, v)
+			it.Annotations, err = ec.unmarshalOAnnotationSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -774,26 +774,26 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 
 // region    **************************** object.gotpl ****************************
 
-var annotationsImplementors = []string{"Annotations"}
+var annotationImplementors = []string{"Annotation"}
 
-func (ec *executionContext) _Annotations(ctx context.Context, sel ast.SelectionSet, obj *model.Annotations) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, annotationsImplementors)
+func (ec *executionContext) _Annotation(ctx context.Context, sel ast.SelectionSet, obj *model.Annotation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, annotationImplementors)
 	out := graphql.NewFieldSet(fields)
 	var invalids uint32
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("Annotations")
+			out.Values[i] = graphql.MarshalString("Annotation")
 		case "key":
 
-			out.Values[i] = ec._Annotations_key(ctx, field, obj)
+			out.Values[i] = ec._Annotation_key(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
 		case "value":
 
-			out.Values[i] = ec._Annotations_value(ctx, field, obj)
+			out.Values[i] = ec._Annotation_value(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -897,7 +897,7 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Annotations) graphql.Marshaler {
+func (ec *executionContext) marshalNAnnotation2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Annotation) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -921,7 +921,7 @@ func (ec *executionContext) marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋg
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNAnnotations2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotations(ctx, sel, v[i])
+			ret[i] = ec.marshalNAnnotation2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotation(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -941,26 +941,26 @@ func (ec *executionContext) marshalNAnnotations2ᚕᚖgithubᚗcomᚋguacsecᚋg
 	return ret
 }
 
-func (ec *executionContext) marshalNAnnotations2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotations(ctx context.Context, sel ast.SelectionSet, v *model.Annotations) graphql.Marshaler {
+func (ec *executionContext) marshalNAnnotation2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotation(ctx context.Context, sel ast.SelectionSet, v *model.Annotation) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._Annotations(ctx, sel, v)
+	return ec._Annotation(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNAnnotationsInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationsInputSpec, error) {
+func (ec *executionContext) unmarshalNAnnotationInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationInputSpec, error) {
 	var vSlice []interface{}
 	if v != nil {
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]*model.AnnotationsInputSpec, len(vSlice))
+	res := make([]*model.AnnotationInputSpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNAnnotationsInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpec(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNAnnotationInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationInputSpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -968,13 +968,13 @@ func (ec *executionContext) unmarshalNAnnotationsInputSpec2ᚕᚖgithubᚗcomᚋ
 	return res, nil
 }
 
-func (ec *executionContext) unmarshalNAnnotationsInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsInputSpec(ctx context.Context, v interface{}) (*model.AnnotationsInputSpec, error) {
-	res, err := ec.unmarshalInputAnnotationsInputSpec(ctx, v)
+func (ec *executionContext) unmarshalNAnnotationInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationInputSpec(ctx context.Context, v interface{}) (*model.AnnotationInputSpec, error) {
+	res, err := ec.unmarshalInputAnnotationInputSpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNAnnotationsSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpec(ctx context.Context, v interface{}) (*model.AnnotationsSpec, error) {
-	res, err := ec.unmarshalInputAnnotationsSpec(ctx, v)
+func (ec *executionContext) unmarshalNAnnotationSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationSpec(ctx context.Context, v interface{}) (*model.AnnotationSpec, error) {
+	res, err := ec.unmarshalInputAnnotationSpec(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -1041,7 +1041,7 @@ func (ec *executionContext) unmarshalNHasSBOMInputSpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOAnnotationsSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationsSpec, error) {
+func (ec *executionContext) unmarshalOAnnotationSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationSpecᚄ(ctx context.Context, v interface{}) ([]*model.AnnotationSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -1050,10 +1050,10 @@ func (ec *executionContext) unmarshalOAnnotationsSpec2ᚕᚖgithubᚗcomᚋguacs
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]*model.AnnotationsSpec, len(vSlice))
+	res := make([]*model.AnnotationSpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNAnnotationsSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationsSpec(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNAnnotationSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐAnnotationSpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -38,7 +38,7 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
-	Annotations struct {
+	Annotation struct {
 		Key   func(childComplexity int) int
 		Value func(childComplexity int) int
 	}
@@ -346,19 +346,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
-	case "Annotations.key":
-		if e.complexity.Annotations.Key == nil {
+	case "Annotation.key":
+		if e.complexity.Annotation.Key == nil {
 			break
 		}
 
-		return e.complexity.Annotations.Key(childComplexity), true
+		return e.complexity.Annotation.Key(childComplexity), true
 
-	case "Annotations.value":
-		if e.complexity.Annotations.Value == nil {
+	case "Annotation.value":
+		if e.complexity.Annotation.Value == nil {
 			break
 		}
 
-		return e.complexity.Annotations.Value(childComplexity), true
+		return e.complexity.Annotation.Value(childComplexity), true
 
 	case "Artifact.algorithm":
 		if e.complexity.Artifact.Algorithm == nil {
@@ -1883,8 +1883,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
-		ec.unmarshalInputAnnotationsInputSpec,
-		ec.unmarshalInputAnnotationsSpec,
+		ec.unmarshalInputAnnotationInputSpec,
+		ec.unmarshalInputAnnotationSpec,
 		ec.unmarshalInputArtifactInputSpec,
 		ec.unmarshalInputArtifactSpec,
 		ec.unmarshalInputBuilderInputSpec,
@@ -2895,16 +2895,16 @@ type HasSBOM {
   algorithm: String!
   digest: String!
   downloadLocation: String!
-  annotations: [Annotations!]!
+  annotations: [Annotation!]!
   origin: String!
   collector: String!
 }
 
 
 """
-Annotations are key-value pairs to provide additional information or metadata about SBOM
+Annotation are key-value pairs to provide additional information or metadata about SBOM
 """
-type Annotations {
+type Annotation {
   key: String!
   value: String!
 }
@@ -2922,15 +2922,15 @@ input HasSBOMSpec {
   algorithm: String
   digest: String
   downloadLocation: String
-  annotations: [AnnotationsSpec!] = []
+  annotations: [AnnotationSpec!] = []
   origin: String
   collector: String
 }
 
 """
-AnnotationsSpec is the same as Annotations, but usable as query input.
+AnnotationSpec is the same as Annotations, but usable as query input.
 """
-input AnnotationsSpec {
+input AnnotationSpec {
   key: String!
   value: String!
 }
@@ -2945,7 +2945,7 @@ input HasSBOMInputSpec {
   algorithm: String!
   digest: String!
   downloadLocation: String!
-  annotations: [AnnotationsInputSpec!]!
+  annotations: [AnnotationInputSpec!]!
   origin: String!
   collector: String!
 }
@@ -2953,7 +2953,7 @@ input HasSBOMInputSpec {
 """
 AnnotationsSpec is the same as Annotations, but usable as mutation input.
 """
-input AnnotationsInputSpec {
+input AnnotationInputSpec {
   key: String!
   value: String!
 }

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -43,20 +43,20 @@ type Vulnerability interface {
 	IsVulnerability()
 }
 
-// Annotations are key-value pairs to provide additional information or metadata about SBOM
-type Annotations struct {
+// Annotation are key-value pairs to provide additional information or metadata about SBOM
+type Annotation struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
 // AnnotationsSpec is the same as Annotations, but usable as mutation input.
-type AnnotationsInputSpec struct {
+type AnnotationInputSpec struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-// AnnotationsSpec is the same as Annotations, but usable as query input.
-type AnnotationsSpec struct {
+// AnnotationSpec is the same as Annotations, but usable as query input.
+type AnnotationSpec struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
@@ -397,7 +397,7 @@ type HasSbom struct {
 	Algorithm        string          `json:"algorithm"`
 	Digest           string          `json:"digest"`
 	DownloadLocation string          `json:"downloadLocation"`
-	Annotations      []*Annotations  `json:"annotations"`
+	Annotations      []*Annotation   `json:"annotations"`
 	Origin           string          `json:"origin"`
 	Collector        string          `json:"collector"`
 }
@@ -408,13 +408,13 @@ func (HasSbom) IsNode() {}
 //
 // All fields are required.
 type HasSBOMInputSpec struct {
-	URI              string                  `json:"uri"`
-	Algorithm        string                  `json:"algorithm"`
-	Digest           string                  `json:"digest"`
-	DownloadLocation string                  `json:"downloadLocation"`
-	Annotations      []*AnnotationsInputSpec `json:"annotations"`
-	Origin           string                  `json:"origin"`
-	Collector        string                  `json:"collector"`
+	URI              string                 `json:"uri"`
+	Algorithm        string                 `json:"algorithm"`
+	Digest           string                 `json:"digest"`
+	DownloadLocation string                 `json:"downloadLocation"`
+	Annotations      []*AnnotationInputSpec `json:"annotations"`
+	Origin           string                 `json:"origin"`
+	Collector        string                 `json:"collector"`
 }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
@@ -427,7 +427,7 @@ type HasSBOMSpec struct {
 	Algorithm        *string              `json:"algorithm,omitempty"`
 	Digest           *string              `json:"digest,omitempty"`
 	DownloadLocation *string              `json:"downloadLocation,omitempty"`
-	Annotations      []*AnnotationsSpec   `json:"annotations,omitempty"`
+	Annotations      []*AnnotationSpec    `json:"annotations,omitempty"`
 	Origin           *string              `json:"origin,omitempty"`
 	Collector        *string              `json:"collector,omitempty"`
 }

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -43,6 +43,24 @@ type Vulnerability interface {
 	IsVulnerability()
 }
 
+// Annotations are key-value pairs to provide additional information or metadata about SBOM
+type Annotations struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// AnnotationsSpec is the same as Annotations, but usable as mutation input.
+type AnnotationsInputSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// AnnotationsSpec is the same as Annotations, but usable as query input.
+type AnnotationsSpec struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 // Artifact represents the artifact and contains a digest field
 //
 // Both field are mandatory and canonicalized to be lowercase.
@@ -364,17 +382,24 @@ type GHSASpec struct {
 //
 // subject - union type that can be either a package or source object type
 // uri (property) - identifier string for the SBOM
+// algorithm - cryptographic algorithm of the digest
+// digest - hash of the SBOM
+// downloadLocation - the download location of the SBOM
+// annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 // origin (property) - where this attestation was generated from (based on which document)
 // collector (property) - the GUAC collector that collected the document that generated this attestation
 //
 // Note: Only package object or source object can be defined. Not both.
 type HasSbom struct {
-	ID         string          `json:"id"`
-	Subject    PackageOrSource `json:"subject"`
-	URI        string          `json:"uri"`
-	Annotation string          `json:"annotation"`
-	Origin     string          `json:"origin"`
-	Collector  string          `json:"collector"`
+	ID               string          `json:"id"`
+	Subject          PackageOrSource `json:"subject"`
+	URI              string          `json:"uri"`
+	Algorithm        string          `json:"algorithm"`
+	Digest           string          `json:"digest"`
+	DownloadLocation string          `json:"downloadLocation"`
+	Annotations      []*Annotations  `json:"annotations"`
+	Origin           string          `json:"origin"`
+	Collector        string          `json:"collector"`
 }
 
 func (HasSbom) IsNode() {}
@@ -383,23 +408,28 @@ func (HasSbom) IsNode() {}
 //
 // All fields are required.
 type HasSBOMInputSpec struct {
-	URI        string `json:"uri"`
-	Annotation string `json:"annotation"`
-	Origin     string `json:"origin"`
-	Collector  string `json:"collector"`
+	URI              string                  `json:"uri"`
+	Algorithm        string                  `json:"algorithm"`
+	Digest           string                  `json:"digest"`
+	DownloadLocation string                  `json:"downloadLocation"`
+	Annotations      []*AnnotationsInputSpec `json:"annotations"`
+	Origin           string                  `json:"origin"`
+	Collector        string                  `json:"collector"`
 }
 
-// HashEqualSpec allows filtering the list of HasSBOM to return.
+// HasSBOMSpec allows filtering the list of HasSBOM to return.
 //
-// Only the package or source can be added, not both. HasSourceAt will be used to create the package to source
-// relationship.
+// Only the package or source can be added, not both
 type HasSBOMSpec struct {
-	ID         *string              `json:"id,omitempty"`
-	Subject    *PackageOrSourceSpec `json:"subject,omitempty"`
-	URI        *string              `json:"uri,omitempty"`
-	Annotation *string              `json:"annotation,omitempty"`
-	Origin     *string              `json:"origin,omitempty"`
-	Collector  *string              `json:"collector,omitempty"`
+	ID               *string              `json:"id,omitempty"`
+	Subject          *PackageOrSourceSpec `json:"subject,omitempty"`
+	URI              *string              `json:"uri,omitempty"`
+	Algorithm        *string              `json:"algorithm,omitempty"`
+	Digest           *string              `json:"digest,omitempty"`
+	DownloadLocation *string              `json:"downloadLocation,omitempty"`
+	Annotations      []*AnnotationsSpec   `json:"annotations,omitempty"`
+	Origin           *string              `json:"origin,omitempty"`
+	Collector        *string              `json:"collector,omitempty"`
 }
 
 // HasSLSA records that a subject node has a SLSA attestation.

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -37,16 +37,16 @@ type HasSBOM {
   algorithm: String!
   digest: String!
   downloadLocation: String!
-  annotations: [Annotations!]!
+  annotations: [Annotation!]!
   origin: String!
   collector: String!
 }
 
 
 """
-Annotations are key-value pairs to provide additional information or metadata about SBOM
+Annotation are key-value pairs to provide additional information or metadata about SBOM
 """
-type Annotations {
+type Annotation {
   key: String!
   value: String!
 }
@@ -64,15 +64,15 @@ input HasSBOMSpec {
   algorithm: String
   digest: String
   downloadLocation: String
-  annotations: [AnnotationsSpec!] = []
+  annotations: [AnnotationSpec!] = []
   origin: String
   collector: String
 }
 
 """
-AnnotationsSpec is the same as Annotations, but usable as query input.
+AnnotationSpec is the same as Annotations, but usable as query input.
 """
-input AnnotationsSpec {
+input AnnotationSpec {
   key: String!
   value: String!
 }
@@ -87,7 +87,7 @@ input HasSBOMInputSpec {
   algorithm: String!
   digest: String!
   downloadLocation: String!
-  annotations: [AnnotationsInputSpec!]!
+  annotations: [AnnotationInputSpec!]!
   origin: String!
   collector: String!
 }
@@ -95,7 +95,7 @@ input HasSBOMInputSpec {
 """
 AnnotationsSpec is the same as Annotations, but usable as mutation input.
 """
-input AnnotationsInputSpec {
+input AnnotationInputSpec {
   key: String!
   value: String!
 }

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -21,6 +21,10 @@ HasSBOM is an attestation represents that a package object or source object has 
 
 subject - union type that can be either a package or source object type
 uri (property) - identifier string for the SBOM
+algorithm - cryptographic algorithm of the digest
+digest - hash of the SBOM 
+downloadLocation - the download location of the SBOM
+annotations - this field may be used to provide additional information or metadata about SBOM. Such as SBOM scorecard information
 origin (property) - where this attestation was generated from (based on which document)
 collector (property) - the GUAC collector that collected the document that generated this attestation
 
@@ -30,24 +34,47 @@ type HasSBOM {
   id: ID!
   subject: PackageOrSource!
   uri: String!
-  annotation: String!
+  algorithm: String!
+  digest: String!
+  downloadLocation: String!
+  annotations: [Annotations!]!
   origin: String!
   collector: String!
 }
 
-"""
-HashEqualSpec allows filtering the list of HasSBOM to return.
 
-Only the package or source can be added, not both. HasSourceAt will be used to create the package to source
-relationship.
+"""
+Annotations are key-value pairs to provide additional information or metadata about SBOM
+"""
+type Annotations {
+  key: String!
+  value: String!
+}
+
+
+"""
+HasSBOMSpec allows filtering the list of HasSBOM to return.
+
+Only the package or source can be added, not both
 """
 input HasSBOMSpec {
   id: ID
   subject: PackageOrSourceSpec
   uri: String
-  annotation: String
+  algorithm: String
+  digest: String
+  downloadLocation: String
+  annotations: [AnnotationsSpec!] = []
   origin: String
   collector: String
+}
+
+"""
+AnnotationsSpec is the same as Annotations, but usable as query input.
+"""
+input AnnotationsSpec {
+  key: String!
+  value: String!
 }
 
 """
@@ -57,9 +84,20 @@ All fields are required.
 """
 input HasSBOMInputSpec {
   uri: String!
-  annotation: String!
+  algorithm: String!
+  digest: String!
+  downloadLocation: String!
+  annotations: [AnnotationsInputSpec!]!
   origin: String!
   collector: String!
+}
+
+"""
+AnnotationsSpec is the same as Annotations, but usable as mutation input.
+"""
+input AnnotationsInputSpec {
+  key: String!
+  value: String!
 }
 
 extend type Query {


### PR DESCRIPTION
Part of issue https://github.com/guacsec/guac/issues/754

- Update HasSBOM schema to include:
```
uri: String!
algorithm: String!
digest: String!
downloadLocation: String!
annotations: [Annotations!]!
```

- remove old annotation from backend implementation for HasSBOM
- implemented in memory resolver update for HasSBOM
- fix testdata error for `isDependency`