### PR TITLE
Fix interval in docker compose.

### DIFF
--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -16,3 +16,7 @@ gql-backend: inmem
 gql-port: 8080
 gql-debug: true
 gql-endpoint: http://guac-graphql:8080/query
+
+# certifier polling
+poll: true
+interval: 5m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - ./container_files/guac:/guac
   osv-certifier:
     image: "local-organic-guac"
-    command: "/opt/guac/guacone certifier osv --poll --interval 5"
+    command: "/opt/guac/guacone certifier osv"
     working_dir: /guac
     restart: on-failure
     depends_on:


### PR DESCRIPTION
Fix for change here: https://github.com/guacsec/guac/commit/11a0fc3bc893b5d43ff958a19bf5ed98c4d5e6fd#diff-44d573cf29eee810e1163bbd743b22eafca57fb85946ab7e35507cc8be8d3b95

It is the same as the default, but go ahead and add to `container_files/guac/guac.yaml`