### PR TITLE
CertifyScorecard unit tests

### DIFF
--- a/docs/GraphQL.md
+++ b/docs/GraphQL.md
@@ -1,28 +1,30 @@
 # GUAC GraphQL definitions
 
-[GraphQL](https://graphql.org/) allows developers to define an API for a
-service using a definition language and then serve this API via a single
-endpoint. GraphQL also represents the runtime for fulfilling these queries. The
-design of GraphQL is that queries can ask exactly for the data they need and
-only receive that data. This empowers clients to be in control and more
-resilient in the face of API changes. To get started, consult [the official
-documentation](https://graphql.org/learn/).
+[GraphQL](https://graphql.org/) allows developers to define an API for a service
+using a definition language and then serve this API via a single endpoint.
+GraphQL also represents the runtime for fulfilling these queries. The design of
+GraphQL is that queries can ask exactly for the data they need and only receive
+that data. This empowers clients to be in control and more resilient in the face
+of API changes. To get started, consult
+[the official documentation](https://graphql.org/learn/).
 
-This documents provides some insight into how the GraphQL API matches the [GUAC
-ontology](https://github.com/guacsec/guac/blob/main/docs/ontology.md) and its
+This documents provides some insight into how the GraphQL API matches the
+[GUAC ontology](https://github.com/guacsec/guac/blob/main/docs/ontology.md) and
+its
 [definition](https://github.com/guacsec/guac/blob/main/docs/ontology-definitions.md).
 
 Note: the GraphQL definitions are not yet stable, they might change in future
 code changes. To get an up to date view of the definitions, you can use one of
 the following:
 
-- Directly consult the source of truth represented by the [GraphQL SDL
-  schema](https://github.com/guacsec/guac/tree/main/pkg/assembler/graphql/schema).
+- Directly consult the source of truth represented by the
+  [GraphQL SDL schema](https://github.com/guacsec/guac/tree/main/pkg/assembler/graphql/schema).
 - Look at the generated Go documentation using `godoc` and analyzing the
   `guacsec/guac/pkg/assembler/graphql/model` package.
-- Open the playground by passing `--gql-debug` to [`guacgql`
-  component](https://github.com/guacsec/guac/blob/main/docs/Compose.md), then
-  consult the documentation tab of the [Graphiql editor](https://github.com/graphql/graphiql).
+- Open the playground by passing `--gql-debug` to
+  [`guacgql` component](https://github.com/guacsec/guac/blob/main/docs/Compose.md),
+  then consult the documentation tab of the
+  [Graphiql editor](https://github.com/graphql/graphiql).
 - Use [GraphQL Voyager](https://ivangoncharov.github.io/graphql-voyager/). You
   can load the schema by using the introspection query on the `guacgql` server
   or by concatenating all the source of truth documents.
@@ -31,8 +33,8 @@ Note: If you change the GraphQL schema, you will need to regenerate the code
 using `make generate` before you can use any of the above steps.
 
 Note: GUAC uses GraphQL internally to ingest data and for the integrations
-provided out-of-the box. Consult the [GUAC client-side
-operations](https://github.com/guacsec/guac/tree/main/pkg/assembler/clients/operations)
+provided out-of-the box. Consult the
+[GUAC client-side operations](https://github.com/guacsec/guac/tree/main/pkg/assembler/clients/operations)
 for the document queries.
 
 In the remainder of this document, we will go over the existing GraphQL types.
@@ -631,10 +633,10 @@ definition for these as of now.
 
 ## Topological Definitions
 
-Each GraphQL type defined so far has a semantic meaning, tied to the [GUAC
-ontology](./ontology.md). However, in some cases, users might want to see what
-GraphQL types are linked to a specific type, or they might want to find a link
-between two different nodes. For these cases, we currently provide an
+Each GraphQL type defined so far has a semantic meaning, tied to the
+[GUAC ontology](./ontology.md). However, in some cases, users might want to see
+what GraphQL types are linked to a specific type, or they might want to find a
+link between two different nodes. For these cases, we currently provide an
 experimental interface to get topological information about the GUAC graph.
 
 Note: These definitions are subject to change and might be removed in future
@@ -644,8 +646,8 @@ First, we define a union of all nodes in the GUAC ontology and an enum for all
 the possible edges between them.
 
 ```gql
-union Node
-  = Package
+union Node =
+    Package
   | Source
   | Artifact
   | Builder

--- a/internal/testing/ptrfrom/ptrfrom.go
+++ b/internal/testing/ptrfrom/ptrfrom.go
@@ -32,5 +32,8 @@ func Int(v int) *int { return &v }
 // Int64 helps get int64 pointers for test literals
 func Int64(v int64) *int64 { return &v }
 
+// Float64 helps get float64 pofloaters for test literals
+func Float64(v float64) *float64 { return &v }
+
 // String helps get string pointers for test literals
 func String(v string) *string { return &v }

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -18,6 +18,7 @@ package inmem
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,6 +60,10 @@ type node interface {
 type indexType map[uint32]node
 
 var errNotFound = errors.New("Not found")
+
+// Scorecard scores are in range of 1-10, so a single step at 100 should be
+// plenty big
+var epsilon = math.Nextafter(100, 100.1) - 100
 
 // atomic add to ensure ID is not duplicated
 func (c *demoClient) getNextID() uint32 {
@@ -182,6 +187,17 @@ func toLower(filter *string) *string {
 		return &lower
 	}
 	return nil
+}
+
+func noMatchFloat(filter *float64, value float64) bool {
+	if filter != nil {
+		return math.Abs(*filter-value) > epsilon
+	}
+	return false
+}
+
+func floatEqual(x float64, y float64) bool {
+	return math.Abs(x-y) < epsilon
 }
 
 func byID[E node](id uint32, c *demoClient) (E, error) {

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -84,10 +84,14 @@ func (c *demoClient) certifyScorecard(ctx context.Context, source model.SourceIn
 		if err != nil {
 			return nil, gqlerror.Errorf("%v ::  %s", funcName, err)
 		}
-		if sourceID == v.sourceID && scorecard.TimeScanned.UTC() == v.timeScanned && scorecard.AggregateScore == v.aggregateScore &&
-			scorecard.ScorecardVersion == v.scorecardVersion && scorecard.ScorecardCommit == v.scorecardCommit && scorecard.Origin == v.origin &&
-			scorecard.Collector == v.collector && reflect.DeepEqual(checksMap, v.checks) {
-
+		if sourceID == v.sourceID &&
+			scorecard.TimeScanned.UTC() == v.timeScanned &&
+			floatEqual(scorecard.AggregateScore, v.aggregateScore) &&
+			scorecard.ScorecardVersion == v.scorecardVersion &&
+			scorecard.ScorecardCommit == v.scorecardCommit &&
+			scorecard.Origin == v.origin &&
+			scorecard.Collector == v.collector &&
+			reflect.DeepEqual(checksMap, v.checks) {
 			collectedScorecardLink = *v
 			duplicate = true
 			break
@@ -159,7 +163,7 @@ func (c *demoClient) Scorecards(ctx context.Context, filter *model.CertifyScorec
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
 		if exactSource != nil {
-			search = append(search, exactSource.scorecardLinks...)
+			search = exactSource.scorecardLinks
 			foundOne = true
 		}
 	}
@@ -192,10 +196,10 @@ func (c *demoClient) Scorecards(ctx context.Context, filter *model.CertifyScorec
 func (c *demoClient) addSCIfMatch(out []*model.CertifyScorecard,
 	filter *model.CertifyScorecardSpec, link *scorecardLink) (
 	[]*model.CertifyScorecard, error) {
-	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.UTC() == link.timeScanned {
+	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.UTC() != link.timeScanned {
 		return out, nil
 	}
-	if filter != nil && filter.AggregateScore != nil && *filter.AggregateScore != link.aggregateScore {
+	if filter != nil && noMatchFloat(filter.AggregateScore, link.aggregateScore) {
 		return out, nil
 	}
 	if filter != nil && noMatchChecks(filter.Checks, link.checks) {

--- a/pkg/assembler/backends/inmem/certifyScorecard_test.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard_test.go
@@ -1,0 +1,535 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmem_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"golang.org/x/exp/slices"
+)
+
+func TestCertifyScorecard(t *testing.T) {
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Src *model.SourceInputSpec
+		SC  *model.ScorecardInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		Query        *model.CertifyScorecardSpec
+		ExpSC        []*model.CertifyScorecard
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Origin: ptrfrom.String("test origin"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks: []*model.ScorecardCheck{},
+						Origin: "test origin",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Ingest same",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Origin: ptrfrom.String("test origin"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks: []*model.ScorecardCheck{},
+						Origin: "test origin",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query multiple",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin one",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore: 4.4,
+						Origin:         "test origin two",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore: 4.9,
+						Origin:         "test origin two",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Origin: ptrfrom.String("test origin two"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks:         []*model.ScorecardCheck{},
+						AggregateScore: 4.4,
+						Origin:         "test origin two",
+					},
+				},
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks:         []*model.ScorecardCheck{},
+						AggregateScore: 4.9,
+						Origin:         "test origin two",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query Source",
+			InSrc: []*model.SourceInputSpec{s1, s2},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+				{
+					Src: s2,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Source: &model.SourceSpec{
+					Namespace: ptrfrom.String("github.com/jeff"),
+				},
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks: []*model.ScorecardCheck{},
+						Origin: "test origin",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query Time",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      testTime,
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				TimeScanned: &testTime,
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks:           []*model.ScorecardCheck{},
+						AggregateScore:   1.5,
+						TimeScanned:      testTime,
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query Score",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   5.7,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				AggregateScore: ptrfrom.Float64(57.0 / 10),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks:           []*model.ScorecardCheck{},
+						AggregateScore:   5.7,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query Checks",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Checks: []*model.ScorecardCheckInputSpec{
+							{
+								Check: "check one",
+								Score: 5,
+							},
+						},
+						ScorecardVersion: "123",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Checks: []*model.ScorecardCheckInputSpec{
+							{
+								Check: "check one",
+								Score: 5,
+							},
+							{
+								Check: "check two",
+								Score: 6,
+							},
+						},
+						ScorecardVersion: "456",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Checks: []*model.ScorecardCheckSpec{
+					{
+						Check: "check one",
+						Score: 5,
+					},
+				},
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks: []*model.ScorecardCheck{
+							{
+								Check: "check one",
+								Score: 5,
+							},
+						},
+						ScorecardVersion: "123",
+					},
+				},
+			},
+		},
+		{
+			Name:  "Query None",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   5.7,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				ScorecardVersion: ptrfrom.String("456"),
+			},
+			ExpSC: nil,
+		},
+		{
+			Name:  "Query ID",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				ID: ptrfrom.String("5"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: s1out,
+					Scorecard: &model.Scorecard{
+						Checks:           []*model.ScorecardCheck{},
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+		},
+		{
+			Name: "Ingest error",
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				ID: ptrfrom.String("4294967296"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := inmem.GetBackend(nil)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.CertifyScorecard(ctx, *o.Src, *o.SC)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+			got, err := b.Scorecards(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpSC, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCertifyScorecardNeighbors(t *testing.T) {
+	type call struct {
+		Src *model.SourceInputSpec
+		SC  *model.ScorecardInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		ExpNeighbors map[string][]string
+	}{
+		{
+			Name:  "HappyPath",
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+			},
+			ExpNeighbors: map[string][]string{
+				"4": []string{"2", "5"}, // src name
+				"5": []string{"2"},      // SC
+			},
+		},
+		{
+			Name:  "Multiple",
+			InSrc: []*model.SourceInputSpec{s1, s2},
+			Calls: []call{
+				{
+					Src: s1,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+				{
+					Src: s2,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+				{
+					Src: s2,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin two",
+					},
+				},
+			},
+			ExpNeighbors: map[string][]string{
+				// test sources are all type git, id:2
+				"4": []string{"2", "7"},      // src name 1 -> src namespace, SC1
+				"6": []string{"2", "8", "9"}, // src name 2 -> src namespace, SC2, SC3
+				"7": []string{"2"},           // SC 1
+				"8": []string{"2"},           // SC 2
+				"9": []string{"2"},           // SC 3
+			},
+		},
+	}
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := inmem.GetBackend(nil)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				if _, err := b.CertifyScorecard(ctx, *o.Src, *o.SC); err != nil {
+					t.Fatalf("Could not ingest CertifyScorecard: %v", err)
+				}
+			}
+			for q, r := range test.ExpNeighbors {
+				got, err := b.Neighbors(ctx, q, nil)
+				if err != nil {
+					t.Fatalf("Could not query neighbors: %s", err)
+				}
+				gotIDs := convNodes(got)
+				slices.Sort(r)
+				slices.Sort(gotIDs)
+				if diff := cmp.Diff(r, gotIDs); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scorecard unit tests, fix logic error comparing time when querying. As a caution, add float compare for scores using epsilon.