### PR TITLE
build: improve building in non-docker environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ LDFLAGS="-X $(PKG).version=$(VERSION) -X $(PKG).commit=$(COMMIT) -X $(PKG).date=
 
 .DEFAULT_GOAL := build
 
+CONTAINER ?= docker
+
 .PHONY: all
 all: test cover fmt lint build generate
 
@@ -92,8 +94,8 @@ generate:
 
 .PHONY: container
 container: check-docker-tool-check
-	docker build -f dockerfiles/Dockerfile.guac-cont -t local-organic-guac .
-	docker build -f dockerfiles/Dockerfile.healthcheck -t local-healthcheck .
+	$(CONTAINER) build -f dockerfiles/Dockerfile.guac-cont -t local-organic-guac .
+	$(CONTAINER) build -f dockerfiles/Dockerfile.healthcheck -t local-healthcheck .
 
 
 # To run the service, run `make container` and then `make service`
@@ -104,17 +106,17 @@ start-service:
 	# not handle that well.
 	#
 	# if container images are missing, run `make container` first
-	docker compose up --force-recreate	
+	$(CONTAINER) compose up --force-recreate
 
 # to flush state, service-stop must be used else state is taken from old containers
 .PHONY: stop-service
 stop-service:
-	docker compose down
+	$(CONTAINER) compose down
 
 .PHONY: check-docker-tool-check
 check-docker-tool-check:
-	@if ! command -v docker &> /dev/null; then \
-		echo "Docker is not installed. Please install Docker and try again."; \
+	@if ! command -v $(CONTAINER) &> /dev/null; then \
+		echo "'$(CONTAINER)' is not installed. Please install '$(CONTAINER)' and try again. Or set the CONTAINER variable to a different container runtime engine."; \
 		exit 1; \
 	fi
 

--- a/dockerfiles/Dockerfile.guac-cont
+++ b/dockerfiles/Dockerfile.guac-cont
@@ -1,9 +1,9 @@
-FROM golang:1.19 as builder
+FROM docker.io/library/golang:1.19 as builder
 ADD . /go/src/github.com/guacsec/guac/
 WORKDIR /go/src/github.com/guacsec/guac/
 RUN rm -rf bin/ && make build
 
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 RUN apt update
 RUN apt install -y ca-certificates
 WORKDIR /root

--- a/dockerfiles/Dockerfile.healthcheck
+++ b/dockerfiles/Dockerfile.healthcheck
@@ -1,2 +1,2 @@
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 RUN apt update && apt install -y curl netcat


### PR DESCRIPTION
Having podman installed, there are two little pain points. For one, the makefile explicitly checks for a binary named "docker". This change makes this configurable and allows the user to use "make CONTAINER=podman" to override the (still default) docker name.

Second, the dockerfiles don't use fully qualified docker images. Even with docker, this can lead to unexpected results, as it's not guaranteed that you get the images from docker.io. That's why on e.g. Fedora, an interactive chooser shows up, asking the user for confirmation. Or, if the user already did choose as system wide default, one might not get the correct images.

This can easily be solved by using fully qualified image names.