### PR TITLE
Update SLSA parser to support 1.0 and old versions.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/fsouza/fake-gcs-server v1.44.2
-	github.com/in-toto/in-toto-golang v0.7.1
+	github.com/in-toto/in-toto-golang v0.8.0
 	github.com/neo4j/neo4j-go-driver/v4 v4.4.7
 	github.com/secure-systems-lab/go-securesystemslib v0.5.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1377,8 +1377,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/in-toto/in-toto-golang v0.7.1 h1:IzOB18y7/4KoEp4/RiWnuIXUpqi9+5yGlRy/t/QRDWE=
-github.com/in-toto/in-toto-golang v0.7.1/go.mod h1:m7HiDiYvPz+7SkqU9Tnt9hNgJfA31/nr1GSlDlxrQmE=
+github.com/in-toto/in-toto-golang v0.8.0 h1:MTVK138TdSUbScuy3XQiRlV5U5a1UkFdz+2gyvF42V0=
+github.com/in-toto/in-toto-golang v0.8.0/go.mod h1:u8GkjDht81AcD7GrNAPLZl4jsRF//f306QDHZ5mBIyI=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -240,7 +240,7 @@ type CertifyGoodIngest struct {
 }
 
 type HasSBOMIngest struct {
-	// hasSBOM describes either pkg or src
+	// hasSBOM describes either pkg or artifact
 	Pkg      *generated.PkgInputSpec
 	Artifact *generated.ArtifactInputSpec
 

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -21,13 +21,18 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/in-toto/in-toto-golang/in_toto"
+	scommon "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa01 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"github.com/jeremywohl/flatten"
+
 	"github.com/guacsec/guac/pkg/assembler"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
-	"github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/jeremywohl/flatten"
 )
 
 // each subject or object is made of:
@@ -36,7 +41,7 @@ import (
 // - An IsOccurence input spec which will generate a predicate for each occurence
 type slsaEntity struct {
 	artifacts []*model.ArtifactInputSpec
-	occurence model.IsOccurrenceInputSpec
+	occurence *model.IsOccurrenceInputSpec
 
 	// Either pkg or source
 	pkg    *model.PkgInputSpec
@@ -44,136 +49,209 @@ type slsaEntity struct {
 }
 
 type slsaParser struct {
-	doc *processor.Document
-
-	subjects        []slsaEntity
-	materials       []slsaEntity
-	builder         model.BuilderInputSpec
-	slsaAttestation model.SLSAInputSpec
-
+	header            *in_toto.StatementHeader
+	s01smt            *in_toto.ProvenanceStatementSLSA01
+	s02smt            *in_toto.ProvenanceStatementSLSA02
+	s1smt             *in_toto.ProvenanceStatementSLSA1
+	subjects          []*slsaEntity
+	materials         []*slsaEntity
+	bareMaterials     []*model.ArtifactInputSpec
+	builder           *model.BuilderInputSpec
+	slsaAttestation   *model.SLSAInputSpec
 	identifierStrings *common.IdentifierStrings
 }
 
 // NewSLSAParser initializes the slsaParser
 func NewSLSAParser() common.DocumentParser {
 	return &slsaParser{
-		subjects:          []slsaEntity{},
-		materials:         []slsaEntity{},
-		slsaAttestation:   model.SLSAInputSpec{},
-		builder:           model.BuilderInputSpec{},
 		identifierStrings: &common.IdentifierStrings{},
 	}
 }
 
 // Parse breaks out the document into the graph components
 func (s *slsaParser) Parse(ctx context.Context, doc *processor.Document) error {
-	s.doc = doc
-	statement, err := parseSlsaPredicate(doc.Blob)
-	if err != nil {
-		return fmt.Errorf("failed to parse slsa predicate: %w", err)
-	}
-	s.getSubject(statement)
-	s.getMaterials(statement)
-	err = s.getSLSA(statement)
-	if err != nil {
+	if err := s.parseSlsaPredicate(doc.Blob); err != nil {
 		return err
 	}
-	s.getBuilder(statement)
+	if err := s.getSubject(); err != nil {
+		return err
+	}
+	if err := s.getMaterials(); err != nil {
+		return err
+	}
+	if err := s.getSLSA(); err != nil {
+		return err
+	}
+	s.getBuilder()
 	return nil
 }
 
-func (s *slsaParser) getSubject(statement *in_toto.ProvenanceStatement) {
+func (s *slsaParser) getSubject() error {
 	// append artifact node for the subjects
-	for _, sub := range statement.Subject {
-		artifacts := []*model.ArtifactInputSpec{}
-		for alg, ds := range sub.Digest {
-			artifacts = append(artifacts, &model.ArtifactInputSpec{
-				Algorithm: alg,
-				Digest:    strings.Trim(ds, "'"), // some slsa documents incorrectly add additional quotes
-			})
-
-			s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, sub.Name)
+	for _, sub := range s.header.Subject {
+		s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, sub.Name)
+		se, err := getSlsaEntity(sub.Name, sub.Digest)
+		if err != nil {
+			return err
 		}
-		s.subjects = append(s.subjects, getSlsaEntity(sub.Name, artifacts))
+		s.subjects = append(s.subjects, se)
 	}
+	return nil
 }
 
-func (s *slsaParser) getMaterials(statement *in_toto.ProvenanceStatement) {
+func (s *slsaParser) getMaterials() error {
+	switch s.header.PredicateType {
+	case slsa01.PredicateSLSAProvenance:
+		if err := s.getMaterials0(s.s01smt.Predicate.Materials); err != nil {
+			return err
+		}
+	case slsa02.PredicateSLSAProvenance:
+		if err := s.getMaterials0(s.s02smt.Predicate.Materials); err != nil {
+			return err
+		}
+	case slsa1.PredicateSLSAProvenance:
+		if err := s.getMaterials1(s.s1smt.Predicate.BuildDefinition.ResolvedDependencies); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *slsaParser) getMaterials1(rds []slsa1.ResourceDescriptor) error {
+	for _, rd := range rds {
+		// Only one of URI, Digest, or Content is required.
+		// https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md
+		if len(rd.Digest) == 0 {
+			// Skip if Digest is empty
+			continue
+		}
+		if rd.URI == "" {
+			// If URI is empty, just add artifacts
+			s.bareMaterials = append(s.bareMaterials, getArtifacts(rd.Digest)...)
+			continue
+		}
+		// Digest(s) and URI are set, create IsOccurrence between them.
+		s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, rd.URI)
+		se, err := getSlsaEntity(rd.URI, rd.Digest)
+		if err != nil {
+			return err
+		}
+		s.materials = append(s.materials, se)
+	}
+	return nil
+}
+
+func (s *slsaParser) getMaterials0(materials []scommon.ProvenanceMaterial) error {
 	// append dependency nodes for the materials
-	for _, mat := range statement.Predicate.Materials {
-		artifacts := []*model.ArtifactInputSpec{}
-		for alg, ds := range mat.Digest {
-			artifacts = append(artifacts, &model.ArtifactInputSpec{
-				Algorithm: alg,
-				Digest:    strings.Trim(ds, "'"), // some slsa documents incorrectly add additional quotes
-			})
-
-			s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, mat.URI)
+	for _, mat := range materials {
+		s.identifierStrings.UnclassifiedStrings = append(s.identifierStrings.UnclassifiedStrings, mat.URI)
+		se, err := getSlsaEntity(mat.URI, mat.Digest)
+		if err != nil {
+			return err
 		}
-		s.materials = append(s.materials, getSlsaEntity(mat.URI, artifacts))
+		s.materials = append(s.materials, se)
 	}
+	return nil
 }
 
-func getSlsaEntity(name string, artifacts []*model.ArtifactInputSpec) slsaEntity {
-	s := slsaEntity{
+func getArtifacts(digests scommon.DigestSet) []*model.ArtifactInputSpec {
+	var artifacts []*model.ArtifactInputSpec
+	for alg, ds := range digests {
+		artifacts = append(artifacts, &model.ArtifactInputSpec{
+			Algorithm: alg,
+			Digest:    strings.Trim(ds, "'"), // some slsa documents incorrectly add additional quotes
+		})
+	}
+	return artifacts
+}
+
+func getSlsaEntity(name string, digests scommon.DigestSet) (*slsaEntity, error) {
+	artifacts := getArtifacts(digests)
+	slsa := &slsaEntity{
 		artifacts: artifacts,
+		occurence: &model.IsOccurrenceInputSpec{
+			Justification: "from SLSA definition of checksums for subject/materials",
+		},
 	}
 
-	var (
-		src *model.SourceInputSpec
-		pkg *model.PkgInputSpec
-	)
-	pkg, err := helpers.PurlToPkg(name)
-	if err == nil {
-		s.pkg = pkg
-		goto finish
+	if pkg, err := helpers.PurlToPkg(name); err == nil {
+		slsa.pkg = pkg
+		return slsa, nil
 	}
 
-	src, err = helpers.VcsToSrc(name)
-	if err == nil {
-		s.source = src
-		goto finish
+	if src, err := helpers.VcsToSrc(name); err == nil {
+		slsa.source = src
+		return slsa, nil
 	}
 
 	// else we create a GUAC package for it
-	pkg, err = helpers.PurlToPkg(helpers.GuacGenericPurl(name))
+	pkg, err := helpers.PurlToPkg(helpers.GuacGenericPurl(name))
 	if err == nil {
-		s.pkg = pkg
-		goto finish
-	} else {
-		panic("unable to get Guac Generic Purl, this should not happen")
+		slsa.pkg = pkg
+		return slsa, nil
 	}
 
-finish:
-	s.occurence = model.IsOccurrenceInputSpec{
-		Justification: "from SLSA definition of checksums for subject/materials",
-	}
-
-	return s
+	return nil, fmt.Errorf("%w unable to get Guac Generic Purl, this should not happen", err)
 }
 
-func (s *slsaParser) getSLSA(stmt *in_toto.ProvenanceStatement) error {
-	inp := model.SLSAInputSpec{}
-	inp.BuildType = stmt.Predicate.BuildType
-
-	inp.SlsaVersion = stmt.PredicateType
+func fillSLSA01(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA01) {
+	inp.BuildType = stmt.Predicate.Recipe.Type
 	if stmt.Predicate.Metadata.BuildStartedOn != nil {
 		inp.StartedOn = *stmt.Predicate.Metadata.BuildStartedOn
 	}
 	if stmt.Predicate.Metadata.BuildFinishedOn != nil {
 		inp.FinishedOn = *stmt.Predicate.Metadata.BuildStartedOn
 	}
+}
 
-	data, _ := json.Marshal(stmt.Predicate)
+func fillSLSA02(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA02) {
+	inp.BuildType = stmt.Predicate.BuildType
+	if stmt.Predicate.Metadata.BuildStartedOn != nil {
+		inp.StartedOn = *stmt.Predicate.Metadata.BuildStartedOn
+	}
+	if stmt.Predicate.Metadata.BuildFinishedOn != nil {
+		inp.FinishedOn = *stmt.Predicate.Metadata.BuildStartedOn
+	}
+}
+
+func fillSLSA1(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA1) {
+	inp.BuildType = stmt.Predicate.BuildDefinition.BuildType
+	if stmt.Predicate.RunDetails.BuildMetadata.StartedOn != nil {
+		inp.StartedOn = *stmt.Predicate.RunDetails.BuildMetadata.StartedOn
+	}
+	if stmt.Predicate.RunDetails.BuildMetadata.FinishedOn != nil {
+		inp.FinishedOn = *stmt.Predicate.RunDetails.BuildMetadata.FinishedOn
+	}
+}
+
+func (s *slsaParser) getSLSA() error {
+	inp := &model.SLSAInputSpec{
+		SlsaVersion: s.header.PredicateType,
+	}
+
+	var pred any
+	switch s.header.PredicateType {
+	case slsa01.PredicateSLSAProvenance:
+		fillSLSA01(inp, s.s01smt)
+		pred = s.s01smt.Predicate
+	case slsa02.PredicateSLSAProvenance:
+		fillSLSA02(inp, s.s02smt)
+		pred = s.s02smt.Predicate
+	case slsa1.PredicateSLSAProvenance:
+		fillSLSA1(inp, s.s1smt)
+		pred = s.s1smt.Predicate
+	}
+
+	data, _ := json.Marshal(pred)
 	var genericMap map[string]any
 	err := json.Unmarshal(data, &genericMap)
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not unmarshal SLSA Predicate to map: %w", err)
 	}
 
 	flatMap, err := flatten.Flatten(genericMap, "slsa.", flatten.SeparatorStyle{Middle: "."})
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not flatten SLSA Predicate map: %w", err)
 	}
 
 	for k, v := range flatMap {
@@ -188,18 +266,43 @@ func (s *slsaParser) getSLSA(stmt *in_toto.ProvenanceStatement) error {
 	return nil
 }
 
-func (s *slsaParser) getBuilder(statement *in_toto.ProvenanceStatement) {
-	s.builder = model.BuilderInputSpec{
-		Uri: statement.Predicate.Builder.ID,
+func (s *slsaParser) getBuilder() {
+	s.builder = &model.BuilderInputSpec{}
+	switch s.header.PredicateType {
+	case slsa01.PredicateSLSAProvenance:
+		s.builder.Uri = s.s01smt.Predicate.Builder.ID
+	case slsa02.PredicateSLSAProvenance:
+		s.builder.Uri = s.s02smt.Predicate.Builder.ID
+	case slsa1.PredicateSLSAProvenance:
+		s.builder.Uri = s.s1smt.Predicate.RunDetails.Builder.ID
 	}
 }
 
-func parseSlsaPredicate(p []byte) (*in_toto.ProvenanceStatement, error) {
-	predicate := in_toto.ProvenanceStatement{}
-	if err := json.Unmarshal(p, &predicate); err != nil {
-		return nil, err
+func (s *slsaParser) parseSlsaPredicate(p []byte) error {
+	s.header = &in_toto.StatementHeader{}
+	if err := json.Unmarshal(p, s.header); err != nil {
+		return fmt.Errorf("Could not unmarshal SLSA statement header: %w", err)
 	}
-	return &predicate, nil
+	switch s.header.PredicateType {
+	case slsa01.PredicateSLSAProvenance:
+		s.s01smt = &in_toto.ProvenanceStatementSLSA01{}
+		if err := json.Unmarshal(p, s.s01smt); err != nil {
+			return fmt.Errorf("Could not unmarshal v0.1 SLSA provenance statement : %w", err)
+		}
+	case slsa02.PredicateSLSAProvenance:
+		s.s02smt = &in_toto.ProvenanceStatementSLSA02{}
+		if err := json.Unmarshal(p, s.s02smt); err != nil {
+			return fmt.Errorf("Could not unmarshal v0.2 SLSA provenance statement : %w", err)
+		}
+	case slsa1.PredicateSLSAProvenance:
+		s.s1smt = &in_toto.ProvenanceStatementSLSA1{}
+		if err := json.Unmarshal(p, s.s1smt); err != nil {
+			return fmt.Errorf("Could not unmarshal v1.0 SLSA provenance statement : %w", err)
+		}
+	default:
+		return fmt.Errorf("Unknown SLSA PredicateType: %q", s.header.PredicateType)
+	}
+	return nil
 }
 
 func (s *slsaParser) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
@@ -212,7 +315,7 @@ func (s *slsaParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				Pkg:          o.pkg,
 				Src:          o.source,
 				Artifact:     a,
-				IsOccurrence: &o.occurence,
+				IsOccurrence: o.occurence,
 			})
 		}
 	}
@@ -223,26 +326,29 @@ func (s *slsaParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				Pkg:          o.pkg,
 				Src:          o.source,
 				Artifact:     a,
-				IsOccurrence: &o.occurence,
+				IsOccurrence: o.occurence,
 			})
 		}
 	}
 
 	// Assemble materials
-	materials := []model.ArtifactInputSpec{}
+	var materials []model.ArtifactInputSpec
 	for _, o := range s.materials {
 		for _, a := range o.artifacts {
 			materials = append(materials, *a)
 		}
+	}
+	for _, a := range s.bareMaterials {
+		materials = append(materials, *a)
 	}
 
 	for _, o := range s.subjects {
 		for _, a := range o.artifacts {
 			preds.HasSlsa = append(preds.HasSlsa, assembler.HasSlsaIngest{
 				Artifact:  a,
-				HasSlsa:   &s.slsaAttestation,
+				HasSlsa:   s.slsaAttestation,
 				Materials: materials,
-				Builder:   &s.builder,
+				Builder:   s.builder,
 			})
 		}
 	}

--- a/pkg/ingestor/parser/slsa/parser_slsa_test.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa_test.go
@@ -33,12 +33,20 @@ func Test_slsaParser(t *testing.T) {
 		doc            *processor.Document
 		wantPredicates *assembler.IngestPredicates
 		wantErr        bool
-	}{{
-		name:           "testing",
-		doc:            &testdata.Ite6SLSADoc,
-		wantPredicates: &testdata.SlsaPreds,
-		wantErr:        false,
-	}}
+	}{
+		{
+			name:           "testing v0.2",
+			doc:            &testdata.Ite6SLSADoc,
+			wantPredicates: &testdata.SlsaPreds,
+			wantErr:        false,
+		},
+		{
+			name:           "testing v0.1",
+			doc:            &testdata.Ite6SLSA1Doc,
+			wantPredicates: &testdata.SlsaPreds1,
+			wantErr:        false,
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSLSAParser()
@@ -52,6 +60,7 @@ func Test_slsaParser(t *testing.T) {
 			}
 
 			preds := s.GetPredicates(ctx)
+			//fmt.Println(preds.HasSlsa[0].HasSlsa.SlsaPredicate)
 			if d := cmp.Diff(tt.wantPredicates, preds, testdata.IngestPredicatesCmpOpts...); len(d) != 0 {
 				t.Errorf("slsa.GetPredicate mismatch values (+got, -expected): %s", d)
 			}


### PR DESCRIPTION
Need to add a test, I don't see an example on the doc page: https://slsa.dev/provenance/v1 The older versions had some.

Fixes #793

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
