### PR TITLE
update query vuln to utilize proper dependency version range, add table and cleanup doc

### DIFF
--- a/cmd/guacone/cmd/query_known.go
+++ b/cmd/guacone/cmd/query_known.go
@@ -106,7 +106,6 @@ var queryKnownCmd = &cobra.Command{
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		t := table.NewWriter()
-		// you can also instantiate the object directly
 		tTemp := table.Table{}
 		tTemp.Render()
 		t.AppendHeader(rowHeader)

--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -23,17 +23,23 @@ import (
 	"strings"
 
 	"github.com/Khan/genqlient/graphql"
-	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/misc/depversion"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-const guacType string = "guac"
+const (
+	guacType string = "guac"
+	osvType  string = "osv"
+	cveType  string = "cve"
+	ghsaType string = "ghsa"
+)
 
 type queryOptions struct {
 	// gql endpoint
@@ -46,7 +52,7 @@ type queryOptions struct {
 }
 
 var queryVulnCmd = &cobra.Command{
-	Use:   "queryVuln [flags]",
+	Use:   "query_vuln [flags]",
 	Short: "query if a package is affected by the specified vulnerability",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
@@ -68,6 +74,12 @@ var queryVulnCmd = &cobra.Command{
 
 		httpClient := http.Client{}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
+
+		t := table.NewWriter()
+		// you can also instantiate the object directly
+		tTemp := table.Table{}
+		tTemp.Render()
+		t.AppendHeader(rowHeader)
 
 		pkgInput, err := helpers.PurlToPkg(opts.purl)
 		if err != nil {
@@ -99,6 +111,7 @@ var queryVulnCmd = &cobra.Command{
 		}
 
 		if opts.vulnerabilityID != "" {
+			tableRows := []table.Row{}
 			cveResponse := &model.CVEsResponse{}
 			ghsaResponse := &model.GHSAsResponse{}
 
@@ -115,6 +128,8 @@ var queryVulnCmd = &cobra.Command{
 					}
 					if len(cveResponse.Cve) == 0 {
 						logger.Debugf("error failed to find CVE or OSV matching vulnerability ID")
+					} else {
+						tableRows = append(tableRows, table.Row{cveType, cveResponse.Cve[0].Id, "vulnerability ID: " + cveResponse.Cve[0].CveId})
 					}
 				} else if strings.HasPrefix(opts.vulnerabilityID, "ghsa") {
 					ghsaResponse, err = model.GHSAs(ctx, gqlclient, &model.GHSASpec{GhsaId: &opts.vulnerabilityID})
@@ -123,10 +138,14 @@ var queryVulnCmd = &cobra.Command{
 					}
 					if len(ghsaResponse.Ghsa) == 0 {
 						logger.Debugf("error failed to find CVE or OSV matching vulnerability ID")
+					} else {
+						tableRows = append(tableRows, table.Row{ghsaType, ghsaResponse.Ghsa[0].Id, "vulnerability ID: " + ghsaResponse.Ghsa[0].GhsaId})
 					}
 				} else {
 					logger.Debugf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
 				}
+			} else {
+				tableRows = append(tableRows, table.Row{osvType, osvResponse.Osv[0].Id, "vulnerability ID: " + osvResponse.Osv[0].OsvId})
 			}
 
 			var path []string
@@ -146,65 +165,75 @@ var queryVulnCmd = &cobra.Command{
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
 			} else {
-				logger.Fatalf("failed to identify vulnerability as cve or ghsa and no results found for OSV")
+				fmt.Printf("Failed to identify vulnerability as cve or ghsa and no results found for OSV\n")
 			}
 			if len(path) > 0 {
-				logger.Infof("found path %v", strings.Join(path, `,`))
-				logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+				t.AppendRows(tableRows)
+				fmt.Println(t.Render())
+				fmt.Printf("Found path %v\n", strings.Join(path, `,`))
+				fmt.Printf("Visualizer url: http://localhost:3000/visualize?path=[%v]\n", strings.Join(path, `,`))
 			} else {
-				logger.Infof("No path to vulnerability ID found!")
+				fmt.Printf("No path to vulnerability ID found!\n")
 			}
 		} else {
 			var path []string
-			var vulnPath []string
+			tableRows := []table.Row{}
 			if pkgResponse.Packages[0].Type != guacType {
-				vulnPath, err = queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
+				vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
 				if err != nil {
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
+				path = append(path, vulnPath...)
+				tableRows = append(tableRows, pkgVulnTableRows...)
 			}
-			depVulnPath, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
+			depVulnPath, depVulnTableRows, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
 			if err != nil {
 				logger.Fatalf("error searching dependency packages match: %v", err)
 			}
-
-			path = append(path, vulnPath...)
 			path = append(path, depVulnPath...)
+			tableRows = append(tableRows, depVulnTableRows...)
 
 			if len(path) > 0 {
 				path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
 					pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
 					pkgResponse.Packages[0].Id}, path...)
-				logger.Infof("found path %v", strings.Join(path, `,`))
-				logger.Infof("Visualizer url: http://localhost:3000/visualize?path=[%v]", strings.Join(path, `,`))
+				t.AppendRows(tableRows)
+
+				fmt.Println(t.Render())
+				fmt.Printf("Found path %v\n", strings.Join(path, `,`))
+				fmt.Printf("Visualizer url: http://localhost:3000/visualize?path=[%v]\n", strings.Join(path, `,`))
 			} else {
-				logger.Infof("No path to vulnerabilities found!")
+				fmt.Printf("No path to vulnerabilities found!\n")
 			}
 		}
 	},
 }
 
-func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, error) {
+func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, []table.Row, error) {
 	path := []string{}
+	tableRows := []table.Row{}
 	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
 	if err != nil {
-		return nil, fmt.Errorf("error querying neighbor for vulnerability: %v", err)
+		return nil, nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
 	}
 	certifyVulnFound := false
 	for _, neighbor := range pkgVersionNeighborResponse.Neighbors {
 		if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
 			certifyVulnFound = true
 			if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityOSV); ok {
+				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.OsvId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}...)
 			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityCVE); ok {
+				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.CveId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}...)
 			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityGHSA); ok {
+				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.GhsaId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
@@ -213,13 +242,14 @@ func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client
 		}
 	}
 	if !certifyVulnFound {
-		return nil, fmt.Errorf("error certify vulnerability node not found, incomplete data. Please ensure certifier has run")
+		return nil, nil, fmt.Errorf("error certify vulnerability node not found, incomplete data. Please ensure certifier has run")
 	}
-	return path, nil
+	return path, tableRows, nil
 }
 
-func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, error) {
+func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, []table.Row, error) {
 	path := []string{}
+	tableRows := []table.Row{}
 	queue := make([]string, 0) // the queue of nodes in bfs
 	type dfsNode struct {
 		expanded bool // true once all node neighbors are added to queue
@@ -242,49 +272,61 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 
 		isDependencyNeighborResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{model.EdgePackageIsDependency})
 		if err != nil {
-			return nil, fmt.Errorf("failed getting package parent:%v", err)
+			return nil, nil, fmt.Errorf("failed getting package parent:%w", err)
 		}
 		for _, neighbor := range isDependencyNeighborResponses.Neighbors {
 			if isDependency, ok := neighbor.(*model.NeighborsNeighborsIsDependency); ok {
 				if isDependency.DependentPackage.Type == guacType {
 					continue
 				}
+
 				depPkgFilter := &model.PkgSpec{
 					Type:      &isDependency.DependentPackage.Type,
 					Namespace: &isDependency.DependentPackage.Namespaces[0].Namespace,
 					Name:      &isDependency.DependentPackage.Namespaces[0].Names[0].Name,
-					Version:   ptrfrom.String(isDependency.VersionRange),
 				}
 
 				depPkgResponse, err := model.Packages(ctx, gqlclient, depPkgFilter)
 				if err != nil {
-					return nil, fmt.Errorf("error querying for dependent package: %v", err)
+					return nil, nil, fmt.Errorf("error querying for dependent package: %w", err)
 				}
-				if len(depPkgResponse.Packages) != 1 {
-					return nil, fmt.Errorf("error too many dependent packages matching purl found")
-				}
+
+				depPkgVersionsMap := map[string]string{}
+				depPkgVersions := []string{}
 				for _, depPkgVersion := range depPkgResponse.Packages[0].Namespaces[0].Names[0].Versions {
-					vulnPath, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, depPkgVersion.Id, model.EdgePackageCertifyVuln)
+					depPkgVersions = append(depPkgVersions, depPkgVersion.Version)
+					depPkgVersionsMap[depPkgVersion.Version] = depPkgVersion.Id
+				}
+
+				matchingDepPkgVersions, err := depversion.WhichVersionMatches(depPkgVersions, isDependency.VersionRange)
+				if err != nil {
+					return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
+				}
+
+				for matchingDepPkgVersion := range matchingDepPkgVersions {
+					matchingDepPkgVersionID := depPkgVersionsMap[matchingDepPkgVersion]
+					vulnPath, foundVulnTableRow, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, matchingDepPkgVersionID, model.EdgePackageCertifyVuln)
 					if err != nil {
-						return nil, fmt.Errorf("error querying neighbor: %v", err)
+						return nil, nil, fmt.Errorf("error querying neighbor: %w", err)
 					}
 					if len(vulnPath) > 0 {
-						path = append(path, isDependency.Id, depPkgVersion.Id,
+						path = append(path, isDependency.Id, matchingDepPkgVersionID,
 							depPkgResponse.Packages[0].Namespaces[0].Names[0].Id, depPkgResponse.Packages[0].Namespaces[0].Id,
 							depPkgResponse.Packages[0].Id)
 						path = append(path, vulnPath...)
+						tableRows = append(tableRows, foundVulnTableRow...)
 					}
 
-					dfsN, seen := nodeMap[depPkgVersion.Id]
+					dfsN, seen := nodeMap[matchingDepPkgVersionID]
 					if !seen {
 						dfsN = dfsNode{
 							parent: now,
 							depth:  nowNode.depth + 1,
 						}
-						nodeMap[depPkgVersion.Id] = dfsN
+						nodeMap[matchingDepPkgVersionID] = dfsN
 					}
 					if !dfsN.expanded {
-						queue = append(queue, depPkgVersion.Id)
+						queue = append(queue, matchingDepPkgVersionID)
 					}
 				}
 			}
@@ -294,14 +336,14 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 		nodeMap[now] = nowNode
 	}
 
-	return path, nil
+	return path, tableRows, nil
 }
 
 func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth, pathsToReturn int) ([]string, error) {
 	path := []string{}
 	vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
 	if err != nil {
-		return nil, fmt.Errorf("error querying neighbor for vulnerability: %v", err)
+		return nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
 	}
 	certifyVulnFound := false
 	numberOfPaths := 0
@@ -310,7 +352,7 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 			certifyVulnFound = true
 			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
 			if err != nil {
-				return nil, fmt.Errorf("error searching dependency packages match: %v", err)
+				return nil, fmt.Errorf("error searching dependency packages match: %w", err)
 			}
 			if len(pkgPath) > 0 {
 				fullVulnPath := append([]string{vulnerabilityNodeID, certifyVuln.Id,

--- a/cmd/guacone/cmd/query_vulnerability.go
+++ b/cmd/guacone/cmd/query_vulnerability.go
@@ -76,7 +76,6 @@ var queryVulnCmd = &cobra.Command{
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		t := table.NewWriter()
-		// you can also instantiate the object directly
 		tTemp := table.Table{}
 		tTemp.Render()
 		t.AppendHeader(rowHeader)
@@ -111,7 +110,7 @@ var queryVulnCmd = &cobra.Command{
 		}
 
 		if opts.vulnerabilityID != "" {
-			tableRows := []table.Row{}
+			var tableRows []table.Row
 			cveResponse := &model.CVEsResponse{}
 			ghsaResponse := &model.GHSAsResponse{}
 
@@ -177,7 +176,7 @@ var queryVulnCmd = &cobra.Command{
 			}
 		} else {
 			var path []string
-			tableRows := []table.Row{}
+			var tableRows []table.Row
 			if pkgResponse.Packages[0].Type != guacType {
 				vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
 				if err != nil {
@@ -210,8 +209,8 @@ var queryVulnCmd = &cobra.Command{
 }
 
 func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, []table.Row, error) {
-	path := []string{}
-	tableRows := []table.Row{}
+	var path []string
+	var tableRows []table.Row
 	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
@@ -248,8 +247,8 @@ func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client
 }
 
 func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, []table.Row, error) {
-	path := []string{}
-	tableRows := []table.Row{}
+	var path []string
+	var tableRows []table.Row
 	queue := make([]string, 0) // the queue of nodes in bfs
 	type dfsNode struct {
 		expanded bool // true once all node neighbors are added to queue
@@ -340,7 +339,7 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 }
 
 func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth, pathsToReturn int) ([]string, error) {
-	path := []string{}
+	var path []string
 	vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
 	if err != nil {
 		return nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
@@ -374,7 +373,7 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 }
 
 func searchDependencyPackagesReverse(ctx context.Context, gqlclient graphql.Client, topPkgID string, searchPkgID string, maxLength int) ([]string, error) {
-	path := []string{}
+	var path []string
 	queue := make([]string, 0) // the queue of nodes in bfs
 	type dfsNode struct {
 		expanded     bool // true once all node neighbors are added to queue

--- a/demo/query_vuln.md
+++ b/demo/query_vuln.md
@@ -129,7 +129,7 @@ In this first example, we will query if our image has any vulnerabilities
 We will start off by running the following command:
 
 ```bash
-./bin/guacone queryVuln --purl "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest"
+./bin/guacone query_vuln --purl "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest"
 ```
 
 **Note**: if you see the following error:
@@ -148,14 +148,25 @@ five minute interval to keep re-scanning for any new packages in GUAC). To force
 the scan to occur immediately please run:
 
 ```bash
-docker run --rm --network guac_default local-organic-guac:latest /opt/guac/guacone certifier osv -p=false --gql-endpoint http://guac-graphql:8080/query
+./bin/guacone certifier osv -p=false
 ```
 
 Successful output will show the following:
 
 ```bash
-{"level":"info","ts":1682083927.505824,"caller":"cmd/query_vulnerability.go:184","msg":"found path 5,4,3,2,104,103,102,101,6,21059,21060,103,102,101,6,21061,21062,103,102,101,6,21063,21064,103,102,101,6,21065,21066,103,102,101,6,21067,21068,103,102,101,6,21069,21070,103,102,101,6,323,322,321,84,6,21055,21056,322,321,84,6"}
-{"level":"info","ts":1682083927.505867,"caller":"cmd/query_vulnerability.go:185","msg":"Visualizer url: http://localhost:3000/visualize?path=[5,4,3,2,104,103,102,101,6,21059,21060,103,102,101,6,21061,21062,103,102,101,6,21063,21064,103,102,101,6,21065,21066,103,102,101,6,21067,21068,103,102,101,6,21069,21070,103,102,101,6,323,322,321,84,6,21055,21056,322,321,84,6]"}
++-------------+-----------+---------------------------------------+
+| NODE TYPE   | NODE ID   | ADDITIONAL INFORMATION                |
++-------------+-----------+---------------------------------------+
+| certifyVuln | 21161     | vulnerability ID: ghsa-7rjr-3q55-vv33 |
+| certifyVuln | 21163     | vulnerability ID: ghsa-8489-44mv-ggj8 |
+| certifyVuln | 21165     | vulnerability ID: ghsa-fxph-q3j8-mv87 |
+| certifyVuln | 21167     | vulnerability ID: ghsa-jfh8-c2jp-5v3q |
+| certifyVuln | 21169     | vulnerability ID: ghsa-p6xc-xr62-6r2g |
+| certifyVuln | 21171     | vulnerability ID: ghsa-vwqq-5vrc-xw9h |
+| certifyVuln | 21148     | vulnerability ID: ghsa-599f-7c49-w659 |
++-------------+-----------+---------------------------------------+
+Found path 5,4,3,2,186,185,184,183,20,21161,21162,185,184,183,20,21163,21164,185,184,183,20,21165,21166,185,184,183,20,21167,21168,185,184,183,20,21169,21170,185,184,183,20,21171,21172,185,184,183,20,339,338,337,202,20,21148,21149,338,337,202,20
+Visualizer url: http://localhost:3000/visualize?path=[5,4,3,2,186,185,184,183,20,21161,21162,185,184,183,20,21163,21164,185,184,183,20,21165,21166,185,184,183,20,21167,21168,185,184,183,20,21169,21170,185,184,183,20,21171,21172,185,184,183,20,339,338,337,202,20,21148,21149,338,337,202,20]
 ```
 
 From the output, you can see that there are vulnerabilities associated with the
@@ -178,16 +189,20 @@ In this example, we will query our image to determine if it is affected by a
 particular vulnerability. If it is, return a path to said vulnerability such
 that we can remediate the culprit.
 
+**Note**: This query will return all paths by default. If you want to only
+return a certain number, you can use the `--path` flag to specify the number.
+
 To do this we will run the following:
 
 ```bash
-./bin/guacone queryVuln --purl "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest" --vulnerabilityID "ghsa-7rjr-3q55-vv33"
+./bin/guacone query_vuln --purl "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest" --vulnerabilityID "ghsa-7rjr-3q55-vv33"
 ```
 
-**Note**: if you see the following errors:
+**Note**: if you see the following:
 
 ```bash
-{"level":"fatal","ts":1681824986.1271732,"caller":"cmd/query_vulnerability.go:160","msg":"failed to identify vulnerability as cve or ghsa and no results found for OSV"}
+Failed to identify vulnerability as cve or ghsa and no results found for OSV
+No path to vulnerability ID found!
 ```
 
 This means that the vulnerability node was not found within GUAC.
@@ -202,8 +217,13 @@ successfully to provide accurate results.
 Successful output will show the following:
 
 ```bash
-{"level":"info","ts":1682083996.850477,"caller":"cmd/query_vulnerability.go:158","msg":"found path 21059,21060,103,102,101,6,104,5,4,3,2"}
-{"level":"info","ts":1682083996.850501,"caller":"cmd/query_vulnerability.go:159","msg":"Visualizer url: http://localhost:3000/visualize?path=[21059,21060,103,102,101,6,104,5,4,3,2]"}
++-----------+-----------+---------------------------------------+
+| NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                |
++-----------+-----------+---------------------------------------+
+| osv       | 21161     | vulnerability ID: ghsa-7rjr-3q55-vv33 |
++-----------+-----------+---------------------------------------+
+Found path 21161,21162,185,184,183,20,186,5,4,3,2
+Visualizer url: http://localhost:3000/visualize?path=[21161,21162,185,184,183,20,186,5,4,3,2]
 ```
 
 Based on the output we see that there is a path to the vulnerability, we can use


### PR DESCRIPTION
# Description of the PR

Update query vuln to utilize proper dependency version range, add table output, cleanup vuln query document.

Part of issue https://github.com/guacsec/guac/issues/769

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
