### PR TITLE
add default purl for cdx and consistent naming for purl

### DIFF
--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -158,9 +158,9 @@ func pkg(typ, namespace, name, version, subpath string, qualifiers map[string]st
 
 func GuacPkgPurl(pkgName string, pkgVersion *string) string {
 	if pkgVersion == nil {
-		return fmt.Sprintf("pkg:guac/%s", pkgName)
+		return fmt.Sprintf("pkg:guac/pkg/%s", pkgName)
 	}
-	return fmt.Sprintf("pkg:guac/%s@%s", pkgName, *pkgVersion)
+	return fmt.Sprintf("pkg:guac/pkg/%s@%s", pkgName, *pkgVersion)
 }
 
 func GuacFilePurl(alg string, digest string, filename *string) string {

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -544,12 +544,12 @@ func TestGuacPkgPurl(t *testing.T) {
 		{
 			pkgName:    "hello",
 			pkgVersion: strP("1.2"),
-			expected:   "pkg:guac/hello@1.2",
+			expected:   "pkg:guac/pkg/hello@1.2",
 		},
 		{
 			pkgName:    "hello",
 			pkgVersion: nil,
-			expected:   "pkg:guac/hello",
+			expected:   "pkg:guac/pkg/hello",
 		},
 	}
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -98,6 +98,8 @@ func (c *cyclonedxParser) getTopLevelPackage(cdxBom *cdx.BOM) error {
 			} else if cdxBom.Metadata.Component.Type == cdx.ComponentTypeFile {
 				// example: file type ("/home/work/test/build/webserver/")
 				purl = "pkg:guac/file/" + cdxBom.Metadata.Component.Name + "&checksum=" + cdxBom.Metadata.Component.Version
+			} else {
+				purl = "pkg:guac/cdx/" + cdxBom.Metadata.Component.Name
 			}
 		}
 


### PR DESCRIPTION
# Description of the PR

add default purl for cdx and consistent naming for purl

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
