### PR TITLE
Fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-Refer to the [GraphQL Guide](./demo/GraphQL.md) to go through a setup.
+Refer to the [GraphQL Guide](./demo/graphql/GraphQL.md) to go through a setup.
 Optionally, you can also consult [docker compose
 documentation](./docs/Compose.md).
 


### PR DESCRIPTION
# Description of the PR

Fixes a broken link to GraphQL demo after the demo got moved to its own folder.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
