### PR TITLE
Fix duplicate vulnerability entries due to different attestation times

### DIFF
--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -165,7 +165,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 		if noKnownVulnID != 0 && noKnownVulnID == v.noKnownVulnID {
 			vulnMatch = true
 		}
-		if vulnMatch && packageID == v.packageID && certifyVuln.TimeScanned.UTC() == v.timeScanned && certifyVuln.DbURI == v.dbURI &&
+		if vulnMatch && packageID == v.packageID && certifyVuln.TimeScanned.Equal(v.timeScanned) && certifyVuln.DbURI == v.dbURI &&
 			certifyVuln.DbVersion == v.dbVersion && certifyVuln.ScannerURI == v.scannerURI && certifyVuln.ScannerVersion == v.scannerVersion &&
 			certifyVuln.Origin == v.origin && certifyVuln.Collector == v.collector {
 
@@ -174,6 +174,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 			break
 		}
 	}
+
 	if !duplicate {
 		if readOnly {
 			c.m.RUnlock()
@@ -189,7 +190,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.P
 			cveID:          cveID,
 			ghsaID:         ghsaID,
 			noKnownVulnID:  noKnownVulnID,
-			timeScanned:    certifyVuln.TimeScanned.UTC(),
+			timeScanned:    certifyVuln.TimeScanned,
 			dbURI:          certifyVuln.DbURI,
 			dbVersion:      certifyVuln.DbVersion,
 			scannerURI:     certifyVuln.ScannerURI,

--- a/pkg/certifier/certify/certify.go
+++ b/pkg/certifier/certify/certify.go
@@ -120,7 +120,6 @@ func Certify(ctx context.Context, query certifier.QueryComponents, emitter certi
 // generateDocuments runs CertifyVulns as a goroutine to scan and generates attestations that
 // are emitted as processor documents to be ingested
 func generateDocuments(ctx context.Context, collectedComponent interface{}, emitter certifier.Emitter, handleErr certifier.ErrHandler) error {
-
 	// docChan to collect artifacts
 	docChan := make(chan *processor.Document, BufferChannelSize)
 	// errChan to receive error from collectors

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -89,8 +89,9 @@ func (o *osvCertifier) CertifyComponent(ctx context.Context, rootComponent inter
 }
 
 func generateDocument(packNodes []*root_package.PackageNode, vulns []osv_scanner.MinimalVulnerability, docChannel chan<- *processor.Document) error {
+	currentTime := time.Now()
 	for _, node := range packNodes {
-		payload, err := json.Marshal(createAttestation(node, vulns))
+		payload, err := json.Marshal(createAttestation(node, vulns, currentTime))
 		if err != nil {
 			return fmt.Errorf("unable to marshal attestation: %w", err)
 		}
@@ -108,8 +109,7 @@ func generateDocument(packNodes []*root_package.PackageNode, vulns []osv_scanner
 	return nil
 }
 
-func createAttestation(packageNode *root_package.PackageNode, vulns []osv_scanner.MinimalVulnerability) *attestation_vuln.VulnerabilityStatement {
-	currentTime := time.Now()
+func createAttestation(packageNode *root_package.PackageNode, vulns []osv_scanner.MinimalVulnerability, currentTime time.Time) *attestation_vuln.VulnerabilityStatement {
 
 	attestation := &attestation_vuln.VulnerabilityStatement{
 		StatementHeader: intoto.StatementHeader{

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -283,7 +283,8 @@ func Test_createAttestation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := createAttestation(&test.args.packageNode, test.args.vulns)
+			currentTime := time.Now()
+			got := createAttestation(&test.args.packageNode, test.args.vulns, currentTime)
 			if !deepEqualIgnoreTimestamp(got, test.want) {
 				t.Errorf("createAttestation() = %v, want %v", got, test.want)
 			}


### PR DESCRIPTION
# Description of the PR

There is an issue when using osv certifier that produces duplicate "certify vulnerability" entries.
There could be more issues related to this, but one that I have identified so far is that every attestation is created with it's own time instead of the unique scan time. That prevents ingest logic to properly identify it as duplicate.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
