### PR TITLE
remove isOccurrence from CertifyVulnerability and parser

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -854,7 +854,7 @@ var (
 		"subject":[
 		   {
 			  "name":"pkg:oci/vul-secondLevel-latest?repository_url=grc.io",
-			  "digest":{"sha256":"fe608dbc4894fc0b9c82908ece9ddddb63bb79083e5b25f2c02f87773bde1aa1"}
+			  "digest":null
 		   }
 		],
 		"predicate":{
@@ -947,9 +947,7 @@ var (
 	}
 
 	SecondLevelPackage = root_package.PackageNode{
-		Purl:      "pkg:oci/vul-secondLevel-latest?repository_url=grc.io",
-		Algorithm: "sha256",
-		Digest:    "fe608dbc4894fc0b9c82908ece9ddddb63bb79083e5b25f2c02f87773bde1aa1",
+		Purl: "pkg:oci/vul-secondLevel-latest?repository_url=grc.io",
 	}
 
 	Log4JPackage = root_package.PackageNode{

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -106,10 +106,6 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		TimeScanned: time.Now().UTC(),
 	}
 
-	neighborIsOccurrence := generated.NeighborsNeighborsIsOccurrence{}
-	neighborIsOccurrence.Artifact.Algorithm = "sha256"
-	neighborIsOccurrence.Artifact.Digest = "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
-
 	tests := []struct {
 		name              string
 		daysSinceLastScan int
@@ -133,9 +129,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 			},
 			wantPackNode: []*PackageNode{
 				{
-					Purl:      "pkg:pypi/django@1.11.1",
-					Algorithm: "",
-					Digest:    "",
+					Purl: "pkg:pypi/django@1.11.1",
 				},
 			},
 			wantErr: false,
@@ -168,9 +162,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 				}, nil
 			},
 			wantPackNode: []*PackageNode{{
-				Purl:      "pkg:pypi/django@1.11.1",
-				Algorithm: "",
-				Digest:    "",
+				Purl: "pkg:pypi/django@1.11.1",
 			}},
 			wantErr: false,
 		}, {
@@ -198,7 +190,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
-					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeStamp, &neighborIsOccurrence},
+					Neighbors: []generated.NeighborsNeighborsNode{&neighborCertifyVulnTimeStamp},
 				}, nil
 			},
 			wantPackNode: []*PackageNode{},
@@ -213,13 +205,11 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
 				return &generated.NeighborsResponse{
-					Neighbors: []generated.NeighborsNeighborsNode{&neighborIsOccurrence},
+					Neighbors: []generated.NeighborsNeighborsNode{},
 				}, nil
 			},
 			wantPackNode: []*PackageNode{{
-				Purl:      "pkg:pypi/django@1.11.1",
-				Algorithm: "sha256",
-				Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+				Purl: "pkg:pypi/django@1.11.1",
 			}},
 			wantErr: false,
 		}, {
@@ -236,13 +226,9 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 				}, nil
 			},
 			wantPackNode: []*PackageNode{{
-				Purl:      "pkg:pypi/django@1.11.1",
-				Algorithm: "",
-				Digest:    "",
+				Purl: "pkg:pypi/django@1.11.1",
 			}, {
-				Purl:      "pkg:conan/openssl.org/openssl@3.0.3",
-				Algorithm: "",
-				Digest:    "",
+				Purl: "pkg:conan/openssl.org/openssl@3.0.3",
 			}},
 			wantErr: false,
 		}}

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -25,7 +25,6 @@ import (
 
 	osv_scanner "github.com/google/osv-scanner/pkg/osv"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 
 	"github.com/guacsec/guac/pkg/certifier"
 	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
@@ -132,12 +131,6 @@ func createAttestation(packageNode *root_package.PackageNode, vulns []osv_scanne
 	}
 
 	subject := intoto.Subject{Name: packageNode.Purl}
-
-	if packageNode.Algorithm != "" && packageNode.Digest != "" {
-		subject.Digest = common.DigestSet{
-			packageNode.Algorithm: packageNode.Digest,
-		}
-	}
 
 	attestation.StatementHeader.Subject = []intoto.Subject{subject}
 

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -28,7 +28,6 @@ import (
 	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	"github.com/guacsec/guac/internal/testing/testdata"
@@ -207,80 +206,40 @@ func Test_createAttestation(t *testing.T) {
 		name string
 		args args
 		want *attestation_vuln.VulnerabilityStatement
-	}{
-		{
-			name: "default",
-			args: args{
-				packageNode: root_package.PackageNode{
-					Purl:      "",
-					Algorithm: "",
-					Digest:    "",
-				},
-				vulns: []osv_scanner.MinimalVulnerability{
-					{
-						ID: "testId",
-					},
-				},
+	}{{
+		name: "default",
+		args: args{
+			packageNode: root_package.PackageNode{
+				Purl: "",
 			},
-			want: &attestation_vuln.VulnerabilityStatement{
-				StatementHeader: intoto.StatementHeader{
-					Type:          intoto.StatementInTotoV01,
-					PredicateType: attestation_vuln.PredicateVuln,
-					Subject:       []intoto.Subject{{Name: ""}},
-				},
-				Predicate: attestation_vuln.VulnerabilityPredicate{
-					Invocation: attestation_vuln.Invocation{
-						Uri:        INVOC_URI,
-						ProducerID: PRODUCER_ID,
-					},
-					Scanner: attestation_vuln.Scanner{
-						Uri:     URI,
-						Version: VERSION,
-						Result:  []attestation_vuln.Result{{VulnerabilityId: "testId"}},
-					},
-					Metadata: attestation_vuln.Metadata{
-						ScannedOn: &currentTime,
-					},
+			vulns: []osv_scanner.MinimalVulnerability{
+				{
+					ID: "testId",
 				},
 			},
 		},
-		{
-			name: "has digests",
-			args: args{
-				packageNode: root_package.PackageNode{
-					Purl:      "",
-					Algorithm: "test",
-					Digest:    "Digest",
-				}},
-			want: &attestation_vuln.VulnerabilityStatement{
-				StatementHeader: intoto.StatementHeader{
-					Type:          intoto.StatementInTotoV01,
-					PredicateType: attestation_vuln.PredicateVuln,
-					Subject: []intoto.Subject{
-						{
-							Name: "",
-							Digest: common.DigestSet{
-								"test": "Digest",
-							},
-						},
-					},
+		want: &attestation_vuln.VulnerabilityStatement{
+			StatementHeader: intoto.StatementHeader{
+				Type:          intoto.StatementInTotoV01,
+				PredicateType: attestation_vuln.PredicateVuln,
+				Subject:       []intoto.Subject{{Name: ""}},
+			},
+			Predicate: attestation_vuln.VulnerabilityPredicate{
+				Invocation: attestation_vuln.Invocation{
+					Uri:        INVOC_URI,
+					ProducerID: PRODUCER_ID,
 				},
-				Predicate: attestation_vuln.VulnerabilityPredicate{
-					Invocation: attestation_vuln.Invocation{
-						Uri:        INVOC_URI,
-						ProducerID: PRODUCER_ID,
-					},
-					Scanner: attestation_vuln.Scanner{
-						Uri:     URI,
-						Version: VERSION,
-					},
-					Metadata: attestation_vuln.Metadata{
-						ScannedOn: &currentTime,
-					},
+				Scanner: attestation_vuln.Scanner{
+					Uri:     URI,
+					Version: VERSION,
+					Result:  []attestation_vuln.Result{{VulnerabilityId: "testId"}},
+				},
+				Metadata: attestation_vuln.Metadata{
+					ScannedOn: &currentTime,
 				},
 			},
 		},
-	}
+	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			currentTime := time.Now()

--- a/pkg/ingestor/parser/vuln/vuln_test.go
+++ b/pkg/ingestor/parser/vuln/vuln_test.go
@@ -40,7 +40,6 @@ func TestParser(t *testing.T) {
 		doc     *processor.Document
 		wantCVs []assembler.CertifyVulnIngest
 		wantIVs []assembler.IsVulnIngest
-		wantIOs []assembler.IsOccurrenceIngest
 		wantErr bool
 	}{{
 		name: "valid vulnerability certifier document",
@@ -232,7 +231,6 @@ func TestParser(t *testing.T) {
 				},
 			},
 		},
-		wantIOs: []assembler.IsOccurrenceIngest{},
 		wantErr: false,
 	}, {
 		name: "no vulnerability certifier document with package digest",
@@ -260,24 +258,6 @@ func TestParser(t *testing.T) {
 			},
 		}},
 		wantIVs: []assembler.IsVulnIngest{},
-		wantIOs: []assembler.IsOccurrenceIngest{
-			{
-				Pkg: &generated.PkgInputSpec{
-					Type:      "maven",
-					Namespace: ptrfrom.String("org.apache.logging.log4j"),
-					Name:      "log4j-core",
-					Version:   ptrfrom.String("2.8.1"),
-					Subpath:   ptrfrom.String(""),
-				},
-				Artifact: &generated.ArtifactInputSpec{
-					Algorithm: "sha256",
-					Digest:    "3a2bd2c5cc4c978e8aefd8bd0ef335fb42ee31d1",
-				},
-				IsOccurrence: &generated.IsOccurrenceInputSpec{
-					Justification: "Package digest reported to vulnerability certifier",
-				},
-			},
-		},
 		wantErr: false,
 	}}
 	ivSortOpt := cmp.Transformer("Sort", func(in []assembler.IsVulnIngest) []assembler.IsVulnIngest {
@@ -291,13 +271,6 @@ func TestParser(t *testing.T) {
 		out := append([]assembler.CertifyVulnIngest(nil), in...)
 		sort.Slice(out, func(i, j int) bool {
 			return strings.Compare(out[i].OSV.OsvId, out[j].OSV.OsvId) > 0
-		})
-		return out
-	})
-	ioSortOpt := cmp.Transformer("Sort", func(in []assembler.IsOccurrenceIngest) []assembler.IsOccurrenceIngest {
-		out := append([]assembler.IsOccurrenceIngest(nil), in...)
-		sort.Slice(out, func(i, j int) bool {
-			return strings.Compare(out[i].Artifact.Digest, out[j].Artifact.Digest) > 0
 		})
 		return out
 	})
@@ -316,9 +289,6 @@ func TestParser(t *testing.T) {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantIVs, ip.IsVuln, ivSortOpt); diff != "" {
-				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.wantIOs, ip.IsOccurrence, ioSortOpt); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
# Description of the PR

FYI @dejanb. As pointed out in https://github.com/guacsec/guac/pull/873#discussion_r1199098636. Multiple hashes sometimes caused multiple versions of the certifyVulnerability to be created (based on timestamp differences). Removing the hashes as `IsOccurrence` does not need to be created by the vulnerability parser.

Testing is complete and this is not a breaking change as all demos still function the same. 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
