### PR TITLE
Use `time.Equal` instead of UTC conversion + `==`.

### DIFF
--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -85,7 +85,7 @@ func (c *demoClient) certifyScorecard(ctx context.Context, source model.SourceIn
 			return nil, gqlerror.Errorf("%v ::  %s", funcName, err)
 		}
 		if sourceID == v.sourceID &&
-			scorecard.TimeScanned.UTC() == v.timeScanned &&
+			scorecard.TimeScanned.Equal(v.timeScanned) &&
 			floatEqual(scorecard.AggregateScore, v.aggregateScore) &&
 			scorecard.ScorecardVersion == v.scorecardVersion &&
 			scorecard.ScorecardCommit == v.scorecardCommit &&

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -197,7 +197,7 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		if artifactID != 0 && artifactID == v.artifactID {
 			subjectMatch = true
 		}
-		if vulnMatch && subjectMatch && vexStatement.KnownSince.UTC() == v.knownSince && vexStatement.VexJustification == v.justification &&
+		if vulnMatch && subjectMatch && vexStatement.KnownSince.Equal(v.knownSince) && vexStatement.VexJustification == v.justification &&
 			vexStatement.Status == v.status && vexStatement.Statement == v.statement && vexStatement.StatusNotes == v.statusNotes &&
 			vexStatement.Origin == v.origin && vexStatement.Collector == v.collector {
 

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -332,7 +332,7 @@ func (c *demoClient) CertifyVuln(ctx context.Context, filter *model.CertifyVulnS
 func (c *demoClient) addCVIfMatch(out []*model.CertifyVuln,
 	filter *model.CertifyVulnSpec,
 	link *vulnerabilityLink) ([]*model.CertifyVuln, error) {
-	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.UTC() == link.timeScanned {
+	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.Equal(link.timeScanned) {
 		return out, nil
 	}
 	if filter != nil && noMatch(filter.DbURI, link.dbURI) {

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -100,7 +100,7 @@ func (c *demoClient) ingestHasSourceAt(ctx context.Context, packageArg model.Pkg
 			return nil, gqlerror.Errorf("%v ::  %s", funcName, err)
 		}
 		if packageID == v.packageID && sourceID == v.sourceID && hasSourceAt.Justification == v.justification &&
-			hasSourceAt.Origin == v.origin && hasSourceAt.Collector == v.collector && hasSourceAt.KnownSince.UTC() == v.knownSince {
+			hasSourceAt.Origin == v.origin && hasSourceAt.Collector == v.collector && hasSourceAt.KnownSince.Equal(v.knownSince) {
 			collectedSrcMapLink = *v
 			duplicate = true
 			break


### PR DESCRIPTION
# Description of the PR

The `time.Equal` API compares across timezones, so it is better. For storage, we still convert to UTC.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
