### PR TITLE
make startedOn and finishedOn optional fields for hasSLSA

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -91,7 +91,8 @@ func ingestScorecards(ctx context.Context, client graphql.Client) {
 
 func ingestSLSA(ctx context.Context, client graphql.Client) {
 	logger := logging.FromContext(ctx)
-
+	startTime := time.Now()
+	finishTime := time.Now().Add(10 * time.Second)
 	predicate := []model.SLSAPredicateInputSpec{
 		{
 			Key:   "buildDefinition.externalParameters.repository",
@@ -124,8 +125,8 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		BuildType:     "Test:SLSA",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
-		StartedOn:     time.Now(),
-		FinishedOn:    time.Now().Add(10 * time.Second),
+		StartedOn:     &startTime,
+		FinishedOn:    &finishTime,
 		Origin:        "Demo ingestion",
 		Collector:     "Demo ingestion",
 	}
@@ -155,8 +156,8 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		BuildType:     "Test:SLSA2",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
-		StartedOn:     time.Now(),
-		FinishedOn:    time.Now().Add(10 * time.Second),
+		StartedOn:     &startTime,
+		FinishedOn:    &finishTime,
 		Origin:        "Demo ingestion",
 		Collector:     "Demo ingestion",
 	}

--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -156,8 +156,6 @@ func ingestSLSA(ctx context.Context, client graphql.Client) {
 		BuildType:     "Test:SLSA2",
 		SlsaPredicate: predicate,
 		SlsaVersion:   "v1",
-		StartedOn:     &startTime,
-		FinishedOn:    &finishTime,
 		Origin:        "Demo ingestion",
 		Collector:     "Demo ingestion",
 	}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -310,7 +310,7 @@ var (
 				HasSlsa: &model.SLSAInputSpec{
 					BuildType:   "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 					SlsaVersion: "https://slsa.dev/provenance/v0.2",
-					StartedOn:   slsaStartTime,
+					StartedOn:   &slsaStartTime,
 					SlsaPredicate: []model.SLSAPredicateInputSpec{
 						{Key: "slsa.metadata.completeness.environment", Value: "true"},
 						{Key: "slsa.metadata.buildStartedOn", Value: "2020-08-19T08:38:00Z"},
@@ -381,7 +381,7 @@ var (
 				HasSlsa: &model.SLSAInputSpec{
 					BuildType:   "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
 					SlsaVersion: "https://slsa.dev/provenance/v1",
-					StartedOn:   slsa1time,
+					StartedOn:   &slsa1time,
 					SlsaPredicate: []model.SLSAPredicateInputSpec{
 						{Key: "slsa.buildDefinition.buildType", Value: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1"},
 						{Key: "slsa.buildDefinition.externalParameters.inputs.build_id", Value: "1.23456768e+08"},

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -182,11 +182,14 @@ func nilToEmpty(input *string) string {
 	return *input
 }
 
-func nilToZeroValue(inputTime *time.Time) time.Time {
-	if inputTime == nil {
-		return time.Time{}
+func timePtrEqual(a, b *time.Time) bool {
+	if a == nil && b == nil {
+		return true
 	}
-	return *inputTime
+	if a != nil && b != nil {
+		return a.Equal(*b)
+	}
+	return false
 }
 
 func toLower(filter *string) *string {

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -179,6 +180,13 @@ func nilToEmpty(input *string) string {
 		return ""
 	}
 	return *input
+}
+
+func nilToZeroValue(inputTime *time.Time) time.Time {
+	if inputTime == nil {
+		return time.Time{}
+	}
+	return *inputTime
 }
 
 func toLower(filter *string) *string {

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -227,8 +227,8 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 			sl.buildType == slsa.BuildType &&
 			cmp.Equal(sl.predicates, preds) &&
 			sl.version == slsa.SlsaVersion &&
-			sl.start == slsa.StartedOn &&
-			sl.finish == slsa.FinishedOn &&
+			sl.start.Equal(nilToZeroValue(slsa.StartedOn)) &&
+			sl.finish.Equal(nilToZeroValue(slsa.FinishedOn)) &&
 			sl.origin == slsa.Origin &&
 			sl.collector == slsa.Collector {
 			return c.convSLSA(sl)
@@ -250,8 +250,8 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 		buildType:  slsa.BuildType,
 		predicates: preds,
 		version:    slsa.SlsaVersion,
-		start:      slsa.StartedOn,
-		finish:     slsa.FinishedOn,
+		start:      nilToZeroValue(slsa.StartedOn),
+		finish:     nilToZeroValue(slsa.FinishedOn),
 		origin:     slsa.Origin,
 		collector:  slsa.Collector,
 	}
@@ -305,8 +305,8 @@ func (c *demoClient) convSLSA(in *hasSLSAStruct) (*model.HasSlsa, error) {
 			BuildType:     in.buildType,
 			SlsaPredicate: in.predicates,
 			SlsaVersion:   in.version,
-			StartedOn:     in.start,
-			FinishedOn:    in.finish,
+			StartedOn:     &in.start,
+			FinishedOn:    &in.finish,
 			Origin:        in.origin,
 			Collector:     in.collector,
 		},

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -38,8 +38,8 @@ type hasSLSAStruct struct {
 	buildType  string
 	predicates []*model.SLSAPredicate
 	version    string
-	start      time.Time
-	finish     time.Time
+	start      *time.Time
+	finish     *time.Time
 	origin     string
 	collector  string
 }
@@ -227,8 +227,8 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 			sl.buildType == slsa.BuildType &&
 			cmp.Equal(sl.predicates, preds) &&
 			sl.version == slsa.SlsaVersion &&
-			sl.start.Equal(nilToZeroValue(slsa.StartedOn)) &&
-			sl.finish.Equal(nilToZeroValue(slsa.FinishedOn)) &&
+			timePtrEqual(sl.start, slsa.StartedOn) &&
+			timePtrEqual(sl.finish, slsa.FinishedOn) &&
 			sl.origin == slsa.Origin &&
 			sl.collector == slsa.Collector {
 			return c.convSLSA(sl)
@@ -250,8 +250,8 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 		buildType:  slsa.BuildType,
 		predicates: preds,
 		version:    slsa.SlsaVersion,
-		start:      nilToZeroValue(slsa.StartedOn),
-		finish:     nilToZeroValue(slsa.FinishedOn),
+		start:      slsa.StartedOn,
+		finish:     slsa.FinishedOn,
 		origin:     slsa.Origin,
 		collector:  slsa.Collector,
 	}
@@ -305,8 +305,8 @@ func (c *demoClient) convSLSA(in *hasSLSAStruct) (*model.HasSlsa, error) {
 			BuildType:     in.buildType,
 			SlsaPredicate: in.predicates,
 			SlsaVersion:   in.version,
-			StartedOn:     &in.start,
-			FinishedOn:    &in.finish,
+			StartedOn:     in.start,
+			FinishedOn:    in.finish,
 			Origin:        in.origin,
 			Collector:     in.collector,
 		},
@@ -324,8 +324,8 @@ func (c *demoClient) addSLSAIfMatch(out []*model.HasSlsa,
 		noMatch(filter.SlsaVersion, link.version) ||
 		noMatch(filter.Origin, link.origin) ||
 		noMatch(filter.Collector, link.collector) ||
-		(filter.StartedOn != nil && !filter.StartedOn.Equal(link.start)) ||
-		(filter.FinishedOn != nil && !filter.FinishedOn.Equal(link.finish)) ||
+		(filter.StartedOn != nil && (link.start == nil || !filter.StartedOn.Equal(*link.start))) ||
+		(filter.FinishedOn != nil && (link.finish == nil || !filter.FinishedOn.Equal(*link.finish))) ||
 		(filter.BuiltBy != nil && filter.BuiltBy.ID != nil && *filter.BuiltBy.ID != nodeID(bb.id)) ||
 		(filter.BuiltBy != nil && filter.BuiltBy.URI != nil && *filter.BuiltBy.URI != bb.uri) ||
 		!matchSLSAPreds(link.predicates, filter.Predicate) ||

--- a/pkg/assembler/backends/inmem/hasSLSA_test.go
+++ b/pkg/assembler/backends/inmem/hasSLSA_test.go
@@ -79,9 +79,11 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
-						BuildType: "test type",
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						BuildType:  "test type",
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -115,9 +117,11 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
-						BuildType: "test type",
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						BuildType:  "test type",
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -151,9 +155,11 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
-						BuildType: "test type one",
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						BuildType:  "test type one",
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -190,6 +196,8 @@ func TestHasSLSA(t *testing.T) {
 						BuiltBy:     b1out,
 						BuiltFrom:   []*model.Artifact{a2out},
 						SlsaVersion: "test type two",
+						StartedOn:   &time.Time{},
+						FinishedOn:  &time.Time{},
 					},
 				},
 			},
@@ -223,9 +231,10 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
-						StartedOn: &testTime,
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						StartedOn:  &testTime,
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -257,8 +266,10 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -296,15 +307,19 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out, a3out},
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out, a3out},
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -336,8 +351,10 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},
@@ -367,8 +384,10 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltBy:    b1out,
+						BuiltFrom:  []*model.Artifact{a2out},
+						StartedOn:  &time.Time{},
+						FinishedOn: &time.Time{},
 					},
 				},
 			},

--- a/pkg/assembler/backends/inmem/hasSLSA_test.go
+++ b/pkg/assembler/backends/inmem/hasSLSA_test.go
@@ -79,11 +79,9 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						BuildType:  "test type",
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
+						BuildType: "test type",
 					},
 				},
 			},
@@ -117,11 +115,9 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						BuildType:  "test type",
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
+						BuildType: "test type",
 					},
 				},
 			},
@@ -155,11 +151,9 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						BuildType:  "test type one",
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
+						BuildType: "test type one",
 					},
 				},
 			},
@@ -196,8 +190,6 @@ func TestHasSLSA(t *testing.T) {
 						BuiltBy:     b1out,
 						BuiltFrom:   []*model.Artifact{a2out},
 						SlsaVersion: "test type two",
-						StartedOn:   &time.Time{},
-						FinishedOn:  &time.Time{},
 					},
 				},
 			},
@@ -231,10 +223,9 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						StartedOn:  &testTime,
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
+						StartedOn: &testTime,
 					},
 				},
 			},
@@ -266,10 +257,8 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 			},
@@ -307,19 +296,15 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out, a3out},
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out, a3out},
 					},
 				},
 			},
@@ -351,10 +336,8 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 			},
@@ -384,10 +367,8 @@ func TestHasSLSA(t *testing.T) {
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
-						BuiltBy:    b1out,
-						BuiltFrom:  []*model.Artifact{a2out},
-						StartedOn:  &time.Time{},
-						FinishedOn: &time.Time{},
+						BuiltBy:   b1out,
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 			},

--- a/pkg/assembler/backends/inmem/hasSLSA_test.go
+++ b/pkg/assembler/backends/inmem/hasSLSA_test.go
@@ -41,6 +41,7 @@ var b2 = &model.BuilderInputSpec{
 
 func TestHasSLSA(t *testing.T) {
 	testTime := time.Unix(1e9+5, 0)
+	testTime2 := time.Unix(1e9, 0)
 	type call struct {
 		Sub  *model.ArtifactInputSpec
 		BF   []*model.ArtifactInputSpec
@@ -203,7 +204,7 @@ func TestHasSLSA(t *testing.T) {
 					BF:  []*model.ArtifactInputSpec{a2},
 					BB:  b1,
 					SLSA: &model.SLSAInputSpec{
-						StartedOn: time.Unix(1e9, 0),
+						StartedOn: &testTime2,
 					},
 				},
 				{
@@ -211,7 +212,7 @@ func TestHasSLSA(t *testing.T) {
 					BF:  []*model.ArtifactInputSpec{a2},
 					BB:  b1,
 					SLSA: &model.SLSAInputSpec{
-						StartedOn: testTime,
+						StartedOn: &testTime,
 					},
 				},
 			},
@@ -224,7 +225,7 @@ func TestHasSLSA(t *testing.T) {
 					Slsa: &model.Slsa{
 						BuiltBy:   b1out,
 						BuiltFrom: []*model.Artifact{a2out},
-						StartedOn: testTime,
+						StartedOn: &testTime,
 					},
 				},
 			},

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -17855,8 +17855,8 @@ type SLSAInputSpec struct {
 	BuildType     string                   `json:"buildType"`
 	SlsaPredicate []SLSAPredicateInputSpec `json:"slsaPredicate"`
 	SlsaVersion   string                   `json:"slsaVersion"`
-	StartedOn     time.Time                `json:"startedOn"`
-	FinishedOn    time.Time                `json:"finishedOn"`
+	StartedOn     *time.Time               `json:"startedOn"`
+	FinishedOn    *time.Time               `json:"finishedOn"`
 	Origin        string                   `json:"origin"`
 	Collector     string                   `json:"collector"`
 }
@@ -17871,10 +17871,10 @@ func (v *SLSAInputSpec) GetSlsaPredicate() []SLSAPredicateInputSpec { return v.S
 func (v *SLSAInputSpec) GetSlsaVersion() string { return v.SlsaVersion }
 
 // GetStartedOn returns SLSAInputSpec.StartedOn, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetStartedOn() time.Time { return v.StartedOn }
+func (v *SLSAInputSpec) GetStartedOn() *time.Time { return v.StartedOn }
 
 // GetFinishedOn returns SLSAInputSpec.FinishedOn, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetFinishedOn() time.Time { return v.FinishedOn }
+func (v *SLSAInputSpec) GetFinishedOn() *time.Time { return v.FinishedOn }
 
 // GetOrigin returns SLSAInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *SLSAInputSpec) GetOrigin() string { return v.Origin }
@@ -23592,9 +23592,9 @@ type allSLSATreeSlsaSLSA struct {
 	// Version of the SLSA predicate
 	SlsaVersion string `json:"slsaVersion"`
 	// Timestamp (RFC3339Nano format) of build start time
-	StartedOn time.Time `json:"startedOn"`
+	StartedOn *time.Time `json:"startedOn"`
 	// Timestamp (RFC3339Nano format) of build end time
-	FinishedOn time.Time `json:"finishedOn"`
+	FinishedOn *time.Time `json:"finishedOn"`
 	// Document from which this attestation is generated from
 	Origin string `json:"origin"`
 	// GUAC collector for the document
@@ -23621,10 +23621,10 @@ func (v *allSLSATreeSlsaSLSA) GetSlsaPredicate() []allSLSATreeSlsaSLSASlsaPredic
 func (v *allSLSATreeSlsaSLSA) GetSlsaVersion() string { return v.SlsaVersion }
 
 // GetStartedOn returns allSLSATreeSlsaSLSA.StartedOn, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetStartedOn() time.Time { return v.StartedOn }
+func (v *allSLSATreeSlsaSLSA) GetStartedOn() *time.Time { return v.StartedOn }
 
 // GetFinishedOn returns allSLSATreeSlsaSLSA.FinishedOn, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetFinishedOn() time.Time { return v.FinishedOn }
+func (v *allSLSATreeSlsaSLSA) GetFinishedOn() *time.Time { return v.FinishedOn }
 
 // GetOrigin returns allSLSATreeSlsaSLSA.Origin, and is useful for accessing the field via an interface.
 func (v *allSLSATreeSlsaSLSA) GetOrigin() string { return v.Origin }

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -450,14 +450,11 @@ func (ec *executionContext) _SLSA_startedOn(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SLSA_startedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -494,14 +491,11 @@ func (ec *executionContext) _SLSA_finishedOn(ctx context.Context, field graphql.
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SLSA_finishedOn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -865,7 +859,7 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("startedOn"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -874,7 +868,7 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("finishedOn"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1078,16 +1072,10 @@ func (ec *executionContext) _SLSA(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = ec._SLSA_startedOn(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "finishedOn":
 
 			out.Values[i] = ec._SLSA_finishedOn(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "origin":
 
 			out.Values[i] = ec._SLSA_origin(ctx, field, obj)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3066,7 +3066,7 @@ input SLSAInputSpec {
   buildType: String!
   slsaPredicate: [SLSAPredicateInputSpec!]!
   slsaVersion: String!
-  startedOn: Time 
+  startedOn: Time
   finishedOn: Time
   origin: String!
   collector: String!

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2999,9 +2999,9 @@ type SLSA {
   "Version of the SLSA predicate"
   slsaVersion: String!
   "Timestamp (RFC3339Nano format) of build start time"
-  startedOn: Time!
+  startedOn: Time
   "Timestamp (RFC3339Nano format) of build end time"
-  finishedOn: Time!
+  finishedOn: Time
   "Document from which this attestation is generated from"
   origin: String!
   "GUAC collector for the document"
@@ -3066,8 +3066,8 @@ input SLSAInputSpec {
   buildType: String!
   slsaPredicate: [SLSAPredicateInputSpec!]!
   slsaVersion: String!
-  startedOn: Time!
-  finishedOn: Time!
+  startedOn: Time 
+  finishedOn: Time
   origin: String!
   collector: String!
 }

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -979,9 +979,9 @@ type Slsa struct {
 	// Version of the SLSA predicate
 	SlsaVersion string `json:"slsaVersion"`
 	// Timestamp (RFC3339Nano format) of build start time
-	StartedOn time.Time `json:"startedOn"`
+	StartedOn *time.Time `json:"startedOn,omitempty"`
 	// Timestamp (RFC3339Nano format) of build end time
-	FinishedOn time.Time `json:"finishedOn"`
+	FinishedOn *time.Time `json:"finishedOn,omitempty"`
 	// Document from which this attestation is generated from
 	Origin string `json:"origin"`
 	// GUAC collector for the document
@@ -993,8 +993,8 @@ type SLSAInputSpec struct {
 	BuildType     string                    `json:"buildType"`
 	SlsaPredicate []*SLSAPredicateInputSpec `json:"slsaPredicate"`
 	SlsaVersion   string                    `json:"slsaVersion"`
-	StartedOn     time.Time                 `json:"startedOn"`
-	FinishedOn    time.Time                 `json:"finishedOn"`
+	StartedOn     *time.Time                `json:"startedOn,omitempty"`
+	FinishedOn    *time.Time                `json:"finishedOn,omitempty"`
 	Origin        string                    `json:"origin"`
 	Collector     string                    `json:"collector"`
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -48,9 +48,9 @@ type SLSA {
   "Version of the SLSA predicate"
   slsaVersion: String!
   "Timestamp (RFC3339Nano format) of build start time"
-  startedOn: Time!
+  startedOn: Time
   "Timestamp (RFC3339Nano format) of build end time"
-  finishedOn: Time!
+  finishedOn: Time
   "Document from which this attestation is generated from"
   origin: String!
   "GUAC collector for the document"
@@ -115,8 +115,8 @@ input SLSAInputSpec {
   buildType: String!
   slsaPredicate: [SLSAPredicateInputSpec!]!
   slsaVersion: String!
-  startedOn: Time!
-  finishedOn: Time!
+  startedOn: Time 
+  finishedOn: Time
   origin: String!
   collector: String!
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -115,7 +115,7 @@ input SLSAInputSpec {
   buildType: String!
   slsaPredicate: [SLSAPredicateInputSpec!]!
   slsaVersion: String!
-  startedOn: Time 
+  startedOn: Time
   finishedOn: Time
   origin: String!
   collector: String!

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -197,30 +197,30 @@ func getSlsaEntity(name string, digests scommon.DigestSet) (*slsaEntity, error) 
 func fillSLSA01(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA01) {
 	inp.BuildType = stmt.Predicate.Recipe.Type
 	if stmt.Predicate.Metadata.BuildStartedOn != nil {
-		inp.StartedOn = *stmt.Predicate.Metadata.BuildStartedOn
+		inp.StartedOn = stmt.Predicate.Metadata.BuildStartedOn
 	}
 	if stmt.Predicate.Metadata.BuildFinishedOn != nil {
-		inp.FinishedOn = *stmt.Predicate.Metadata.BuildStartedOn
+		inp.FinishedOn = stmt.Predicate.Metadata.BuildStartedOn
 	}
 }
 
 func fillSLSA02(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA02) {
 	inp.BuildType = stmt.Predicate.BuildType
 	if stmt.Predicate.Metadata.BuildStartedOn != nil {
-		inp.StartedOn = *stmt.Predicate.Metadata.BuildStartedOn
+		inp.StartedOn = stmt.Predicate.Metadata.BuildStartedOn
 	}
 	if stmt.Predicate.Metadata.BuildFinishedOn != nil {
-		inp.FinishedOn = *stmt.Predicate.Metadata.BuildStartedOn
+		inp.FinishedOn = stmt.Predicate.Metadata.BuildStartedOn
 	}
 }
 
 func fillSLSA1(inp *model.SLSAInputSpec, stmt *in_toto.ProvenanceStatementSLSA1) {
 	inp.BuildType = stmt.Predicate.BuildDefinition.BuildType
 	if stmt.Predicate.RunDetails.BuildMetadata.StartedOn != nil {
-		inp.StartedOn = *stmt.Predicate.RunDetails.BuildMetadata.StartedOn
+		inp.StartedOn = stmt.Predicate.RunDetails.BuildMetadata.StartedOn
 	}
 	if stmt.Predicate.RunDetails.BuildMetadata.FinishedOn != nil {
-		inp.FinishedOn = *stmt.Predicate.RunDetails.BuildMetadata.FinishedOn
+		inp.FinishedOn = stmt.Predicate.RunDetails.BuildMetadata.FinishedOn
 	}
 }
 


### PR DESCRIPTION
# Description of the PR

make startedOn and finishedOn optional fields for hasSLSA

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
