### PR TITLE
Fix parallel ingest when guacgql is in docker.

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -227,7 +228,24 @@ func getIngestor(ctx context.Context) func(processor.DocumentTree) ([]assembler.
 }
 
 func getAssembler(ctx context.Context, graphqlEndpoint string) func([]assembler.IngestPredicates) error {
-	httpClient := http.Client{}
+	// Same as https://pkg.go.dev/net/http#DefaultTransport but with greater
+	// MaxIdleConnsPerHost so that we effectively re-use connections when doing
+	// parallel ingestion calls.
+	var dialer = &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	var customTransport http.RoundTripper = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   30,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	httpClient := http.Client{Transport: customTransport}
 	gqlclient := graphql.NewClient(graphqlEndpoint, &httpClient)
 	f := helpers.GetParallelAssembler(ctx, gqlclient)
 	return f


### PR DESCRIPTION
Parallel ingest is failing half way through when running guacgql in docker. Works fine when running directly, or in k8s with the helm chart. This suggests a resource limitation in the docker networking setup.

Taking a look at the default Go client networking setup, it tries to re-use connections, but limits the number of idle connections per sever to 2. We are trying to do around 20, so they are constantly being closed and re-opened, since we only allow 2 to sit idle.

Bumping the number of idle connections allowed per server fixes the issue for me.

https://pkg.go.dev/net/http#DefaultTransport
https://pkg.go.dev/net/http#Transport
https://pkg.go.dev/net/http#pkg-constants (see DefaultMaxIdleConnsPerHost)

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
