### PR TITLE
feat: add environment file for configuring docker compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+GUAC_IMAGE=local-organic-guac
+#GUAC_IMAGE=ghcr.io/guacsec/guac:v0.1.0
+GUAC_HEALTH_IMAGE=local-healthcheck
+#GUAC_HEALTH_IMAGE=ghcr.io/guacsec/healthcheck:v0.1.0
+GUAC_API_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # it doesn't have utilities within it to perform the check from the container
   # itself.
   service-health-1:
-    image: "local-healthcheck"
+    image: $GUAC_HEALTH_IMAGE
     stdin_open: true
     tty: true
     command:
@@ -50,7 +50,7 @@ services:
         # echo "neo4j-up";
 
   guac-collectsub:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guaccsub"
     working_dir: /guac
     restart: on-failure
@@ -63,7 +63,7 @@ services:
       - ./container_files/guac:/guac
 
   guac-graphql:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guacgql"
     working_dir: /guac
     restart: on-failure
@@ -71,13 +71,13 @@ services:
       service-health-1:
         condition: service_completed_successfully
     ports:
-      - "8080:8080"
+      - "$GUAC_API_PORT:8080"
     volumes:
       - ./container_files/guac:/guac
 
   # GUAC ingestor and oci collector are dependent on the collectsub service to be up
   service-health-2:
-    image: "local-healthcheck"
+    image: $GUAC_HEALTH_IMAGE
     stdin_open: true
     tty: true
     command:
@@ -96,7 +96,7 @@ services:
 
 
   guac-ingestor:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guacingest"
     working_dir: /guac
     restart: on-failure
@@ -108,7 +108,7 @@ services:
 
 
   oci-collector:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guaccollect image"
     working_dir: /guac
     restart: on-failure
@@ -118,7 +118,7 @@ services:
     volumes:
       - ./container_files/guac:/guac
   depsdev-collector:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guaccollect deps_dev"
     working_dir: /guac
     restart: on-failure
@@ -130,7 +130,7 @@ services:
     volumes:
       - ./container_files/guac:/guac
   osv-certifier:
-    image: "local-organic-guac"
+    image: $GUAC_IMAGE
     command: "/opt/guac/guacone certifier osv"
     working_dir: /guac
     restart: on-failure

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1127,7 +1127,7 @@ var (
 				 "qualifiers":null,
 				 "subpath":"",
 				 "type":"pypi",
-				 "version":"3.12.1"
+				 "version":"3.12.2"
 			  },
 			  "DepPackages":null,
 			  "IsDepPackages":null,
@@ -1219,7 +1219,7 @@ var (
 				 "qualifiers":null,
 				 "subpath":"",
 				 "type":"pypi",
-				 "version":"3.12.1"
+				 "version":"3.12.2"
 			  },
 			  "IsDependency":{
 				 "collector":"",


### PR DESCRIPTION
# Description of the PR

Adds an environment file that can be used configure docker compose. At the moment, just image names and GraphQL API ports are configurable through the file.

@lumjjb I tried using `ghcr.io/guacsec/guac:v0.1.0` but it doesn't seem to work. As far as I can see from Helm charts `/opt/guac/` is moved to `/cnb/process`. And also there's no healthcheck image. Would it be OK to unify these two approaches and let folks use tagged images in compose as well? Please let me know if I can help with anything.


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
