### PR TITLE
build multi-arch image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,15 +40,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # tag=v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup pack 
-        uses: buildpacks/github-actions/setup-pack@723a8f4cfec2278c3caddaf5ee1e131c2c447dcd # v5.2.0
-      - name: Build and publish image
+      
+      - name: Cross build
         run: |
           #!/usr/bin/env bash
           set -euo pipefail
@@ -56,19 +57,15 @@ jobs:
           COMMIT=$(git rev-parse HEAD)
           BUILD=$(date +%FT%T%z)
           PKG=github.com/guacsec/guac/pkg/version
-          pack build ${IMAGE_URI_TAG} \
-            --builder ${BUILDER} \
-            --buildpack ${BUILDPACK} \
-            --env BP_GO_BUILD_LDFLAGS="-X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${BUILD}" \
-            --env BP_GO_TARGETS=${BP_GO_TARGETS}
-        shell: bash
-        env:
-          BP_GO_TARGETS: "./cmd/guaccollect:./cmd/guacone:./cmd/guacingest:./cmd/guacgql:./cmd/guaccsub"
-          BUILDER: paketobuildpacks/builder:base
-          BUILDPACK: paketo-buildpacks/go
-      - name: Push image
-        if: startsWith(github.ref, 'refs/tags/')
-        run: docker push ${IMAGE_URI}:${{ github.ref_name }}
+          GO_LDFLAGS="-X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${BUILD}"
+
+          docker buildx bake \
+            -f ./dockerfiles/docker-bake.hcl \
+            --set build.args.GO_LDFLAGS="$GO_LDFLAGS" \
+            --set build.args.IMAGE_TAG="${{ github.ref_name }}" \
+            --push \
+            cross
+
       - name: Install crane
         if: startsWith(github.ref, 'refs/tags/')
         uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,36 @@
+#syntax=docker/dockerfile:1.4
+ARG GO_VERSION=1.18
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0 AS xx
+
+FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS base
+RUN apk add --no-cache git
+COPY --from=xx / /
+WORKDIR /src
+
+FROM base AS build
+ARG TARGETPLATFORM
+ENV CGO_ENABLED=0
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN --mount=target=/go/pkg/mod,type=cache \
+    --mount=target=/root/.cache,type=cache \
+    xx-go build -ldflags="${GO_LDFLAGS}" -o bin/guaccollect cmd/guaccollect/main.go
+RUN --mount=target=/go/pkg/mod,type=cache \
+    --mount=target=/root/.cache,type=cache \
+    xx-go build -ldflags="${GO_LDFLAGS}" -o bin/guaccsub cmd/guaccsub/main.go
+RUN --mount=target=/go/pkg/mod,type=cache \
+    --mount=target=/root/.cache,type=cache \
+    xx-go build -ldflags="${GO_LDFLAGS}" -o bin/guacgql cmd/guacgql/main.go
+RUN --mount=target=/go/pkg/mod,type=cache \
+    --mount=target=/root/.cache,type=cache \
+    xx-go build -ldflags="${GO_LDFLAGS}" -o bin/guacingest cmd/guacingest/main.go
+RUN --mount=target=/go/pkg/mod,type=cache \
+    --mount=target=/root/.cache,type=cache \
+    xx-go build -ldflags="${GO_LDFLAGS}" -o bin/guacone cmd/guacone/main.go
+
+FROM cgr.dev/chainguard/static:latest-glibc
+WORKDIR /app
+COPY --from=build /src/bin /opt/guac

--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -1,0 +1,24 @@
+variable "GO_LDFLAGS" {
+  default = "-w -s"
+}
+
+variable "IMAGE_TAG" {
+  default = "latest"
+}
+
+group "default" {
+  targets = ["build"]
+}
+
+target "build" {
+  dockerfile = "dockerfiles/Dockerfile"
+  args = {
+    GO_LDFLAGS = "${GO_LDFLAGS}"
+  }
+}
+
+target "cross" {
+  inherits = ["build"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm", "darwin/amd64", "darwin/arm64"]
+  tags = ["ghcr.io/tuananh/guac:${IMAGE_TAG}"]
+}


### PR DESCRIPTION
# Description of the PR

Fixes: #887 

Put it as draft for now to seek your feedback

- use `docker buildx bake` to build multi-arch image: `"linux/amd64", "linux/arm64", "linux/arm", "darwin/amd64", "darwin/arm64"`. we can build the complete list if you want ` ["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64", "freebsd/amd64", "freebsd/arm64"]`
- Switch from ubuntu to `cgr.dev/chainguard/static:latest-glibc` as base image for that sweet 0 CVE count.


<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
