### PR TITLE
use POSIX compliant way to redirect file descriptors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ stop-service:
 
 .PHONY: check-docker-tool-check
 check-docker-tool-check:
-	@if ! command -v $(CONTAINER) &> /dev/null; then \
+	@if ! command -v $(CONTAINER) >/dev/null 2>&1; then \
 		echo "'$(CONTAINER)' is not installed. Please install '$(CONTAINER)' and try again. Or set the CONTAINER variable to a different container runtime engine."; \
 		exit 1; \
 	fi
@@ -127,7 +127,7 @@ check-docker-tool-check:
 # Check that protoc is installed.
 .PHONY: check-protoc-tool-check
 check-protoc-tool-check:
-	@if ! command -v protoc &> /dev/null; then \
+	@if ! command -v protoc >/dev/null 2>&1; then \
 		echo "Protoc is not installed. Please install Protoc and try again."; \
 		exit 1; \
 	fi
@@ -135,7 +135,7 @@ check-protoc-tool-check:
 # Check that golangci-lint is installed.
 .PHONY: check-golangci-lint-tool-check
 check-golangci-lint-tool-check:
-	@if ! command -v golangci-lint &> /dev/null; then \
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Golangci-lint is not installed. Please install Golangci-lint and try again."; \
 		exit 1; \
 	fi
@@ -143,7 +143,7 @@ check-golangci-lint-tool-check:
 # Check that mockgen is installed.
 .PHONY: check-mockgen-tool-check
 check-mockgen-tool-check:
-	@if ! command -v mockgen &> /dev/null; then \
+	@if ! command -v mockgen >/dev/null 2>&1; then \
 		echo "mockgen is not installed. Please install mockgen and try again."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
# Description of the PR

Use POSIX compliant syntax to redirect file descriptors. 
The '&>' syntax is bash specific and may not work in other shells.

Fixes #909 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
