### PR TITLE
fix time equal check bug in certifyVuln and ensure that other match in the inmem database

### DIFF
--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -196,7 +196,7 @@ func (c *demoClient) Scorecards(ctx context.Context, filter *model.CertifyScorec
 func (c *demoClient) addSCIfMatch(out []*model.CertifyScorecard,
 	filter *model.CertifyScorecardSpec, link *scorecardLink) (
 	[]*model.CertifyScorecard, error) {
-	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.UTC() != link.timeScanned {
+	if filter != nil && filter.TimeScanned != nil && !filter.TimeScanned.Equal(link.timeScanned) {
 		return out, nil
 	}
 	if filter != nil && noMatchFloat(filter.AggregateScore, link.aggregateScore) {

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -373,7 +373,7 @@ func (c *demoClient) addVexIfMatch(out []*model.CertifyVEXStatement,
 	filter *model.CertifyVEXStatementSpec, link *vexLink) (
 	[]*model.CertifyVEXStatement, error) {
 
-	if filter != nil && filter.KnownSince != nil && filter.KnownSince.UTC() != link.knownSince {
+	if filter != nil && filter.KnownSince != nil && !filter.KnownSince.Equal(link.knownSince) {
 		return out, nil
 	}
 	if filter != nil && filter.VexJustification != nil && *filter.VexJustification != link.justification {

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -332,7 +332,7 @@ func (c *demoClient) CertifyVuln(ctx context.Context, filter *model.CertifyVulnS
 func (c *demoClient) addCVIfMatch(out []*model.CertifyVuln,
 	filter *model.CertifyVulnSpec,
 	link *vulnerabilityLink) ([]*model.CertifyVuln, error) {
-	if filter != nil && filter.TimeScanned != nil && filter.TimeScanned.Equal(link.timeScanned) {
+	if filter != nil && filter.TimeScanned != nil && !filter.TimeScanned.Equal(link.timeScanned) {
 		return out, nil
 	}
 	if filter != nil && noMatch(filter.DbURI, link.dbURI) {

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -261,7 +261,7 @@ func (c *demoClient) addSrcIfMatch(out []*model.HasSourceAt,
 	if filter != nil && noMatch(filter.Collector, link.collector) {
 		return out, nil
 	}
-	if filter != nil && filter.KnownSince != nil && filter.KnownSince.UTC() != link.knownSince {
+	if filter != nil && filter.KnownSince != nil && !filter.KnownSince.Equal(link.knownSince) {
 		return out, nil
 	}
 	foundHasSourceAt, err := c.buildHasSourceAt(link, filter, false)


### PR DESCRIPTION
# Description of the PR

fix time equal check bug in certifyVuln and ensure that other match in the inmem database

fixes #921 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
