### PR TITLE
add support for 'githubactions' package types

### DIFF
--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -73,7 +73,7 @@ func purlConvert(p purl.PackageURL) (*model.PkgInputSpec, error) {
 	// so that they can be referenced with higher specificity in GUAC
 	//
 	// PURL types not defined in purl library handled generically
-	case "alpine", "alpm", "apk", "huggingface", "mlflow", "qpkg", "pub", "swid", PurlTypeGuac:
+	case "alpine", "alpm", "apk", "huggingface", "githubactions", "mlflow", "qpkg", "pub", "swid", PurlTypeGuac:
 		fallthrough
 	// PURL types defined in purl library handled generically
 	case purl.TypeBitbucket, purl.TypeCocoapods, purl.TypeCargo,

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -117,6 +117,9 @@ func TestPurlConvert(t *testing.T) {
 			purlUri:  "pkg:github/package-url/purl-spec@244fd47e07d1004#everybody/loves/dogs",
 			expected: pkg("github", "package-url", "purl-spec", "244fd47e07d1004", "everybody/loves/dogs", map[string]string{}),
 		}, {
+			purlUri:  "pkg:githubactions/shufo/auto-assign-reviewer-by-files@1.1.4",
+			expected: pkg("githubactions", "shufo", "auto-assign-reviewer-by-files", "1.1.4", "", map[string]string{}),
+		}, {
 			purlUri:  "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c#api",
 			expected: pkg("golang", "github.com/gorilla", "context", "234fd47e07d1004f0aed9c", "api", map[string]string{}),
 		}, {


### PR DESCRIPTION
# Description of the PR

This adds support for 'githubactions' package types which look like they can be generically handled like the others.

I hit the error with the unsupported purl type when trying to import the SBOM for the OpenNMS project: https://github.com/OpenNMS/opennms/network/dependencies

With the patch, it now imports successfully:
```
% curl 'http://localhost:8080/query' -s -X POST -H 'content-type: application/json' \                  
  --data '{     
    "query": "{ packages(pkgSpec: {}) { type } }"
  }' | jq
{
  "data": {
    "packages": [
      {
        "type": "guac"
      },
      {
        "type": "maven"
      },
      {
        "type": "npm"
      },
      {
        "type": "githubactions"
      }
    ]
  }
}
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
