### PR TITLE
Remove DoesRangeInclude error testing

### DIFF
--- a/pkg/misc/depversion/depversion.go
+++ b/pkg/misc/depversion/depversion.go
@@ -116,7 +116,7 @@ func ParseVersionValue(s string) VersionValue {
 	return vv
 }
 
-// formatting issues are handled in WhichVersionMatched, error not expected to be thrown
+// formatting issues are handled in WhichVersionMatches, error not expected to be thrown
 func DoesRangeInclude(versions []string, versionRange string) (bool, error) {
 	versionMap, err := WhichVersionMatches(versions, versionRange)
 

--- a/pkg/misc/depversion/depversion.go
+++ b/pkg/misc/depversion/depversion.go
@@ -116,6 +116,7 @@ func ParseVersionValue(s string) VersionValue {
 	return vv
 }
 
+// formatting issues are handled in WhichVersionMatched, error not expected to be thrown
 func DoesRangeInclude(versions []string, versionRange string) (bool, error) {
 	versionMap, err := WhichVersionMatches(versions, versionRange)
 

--- a/pkg/misc/depversion/depversion.go
+++ b/pkg/misc/depversion/depversion.go
@@ -116,7 +116,7 @@ func ParseVersionValue(s string) VersionValue {
 	return vv
 }
 
-// formatting issues are handled in WhichVersionMatches, error not expected to be thrown
+// formatting issues are handled in WhichVersionMatches, errors not expected to be thrown
 func DoesRangeInclude(versions []string, versionRange string) (bool, error) {
 	versionMap, err := WhichVersionMatches(versions, versionRange)
 

--- a/pkg/misc/depversion/depversion_test.go
+++ b/pkg/misc/depversion/depversion_test.go
@@ -485,16 +485,3 @@ func Test_DoesRangeInclude(t *testing.T) {
 		})
 	}
 }
-
-func Test_DoesRangeInclude_Errors(t *testing.T) {
-	res1, err1 := DoesRangeInclude([]string{"3.0", "1.0", "2.0"}, ">1.0 , <2.0")
-	res2, err2 := DoesRangeInclude([]string{"anythinggoes", "1.0", "2.0"}, "bad range")
-
-	if err1 != nil || err2 != nil {
-		t.Errorf("expected error for DoesRangeInclude and did not receive an error")
-	}
-
-	if res1 != false || res2 != false {
-		t.Errorf("expected error for DoesRangeInclude and did not receive false result as expected")
-	}
-}


### PR DESCRIPTION
# Description of the PR

Removes error testing from #886 because errors are not expected to be thrown
Tests were incorrec/unecessary for these cases

# PR Checklist

- [ x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ x] All new changes are covered by tests
- [ x] If GraphQL schema is changed, `make generate` has been run
- [ x] If `collectsub` protobuf has been changed, `make proto` has been run
- [ x] All CI checks are passing (tests and formatting)
- [ x] All dependent PRs have already been merged
