### PR TITLE
Changed build tag to separate  scorecardRunner_test.go to run only on…

### DIFF
--- a/pkg/certifier/scorecard/scorecardRunner_test.go
+++ b/pkg/certifier/scorecard/scorecardRunner_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
+//go:build integrationMerge
 
 package scorecard
 


### PR DESCRIPTION
… Merge

# Description of the PR

Changed build tag to separate  scorecardRunner_test.go to run only on Merge

Adds to Fixes in #906

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
