### PR TITLE
fix deps.dev unit test

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1127,7 +1127,7 @@ var (
 				 "qualifiers":null,
 				 "subpath":"",
 				 "type":"pypi",
-				 "version":"3.12.0"
+				 "version":"3.12.1"
 			  },
 			  "DepPackages":null,
 			  "IsDepPackages":null,
@@ -1219,7 +1219,7 @@ var (
 				 "qualifiers":null,
 				 "subpath":"",
 				 "type":"pypi",
-				 "version":"3.12.0"
+				 "version":"3.12.1"
 			  },
 			  "IsDependency":{
 				 "collector":"",


### PR DESCRIPTION
# Description of the PR

Unit test failing due to updated dependency on - https://deps.dev/pypi/wheel-axle-runtime/0.0.4.dev20230415195356/dependencies

Updated expected output to match. Resolves the current CI issues.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
