### PR TITLE
ci: add schedule daily snapshot build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ name: release
 
 on:
   workflow_dispatch: # testing only, trigger manually to test it works
+  schedule:
+    - cron: 0 0 * * * # every day at 0:00, build latest on default branch (main)
   push:
     branches:
       - main


### PR DESCRIPTION
# Description of the PR

Snapshot build logic is already there, i just add schedule to trigger every day at 0:00

Fixes: #941

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
