### PR TITLE
use current docker context of host for buildx

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
   - use: buildx
     goos: linux
     goarch: arm64
@@ -33,6 +34,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
 
 docker_manifests:
 - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}"

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ build_local_container: GORELEASER_CURRENT_TAG ?= v0.0.0-$(LOCAL_IMAGE_NAME)
 build_local_container:
 	GITHUB_REPOSITORY=$(GITHUB_REPOSITORY) \
 	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) \
+	DOCKER_CONTEXT=$(shell docker context show) \
 	goreleaser release --clean --snapshot --skip-sign --skip-sbom
 
 # Build and package a guac container for local testing


### PR DESCRIPTION
# Description of the PR

Default to the current docker context, which is assumed to be functional, for goreleaser buildx build.

Fixes #949 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
