### PR TITLE
special case for arch x86_64 should be converted to amd64 for GOARCH …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKG=github.com/guacsec/guac/pkg/version
 LDFLAGS="-X $(PKG).Version=$(VERSION) -X $(PKG).Commit=$(COMMIT) -X $(PKG).Date=$(BUILD)"
 
 CONTAINER ?= docker
-CPUTYPE=$(shell uname -m)
+CPUTYPE=$(shell uname -m | sed 's/x86_64/amd64/')
 GITHUB_REPOSITORY ?= guacsec/guac
 LOCAL_IMAGE_NAME ?= local-organic-guac
 


### PR DESCRIPTION
…consistency

# Description of the PR

Fix issue when building and tagging container via make container because `uname -m` returns  x86_64 but container ecosystem uses amd64


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
