### PR TITLE
feat(collector): expose Google Cloud Storage collector from guacone CLI

### DIFF
--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -1,0 +1,183 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/guacsec/guac/pkg/cli"
+	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/collector/gcs"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/api/option"
+)
+
+type gcsOptions struct {
+	graphqlEndpoint string
+	csubAddr        string
+	bucket          string
+}
+
+const gcsCredentialsPathFlag = "gcp-credentials-path"
+
+var gcsCmd = &cobra.Command{
+	Use:     "gcs [flags] bucket_name",
+	Short:   "takes SBOMs and attestations from a Google Cloud Storage bucket and injects them to GUAC graph. This command talks directly to the graphQL endpoint",
+	Example: "guacone collect gcs my-bucket --gcs-credentials-path /secret/sa.json",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateGCSFlags(viper.GetString("gql-addr"), viper.GetString("csub-addr"), args)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		gcsOpts := []option.ClientOption{
+			option.WithUserAgent(version.UserAgent),
+		}
+
+		// Credential flag is not mandatory since they can also be loaded from
+		// the environment variable GOOGLE_APPLICATION_CREDENTIALS by the client, by default
+		if credsPath := viper.GetString(gcsCredentialsPathFlag); credsPath != "" {
+			gcsOpts = append(gcsOpts, option.WithCredentialsFile(credsPath))
+		}
+
+		client, err := storage.NewClient(ctx, gcsOpts...)
+		cobra.CheckErr(err)
+
+		// Register collector by providing a new GCS Client and bucket name
+		gcsCollector, err := gcs.NewGCSCollector(gcs.WithBucket(opts.bucket), gcs.WithClient(client))
+		if err != nil {
+			logger.Errorf("unable to create gcs client: %v", err)
+		}
+
+		err = collector.RegisterDocumentCollector(gcsCollector, gcs.CollectorGCS)
+		if err != nil {
+			logger.Errorf("unable to register gcs collector: %v", err)
+		}
+
+		// initialize collectsub client
+		csubClient, err := csub_client.NewClient(opts.csubAddr)
+		if err != nil {
+			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
+			csubClient = nil
+		} else {
+			defer csubClient.Close()
+		}
+
+		// TODO: this code could be extracted to a function and reused by the
+		// other collectors (files and oci)
+		// Get pipeline of components
+		processorFunc := getProcessor(ctx)
+		ingestorFunc := getIngestor(ctx)
+		collectSubEmitFunc := getCollectSubEmit(ctx, csubClient)
+		assemblerFunc := getAssembler(ctx, opts.graphqlEndpoint)
+
+		totalNum := 0
+		gotErr := false
+		// Set emit function to go through the entire pipeline
+		emit := func(d *processor.Document) error {
+			totalNum += 1
+			start := time.Now()
+
+			docTree, err := processorFunc(d)
+			if err != nil {
+				gotErr = true
+				return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
+			}
+
+			predicates, idstrings, err := ingestorFunc(docTree)
+			if err != nil {
+				gotErr = true
+				return fmt.Errorf("unable to ingest doc tree: %v", err)
+			}
+
+			err = collectSubEmitFunc(idstrings)
+			if err != nil {
+				logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
+			}
+
+			err = assemblerFunc(predicates)
+			if err != nil {
+				gotErr = true
+				return fmt.Errorf("unable to assemble graphs: %v", err)
+			}
+			t := time.Now()
+			elapsed := t.Sub(start)
+			logger.Infof("[%v] completed doc %+v", elapsed, d.SourceInformation)
+			return nil
+		}
+
+		// Collect
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("collector ended gracefully")
+				return true
+			}
+			logger.Errorf("collector ended with error: %v", err)
+			return false
+		}
+		if err := collector.Collect(ctx, emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		if gotErr {
+			logger.Fatalf("completed ingestion with errors")
+		} else {
+			logger.Infof("completed ingesting %v documents", totalNum)
+		}
+	},
+}
+
+func validateGCSFlags(gqlEndpoint string, csubAddr string, args []string) (gcsOptions, error) {
+	var opts gcsOptions
+	opts.graphqlEndpoint = gqlEndpoint
+	opts.csubAddr = csubAddr
+
+	if len(args) < 1 {
+		return opts, fmt.Errorf("expected positional argument for bucket_path")
+	}
+	opts.bucket = args[0]
+	return opts, nil
+}
+
+func init() {
+	set, err := cli.BuildFlags([]string{gcsCredentialsPathFlag})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	gcsCmd.Flags().AddFlagSet(set)
+	if err := viper.BindPFlags(gcsCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+
+	collectCmd.AddCommand(gcsCmd)
+}

--- a/cmd/guacone/cmd/gcs_test.go
+++ b/cmd/guacone/cmd/gcs_test.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "testing"
+
+func TestValidateGCSFlags(t *testing.T) {
+	testCases := []struct {
+		name            string
+		args            []string
+		credentialsPath string
+		credsEnvVarSet  bool
+		errorMsg        string
+	}{
+		{
+			name:     "no args",
+			errorMsg: "expected positional argument: bucket",
+		},
+		{
+			name:     "no credentials",
+			args:     []string{"bucket"},
+			errorMsg: "expected either --gcp-credentials-path flag or GOOGLE_APPLICATION_CREDENTIALS environment variable",
+		},
+		{
+			name:            "credentials path and env var set",
+			args:            []string{"bucket"},
+			credentialsPath: "/path/to/creds.json",
+			credsEnvVarSet:  true,
+			errorMsg:        "",
+		},
+		{
+			name:            "credentials path and env var not set",
+			args:            []string{"bucket"},
+			credentialsPath: "/path/to/creds.json",
+		},
+		{
+			name:           "credentials path not set and env var set",
+			args:           []string{"bucket"},
+			credsEnvVarSet: true,
+			errorMsg:       "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.credsEnvVarSet {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
+			}
+
+			o, err := validateGCSFlags("", "", tc.credentialsPath, tc.args)
+			if err != nil {
+				if tc.errorMsg != err.Error() {
+					t.Errorf("expected error message: %s, got: %s", tc.errorMsg, err.Error())
+				}
+			} else {
+				if tc.errorMsg != "" {
+					t.Errorf("expected error message: %s, got: %s", tc.errorMsg, err.Error())
+				}
+
+				if o.bucket != tc.args[0] {
+					t.Errorf("expected bucket: %s, got: %s", tc.args[0], o.bucket)
+				}
+			}
+		})
+	}
+
+}

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -65,6 +65,9 @@ func init() {
 	set.StringP("vuln-id", "v", "", "CVE, GHSA or OSV ID to check")
 	set.Int("num-path", 0, "number of paths to return, 0 means all paths")
 
+	// Google Cloud platform flags
+	set.String("gcp-credentials-path", "", "Path to the Google Cloud service account credentials json file.\nAlternatively you can set GOOGLE_APPLICATION_CREDENTIALS=<path> in your environment.")
+
 	set.VisitAll(func(f *pflag.Flag) {
 		flagStore[f.Name] = f
 	})


### PR DESCRIPTION
Exposes the Google Cloud Storage collector through `guacone` CLI. 

This PR is in the context of https://github.com/chainloop-dev/chainloop/issues/209. We want Chainloop to populate blob storage buckets with metadata that then Guac can import. 


![Peek 2023-06-27 16-54](https://github.com/guacsec/guac/assets/24523/1b50ace1-e594-41e7-b633-6772d17ec7c7)

In the linked issue, @lumjjb suggested exploring the existing GCS integration, and I believe this is a first step, to have an on-demand, client-side collection trigger for now. On another PR I could explore how to enable unattended, collection via a subscribed, collector handler.  

```sh
$ guacone collect gcs
Error: accepts 1 arg(s), received 0
Usage:
  guacone collect gcs [flags] bucket_name

Examples:
guacone collect gcs my-bucket --gcs-credentials-path /secret/sa.json

Flags:
      --gcp-credentials-path string   Path to the Google Cloud service account credentials json file.
                                      Alternatively you can set GOOGLE_APPLICATION_CREDENTIALS=<path> in your environment.
  -h, --help                          help for gcs

Global Flags:
      --csub-addr string   address to connect to collect-sub service (default "localhost:2782")
      --gql-addr string    endpoint used to connect to graphQL server (default "http://localhost:8080/query")
```

The command can receive the credentials path from both a flag 

```sh
$ guacone collect gcs test-guac --gcp-credentials-path service-account-devel.json 
```

or using default Google Cloud Client credentials env var

```sh
GOOGLE_APPLICATION_CREDENTIALS=service-account-devel.json guacone collect gcs test-guac
```

Some context on the implementation choices have been added inline as PR comments.

### Implementation considerations

- Since it's my first PR, I tried to follow as many patterns I could find, avoiding most refactoring efforts. 

See the code below for example. This code is repeated in each collector and could get extracted (I think). But I don't feel with the authority nor with the enough code base understanding to perform a refactoring like that. Maybe in another PR down the line :)

https://github.com/guacsec/guac/blob/9bfd464451df767738f777f4d4d66287bf411a26/cmd/guacone/cmd/files.go#L125-L140

Collector package updates:

- I moved the Google Cloud client generation outside to simplify testing of the module, and decouple the package from the client configuration. For example today it uses a credentials file but tomorrow the creds might come from something else.   
- I saw in some other collector that the options pattern was implemented, I moved the constructor to that pattern as well for consistency.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests 

**DISCLAIMER**: I didn't add tests to the new cobra command, I've not seen any tests on that package / layer so I am not sure what's the convention here.

- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged

Thank you!