### PR TITLE
update spdx parsing and check for spdxIdentifier==DOCUMENT

### DIFF
--- a/internal/testing/testdata/exampledata/invalid-spdx-identifier-spdx.json
+++ b/internal/testing/testdata/exampledata/invalid-spdx-identifier-spdx.json
@@ -1,0 +1,49 @@
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "",
+  "creationInfo": {
+    "created": "2020-11-24T01:12:27Z",
+    "creators": [
+      {
+        "Person": "Nisha K (nishak@vmware.com)"
+      }
+    ]
+  },
+  "name": "hello-imports.spdx.json",
+  "documentNamespace": "https://swinslow.net/spdx-examples/example7/hello-imports",
+  "documentDescribes": [
+    "SPDXRef-go-module-golang.org/x/text",
+    "SPDXRef-go-module-rsc.io/quote",
+    "SPDXRef-go-module-rsc.io/sampler"
+  ],
+  "packages": [
+    {
+      "packageName": "golang.org/x/text",
+      "SPDXID": "SPDXRef-go-module-golang.org/x/text",
+      "downloadLocation": "go://golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c",
+      "filesAnalyzed": false,
+      "packageLicenseConcluded": "NOASSERTION",
+      "packageLicenseDeclared": "NOASSERTION",
+      "packageCopyrightText": "NOASSERTION"
+    },
+    {
+      "packageName": "rsc.io/quote",
+      "SPDXID": "SPDXRef-go-module-rsc.io/quote",
+      "downloadLocation": "go://rsc.io/quote@v1.5.2",
+      "filesAnalyzed": false,
+      "packageLicenseConcluded": "NOASSERTION",
+      "packageLicenseDeclared": "NOASSERTION",
+      "packageCopyrightText": "NOASSERTION"
+    },
+    {
+      "packageName": "rsc.io/sampler",
+      "SPDXID": "SPDXRef-go-module-rsc.io/sampler",
+      "downloadLocation": "go://rsc.io/sampler@v1.3.0",
+      "filesAnalyzed": false,
+      "packageLicenseConcluded": "NOASSERTION",
+      "packageLicenseDeclared": "NOASSERTION",
+      "packageCopyrightText": "NOASSERTION"
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -50,6 +50,10 @@ var (
 	//go:embed exampledata/invalid-spdx.json
 	SpdxInvalidExample []byte
 
+	// Invalid SPDXIdentifier document
+	//go:embed exampledata/invalid-spdx-identifier-spdx.json
+	SpdxInvalidSPDXIdentifierExample []byte
+
 	// Example scorecard
 	//go:embed exampledata/kubernetes-scorecard.json
 	ScorecardExample []byte

--- a/pkg/handler/processor/guesser/type_spdx.go
+++ b/pkg/handler/processor/guesser/type_spdx.go
@@ -16,17 +16,19 @@
 package guesser
 
 import (
+	"bytes"
+
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/json"
 )
 
 type spdxTypeGuesser struct{}
 
 func (_ *spdxTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
-	spdxDoc := &spdx.Document{}
 	switch format {
 	case processor.FormatJSON:
-		if err := spdxDoc.UnmarshalJSON(blob); err == nil {
+		spdxDoc, err := json.Read(bytes.NewReader(blob))
+		if err == nil {
 			// This is set to check for DocumentNamespace since there seem to
 			// be some SBOMs in the wild that don't use certain fields like
 			// document name.

--- a/pkg/handler/processor/spdx/spdx.go
+++ b/pkg/handler/processor/spdx/spdx.go
@@ -16,10 +16,11 @@
 package spdx
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/json"
 )
 
 // SPDXProcessor processes SPDX documents.
@@ -34,8 +35,14 @@ func (p *SPDXProcessor) ValidateSchema(d *processor.Document) error {
 
 	switch d.Format {
 	case processor.FormatJSON:
-		doc := &spdx.Document{}
-		return doc.UnmarshalJSON(d.Blob)
+		doc, err := json.Read(bytes.NewReader(d.Blob))
+		if err != nil {
+			return err
+		}
+		if doc.SPDXIdentifier != "DOCUMENT" {
+			return fmt.Errorf("document SPDXIdentifier should be DOCUMENT")
+		}
+		return nil
 	}
 
 	return fmt.Errorf("unable to support parsing of SPDX document format: %v", d.Format)

--- a/pkg/handler/processor/spdx/spdx_test.go
+++ b/pkg/handler/processor/spdx/spdx_test.go
@@ -111,6 +111,15 @@ func TestSPDXProcessor_ValidateSchema(t *testing.T) {
 			SourceInformation: processor.SourceInformation{},
 		},
 		expectErr: true,
+	}, {
+		name: "invalid SPDX DocumentIdentifier",
+		doc: processor.Document{
+			Blob:              testdata.SpdxInvalidSPDXIdentifierExample,
+			Format:            processor.FormatJSON,
+			Type:              processor.DocumentSPDX,
+			SourceInformation: processor.SourceInformation{},
+		},
+		expectErr: true,
 	}}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -16,6 +16,7 @@
 package spdx
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -26,6 +27,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spdx/tools-golang/json"
 	spdx "github.com/spdx/tools-golang/spdx"
 	spdx_common "github.com/spdx/tools-golang/spdx/v2/common"
 	"golang.org/x/exp/slices"
@@ -175,11 +177,7 @@ func (s *spdxParser) getFiles() error {
 }
 
 func parseSpdxBlob(p []byte) (*spdx.Document, error) {
-	doc := &spdx.Document{}
-	if err := doc.UnmarshalJSON(p); err != nil {
-		return nil, err
-	}
-	return doc, nil
+	return json.Read(bytes.NewReader(p))
 }
 
 func (s *spdxParser) getPackageElement(elementID string) []*model.PkgInputSpec {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -64,6 +64,7 @@ func Test_spdxParser(t *testing.T) {
 			doc: &processor.Document{
 				Blob: []byte(`
 			{
+			"spdxVersion": "SPDX-2.3",
 			"SPDXID":"SPDXRef-DOCUMENT",
 			"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
 			"packages":[
@@ -110,6 +111,7 @@ func Test_spdxParser(t *testing.T) {
 			doc: &processor.Document{
 				Blob: []byte(`
 			{
+			"spdxVersion": "SPDX-2.3",
 			"SPDXID":"SPDXRef-DOCUMENT",
 			"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
 			"packages":[
@@ -173,6 +175,7 @@ func Test_spdxParser(t *testing.T) {
 			doc: &processor.Document{
 				Blob: []byte(`
 		{
+		"spdxVersion": "SPDX-2.3",
 		"SPDXID":"SPDXRef-DOCUMENT",
 		"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
 		"packages":[
@@ -219,6 +222,7 @@ func Test_spdxParser(t *testing.T) {
 			doc: &processor.Document{
 				Blob: []byte(`
 		{
+		"spdxVersion": "SPDX-2.3",
 		"SPDXID":"SPDXRef-DOCUMENT",
 		"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
 		"relationships":[


### PR DESCRIPTION
# Description of the PR

Fix SPDX parsing and update to check that SPDXIdentifier is consistent for #979 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
