### PR TITLE
Implement FIndSoftware for Arango backend

### DIFF
--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -19,9 +19,157 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+// TODO(lumjjb): add source when it is implemented in arango backend
 func (c *arangoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
-	return []model.PackageSourceOrArtifact{}, fmt.Errorf("not implemented: FindSoftware")
+
+	queryValues := map[string]any{}
+	queryValues["searchText"] = searchText
+	query := `
+FOR doc in GuacSearch
+SEARCH PHRASE(doc.guacKey, @searchText, "text_en") || PHRASE(doc.guacKey, @searchText, "customgram") || doc.digest == @searchText
+
+LET parsedDoc =
+    IS_SAME_COLLECTION(doc, "PkgName") ?
+    // PkgName case
+    (
+        FOR pNs in PkgNamespace
+          FILTER pNs._id == doc._parent
+
+        FOR pType in PkgType
+          FILTER pType._id == pNs._parent
+
+        RETURN {
+          'nodeType': 'pkgName',
+          'id': doc._id,
+          'pkgName': {
+              'type': pType.type,
+              'namespace': pNs.namespace,
+              'name': doc.name,
+              'nameDoc': doc
+          }
+        }
+    ) : (IS_SAME_COLLECTION(doc, "PkgVersion") ?
+    // PkgVersion case
+    (
+        FOR pName in PkgName
+          FILTER pName._id == doc._parent
+        FOR pNs in PkgNamespace
+          FILTER pNs._id == pName._parent
+        FOR pType in PkgType
+          FILTER pType._id == pNs._parent
+
+        RETURN {
+          'nodeType': 'pkgVersion',
+          'id': doc._id,
+          'pkgVersion': {
+              'type': pType.type,
+              'namespace': pNs.namespace,
+              'name': pName.name,
+              'version': doc.version,
+              'subpath': doc.subpath,
+              'qualifier_list': doc.qualifier_list,
+              'versionDoc': doc
+          }
+        }
+    )
+    :
+    // Artifact case
+    (RETURN {
+        'nodeType': 'artifact',
+         'id': doc._id,
+         'artifact': {
+            'algorithm': doc.algorithm,
+            'digest': doc.digest
+         }
+    })
+    )
+
+RETURN {
+"parsedDoc": parsedDoc
+}
+
+`
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, queryValues, "FindSoftware")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+	}
+	defer cursor.Close()
+
+	type parsedDoc struct {
+		NodeType string `json:"nodeType"`
+		Id       string `json:"id"`
+		PkgName  *struct {
+			PkgType   string `json:"type"`
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+		} `json:"pkgName,omitempty"`
+		PkgVersion *struct {
+			PkgType       string      `json:"type"`
+			Namespace     string      `json:"namespace"`
+			Name          string      `json:"name"`
+			Version       string      `json:"version"`
+			Subpath       string      `json:"subpath"`
+			QualifierList interface{} `json:"qualifier_list"`
+		} `json:"pkgVersion,omitempty"`
+		Artifact *model.Artifact `json:"artifact,omitempty"`
+	}
+
+	type collectedData struct {
+		ParsedDoc []parsedDoc `json:"parsedDoc"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to run search: %w, values: %v", err, queryValues)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var results []model.PackageSourceOrArtifact
+	for _, createdValue := range createdValues {
+		for _, d := range createdValue.ParsedDoc {
+			switch d.NodeType {
+			case "artifact":
+				a := d.Artifact
+				if a == nil {
+					return nil, fmt.Errorf("failed to parse result of artifact, got nil when expected non-nil")
+				}
+				results = append(results, a)
+			case "pkgVersion":
+				p := d.PkgVersion
+				if p == nil {
+					return nil, fmt.Errorf("failed to parse result of pkgVersion, got nil when expected non-nil")
+				}
+				pkg, err := generateModelPackage(p.PkgType, p.Namespace, p.Name, p.Version, p.Subpath, p.QualifierList)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
+				}
+				results = append(results, pkg)
+			case "pkgName":
+				p := d.PkgName
+				if p == nil {
+					return nil, fmt.Errorf("failed to parse result of pkgName, got nil when expected non-nil")
+				}
+				pkg, err := generateModelPackage(p.PkgType, p.Namespace, p.Name, nil, nil, nil)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
+				}
+				results = append(results, pkg)
+			}
+		}
+	}
+	return results, nil
 }


### PR DESCRIPTION
# Description of the PR

Implement FindSoftware for arango backend, part of #971 

Example queries:
```
query FS {
	findSoftware(searchText:"aa11fc3ef91319888a5ee1feba786a8237c26ea5e177fa66bc1e564581f464f6") {
   __typename
    ... on Package {
      ...AllPkgTree
    }
    ... on Artifact {
      ...AllArtifactTree
    }
    ... on Source {
      ...AllSourceTree
    }
  }
}
```
<img width="2459" alt="Screenshot 2023-07-07 at 11 55 55 AM" src="https://github.com/guacsec/guac/assets/3060102/54bfe45b-ffdc-472b-a056-f65fa3e64c7d">


```
query FS {
	findSoftware(searchText:"kubernetes") {
   __typename
    ... on Package {
      ...AllPkgTree
    }
    ... on Artifact {
      ...AllArtifactTree
    }
    ... on Source {
      ...AllSourceTree
    }
  }
}
```
<img width="2434" alt="Screenshot 2023-07-07 at 11 56 26 AM" src="https://github.com/guacsec/guac/assets/3060102/0204d88d-d6dc-443d-a78d-a30c002b7225">

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
