### PR TITLE
Remove annotations from hasSBOM gql example

### DIFF
--- a/pkg/assembler/graphql/examples/has_sbom.gql
+++ b/pkg/assembler/graphql/examples/has_sbom.gql
@@ -33,10 +33,6 @@ fragment allHasSBOMTree on HasSBOM {
   algorithm
   digest
   downloadLocation
-  annotations {
-      key
-      value
-  }
   origin
   collector
 }


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
The Visualizer is currently [experiencing an issue](https://github.com/guacsec/guac-visualizer/issues/39) with http 422 errors, and this appears to be the culprit

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
This is a pre-req to fix issue 39 on the guac-visualizer repo
# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
