### PR TITLE
set guacone collect files to ingest doc in parallel with bulk assembler

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -44,7 +43,10 @@ import (
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
 )
+
+const MAX_CONCURRENT_JOBS = 2
 
 type fileOptions struct {
 	// path to the pem file
@@ -121,51 +123,62 @@ var filesCmd = &cobra.Command{
 			defer csubClient.Close()
 		}
 
+		files, filesCtx := errgroup.WithContext(ctx)
+
 		// Get pipeline of components
-		processorFunc := getProcessor(ctx)
-		ingestorFunc := getIngestor(ctx)
-		collectSubEmitFunc := getCollectSubEmit(ctx, csubClient)
-		assemblerFunc := getAssembler(ctx, opts.graphqlEndpoint)
+		processorFunc := getProcessor(filesCtx)
+		ingestorFunc := getIngestor(filesCtx)
+		collectSubEmitFunc := getCollectSubEmit(filesCtx, csubClient)
+		assemblerFunc := getAssembler(filesCtx, opts.graphqlEndpoint)
 
 		totalNum := 0
 		totalSuccess := 0
 		var filesWithErrors []string
 
 		gotErr := false
-		// Set emit function to go through the entire pipeline
+
+		// Backend can only process a few files at a time. Increasing this might cause timeout errors in the database
+		files.SetLimit(3)
+
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 			start := time.Now()
+			files.Go(func() error {
 
-			docTree, err := processorFunc(d)
-			if err != nil {
-				gotErr = true
-				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
-				return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
-			}
+				if filesCtx.Err() != nil {
+					return fmt.Errorf("context error")
+				}
+				fmt.Println(d.SourceInformation.Source)
+				docTree, err := processorFunc(d)
+				if err != nil {
+					gotErr = true
+					filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
+					return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
+				}
 
-			predicates, idstrings, err := ingestorFunc(docTree)
-			if err != nil {
-				gotErr = true
-				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
-				return fmt.Errorf("unable to ingest doc tree: %v", err)
-			}
+				predicates, idstrings, err := ingestorFunc(docTree)
+				if err != nil {
+					gotErr = true
+					filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
+					return fmt.Errorf("unable to ingest doc tree: %v", err)
+				}
 
-			err = collectSubEmitFunc(idstrings)
-			if err != nil {
-				logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
-			}
-
-			err = assemblerFunc(predicates)
-			if err != nil {
-				gotErr = true
-				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
-				return fmt.Errorf("unable to assemble graphs: %v", err)
-			}
-			t := time.Now()
-			elapsed := t.Sub(start)
-			totalSuccess += 1
-			logger.Infof("[%v] completed doc %+v", elapsed, d.SourceInformation)
+				err = collectSubEmitFunc(idstrings)
+				if err != nil {
+					logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
+				}
+				err = assemblerFunc(predicates)
+				if err != nil {
+					gotErr = true
+					filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
+					return fmt.Errorf("unable to assemble graphs: %v", err)
+				}
+				t := time.Now()
+				elapsed := t.Sub(start)
+				totalSuccess += 1
+				logger.Infof("[%v] completed doc %+v", elapsed, d.SourceInformation)
+				return nil
+			})
 			return nil
 		}
 
@@ -178,7 +191,13 @@ var filesCmd = &cobra.Command{
 			logger.Errorf("collector ended with error: %v", err)
 			return false
 		}
+
 		if err := collector.Collect(ctx, emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		err = files.Wait()
+		if err != nil {
 			logger.Fatal(err)
 		}
 
@@ -228,26 +247,9 @@ func getIngestor(ctx context.Context) func(processor.DocumentTree) ([]assembler.
 }
 
 func getAssembler(ctx context.Context, graphqlEndpoint string) func([]assembler.IngestPredicates) error {
-	// Same as https://pkg.go.dev/net/http#DefaultTransport but with greater
-	// MaxIdleConnsPerHost so that we effectively re-use connections when doing
-	// parallel ingestion calls.
-	var dialer = &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}
-	var customTransport http.RoundTripper = &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   30,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-	httpClient := http.Client{Transport: customTransport}
+	httpClient := http.Client{}
 	gqlclient := graphql.NewClient(graphqlEndpoint, &httpClient)
-	f := helpers.GetParallelAssembler(ctx, gqlclient)
+	f := helpers.GetBulkAssembler(ctx, gqlclient)
 	return f
 }
 

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -63,7 +63,7 @@ type fileOptions struct {
 }
 
 var filesCmd = &cobra.Command{
-	Use:   "files [flags] file_path",
+	Use:   "files [flags] file_path (set environment variable MAX_CONCURRENT_JOBS to increase the number of documents to ingest in parallel. Default: 1)",
 	Short: "take a folder of files and create a GUAC graph, this command talks directly to the graphQL endpoint",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -37,7 +37,7 @@ const (
 	collector     string        = "collector"
 	justification string        = "justification"
 	maxRetires    int           = 20
-	retryTImer    time.Duration = time.Microsecond
+	retryTImer    time.Duration = 10 * time.Microsecond
 	guacEmpty     string        = "guac-empty-@@"
 )
 
@@ -405,6 +405,8 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		}
 
 		if err := createView(ctx, db, "GuacSearch", &driver.ArangoSearchViewProperties{
+			CommitInterval:        ptrfrom.Int64(10 * 60 * 1000),
+			ConsolidationInterval: ptrfrom.Int64(10 * 60 * 1000),
 			Links: driver.ArangoSearchLinks{
 				"PkgVersions": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
@@ -414,6 +416,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					Fields: map[string]driver.ArangoSearchElementProperties{
 						"guacKey": {},
 					},
+					InBackground: ptrfrom.Bool(true),
 				},
 				"PkgNames": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
@@ -432,6 +435,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					Fields: map[string]driver.ArangoSearchElementProperties{
 						"guacKey": {},
 					},
+					InBackground: ptrfrom.Bool(true),
 				},
 				"artifacts": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity"},
@@ -441,6 +445,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					Fields: map[string]driver.ArangoSearchElementProperties{
 						"digest": {},
 					},
+					InBackground: ptrfrom.Bool(true),
 				},
 			},
 		}); err != nil {


### PR DESCRIPTION
# Description of the PR

set `guacone collect files` to ingest doc in parallel with bulk assembler. Configurable by setting the environment variable `MAX_CONCURRENT_JOBS` to any number. Defaulting to 1

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
