### PR TITLE
fix allow for go.googlesource.com to be parsed for VcsToSrc

### DIFF
--- a/pkg/assembler/helpers/vcs.go
+++ b/pkg/assembler/helpers/vcs.go
@@ -43,7 +43,7 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 	m := &model.SourceInputSpec{}
 
 	if u.Scheme == "https" {
-		if u.Host == "github.com" || u.Host == "gitlab.com" || strings.Contains(u.Host, "bitbucket") {
+		if u.Host == "go.googlesource.com" || u.Host == "github.com" || u.Host == "gitlab.com" || strings.Contains(u.Host, "bitbucket") {
 			m.Type = "git"
 		} else {
 			return nil, fmt.Errorf("scheme has unknown source type: %s", u.Host)

--- a/pkg/assembler/helpers/vcs_test.go
+++ b/pkg/assembler/helpers/vcs_test.go
@@ -55,6 +55,16 @@ func TestVcsUriToSrc(t *testing.T) {
 			expected: src("git", "github.com/sfackler", "rust-openssl", nil, nil),
 		},
 		{
+			uri:      "https://go.googlesource.com/net",
+			wantErr:  false,
+			expected: src("git", "go.googlesource.com", "net", nil, nil),
+		},
+		{
+			uri:      "https://go.googlesource.com/lint",
+			wantErr:  false,
+			expected: src("git", "go.googlesource.com", "lint", nil, nil),
+		},
+		{
 			uri:     "github.com/sfackler/rust-openssl",
 			wantErr: true,
 		},

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -202,7 +202,7 @@ func (d *depsCollector) fetchDependencies(ctx context.Context, purl string, docC
 		depPurl := "pkg:" + pkgtype + "/" + node.VersionKey.Name + "@" + node.VersionKey.Version
 		depPackageInput, err := helpers.PurlToPkg(depPurl)
 		if err != nil {
-			logger.Infof("unable to parse purl: %v", depPurl)
+			logger.Infof("unable to parse purl: %v, error: %v", depPurl, err)
 			continue
 		}
 		// check if dependent package purl has already been queried. If found, append to the list of dependent packages for top level package
@@ -282,7 +282,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 		if link.Label == sourceRepo {
 			src, err := helpers.VcsToSrc(link.Url)
 			if err != nil {
-				logger.Infof("unable to parse source url: %v", link.Url)
+				logger.Infof("unable to parse source url: %v, error: %v", link.Url, err)
 				continue
 			}
 
@@ -303,7 +303,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 
 			project, err := d.client.GetProject(ctx, projectReq)
 			if err != nil {
-				logger.Debugf("unable to get project for: %v", projectReq.ProjectKey.Id)
+				logger.Debugf("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
 				continue
 			}
 			if project.Scorecard != nil {


### PR DESCRIPTION
# Description of the PR

fix allow for go.googlesource.com to be parsed for VcsToSrc

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
