### PR TITLE
cleanup arango backend, add ingestion of builder, add support for source ingestion for Occurrences, return IDs during ingestion and query

### DIFF
--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -29,11 +29,11 @@ func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifa
 	values := map[string]any{}
 	arangoQueryBuilder := newForQuery("artifacts", "art")
 	if artifactSpec.Algorithm != nil {
-		arangoQueryBuilder.filter("algorithm", "art", "==", "@algorithm")
+		arangoQueryBuilder.filter("art", "algorithm", "==", "@algorithm")
 		values["algorithm"] = strings.ToLower(*artifactSpec.Algorithm)
 	}
 	if artifactSpec.Digest != nil {
-		arangoQueryBuilder.filter("digest", "art", "==", "@digest")
+		arangoQueryBuilder.filter("art", "digest", "==", "@digest")
 		values["digest"] = strings.ToLower(*artifactSpec.Digest)
 	}
 	arangoQueryBuilder.query.WriteString("\n")

--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -27,7 +27,7 @@ import (
 
 func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.ArtifactSpec) ([]*model.Artifact, error) {
 	values := map[string]any{}
-	arangoQueryBuilder := newForQuery("artifacts", "art")
+	arangoQueryBuilder := newForQuery(artifactsStr, "art")
 	if artifactSpec.Algorithm != nil {
 		arangoQueryBuilder.filter("art", "algorithm", "==", "@algorithm")
 		values["algorithm"] = strings.ToLower(*artifactSpec.Algorithm)

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -40,6 +40,62 @@ const (
 	maxRetires    int           = 100
 	retryTimer    time.Duration = time.Microsecond
 	guacEmpty     string        = "guac-empty-@@"
+
+	// Package collections
+	pkgHasTypeStr      string = "pkgHasType"
+	pkgRootsStr        string = "pkgRoots"
+	pkgTypesStr        string = "pkgTypes"
+	pkgHasNamespaceStr string = "pkgHasNamespace"
+	pkgNamespacesStr   string = "pkgNamespaces"
+	pkgHasNameStr      string = "pkgHasName"
+	pkgHasVersionStr   string = "pkgHasVersion"
+	pkgNamesStr        string = "pkgNames"
+	pkgVersionsStr     string = "pkgVersions"
+
+	// source collections
+	srcHasTypeStr      string = "srcHasType"
+	srcRootsStr        string = "srcRoots"
+	srcTypesStr        string = "srcTypes"
+	srcHasNamespaceStr string = "srcHasNamespace"
+	srcNamespacesStr   string = "srcNamespaces"
+	srcHasNameStr      string = "srcHasName"
+	srcNamesStr        string = "srcNames"
+
+	// isDependency collections
+
+	isDependencyEdgesStr string = "isDependencyEdges"
+	isDependenciesStr    string = "isDependencies"
+
+	//isOccurrences collections
+
+	isOccurrencesEdgesStr string = "isOccurrencesEdges"
+	isOccurrencesStr      string = "isOccurrences"
+
+	// hasSLSA collections
+
+	hasSLSAEdgesStr string = "hasSLSAEdges"
+	hasSLSAsStr     string = "hasSLSAs"
+
+	// builder collections
+
+	buildersStr string = "builders"
+
+	// hashEquals collections
+
+	hashEqualsEdgesStr string = "hashEqualsEdges"
+
+	// artifact collection
+
+	artifactsStr string = "artifacts"
+
+	// hasSBOM collection
+
+	hasSBOMEdgesStr string = "hasSBOMEdges"
+	hasSBOMsStr     string = "hasSBOMs"
+
+	// hashEqual collection
+
+	hashEqualsStr string = "hashEquals"
 )
 
 type ArangoConfig struct {
@@ -151,101 +207,101 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 
 		// setup package collections
 		var pkgHasType driver.EdgeDefinition
-		pkgHasType.Collection = "pkgHasType"
+		pkgHasType.Collection = pkgHasTypeStr
 		// define a set of collections where an edge is going out...
-		pkgHasType.From = []string{"pkgRoots"}
+		pkgHasType.From = []string{pkgRootsStr}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasType.To = []string{"pkgTypes"}
+		pkgHasType.To = []string{pkgTypesStr}
 
 		var pkgHasNamespace driver.EdgeDefinition
-		pkgHasNamespace.Collection = "pkgHasNamespace"
+		pkgHasNamespace.Collection = pkgHasNamespaceStr
 		// define a set of collections where an edge is going out...
-		pkgHasNamespace.From = []string{"pkgTypes"}
+		pkgHasNamespace.From = []string{pkgTypesStr}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasNamespace.To = []string{"pkgNamespaces"}
+		pkgHasNamespace.To = []string{pkgNamespacesStr}
 
 		var pkgHasName driver.EdgeDefinition
-		pkgHasName.Collection = "pkgHasName"
+		pkgHasName.Collection = pkgHasNameStr
 		// define a set of collections where an edge is going out...
-		pkgHasName.From = []string{"pkgNamespaces"}
+		pkgHasName.From = []string{pkgNamespacesStr}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasName.To = []string{"pkgNames"}
+		pkgHasName.To = []string{pkgNamesStr}
 
 		var pkgHasVersion driver.EdgeDefinition
-		pkgHasVersion.Collection = "pkgHasVersion"
+		pkgHasVersion.Collection = pkgHasVersionStr
 		// define a set of collections where an edge is going out...
-		pkgHasVersion.From = []string{"pkgNames"}
+		pkgHasVersion.From = []string{pkgNamesStr}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasVersion.To = []string{"pkgVersions"}
+		pkgHasVersion.To = []string{pkgVersionsStr}
 
 		// setup source collections
 		var srcHasType driver.EdgeDefinition
-		srcHasType.Collection = "srcHasType"
+		srcHasType.Collection = srcHasTypeStr
 		// define a set of collections where an edge is going out...
-		srcHasType.From = []string{"srcRoots"}
+		srcHasType.From = []string{srcRootsStr}
 
 		// repeat this for the collections where an edge is going into
-		srcHasType.To = []string{"srcTypes"}
+		srcHasType.To = []string{srcTypesStr}
 
 		var srcHasNamespace driver.EdgeDefinition
-		srcHasNamespace.Collection = "srcHasNamespace"
+		srcHasNamespace.Collection = srcHasNamespaceStr
 		// define a set of collections where an edge is going out...
-		srcHasNamespace.From = []string{"srcTypes"}
+		srcHasNamespace.From = []string{srcTypesStr}
 
 		// repeat this for the collections where an edge is going into
-		srcHasNamespace.To = []string{"srcNamespaces"}
+		srcHasNamespace.To = []string{srcNamespacesStr}
 
 		var srcHasName driver.EdgeDefinition
-		srcHasName.Collection = "srcHasName"
+		srcHasName.Collection = srcHasNameStr
 		// define a set of collections where an edge is going out...
-		srcHasName.From = []string{"srcNamespaces"}
+		srcHasName.From = []string{srcNamespacesStr}
 
 		// repeat this for the collections where an edge is going into
-		srcHasName.To = []string{"srcNames"}
+		srcHasName.To = []string{srcNamesStr}
 
 		var isDependencyEdges driver.EdgeDefinition
-		isDependencyEdges.Collection = "isDependencyEdges"
+		isDependencyEdges.Collection = isDependencyEdgesStr
 		// define a set of collections where an edge is going out...
-		isDependencyEdges.From = []string{"isDependencies", "pkgVersions"}
+		isDependencyEdges.From = []string{isDependenciesStr, pkgVersionsStr}
 
 		// repeat this for the collections where an edge is going into
-		isDependencyEdges.To = []string{"isDependencies", "pkgNames"}
+		isDependencyEdges.To = []string{isDependenciesStr, pkgNamesStr}
 
 		var isOccurrencesEdges driver.EdgeDefinition
-		isOccurrencesEdges.Collection = "isOccurrencesEdges"
+		isOccurrencesEdges.Collection = isOccurrencesEdgesStr
 		// define a set of collections where an edge is going out...
-		isOccurrencesEdges.From = []string{"isOccurrences", "pkgVersions", "srcNames"}
+		isOccurrencesEdges.From = []string{isOccurrencesStr, pkgVersionsStr, srcNamesStr}
 
 		// repeat this for the collections where an edge is going into
-		isOccurrencesEdges.To = []string{"isOccurrences", "artifacts"}
+		isOccurrencesEdges.To = []string{isOccurrencesStr, artifactsStr}
 
 		var hasSLSAEdges driver.EdgeDefinition
-		hasSLSAEdges.Collection = "hasSLSAEdges"
+		hasSLSAEdges.Collection = hasSLSAEdgesStr
 		// define a set of collections where an edge is going out...
-		hasSLSAEdges.From = []string{"builders", "hasSLSAs"}
+		hasSLSAEdges.From = []string{hasSLSAsStr}
 
 		// repeat this for the collections where an edge is going into
-		hasSLSAEdges.To = []string{"builders", "hasSLSAs"}
+		hasSLSAEdges.To = []string{buildersStr}
 
 		var hashEqualsEdges driver.EdgeDefinition
-		hashEqualsEdges.Collection = "hashEqualsEdges"
+		hashEqualsEdges.Collection = hashEqualsEdgesStr
 		// define a set of collections where an edge is going out...
-		hashEqualsEdges.From = []string{"artifacts", "hashEquals"}
+		hashEqualsEdges.From = []string{artifactsStr, hashEqualsStr}
 
 		// repeat this for the collections where an edge is going into
-		hashEqualsEdges.To = []string{"artifacts", "hashEquals"}
+		hashEqualsEdges.To = []string{artifactsStr, hashEqualsStr}
 
 		var hasSBOMEdges driver.EdgeDefinition
-		hasSBOMEdges.Collection = "hasSBOMEdges"
+		hasSBOMEdges.Collection = hasSBOMEdgesStr
 		// define a set of collections where an edge is going out...
-		hasSBOMEdges.From = []string{"pkgVersions", "artifacts"}
+		hasSBOMEdges.From = []string{pkgVersionsStr, artifactsStr}
 
 		// repeat this for the collections where an edge is going into
-		hasSBOMEdges.To = []string{"hasSBOMs"}
+		hasSBOMEdges.To = []string{hasSBOMsStr}
 
 		// A graph can contain additional vertex collections, defined in the set of orphan collections
 		var options driver.CreateGraphOptions
@@ -259,141 +315,141 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		}
 
 		// add indexes to artifact and edge collections
-		if err := createIndexPerCollection(ctx, db, "artifacts", []string{"digest"}, true, "byDigest"); err != nil {
+		if err := createIndexPerCollection(ctx, db, artifactsStr, []string{"digest"}, true, "byDigest"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for artifacts: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "artifacts", []string{"algorithm", "digest"}, true, "byArtAndDigest"); err != nil {
+		if err := createIndexPerCollection(ctx, db, artifactsStr, []string{"algorithm", "digest"}, true, "byArtAndDigest"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for artifacts: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "builders", []string{"uri"}, true, "byUri"); err != nil {
+		if err := createIndexPerCollection(ctx, db, buildersStr, []string{"uri"}, true, "byUri"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for builders: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "hashEquals", []string{"artifactID", "equalArtifactID"}, true, "byArtIDEqualArtID"); err != nil {
+		if err := createIndexPerCollection(ctx, db, hashEqualsStr, []string{"artifactID", "equalArtifactID"}, true, "byArtIDEqualArtID"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for hashEquals: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "hashEqualsEdges", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, hashEqualsEdgesStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for hashEqualsEdges: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgTypes", []string{"_parent", "type"}, true, "byPkgTypeParent"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgTypesStr, []string{"_parent", "type"}, true, "byPkgTypeParent"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgTypes", []string{"type"}, true, "byPkgType"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgTypesStr, []string{"type"}, true, "byPkgType"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgNamespaces", []string{"namespace"}, false, "byPkgNamespace"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgNamespacesStr, []string{"namespace"}, false, "byPkgNamespace"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgNames", []string{"name"}, false, "byPkgNames"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgNamesStr, []string{"name"}, false, "byPkgNames"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgHasTypeStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgHasType: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgHasNamespaceStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgHasNamespace: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgHasNameStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgHasName: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"version"}, false, "byVersion"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgVersionsStr, []string{"version"}, false, "byVersion"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"subpath"}, false, "bySubpath"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgVersionsStr, []string{"subpath"}, false, "bySubpath"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"qualifier_list[*]"}, false, "byQualifierList"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgVersionsStr, []string{"qualifier_list[*]"}, false, "byQualifierList"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgHasVersion", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgHasVersionStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgHasVersion: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcTypes", []string{"_parent", "type"}, true, "bySrcTypeParent"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcTypesStr, []string{"_parent", "type"}, true, "bySrcTypeParent"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcTypes", []string{"type"}, true, "bySrcType"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcTypesStr, []string{"type"}, true, "bySrcType"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcNamespaces", []string{"namespace"}, false, "bySrcNamespace"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcNamespacesStr, []string{"namespace"}, false, "bySrcNamespace"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcNames", []string{"name"}, false, "bySrcNames"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcNamesStr, []string{"name"}, false, "bySrcNames"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcHasTypeStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcHasType: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcHasNamespaceStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcHasNamespace: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcHasNameStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for srcHasName: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "isDependencies", []string{"packageID", "depPackageID", "versionRange", "origin"}, false, "byPkgIDDepPkgIDversionRangeOrigin"); err != nil {
+		if err := createIndexPerCollection(ctx, db, isDependenciesStr, []string{"packageID", "depPackageID", "versionRange", "origin"}, false, "byPkgIDDepPkgIDversionRangeOrigin"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for isDependencies: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "isDependencyEdges", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, isDependencyEdgesStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for isDependencyEdges: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "isOccurrences", []string{"packageID", "artifactID", "origin"}, true, "byPkgIDArtIDOrigin"); err != nil {
+		if err := createIndexPerCollection(ctx, db, isOccurrencesStr, []string{"packageID", "artifactID", "origin"}, true, "byPkgIDArtIDOrigin"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for isOccurrences: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "isOccurrencesEdges", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, isOccurrencesEdgesStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for isOccurrencesEdges: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "hasSBOMs", []string{"digest"}, true, "byDigest"); err != nil {
+		if err := createIndexPerCollection(ctx, db, hasSBOMsStr, []string{"digest"}, true, "byDigest"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for hasSBOMs: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "hasSBOMEdges", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+		if err := createIndexPerCollection(ctx, db, hasSBOMEdgesStr, []string{"_from", "_to"}, true, "byFromTo"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for hasSBOMEdges: %w", err)
 		}
 
 		// GUAC key indices for package
-		if err := createIndexPerCollection(ctx, db, "pkgNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgNamespacesStr, []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
 			return nil, fmt.Errorf("failed to generate guackey index for pkgNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgNamesStr, []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
 			return nil, fmt.Errorf("failed to generate guackey index for pkgNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"guacKey"}, true, "byVersionGuacKey"); err != nil {
+		if err := createIndexPerCollection(ctx, db, pkgVersionsStr, []string{"guacKey"}, true, "byVersionGuacKey"); err != nil {
 			return nil, fmt.Errorf("failed to generate guackey index for pkgVersions: %w", err)
 		}
 
 		// GUAC key indices for source
-		if err := createIndexPerCollection(ctx, db, "srcNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcNamespacesStr, []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
 			return nil, fmt.Errorf("failed to generate guackey index for srcNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "srcNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
+		if err := createIndexPerCollection(ctx, db, srcNamesStr, []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
 			return nil, fmt.Errorf("failed to generate guackey index for srcNames: %w", err)
 		}
 
@@ -422,7 +478,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			CommitInterval:        ptrfrom.Int64(10 * 60 * 1000),
 			ConsolidationInterval: ptrfrom.Int64(10 * 60 * 1000),
 			Links: driver.ArangoSearchLinks{
-				"pkgVersions": driver.ArangoSearchElementProperties{
+				pkgVersionsStr: driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -432,7 +488,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					},
 					InBackground: ptrfrom.Bool(true),
 				},
-				"pkgNames": driver.ArangoSearchElementProperties{
+				pkgNamesStr: driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -441,7 +497,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 						"guacKey": {},
 					},
 				},
-				"srcNames": driver.ArangoSearchElementProperties{
+				srcNamesStr: driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -451,7 +507,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					},
 					InBackground: ptrfrom.Bool(true),
 				},
-				"artifacts": driver.ArangoSearchElementProperties{
+				artifactsStr: driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -151,79 +151,86 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 
 		// setup package collections
 		var pkgHasType driver.EdgeDefinition
-		pkgHasType.Collection = "PkgHasType"
+		pkgHasType.Collection = "pkgHasType"
 		// define a set of collections where an edge is going out...
-		pkgHasType.From = []string{"PkgRoots"}
+		pkgHasType.From = []string{"pkgRoots"}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasType.To = []string{"PkgTypes"}
+		pkgHasType.To = []string{"pkgTypes"}
 
 		var pkgHasNamespace driver.EdgeDefinition
-		pkgHasNamespace.Collection = "PkgHasNamespace"
+		pkgHasNamespace.Collection = "pkgHasNamespace"
 		// define a set of collections where an edge is going out...
-		pkgHasNamespace.From = []string{"PkgTypes"}
+		pkgHasNamespace.From = []string{"pkgTypes"}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasNamespace.To = []string{"PkgNamespaces"}
+		pkgHasNamespace.To = []string{"pkgNamespaces"}
 
 		var pkgHasName driver.EdgeDefinition
-		pkgHasName.Collection = "PkgHasName"
+		pkgHasName.Collection = "pkgHasName"
 		// define a set of collections where an edge is going out...
-		pkgHasName.From = []string{"PkgNamespaces"}
+		pkgHasName.From = []string{"pkgNamespaces"}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasName.To = []string{"PkgNames"}
+		pkgHasName.To = []string{"pkgNames"}
 
 		var pkgHasVersion driver.EdgeDefinition
-		pkgHasVersion.Collection = "PkgHasVersion"
+		pkgHasVersion.Collection = "pkgHasVersion"
 		// define a set of collections where an edge is going out...
-		pkgHasVersion.From = []string{"PkgNames"}
+		pkgHasVersion.From = []string{"pkgNames"}
 
 		// repeat this for the collections where an edge is going into
-		pkgHasVersion.To = []string{"PkgVersions"}
+		pkgHasVersion.To = []string{"pkgVersions"}
 
 		// setup source collections
 		var srcHasType driver.EdgeDefinition
-		srcHasType.Collection = "SrcHasType"
+		srcHasType.Collection = "srcHasType"
 		// define a set of collections where an edge is going out...
-		srcHasType.From = []string{"SrcRoots"}
+		srcHasType.From = []string{"srcRoots"}
 
 		// repeat this for the collections where an edge is going into
-		srcHasType.To = []string{"SrcTypes"}
+		srcHasType.To = []string{"srcTypes"}
 
 		var srcHasNamespace driver.EdgeDefinition
-		srcHasNamespace.Collection = "SrcHasNamespace"
+		srcHasNamespace.Collection = "srcHasNamespace"
 		// define a set of collections where an edge is going out...
-		srcHasNamespace.From = []string{"SrcTypes"}
+		srcHasNamespace.From = []string{"srcTypes"}
 
 		// repeat this for the collections where an edge is going into
-		srcHasNamespace.To = []string{"SrcNamespaces"}
+		srcHasNamespace.To = []string{"srcNamespaces"}
 
 		var srcHasName driver.EdgeDefinition
-		srcHasName.Collection = "SrcHasName"
+		srcHasName.Collection = "srcHasName"
 		// define a set of collections where an edge is going out...
-		srcHasName.From = []string{"SrcNamespaces"}
+		srcHasName.From = []string{"srcNamespaces"}
 
 		// repeat this for the collections where an edge is going into
-		srcHasName.To = []string{"SrcNames"}
+		srcHasName.To = []string{"srcNames"}
 
 		var isDependencyEdges driver.EdgeDefinition
 		isDependencyEdges.Collection = "isDependencyEdges"
 		// define a set of collections where an edge is going out...
-		isDependencyEdges.From = []string{"isDependencies", "PkgVersions"}
+		isDependencyEdges.From = []string{"isDependencies", "pkgVersions"}
 
 		// repeat this for the collections where an edge is going into
-		isDependencyEdges.To = []string{"isDependencies", "PkgNames"}
+		isDependencyEdges.To = []string{"isDependencies", "pkgNames"}
 
 		var isOccurrencesEdges driver.EdgeDefinition
 		isOccurrencesEdges.Collection = "isOccurrencesEdges"
 		// define a set of collections where an edge is going out...
-		isOccurrencesEdges.From = []string{"isOccurrences", "PkgVersions"}
+		isOccurrencesEdges.From = []string{"isOccurrences", "pkgVersions"}
 
 		// repeat this for the collections where an edge is going into
 		isOccurrencesEdges.To = []string{"isOccurrences", "artifacts"}
 
-		// define the edgeCollection to store the edges
+		var hasSLSAEdges driver.EdgeDefinition
+		hasSLSAEdges.Collection = "hasSLSAEdges"
+		// define a set of collections where an edge is going out...
+		hasSLSAEdges.From = []string{"builders", "hasSLSAs"}
+
+		// repeat this for the collections where an edge is going into
+		hasSLSAEdges.To = []string{"builders", "hasSLSAs"}
+
 		var hashEqualsEdges driver.EdgeDefinition
 		hashEqualsEdges.Collection = "hashEqualsEdges"
 		// define a set of collections where an edge is going out...
@@ -235,14 +242,15 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		var hasSBOMEdges driver.EdgeDefinition
 		hasSBOMEdges.Collection = "hasSBOMEdges"
 		// define a set of collections where an edge is going out...
-		hasSBOMEdges.From = []string{"PkgVersions", "artifacts"}
+		hasSBOMEdges.From = []string{"pkgVersions", "artifacts"}
 
 		// repeat this for the collections where an edge is going into
 		hasSBOMEdges.To = []string{"hasSBOMs"}
 
 		// A graph can contain additional vertex collections, defined in the set of orphan collections
 		var options driver.CreateGraphOptions
-		options.EdgeDefinitions = []driver.EdgeDefinition{hashEqualsEdges, pkgHasType, pkgHasNamespace, pkgHasName, pkgHasVersion, srcHasType, srcHasNamespace, srcHasName, isDependencyEdges, isOccurrencesEdges, hasSBOMEdges}
+		options.EdgeDefinitions = []driver.EdgeDefinition{hashEqualsEdges, pkgHasType, pkgHasNamespace, pkgHasName,
+			pkgHasVersion, srcHasType, srcHasNamespace, srcHasName, isDependencyEdges, isOccurrencesEdges, hasSBOMEdges, hasSLSAEdges}
 
 		// create a graph
 		graph, err = db.CreateGraphV2(ctx, "guac", &options)
@@ -254,8 +262,13 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		if err := createIndexPerCollection(ctx, db, "artifacts", []string{"digest"}, true, "byDigest"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for artifacts: %w", err)
 		}
+
 		if err := createIndexPerCollection(ctx, db, "artifacts", []string{"algorithm", "digest"}, true, "byArtAndDigest"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for artifacts: %w", err)
+		}
+
+		if err := createIndexPerCollection(ctx, db, "builders", []string{"uri"}, true, "byUri"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for builders: %w", err)
 		}
 
 		if err := createIndexPerCollection(ctx, db, "hashEquals", []string{"artifactID", "equalArtifactID"}, true, "byArtIDEqualArtID"); err != nil {
@@ -266,76 +279,76 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			return nil, fmt.Errorf("failed to generate index for hashEqualsEdges: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgTypes", []string{"_parent", "type"}, true, "byPkgTypeParent"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgTypes: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgTypes", []string{"_parent", "type"}, true, "byPkgTypeParent"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgTypes", []string{"type"}, true, "byPkgType"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgTypes: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgTypes", []string{"type"}, true, "byPkgType"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgNamespaces", []string{"namespace"}, false, "byPkgNamespace"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgNamespace: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgNamespaces", []string{"namespace"}, false, "byPkgNamespace"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgNames", []string{"name"}, false, "byPkgNames"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgName: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgNames", []string{"name"}, false, "byPkgNames"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgHasType: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgHasType: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgHasNamespace: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgHasNamespace: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgHasName: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgHasName: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgVersions", []string{"version"}, false, "byVersion"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgVersions: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"version"}, false, "byVersion"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgVersions", []string{"subpath"}, false, "bySubpath"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgVersions: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"subpath"}, false, "bySubpath"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgVersions", []string{"qualifier_list[*]"}, false, "byQualifierList"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgVersions: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"qualifier_list[*]"}, false, "byQualifierList"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgHasVersion", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for PkgHasVersion: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgHasVersion", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for pkgHasVersion: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcTypes", []string{"_parent", "type"}, true, "bySrcTypeParent"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcTypes: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcTypes", []string{"_parent", "type"}, true, "bySrcTypeParent"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcTypes", []string{"type"}, true, "bySrcType"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcTypes: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcTypes", []string{"type"}, true, "bySrcType"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcTypes: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcNamespaces", []string{"namespace"}, false, "bySrcNamespace"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcNamespaces: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcNamespaces", []string{"namespace"}, false, "bySrcNamespace"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcNames", []string{"name"}, false, "bySrcNames"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcNames: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcNames", []string{"name"}, false, "bySrcNames"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcHasType: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcHasType", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcHasType: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcHasNamespace: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcHasNamespace", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcHasNamespace: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for SrcHasName: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcHasName", []string{"_from", "_to"}, true, "byFromTo"); err != nil {
+			return nil, fmt.Errorf("failed to generate index for srcHasName: %w", err)
 		}
 
 		if err := createIndexPerCollection(ctx, db, "isDependencies", []string{"packageID", "depPackageID", "origin"}, true, "byPkgIDDepPkgIDOrigin"); err != nil {
@@ -363,25 +376,25 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		}
 
 		// GUAC key indices for package
-		if err := createIndexPerCollection(ctx, db, "PkgNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
-			return nil, fmt.Errorf("failed to generate guackey index for PkgNamespaces: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
+			return nil, fmt.Errorf("failed to generate guackey index for pkgNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
-			return nil, fmt.Errorf("failed to generate guackey index for PkgNames: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
+			return nil, fmt.Errorf("failed to generate guackey index for pkgNames: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "PkgVersions", []string{"guacKey"}, true, "byVersionGuacKey"); err != nil {
-			return nil, fmt.Errorf("failed to generate guackey index for PkgVersions: %w", err)
+		if err := createIndexPerCollection(ctx, db, "pkgVersions", []string{"guacKey"}, true, "byVersionGuacKey"); err != nil {
+			return nil, fmt.Errorf("failed to generate guackey index for pkgVersions: %w", err)
 		}
 
 		// GUAC key indices for source
-		if err := createIndexPerCollection(ctx, db, "SrcNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
-			return nil, fmt.Errorf("failed to generate guackey index for SrcNamespaces: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcNamespaces", []string{"guacKey"}, true, "byNsGuacKey"); err != nil {
+			return nil, fmt.Errorf("failed to generate guackey index for srcNamespaces: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, "SrcNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
-			return nil, fmt.Errorf("failed to generate guackey index for SrcNames: %w", err)
+		if err := createIndexPerCollection(ctx, db, "srcNames", []string{"guacKey"}, true, "byNameGuacKey"); err != nil {
+			return nil, fmt.Errorf("failed to generate guackey index for srcNames: %w", err)
 		}
 
 		if err := createAnalyzer(ctx, db, driver.ArangoSearchAnalyzerDefinition{
@@ -409,7 +422,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			CommitInterval:        ptrfrom.Int64(10 * 60 * 1000),
 			ConsolidationInterval: ptrfrom.Int64(10 * 60 * 1000),
 			Links: driver.ArangoSearchLinks{
-				"PkgVersions": driver.ArangoSearchElementProperties{
+				"pkgVersions": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -419,7 +432,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 					},
 					InBackground: ptrfrom.Bool(true),
 				},
-				"PkgNames": driver.ArangoSearchElementProperties{
+				"pkgNames": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -428,7 +441,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 						"guacKey": {},
 					},
 				},
-				"SrcNames": driver.ArangoSearchElementProperties{
+				"srcNames": driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
@@ -733,7 +746,7 @@ func preIngestPkgRoot(ctx context.Context, db driver.Database) (*pkgRootData, er
 		UPSERT { root: "pkg" }
 		INSERT { root: "pkg" }
 		UPDATE {}
-		IN PkgRoots
+		IN pkgRoots
 		RETURN NEW`
 
 	cursor, err := executeQueryWithRetry(ctx, db, query, nil, "preIngestPkgRoot")
@@ -776,12 +789,12 @@ func preIngestPkgTypes(ctx context.Context, db driver.Database, pkgRoot *pkgRoot
 			UPSERT { type: @pkgType, _parent: @rootID }
 			INSERT { type: @pkgType, _parent: @rootID }
 			UPDATE {}
-			IN PkgTypes OPTIONS { indexHint: "byPkgTypeParent" }
+			IN pkgTypes OPTIONS { indexHint: "byPkgTypeParent" }
 			RETURN NEW
 		  )
 	
 		  LET pkgHasTypeCollection = (
-			INSERT { _key: CONCAT("pkgHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "PkgHasType" } INTO PkgHasType OPTIONS { overwriteMode: "ignore" }
+			INSERT { _key: CONCAT("pkgHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "pkgHasType" } INTO pkgHasType OPTIONS { overwriteMode: "ignore" }
 		  )
 	
 		RETURN {
@@ -824,7 +837,7 @@ func preIngestSrcRoot(ctx context.Context, db driver.Database) (*srcRootData, er
 		UPSERT { root: "src" }
 		INSERT { root: "src" }
 		UPDATE {}
-		IN SrcRoots
+		IN srcRoots
 		RETURN NEW`
 
 	cursor, err := executeQueryWithRetry(ctx, db, query, nil, "preIngestSrcRoot")
@@ -867,12 +880,12 @@ func preIngestSrcTypes(ctx context.Context, db driver.Database, srcRoot *srcRoot
 			UPSERT { type: @srcType, _parent: @rootID }
 			INSERT { type: @srcType, _parent: @rootID }
 			UPDATE {}
-			IN SrcTypes OPTIONS { indexHint: "byType" }
+			IN srcTypes OPTIONS { indexHint: "byType" }
 			RETURN NEW
 		  )
 	
 		  LET pkgHasTypeCollection = (
-			INSERT { _key: CONCAT("srcHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "SrcHasType" } INTO SrcHasType OPTIONS { overwriteMode: "ignore" }
+			INSERT { _key: CONCAT("srcHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "srcHasType" } INTO srcHasType OPTIONS { overwriteMode: "ignore" }
 		  )
 	
 		RETURN {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -626,9 +626,6 @@ func getPreloadString(prefix, name string) string {
 	return name
 }
 
-func (c *arangoClient) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
-	panic(fmt.Errorf("not implemented: Builders - Builders"))
-}
 func (c *arangoClient) Cve(ctx context.Context, cveSpec *model.CVESpec) ([]*model.Cve, error) {
 	panic(fmt.Errorf("not implemented: Cve - Cve"))
 }
@@ -673,9 +670,7 @@ func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *mod
 }
 
 // Mutations for software trees (read-write queries)
-func (c *arangoClient) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {
-	panic(fmt.Errorf("not implemented: IngestBuilder - IngestBuilder"))
-}
+
 func (c *arangoClient) IngestCve(ctx context.Context, cve *model.CVEInputSpec) (*model.Cve, error) {
 	panic(fmt.Errorf("not implemented: IngestCve - IngestCve"))
 }

--- a/pkg/assembler/backends/arangodb/builder.go
+++ b/pkg/assembler/backends/arangodb/builder.go
@@ -1,0 +1,174 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+func (c *arangoClient) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery("artifacts", "art")
+	if builderSpec.Algorithm != nil {
+		arangoQueryBuilder.filter("algorithm", "art", "==", "@algorithm")
+		values["algorithm"] = strings.ToLower(*artifactSpec.Algorithm)
+	}
+	if artifactSpec.Digest != nil {
+		arangoQueryBuilder.filter("digest", "art", "==", "@digest")
+		values["digest"] = strings.ToLower(*artifactSpec.Digest)
+	}
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		"id": art._id,
+		"algorithm": art.algorithm,
+		"digest": art.digest
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "Artifacts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+	}
+	defer cursor.Close()
+
+	var collectedArtifacts []*model.Artifact
+	for {
+		var doc *model.Artifact
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to query artifact: %w", err)
+			}
+		} else {
+			collectedArtifacts = append(collectedArtifacts, doc)
+		}
+	}
+
+	return collectedArtifacts, nil
+}
+
+func (c *arangoClient) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
+
+	listOfValues := []map[string]any{}
+
+	for i := range artifacts {
+		values := map[string]any{}
+
+		values["algorithm"] = strings.ToLower(artifacts[i].Algorithm)
+		values["digest"] = strings.ToLower(artifacts[i].Digest)
+
+		listOfValues = append(listOfValues, values)
+	}
+
+	var documents []string
+	for _, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		documents = append(documents, string(bs))
+	}
+
+	queryValues := map[string]any{}
+	queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+	var sb strings.Builder
+
+	sb.WriteString("for doc in [")
+	for i, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		if i == len(listOfValues)-1 {
+			sb.WriteString(string(bs))
+		} else {
+			sb.WriteString(string(bs) + ",")
+		}
+	}
+	sb.WriteString("]")
+
+	query := `
+UPSERT { algorithm:doc.algorithm, digest:doc.digest } 
+INSERT { algorithm:doc.algorithm, digest:doc.digest } 
+UPDATE {} IN artifacts OPTIONS { indexHint: "byArtAndDigest" }
+RETURN NEW`
+
+	sb.WriteString(query)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestArtifacts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+	}
+	defer cursor.Close()
+
+	var createdArtifacts []*model.Artifact
+	for {
+		var doc *model.Artifact
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to ingest artifact: %w", err)
+			}
+		} else {
+			createdArtifacts = append(createdArtifacts, doc)
+		}
+	}
+	return createdArtifacts, nil
+
+}
+
+func (c *arangoClient) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {
+	values := map[string]any{}
+	values["algorithm"] = strings.ToLower(artifact.Algorithm)
+	values["digest"] = strings.ToLower(artifact.Digest)
+
+	query := `
+UPSERT { algorithm:@algorithm, digest:@digest } 
+INSERT { algorithm:@algorithm, digest:@digest } 
+UPDATE {} IN artifacts OPTIONS { indexHint: "byArtAndDigest" }
+RETURN NEW`
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, values, "IngestArtifact")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+	}
+	defer cursor.Close()
+
+	var createdArtifacts []*model.Artifact
+	for {
+		var doc *model.Artifact
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to ingest artifact: %w", err)
+			}
+		} else {
+			createdArtifacts = append(createdArtifacts, doc)
+		}
+	}
+	if len(createdArtifacts) == 1 {
+		return createdArtifacts[0], nil
+	} else {
+		return nil, fmt.Errorf("number of artifacts ingested is greater than one")
+	}
+}

--- a/pkg/assembler/backends/arangodb/builder.go
+++ b/pkg/assembler/backends/arangodb/builder.go
@@ -27,7 +27,7 @@ import (
 
 func (c *arangoClient) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
 	values := map[string]any{}
-	arangoQueryBuilder := newForQuery("builders", "build")
+	arangoQueryBuilder := newForQuery(buildersStr, "build")
 	if builderSpec.URI != nil {
 		arangoQueryBuilder.filter("build", "uri", "==", "@uri")
 		values["uri"] = builderSpec.URI

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -132,13 +132,13 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 
 		query := `
 		LET firstPkg = FIRST(
-			FOR pVersion in PkgVersions
+			FOR pVersion in pkgVersions
 			  FILTER pVersion.guacKey == @pkgVersionGuacKey
-			FOR pName in PkgNames
+			FOR pName in pkgNames
 			  FILTER pName._id == pVersion._parent
-			FOR pNs in PkgNamespaces
+			FOR pNs in pkgNamespaces
 			  FILTER pNs._id == pName._parent
-			FOR pType in PkgTypes
+			FOR pType in pkgTypes
 			  FILTER pType._id == pNs._parent
 	
 			RETURN {

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -30,34 +30,45 @@ const (
 	dependencyType string = "dependencyType"
 )
 
+// Query IsDependency
+
+func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error) {
+	return []*model.IsDependency{}, fmt.Errorf("not implemented: IsDependency")
+}
+
 // Ingest IsDependency
 
-func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgInputSpec, depPkg []*model.PkgInputSpec, dependency []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
-	if len(pkg) != len(depPkg) {
+func getDependencyQueryValues(pkg *model.PkgInputSpec, depPkg *model.PkgInputSpec, dependency *model.IsDependencyInputSpec) map[string]any {
+	values := map[string]any{}
+
+	// add guac keys
+	pkgId := guacPkgId(*pkg)
+	depPkgId := guacPkgId(*depPkg)
+	values["pkgVersionGuacKey"] = pkgId.VersionId
+	values["secondPkgNameGuacKey"] = depPkgId.NameId
+
+	// isDependency
+
+	values[versionRange] = dependency.VersionRange
+	values[dependencyType] = dependency.DependencyType.String()
+	values[justification] = dependency.Justification
+	values[origin] = dependency.Origin
+	values[collector] = dependency.Collector
+
+	return values
+}
+
+func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
+	if len(pkgs) != len(depPkgs) {
 		return nil, fmt.Errorf("uneven packages and dependent packages for ingestion")
-	} else if len(pkg) != len(dependency) {
+	} else if len(pkgs) != len(dependencies) {
 		return nil, fmt.Errorf("uneven packages and isDependency for ingestion")
 	}
 
 	listOfValues := []map[string]any{}
 
-	for i := range pkg {
-		values := map[string]any{}
-
-		// add guac keys
-		pkgId := guacPkgId(*pkg[i])
-		depPkgId := guacPkgId(*depPkg[i])
-		values["pkgVersionGuacKey"] = pkgId.VersionId
-		values["secondPkgNameGuacKey"] = depPkgId.NameId
-
-		// isDependency
-
-		values[versionRange] = dependency[i].VersionRange
-		values[dependencyType] = dependency[i].DependencyType.String()
-		values[justification] = dependency[i].Justification
-		values[origin] = dependency[i].Origin
-		values[collector] = dependency[i].Collector
-		listOfValues = append(listOfValues, values)
+	for i := range pkgs {
+		listOfValues = append(listOfValues, getDependencyQueryValues(pkgs[i], depPkgs[i], dependencies[i]))
 	}
 
 	var documents []string
@@ -95,9 +106,13 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgI
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
+		  'typeID': pType._id,
 		  'type': pType.type,
+		  'namespace_id': pNs._id,
 		  'namespace': pNs.namespace,
+		  'name_id': pName._id,
 		  'name': pName.name,
+		  'version_id': pVersion._id,
 		  'version': pVersion.version,
 		  'subpath': pVersion.subpath,
 		  'qualifier_list': pVersion.qualifier_list,
@@ -114,10 +129,13 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgI
           FILTER pType._id == pNs._parent
 
         RETURN {
-          'type': pType.type,
-          'namespace': pNs.namespace,
-          'name': pName.name,
-          'nameDoc': pName
+		  'typeID': pType._id,
+		  'type': pType.type,
+		  'namespace_id': pNs._id,
+		  'namespace': pNs.namespace,
+		  'name_id': pName._id,
+		  'name': pName.name,
+		  'nameDoc': pName
         }
     )
 		
@@ -136,109 +154,46 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgI
 		)
 		
 	RETURN {
-		  'firstPkgType': firstPkg.type,
-		  'firstPkgNamespace': firstPkg.namespace,
-		  'firstPkgName': firstPkg.name,
-		  'firstPkgVersion': firstPkg.version,
-		  'firstPkgSubpath': firstPkg.subpath,
-		  'firstPkgQualifier_list': firstPkg.qualifier_list,
-		  'secondPkgType': secondPkg.type,
-		  'secondPkgNamespace': secondPkg.namespace,
-		  'secondPkgName': secondPkg.name,
-		  'versionRange': isDependency.versionRange,
-		  'dependencyType': isDependency.dependencyType,
-		  'justification': isDependency.justification,
-		  'collector': isDependency.collector,
-		  'origin': isDependency.origin
+		'pkgVersion': {
+			'type_id': firstPkg.typeID,
+			'type': firstPkg.type,
+			'namespace_id': firstPkg.namespace_id,
+			'namespace': firstPkg.namespace,
+			'name_id': firstPkg.name_id,
+			'name': firstPkg.name,
+			'version_id': firstPkg.version_id,
+			'version': firstPkg.version,
+			'subpath': firstPkg.subpath,
+			'qualifier_list': firstPkg.qualifier_list
+		},
+		'depPkg': {
+			'type_id': secondPkg.typeID,
+			'type': secondPkg.type,
+			'namespace_id': secondPkg.namespace_id,
+			'namespace': secondPkg.namespace,
+			'name_id': secondPkg.name_id,
+			'name': secondPkg.name
+		},
+		'isDependency_id': isDependency._id,
+		'versionRange': isDependency.versionRange,
+		'dependencyType': isDependency.dependencyType,
+		'justification': isDependency.justification,
+		'collector': isDependency.collector,
+		'origin': isDependency.origin
 	}`
 
 	sb.WriteString(query)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestDependency")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+		return nil, fmt.Errorf("failed to ingest isDependency: %w", err)
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		FirstPkgType          string      `json:"firstPkgType"`
-		FirstPkgNamespace     string      `json:"firstPkgNamespace"`
-		FirstPkgName          string      `json:"firstPkgName"`
-		FirstPkgVersion       string      `json:"firstPkgVersion"`
-		FirstPkgSubpath       string      `json:"firstPkgSubpath"`
-		FirstPkgQualifierList interface{} `json:"firstPkgQualifier_list"`
-		SecondPkgType         string      `json:"secondPkgType"`
-		SecondPkgNamespace    string      `json:"secondPkgNamespace"`
-		SecondPkgName         string      `json:"secondPkgName"`
-		VersionRange          string      `json:"versionRange"`
-		DependencyType        string      `json:"dependencyType"`
-		Justification         string      `json:"justification"`
-		Collector             string      `json:"collector"`
-		Origin                string      `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest dependency: %w, values: %v", err, queryValues)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var isDependencyList []*model.IsDependency
-	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.FirstPkgType, createdValue.FirstPkgNamespace,
-			createdValue.FirstPkgName, createdValue.FirstPkgVersion, createdValue.FirstPkgSubpath, createdValue.FirstPkgQualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
-		depPkg, err := generateModelPackage(createdValue.SecondPkgType, createdValue.SecondPkgNamespace,
-			createdValue.SecondPkgName, nil, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get dependent model.package with err: %w", err)
-		}
-		dependencyTypeEnum, err := convertDependencyTypeToEnum(createdValue.DependencyType)
-		if err != nil {
-			return nil, fmt.Errorf("convertDependencyTypeToEnum failed with error: %w", err)
-		}
-
-		isDependency := &model.IsDependency{
-			Package:          pkg,
-			DependentPackage: depPkg,
-			VersionRange:     createdValue.VersionRange,
-			DependencyType:   dependencyTypeEnum,
-			Origin:           createdValue.Collector,
-			Collector:        createdValue.Origin,
-		}
-		isDependencyList = append(isDependencyList, isDependency)
-	}
-
-	return isDependencyList, nil
-
+	return getIsDependency(ctx, cursor)
 }
 
 func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
-	values := map[string]any{}
-
-	// add guac keys
-	pkgId := guacPkgId(pkg)
-	depPkgId := guacPkgId(depPkg)
-	values["pkgVersionGuacKey"] = pkgId.VersionId
-	values["secondPkgNameGuacKey"] = depPkgId.NameId
-
-	values[versionRange] = dependency.VersionRange
-	values[dependencyType] = dependency.DependencyType.String()
-	values[justification] = dependency.Justification
-	values[origin] = dependency.Origin
-	values[collector] = dependency.Collector
-
 	query := `
 	LET firstPkg = FIRST(
 		FOR pVersion in pkgVersions
@@ -251,9 +206,13 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
+		  'typeID': pType._id,
 		  'type': pType.type,
+		  'namespace_id': pNs._id,
 		  'namespace': pNs.namespace,
+		  'name_id': pName._id,
 		  'name': pName.name,
+		  'version_id': pVersion._id,
 		  'version': pVersion.version,
 		  'subpath': pVersion.subpath,
 		  'qualifier_list': pVersion.qualifier_list,
@@ -270,10 +229,13 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
           FILTER pType._id == pNs._parent
 
         RETURN {
-          'type': pType.type,
-          'namespace': pNs.namespace,
-          'name': pName.name,
-          'nameDoc': pName
+		  'typeID': pType._id,
+		  'type': pType.type,
+		  'namespace_id': pNs._id,
+		  'namespace': pNs.namespace,
+		  'name_id': pName._id,
+		  'name': pName.name,
+		  'nameDoc': pName
         }
     )
 	  
@@ -292,88 +254,49 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
 	  )
 	  
 	  RETURN {
-		  "firstPkgType": firstPkg.type,
-		  "firstPkgNamespace": firstPkg.namespace,
-		  "firstPkgName": firstPkg.name,
-		  "firstPkgVersion": firstPkg.version,
-		  "firstPkgSubpath": firstPkg.subpath,
-		  "firstPkgQualifier_list": firstPkg.qualifier_list,
-		  "secondPkgType": secondPkg.type,
-		  "secondPkgNamespace": secondPkg.namespace,
-		  "secondPkgName": secondPkg.name,
-		  "versionRange": isDependency.versionRange,
-		  "dependencyType": isDependency.dependencyType,
-		  "justification": isDependency.justification,
-		  "collector": isDependency.collector,
-		  "origin": isDependency.origin
+		'pkgVersion': {
+			'type_id': firstPkg.typeID,
+			'type': firstPkg.type,
+			'namespace_id': firstPkg.namespace_id,
+			'namespace': firstPkg.namespace,
+			'name_id': firstPkg.name_id,
+			'name': firstPkg.name,
+			'version_id': firstPkg.version_id,
+			'version': firstPkg.version,
+			'subpath': firstPkg.subpath,
+			'qualifier_list': firstPkg.qualifier_list
+		},
+		'depPkg': {
+			'type_id': secondPkg.typeID,
+			'type': secondPkg.type,
+			'namespace_id': secondPkg.namespace_id,
+			'namespace': secondPkg.namespace,
+			'name_id': secondPkg.name_id,
+			'name': secondPkg.name
+		},
+		'isDependency_id': isDependency._id,
+		'versionRange': isDependency.versionRange,
+		'dependencyType': isDependency.dependencyType,
+		'justification': isDependency.justification,
+		'collector': isDependency.collector,
+		'origin': isDependency.origin
 	  }`
 
-	cursor, err := executeQueryWithRetry(ctx, c.db, query, values, "IngestDependency")
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, getDependencyQueryValues(&pkg, &depPkg, &dependency), "IngestDependency")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+		return nil, fmt.Errorf("failed to ingest isDependency: %w", err)
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		FirstPkgType          string      `json:"firstPkgType"`
-		FirstPkgNamespace     string      `json:"firstPkgNamespace"`
-		FirstPkgName          string      `json:"firstPkgName"`
-		FirstPkgVersion       string      `json:"firstPkgVersion"`
-		FirstPkgSubpath       string      `json:"firstPkgSubpath"`
-		FirstPkgQualifierList interface{} `json:"firstPkgQualifier_list"`
-		SecondPkgType         string      `json:"secondPkgType"`
-		SecondPkgNamespace    string      `json:"secondPkgNamespace"`
-		SecondPkgName         string      `json:"secondPkgName"`
-		VersionRange          string      `json:"versionRange"`
-		DependencyType        string      `json:"dependencyType"`
-		Justification         string      `json:"justification"`
-		Collector             string      `json:"collector"`
-		Origin                string      `json:"origin"`
+	isDependencyList, err := getIsDependency(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dependency from arango cursor: %w", err)
 	}
 
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest dependency: %w, values: %v", err, values)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-	if len(createdValues) == 1 {
-
-		pkg, err := generateModelPackage(createdValues[0].FirstPkgType, createdValues[0].FirstPkgNamespace,
-			createdValues[0].FirstPkgName, createdValues[0].FirstPkgVersion, createdValues[0].FirstPkgSubpath, createdValues[0].FirstPkgQualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
-		depPkg, err := generateModelPackage(createdValues[0].SecondPkgType, createdValues[0].SecondPkgNamespace,
-			createdValues[0].SecondPkgName, nil, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get dependent model.package with err: %w", err)
-		}
-		dependencyTypeEnum, err := convertDependencyTypeToEnum(createdValues[0].DependencyType)
-		if err != nil {
-			return nil, fmt.Errorf("convertDependencyTypeToEnum failed with error: %w", err)
-		}
-
-		isDependency := &model.IsDependency{
-			Package:          pkg,
-			DependentPackage: depPkg,
-			VersionRange:     createdValues[0].VersionRange,
-			DependencyType:   dependencyTypeEnum,
-			Origin:           createdValues[0].Collector,
-			Collector:        createdValues[0].Origin,
-		}
-
-		return isDependency, nil
+	if len(isDependencyList) == 1 {
+		return isDependencyList[0], nil
 	} else {
-		return nil, fmt.Errorf("number of hashEqual ingested is greater than one")
+		return nil, fmt.Errorf("number of dependency ingested is greater than one")
 	}
 }
 
@@ -388,4 +311,82 @@ func convertDependencyTypeToEnum(status string) (model.DependencyType, error) {
 		return model.DependencyTypeUnknown, nil
 	}
 	return model.DependencyTypeUnknown, fmt.Errorf("failed to convert DependencyType to enum")
+}
+
+func getIsDependency(ctx context.Context, cursor driver.Cursor) ([]*model.IsDependency, error) {
+	type collectedData struct {
+		PkgVersion struct {
+			TypeID        string        `json:"type_id"`
+			PkgType       string        `json:"type"`
+			NamespaceID   string        `json:"namespace_id"`
+			Namespace     string        `json:"namespace"`
+			NameID        string        `json:"name_id"`
+			Name          string        `json:"name"`
+			VersionID     string        `json:"version_id"`
+			Version       string        `json:"version"`
+			Subpath       string        `json:"subpath"`
+			QualifierList []interface{} `json:"qualifier_list"`
+		} `json:"pkgVersion"`
+		DepPkg struct {
+			TypeID      string `json:"type_id"`
+			PkgType     string `json:"type"`
+			NamespaceID string `json:"namespace_id"`
+			Namespace   string `json:"namespace"`
+			NameID      string `json:"name_id"`
+			Name        string `json:"name"`
+		} `json:"depPkg"`
+		IsDependencyID string `json:"isDependency_id"`
+		VersionRange   string `json:"versionRange"`
+		DependencyType string `json:"dependencyType"`
+		Justification  string `json:"justification"`
+		Collector      string `json:"collector"`
+		Origin         string `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to package dependency from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var isDependencyList []*model.IsDependency
+	for _, createdValue := range createdValues {
+		pkg, err := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
+		}
+		depPkg, err := generateModelPackage(createdValue.DepPkg.TypeID, createdValue.DepPkg.PkgType, createdValue.DepPkg.NamespaceID, createdValue.DepPkg.Namespace, createdValue.DepPkg.NameID,
+			createdValue.DepPkg.Name, nil, nil, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dependent model.package with err: %w", err)
+		}
+		dependencyTypeEnum, err := convertDependencyTypeToEnum(createdValue.DependencyType)
+		if err != nil {
+			return nil, fmt.Errorf("convertDependencyTypeToEnum failed with error: %w", err)
+		}
+
+		isDependency := &model.IsDependency{
+			ID:               createdValue.IsDependencyID,
+			Package:          pkg,
+			DependentPackage: depPkg,
+			VersionRange:     createdValue.VersionRange,
+			DependencyType:   dependencyTypeEnum,
+			Justification:    createdValue.Justification,
+			Origin:           createdValue.Collector,
+			Collector:        createdValue.Origin,
+		}
+		isDependencyList = append(isDependencyList, isDependency)
+	}
+
+	return isDependencyList, nil
 }

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -85,13 +85,13 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgI
 	query := `
 
 	LET firstPkg = FIRST(
-		FOR pVersion in PkgVersions
+		FOR pVersion in pkgVersions
 		  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
-		FOR pName in PkgNames
+		FOR pName in pkgNames
 		  FILTER pName._id == pVersion._parent
-		FOR pNs in PkgNamespaces
+		FOR pNs in pkgNamespaces
 		  FILTER pNs._id == pName._parent
-		FOR pType in PkgTypes
+		FOR pType in pkgTypes
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
@@ -106,11 +106,11 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkg []*model.PkgI
 	)
 
     LET secondPkg = FIRST(
-        FOR pName in PkgNames
+        FOR pName in pkgNames
           FILTER pName.guacKey == doc.secondPkgNameGuacKey
-        FOR pNs in PkgNamespaces
+        FOR pNs in pkgNamespaces
           FILTER pNs._id == pName._parent
-        FOR pType in PkgTypes
+        FOR pType in pkgTypes
           FILTER pType._id == pNs._parent
 
         RETURN {
@@ -241,13 +241,13 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
 
 	query := `
 	LET firstPkg = FIRST(
-		FOR pVersion in PkgVersions
+		FOR pVersion in pkgVersions
 		  FILTER pVersion.guacKey == @pkgVersionGuacKey
-		FOR pName in PkgNames
+		FOR pName in pkgNames
 		  FILTER pName._id == pVersion._parent
-		FOR pNs in PkgNamespaces
+		FOR pNs in pkgNamespaces
 		  FILTER pNs._id == pName._parent
-		FOR pType in PkgTypes
+		FOR pType in pkgTypes
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
@@ -262,11 +262,11 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
 	)
 
     LET secondPkg = FIRST(
-        FOR pName in PkgNames
+        FOR pName in pkgNames
           FILTER pName.guacKey == @secondPkgNameGuacKey
-        FOR pNs in PkgNamespaces
+        FOR pNs in pkgNamespaces
           FILTER pNs._id == pName._parent
-        FOR pType in PkgTypes
+        FOR pType in pkgTypes
           FILTER pType._id == pNs._parent
 
         RETURN {

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -90,13 +90,13 @@ func (c *arangoClient) IngestOccurrences(ctx context.Context, subject model.Pack
 
 	query := `
 	LET firstPkg = FIRST(
-		FOR pVersion in PkgVersions
+		FOR pVersion in pkgVersions
 		  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
-		FOR pName in PkgNames
+		FOR pName in pkgNames
 		  FILTER pName._id == pVersion._parent
-		FOR pNs in PkgNamespaces
+		FOR pNs in pkgNamespaces
 		  FILTER pNs._id == pName._parent
-		FOR pType in PkgTypes
+		FOR pType in pkgTypes
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
@@ -224,13 +224,13 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 
 	query := `
 	LET firstPkg = FIRST(
-		FOR pVersion in PkgVersions
+		FOR pVersion in pkgVersions
 		  FILTER pVersion.guacKey == @pkgVersionGuacKey
-		FOR pName in PkgNames
+		FOR pName in pkgNames
 		  FILTER pName._id == pVersion._parent
-		FOR pNs in PkgNamespaces
+		FOR pNs in pkgNamespaces
 		  FILTER pNs._id == pName._parent
-		FOR pType in PkgType
+		FOR pType in pkgTypes
 		  FILTER pType._id == pNs._parent
 
 		RETURN {

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -27,202 +27,264 @@ import (
 
 // Query IsOccurrence
 func (c *arangoClient) IsOccurrence(ctx context.Context, isOccurrenceSpec *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error) {
-	panic(fmt.Errorf("not implemented: IsOccurrence - IsOccurrence"))
+	return []*model.IsOccurrence{}, fmt.Errorf("not implemented: IsOccurrence")
 }
 
 // Ingest IngestOccurrence
 
-func (c *arangoClient) IngestOccurrences(ctx context.Context, subject model.PackageOrSourceInputs, artifact []*model.ArtifactInputSpec, occurrence []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
-
-	// TODO(pxp928): currently only supporting package for testing. Will add in source once testing is completed
-	if len(subject.Packages) == 0 {
-		return nil, fmt.Errorf("source as a subject is currently unimplemented for the IngestOccurrence")
-	}
-
-	if len(subject.Packages) != len(artifact) {
-		return nil, fmt.Errorf("uneven packages and artifacts for ingestion")
-	} else if len(subject.Packages) != len(occurrence) {
-		return nil, fmt.Errorf("uneven packages and occurrence for ingestion")
-	}
-
-	listOfValues := []map[string]any{}
-
-	for i := range subject.Packages {
-		values := map[string]any{}
-
-		// add guac keys
-		pkgId := guacPkgId(*subject.Packages[i])
-		values["pkgVersionGuacKey"] = pkgId.VersionId
-
-		// dependent package
-		values["art_algorithm"] = strings.ToLower(artifact[i].Algorithm)
-		values["art_digest"] = strings.ToLower(artifact[i].Digest)
-
-		// isDependency
-
-		values[justification] = occurrence[i].Justification
-		values[origin] = occurrence[i].Origin
-		values[collector] = occurrence[i].Collector
-		listOfValues = append(listOfValues, values)
-	}
-
-	var documents []string
-	for _, val := range listOfValues {
-		bs, _ := json.Marshal(val)
-		documents = append(documents, string(bs))
-	}
-
-	queryValues := map[string]any{}
-	queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
-
-	var sb strings.Builder
-
-	sb.WriteString("for doc in [")
-	for i, val := range listOfValues {
-		bs, _ := json.Marshal(val)
-		if i == len(listOfValues)-1 {
-			sb.WriteString(string(bs))
-		} else {
-			sb.WriteString(string(bs) + ",")
-		}
-	}
-	sb.WriteString("]")
-
-	query := `
-	LET firstPkg = FIRST(
-		FOR pVersion in pkgVersions
-		  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
-		FOR pName in pkgNames
-		  FILTER pName._id == pVersion._parent
-		FOR pNs in pkgNamespaces
-		  FILTER pNs._id == pName._parent
-		FOR pType in pkgTypes
-		  FILTER pType._id == pNs._parent
-
-		RETURN {
-		  'type': pType.type,
-		  'namespace': pNs.namespace,
-		  'name': pName.name,
-		  'version': pVersion.version,
-		  'subpath': pVersion.subpath,
-		  'qualifier_list': pVersion.qualifier_list,
-		  'versionDoc': pVersion
-		}
-	)
-	  
-	  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
-	  
-	  LET isOccurrence = FIRST(
-		  UPSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			  INSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			  UPDATE {} IN isOccurrences
-			  RETURN NEW
-	  )
-	  
-	  LET edgeCollection = (FOR edgeData IN [
-		{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
-		{fromKey: firstPkg.versionDoc._key, toKey: isOccurrence._key, from: firstPkg.versionDoc._id, to: isOccurrence._id, label: "subject"}]
-	
-	  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
-	  )
-	  
-	  RETURN {
-		  "firstPkgType": firstPkg.type,
-		  "firstPkgNamespace": firstPkg.namespace,
-		  "firstPkgName": firstPkg.name,
-		  "firstPkgVersion": firstPkg.version,
-		  "firstPkgSubpath": firstPkg.subpath,
-		  "firstPkgQualifier_list": firstPkg.qualifier_list,
-		  "artAlgo": artifact.algorithm,
-		  "artDigest": artifact.digest,
-		  "justification": isOccurrence.justification,
-		  "collector": isOccurrence.collector,
-		  "origin": isOccurrence.origin
-	  }`
-
-	sb.WriteString(query)
-
-	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestOccurrence")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
-	}
-	defer cursor.Close()
-
-	type collectedData struct {
-		FirstPkgType          string      `json:"firstPkgType"`
-		FirstPkgNamespace     string      `json:"firstPkgNamespace"`
-		FirstPkgName          string      `json:"firstPkgName"`
-		FirstPkgVersion       string      `json:"firstPkgVersion"`
-		FirstPkgSubpath       string      `json:"firstPkgSubpath"`
-		FirstPkgQualifierList interface{} `json:"firstPkgQualifier_list"`
-		ArtAlgo               string      `json:"artAlgo"`
-		ArtDigest             string      `json:"artDigest"`
-		Justification         string      `json:"justification"`
-		Collector             string      `json:"collector"`
-		Origin                string      `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest occurrence: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var isOccurrenceList []*model.IsOccurrence
-	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.FirstPkgType, createdValue.FirstPkgNamespace,
-			createdValue.FirstPkgName, createdValue.FirstPkgVersion, createdValue.FirstPkgSubpath, createdValue.FirstPkgQualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
-
-		algorithm := createdValue.ArtAlgo
-		digest := createdValue.ArtDigest
-		artifact := generateModelArtifact(algorithm, digest)
-
-		isOccurrence := &model.IsOccurrence{
-			Subject:   pkg,
-			Artifact:  artifact,
-			Origin:    createdValue.Collector,
-			Collector: createdValue.Origin,
-		}
-		isOccurrenceList = append(isOccurrenceList, isOccurrence)
-
-	}
-
-	return isOccurrenceList, nil
-}
-
-func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error) {
+func getOccurrenceQueryValues(pkg *model.PkgInputSpec, src *model.SourceInputSpec, artifact *model.ArtifactInputSpec, occurrence *model.IsOccurrenceInputSpec) map[string]any {
 	values := map[string]any{}
-
-	// TODO(pxp928): currently only supporting package for testing. Will add in source once testing is completed
-	if subject.Package == nil {
-		return nil, fmt.Errorf("source as a subject is currently unimplemented for the IngestOccurrence")
-	}
-
 	// add guac keys
-	pkgId := guacPkgId(*subject.Package)
-	values["pkgVersionGuacKey"] = pkgId.VersionId
-
+	if pkg != nil {
+		pkgId := guacPkgId(*pkg)
+		values["pkgVersionGuacKey"] = pkgId.VersionId
+	} else {
+		source := guacSrcId(*src)
+		values["srcNameGuacKey"] = source.NameId
+	}
 	values["art_algorithm"] = strings.ToLower(artifact.Algorithm)
 	values["art_digest"] = strings.ToLower(artifact.Digest)
 	values[justification] = occurrence.Justification
 	values[origin] = occurrence.Origin
 	values[collector] = occurrence.Collector
-	// values["typeID"] = c.pkgTypeMap[subject.Package.Type].Id
-	// values["typeValue"] = c.pkgTypeMap[subject.Package.Type].PkgType
 
-	query := `
+	return values
+}
+
+func (c *arangoClient) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
+	if len(subjects.Packages) > 0 {
+		if len(subjects.Packages) != len(artifacts) {
+			return nil, fmt.Errorf("uneven packages and artifacts for ingestion")
+		} else if len(subjects.Packages) != len(occurrences) {
+			return nil, fmt.Errorf("uneven packages and occurrence for ingestion")
+		}
+
+		listOfValues := []map[string]any{}
+
+		for i := range subjects.Packages {
+			listOfValues = append(listOfValues, getOccurrenceQueryValues(subjects.Packages[i], nil, artifacts[i], occurrences[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+		  
+		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
+		  
+		  LET isOccurrence = FIRST(
+			  UPSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN isOccurrences
+				  RETURN NEW
+		  )
+		  
+		  LET edgeCollection = (FOR edgeData IN [
+			{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
+			{fromKey: firstPkg.versionDoc._key, toKey: isOccurrence._key, from: firstPkg.versionDoc._id, to: isOccurrence._id, label: "subject"}]
+		
+		  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'artifact': {
+				'id': artifact._id,
+				'algorithm': artifact.algorithm,
+				'digest': artifact.digest
+			},
+			'isOccurrence_id': isOccurrence._id,
+     		'justification': isOccurrence.justification,
+			'collector': isOccurrence.collector,
+			'origin': isOccurrence.origin
+		  }`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestOccurrence")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package occurrence: %w", err)
+		}
+		defer cursor.Close()
+
+		isOccurrenceList, err := getPkgIsOccurrence(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+		}
+
+		return isOccurrenceList, nil
+
+	} else if len(subjects.Sources) > 0 {
+		if len(subjects.Sources) != len(artifacts) {
+			return nil, fmt.Errorf("uneven sources and artifacts for ingestion")
+		} else if len(subjects.Sources) != len(occurrences) {
+			return nil, fmt.Errorf("uneven sources and occurrence for ingestion")
+		}
+
+		listOfValues := []map[string]any{}
+
+		for i := range subjects.Sources {
+			listOfValues = append(listOfValues, getOccurrenceQueryValues(nil, subjects.Sources[i], artifacts[i], occurrences[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == doc.srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
+		  
+		  LET isOccurrence = FIRST(
+			  UPSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN isOccurrences
+				  RETURN NEW
+		  )
+		  
+		  LET edgeCollection = (FOR edgeData IN [
+			{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
+			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.nameDoc._id, to: isOccurrence._id, label: "subject"}]
+		
+		  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+		  
+		  RETURN {
+			'srcName': {
+				'type_id': firstSrc.typeID,
+				'type': firstSrc.type,
+				'namespace_id': firstSrc.namespace_id,
+				'namespace': firstSrc.namespace,
+				'name_id': firstSrc.name_id,
+				'name': firstSrc.name,
+				'commit': firstSrc.commit,
+				'tag': firstSrc.tag
+			},
+			'artifact': {
+				'id': artifact._id,
+				'algorithm': artifact.algorithm,
+				'digest': artifact.digest
+			},
+			'isOccurrence_id': isOccurrence._id,
+     		'justification': isOccurrence.justification,
+			'collector': isOccurrence.collector,
+			'origin': isOccurrence.origin
+		  }`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestOccurrence")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source occurrence: %w", err)
+		}
+		defer cursor.Close()
+		isOccurrenceList, err := getSrcIsOccurrence(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+		}
+
+		return isOccurrenceList, nil
+
+	} else {
+		return nil, fmt.Errorf("package or source not specified for IngestOccurrence")
+	}
+}
+
+func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error) {
+	if subject.Package != nil {
+		query := `
 	LET firstPkg = FIRST(
 		FOR pVersion in pkgVersions
 		  FILTER pVersion.guacKey == @pkgVersionGuacKey
@@ -234,9 +296,13 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 		  FILTER pType._id == pNs._parent
 
 		RETURN {
+		  'typeID': pType._id,
 		  'type': pType.type,
+		  'namespace_id': pNs._id,
 		  'namespace': pNs.namespace,
+		  'name_id': pName._id,
 		  'name': pName.name,
+		  'version_id': pVersion._id,
 		  'version': pVersion.version,
 		  'subpath': pVersion.subpath,
 		  'qualifier_list': pVersion.qualifier_list,
@@ -260,38 +326,149 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 	  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
 	)
 	  
-	  RETURN {
-		  "firstPkgType": firstPkg.type,
-		  "firstPkgNamespace": firstPkg.namespace,
-		  "firstPkgName": firstPkg.name,
-		  "firstPkgVersion": firstPkg.version,
-		  "firstPkgSubpath": firstPkg.subpath,
-		  "firstPkgQualifier_list": firstPkg.qualifier_list,
-		  "artAlgo": artifact.algorithm,
-		  "artDigest": artifact.digest,
-		  "justification": isOccurrence.justification,
-		  "collector": isOccurrence.collector,
-		  "origin": isOccurrence.origin
+	RETURN {
+		'pkgVersion': {
+			'type_id': firstPkg.typeID,
+			'type': firstPkg.type,
+			'namespace_id': firstPkg.namespace_id,
+			'namespace': firstPkg.namespace,
+			'name_id': firstPkg.name_id,
+			'name': firstPkg.name,
+			'version_id': firstPkg.version_id,
+			'version': firstPkg.version,
+			'subpath': firstPkg.subpath,
+			'qualifier_list': firstPkg.qualifier_list
+		},
+		'artifact': {
+			'id': artifact._id,
+			'algorithm': artifact.algorithm,
+			'digest': artifact.digest
+		},
+		'isOccurrence_id': isOccurrence._id,
+		'justification': isOccurrence.justification,
+		'collector': isOccurrence.collector,
+		'origin': isOccurrence.origin
 	  }`
 
-	cursor, err := executeQueryWithRetry(ctx, c.db, query, values, "IngestOccurrence")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
-	}
-	defer cursor.Close()
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getOccurrenceQueryValues(subject.Package, nil, &artifact, &occurrence), "IngestOccurrence")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package occurrence: %w", err)
+		}
+		defer cursor.Close()
 
+		isOccurrenceList, err := getPkgIsOccurrence(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+		}
+
+		if len(isOccurrenceList) == 1 {
+			return isOccurrenceList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of occurrences ingested is greater than one")
+		}
+
+	} else if subject.Source != nil {
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == @srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
+		  
+		  LET isOccurrence = FIRST(
+			  UPSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
+				  INSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
+				  UPDATE {} IN isOccurrences
+				  RETURN NEW
+		  )
+		  
+		  LET edgeCollection = (FOR edgeData IN [
+			{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
+			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.nameDoc._id, to: isOccurrence._id, label: "subject"}]
+		
+		  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+		  
+		  RETURN {
+			'srcName': {
+				'type_id': firstSrc.typeID,
+				'type': firstSrc.type,
+				'namespace_id': firstSrc.namespace_id,
+				'namespace': firstSrc.namespace,
+				'name_id': firstSrc.name_id,
+				'name': firstSrc.name,
+				'commit': firstSrc.commit,
+				'tag': firstSrc.tag
+			},
+			'artifact': {
+				'id': artifact._id,
+				'algorithm': artifact.algorithm,
+				'digest': artifact.digest
+			},
+			'isOccurrence_id': isOccurrence._id,
+     		'justification': isOccurrence.justification,
+			'collector': isOccurrence.collector,
+			'origin': isOccurrence.origin
+		  }`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getOccurrenceQueryValues(nil, subject.Source, &artifact, &occurrence), "IngestOccurrence")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source occurrence: %w", err)
+		}
+		defer cursor.Close()
+
+		isOccurrenceList, err := getSrcIsOccurrence(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+		}
+
+		if len(isOccurrenceList) == 1 {
+			return isOccurrenceList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of occurrences ingested is greater than one")
+		}
+
+	} else {
+		return nil, fmt.Errorf("package or source not specified for IngestOccurrence")
+	}
+}
+
+func getPkgIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsOccurrence, error) {
 	type collectedData struct {
-		FirstPkgType          string      `json:"firstPkgType"`
-		FirstPkgNamespace     string      `json:"firstPkgNamespace"`
-		FirstPkgName          string      `json:"firstPkgName"`
-		FirstPkgVersion       string      `json:"firstPkgVersion"`
-		FirstPkgSubpath       string      `json:"firstPkgSubpath"`
-		FirstPkgQualifierList interface{} `json:"firstPkgQualifier_list"`
-		ArtAlgo               string      `json:"artAlgo"`
-		ArtDigest             string      `json:"artDigest"`
-		Justification         string      `json:"justification"`
-		Collector             string      `json:"collector"`
-		Origin                string      `json:"origin"`
+		PkgVersion struct {
+			TypeID        string        `json:"type_id"`
+			PkgType       string        `json:"type"`
+			NamespaceID   string        `json:"namespace_id"`
+			Namespace     string        `json:"namespace"`
+			NameID        string        `json:"name_id"`
+			Name          string        `json:"name"`
+			VersionID     string        `json:"version_id"`
+			Version       string        `json:"version"`
+			Subpath       string        `json:"subpath"`
+			QualifierList []interface{} `json:"qualifier_list"`
+		} `json:"pkgVersion"`
+		Artifact       model.Artifact `json:"artifact"`
+		IsOccurrenceID string         `json:"isOccurrence_id"`
+		Justification  string         `json:"justification"`
+		Collector      string         `json:"collector"`
+		Origin         string         `json:"origin"`
 	}
 
 	var createdValues []collectedData
@@ -302,32 +479,80 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 			if driver.IsNoMoreDocuments(err) {
 				break
 			} else {
-				return nil, fmt.Errorf("failed to ingest occurrence: %w", err)
+				return nil, fmt.Errorf("failed to package occurrence from cursor: %w", err)
 			}
 		} else {
 			createdValues = append(createdValues, doc)
 		}
 	}
-	if len(createdValues) == 1 {
 
-		pkg, err := generateModelPackage(createdValues[0].FirstPkgType, createdValues[0].FirstPkgNamespace,
-			createdValues[0].FirstPkgName, createdValues[0].FirstPkgVersion, createdValues[0].FirstPkgSubpath, createdValues[0].FirstPkgQualifierList)
+	var isOccurrenceList []*model.IsOccurrence
+	for _, createdValue := range createdValues {
+		pkg, err := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
 		}
-		algorithm := createdValues[0].ArtAlgo
-		digest := createdValues[0].ArtDigest
-		artifact := generateModelArtifact(algorithm, digest)
 
 		isOccurrence := &model.IsOccurrence{
+			ID:        createdValue.IsOccurrenceID,
 			Subject:   pkg,
-			Artifact:  artifact,
-			Origin:    createdValues[0].Collector,
-			Collector: createdValues[0].Origin,
+			Artifact:  &createdValue.Artifact,
+			Origin:    createdValue.Collector,
+			Collector: createdValue.Origin,
 		}
-
-		return isOccurrence, nil
-	} else {
-		return nil, fmt.Errorf("number of hashEqual ingested is greater than one")
+		isOccurrenceList = append(isOccurrenceList, isOccurrence)
 	}
+	return isOccurrenceList, nil
+}
+
+func getSrcIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsOccurrence, error) {
+	type collectedData struct {
+		SrcName struct {
+			TypeID      string `json:"type_id"`
+			SrcType     string `json:"type"`
+			NamespaceID string `json:"namespace_id"`
+			Namespace   string `json:"namespace"`
+			NameID      string `json:"name_id"`
+			Name        string `json:"name"`
+			Commit      string `json:"commit"`
+			Tag         string `json:"tag"`
+		} `json:"srcName"`
+		Artifact       model.Artifact `json:"artifact"`
+		IsOccurrenceID string         `json:"isOccurrence_id"`
+		Justification  string         `json:"justification"`
+		Collector      string         `json:"collector"`
+		Origin         string         `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to get source occurrence from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var isOccurrenceList []*model.IsOccurrence
+	for _, createdValue := range createdValues {
+		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+			createdValue.SrcName.NameID, createdValue.SrcName.Name, &createdValue.SrcName.Commit, &createdValue.SrcName.Tag)
+
+		isOccurrence := &model.IsOccurrence{
+			ID:        createdValue.IsOccurrenceID,
+			Subject:   src,
+			Artifact:  &createdValue.Artifact,
+			Origin:    createdValue.Collector,
+			Collector: createdValue.Origin,
+		}
+		isOccurrenceList = append(isOccurrenceList, isOccurrence)
+	}
+	return isOccurrenceList, nil
 }

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -160,7 +160,7 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	  UPSERT { namespace: doc.namespace, _parent: doc.typeID , guacKey: doc.guacNsKey}
 	  INSERT { namespace: doc.namespace, _parent: doc.typeID , guacKey: doc.guacNsKey}
 	  UPDATE {}
-	  IN PkgNamespaces OPTIONS { indexHint: "byNsGuacKey" }
+	  IN pkgNamespaces OPTIONS { indexHint: "byNsGuacKey" }
 	  RETURN NEW
 	)
 	
@@ -168,7 +168,7 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	  UPSERT { name: doc.name, _parent: ns._id, guacKey: doc.guacNameKey}
 	  INSERT { name: doc.name, _parent: ns._id, guacKey: doc.guacNameKey}
 	  UPDATE {}
-	  IN PkgNames OPTIONS { indexHint: "byNameGuacKey" }
+	  IN pkgNames OPTIONS { indexHint: "byNameGuacKey" }
 	  RETURN NEW
 	)
 	
@@ -176,20 +176,20 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	  UPSERT { version: doc.version, subpath: doc.subpath, qualifier_list: doc.qualifier, _parent: name._id, guacKey: doc.guacVersionKey}
 	  INSERT { version: doc.version, subpath: doc.subpath, qualifier_list: doc.qualifier, _parent: name._id, guacKey: doc.guacVersionKey}
 	  UPDATE {}
-	  IN PkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
+	  IN pkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
 	  RETURN NEW
 	)
   
 	LET pkgHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("pkgHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "PkgHasNamespace"} INTO PkgHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("pkgHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "pkgHasNamespace"} INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasNameCollection = (
-	  INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "PkgHasName"} INTO PkgHasName OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "pkgHasName"} INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasVersionCollection = (
-	  INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "PkgHasVersion"} INTO PkgHasVersion OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "pkgHasVersion"} INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
 	)
 	  
   RETURN {
@@ -293,7 +293,7 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 		UPSERT { namespace: @namespace, _parent: @typeID , guacKey: @guacNsKey}
 		INSERT { namespace: @namespace, _parent: @typeID , guacKey: @guacNsKey}
 		UPDATE {}
-		IN PkgNamespaces OPTIONS { indexHint: "byNsGuacKey" }
+		IN pkgNamespaces OPTIONS { indexHint: "byNsGuacKey" }
 		RETURN NEW
 	  )
 	  
@@ -301,7 +301,7 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 		UPSERT { name: @name, _parent: ns._id, guacKey: @guacNameKey}
 		INSERT { name: @name, _parent: ns._id, guacKey: @guacNameKey}
 		UPDATE {}
-		IN PkgNames OPTIONS { indexHint: "byNameGuacKey" }
+		IN pkgNames OPTIONS { indexHint: "byNameGuacKey" }
 		RETURN NEW
 	  )
 	  
@@ -309,20 +309,20 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 		UPSERT { version: @version, subpath: @subpath, qualifier_list: @qualifier, _parent: name._id, guacKey: @guacVersionKey}
 		INSERT { version: @version, subpath: @subpath, qualifier_list: @qualifier, _parent: name._id, guacKey: @guacVersionKey}
 		UPDATE {}
-		IN PkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
+		IN pkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
 		RETURN NEW
 	  )
 	
 	  LET pkgHasNamespaceCollection = (
-		INSERT { _key: CONCAT("pkgHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "PkgHasNamespace"} INTO PkgHasNamespace OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "pkgHasNamespace"} INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
 	  )
 	  
 	  LET pkgHasNameCollection = (
-		INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "PkgHasName"} INTO PkgHasName OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "pkgHasName"} INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
 	  )
 	  
 	  LET pkgHasVersionCollection = (
-		INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "PkgHasVersion"} INTO PkgHasVersion OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "pkgHasVersion"} INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
 	  )
 		
 	RETURN {
@@ -491,25 +491,25 @@ func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("PkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("PkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasName", "pName", "pNs")
+	arangoQueryBuilder.ForOutBound("pkgHasName", "pName", "pNs")
 	if pkgSpec.Name != nil {
 		arangoQueryBuilder.filter("pName", "name", "==", "@name")
 		values["name"] = *pkgSpec.Name
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasVersion", "pVersion", "pName")
+	arangoQueryBuilder.ForOutBound("pkgHasVersion", "pVersion", "pName")
 	if pkgSpec.Version != nil {
 		arangoQueryBuilder.filter("pVersion", "version", "==", "@version")
 		values["version"] = *pkgSpec.Version
@@ -644,10 +644,10 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("PkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("PkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
@@ -697,15 +697,15 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("PkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("PkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
@@ -772,20 +772,20 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("PkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("PkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("PkgHasName", "pName", "pNs")
+	arangoQueryBuilder.ForOutBound("pkgHasName", "pName", "pNs")
 	if pkgSpec.Name != nil {
 		arangoQueryBuilder.filter("pName", "name", "==", "@name")
 		values["name"] = *pkgSpec.Name

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -315,25 +315,25 @@ func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasName", "pName", "pNs")
+	arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
 	if pkgSpec.Name != nil {
 		arangoQueryBuilder.filter("pName", "name", "==", "@name")
 		values["name"] = *pkgSpec.Name
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasVersion", "pVersion", "pName")
+	arangoQueryBuilder.ForOutBound(pkgHasVersionStr, "pVersion", "pName")
 	if pkgSpec.Version != nil {
 		arangoQueryBuilder.filter("pVersion", "version", "==", "@version")
 		values["version"] = *pkgSpec.Version
@@ -375,10 +375,10 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
@@ -428,15 +428,15 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
@@ -503,20 +503,20 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("pkgRoots", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound("pkgHasType", "pType", "pRoot")
+	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasNamespace", "pNs", "pType")
+	arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("pkgHasName", "pName", "pNs")
+	arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
 	if pkgSpec.Name != nil {
 		arangoQueryBuilder.filter("pName", "name", "==", "@name")
 		values["name"] = *pkgSpec.Name

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -83,54 +83,56 @@ func guacPkgId(pkg model.PkgInputSpec) PkgIds {
 	return ids
 }
 
+func getPackageQueryValues(c *arangoClient, pkg *model.PkgInputSpec) map[string]any {
+	values := map[string]any{}
+
+	// add guac keys
+	values["typeID"] = c.pkgTypeMap[pkg.Type].Id
+	values["typeKey"] = c.pkgTypeMap[pkg.Type].Key
+	values["typeValue"] = c.pkgTypeMap[pkg.Type].PkgType
+
+	guacIds := guacPkgId(*pkg)
+	values["guacNsKey"] = guacIds.NamespaceId
+	values["guacNameKey"] = guacIds.NameId
+	values["guacVersionKey"] = guacIds.VersionId
+
+	values["name"] = pkg.Name
+	if pkg.Namespace != nil {
+		values["namespace"] = *pkg.Namespace
+	} else {
+		values["namespace"] = ""
+	}
+	if pkg.Version != nil {
+		values["version"] = *pkg.Version
+	} else {
+		values["version"] = ""
+	}
+	if pkg.Subpath != nil {
+		values["subpath"] = *pkg.Subpath
+	} else {
+		values["subpath"] = ""
+	}
+
+	// To ensure consistency, always sort the qualifiers by key
+	qualifiersMap := map[string]string{}
+	keys := []string{}
+	for _, kv := range pkg.Qualifiers {
+		qualifiersMap[kv.Key] = kv.Value
+		keys = append(keys, kv.Key)
+	}
+	sort.Strings(keys)
+	qualifiers := []string{}
+	for _, k := range keys {
+		qualifiers = append(qualifiers, k, qualifiersMap[k])
+	}
+	values["qualifier"] = qualifiers
+	return values
+}
+
 func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]*model.Package, error) {
 	listOfValues := []map[string]any{}
-
 	for i := range pkgs {
-		values := map[string]any{}
-
-		// add guac keys
-		values["typeID"] = c.pkgTypeMap[pkgs[i].Type].Id
-		values["typeKey"] = c.pkgTypeMap[pkgs[i].Type].Key
-		values["typeValue"] = c.pkgTypeMap[pkgs[i].Type].PkgType
-
-		guacIds := guacPkgId(*pkgs[i])
-		values["guacNsKey"] = guacIds.NamespaceId
-		values["guacNameKey"] = guacIds.NameId
-		values["guacVersionKey"] = guacIds.VersionId
-
-		values["name"] = pkgs[i].Name
-		if pkgs[i].Namespace != nil {
-			values["namespace"] = *pkgs[i].Namespace
-		} else {
-			values["namespace"] = ""
-		}
-		if pkgs[i].Version != nil {
-			values["version"] = *pkgs[i].Version
-		} else {
-			values["version"] = ""
-		}
-		if pkgs[i].Subpath != nil {
-			values["subpath"] = *pkgs[i].Subpath
-		} else {
-			values["subpath"] = ""
-		}
-
-		// To ensure consistency, always sort the qualifiers by key
-		qualifiersMap := map[string]string{}
-		keys := []string{}
-		for _, kv := range pkgs[i].Qualifiers {
-			qualifiersMap[kv.Key] = kv.Value
-			keys = append(keys, kv.Key)
-		}
-		sort.Strings(keys)
-		qualifiers := []string{}
-		for _, k := range keys {
-			qualifiers = append(qualifiers, k, qualifiersMap[k])
-		}
-		values["qualifier"] = qualifiers
-
-		listOfValues = append(listOfValues, values)
+		listOfValues = append(listOfValues, getPackageQueryValues(c, pkgs[i]))
 	}
 
 	var documents []string
@@ -193,101 +195,29 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	)
 	  
   RETURN {
-  "type": doc.typeValue,
-  "namespace": ns.namespace,
-  "name": name.name,
-  "version": pkgVersionObj.version,
-  "subpath": pkgVersionObj.subpath,
-  "qualifier_list": pkgVersionObj.qualifier_list
+	"type_id": doc.typeID,
+	"type": doc.typeValue,
+	"namespace_id": ns._id,
+	"namespace": ns.namespace,
+	"name_id": name._id,
+	"name": name.name,
+	"version_id": pkgVersionObj._id,
+	"version": pkgVersionObj.version,
+	"subpath": pkgVersionObj.subpath,
+	"qualifier_list": pkgVersionObj.qualifier_list
 }`
 
 	sb.WriteString(query)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestPackages")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+		return nil, fmt.Errorf("failed to ingest package: %w", err)
 	}
 
-	type collectedData struct {
-		PkgType       string      `json:"type"`
-		Namespace     string      `json:"namespace"`
-		Name          string      `json:"name"`
-		Version       string      `json:"version"`
-		Subpath       string      `json:"subpath"`
-		QualifierList interface{} `json:"qualifier_list"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				cursor.Close()
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest package: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var packageList []*model.Package
-	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.PkgType, createdValue.Namespace,
-			createdValue.Name, createdValue.Version, createdValue.Subpath, createdValue.QualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
-		packageList = append(packageList, pkg)
-	}
-
-	return packageList, nil
+	return getPackages(ctx, cursor)
 }
 
 func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error) {
-
-	values := map[string]any{}
-	values["name"] = pkg.Name
-	if pkg.Namespace != nil {
-		values["namespace"] = *pkg.Namespace
-	} else {
-		values["namespace"] = ""
-	}
-	if pkg.Version != nil {
-		values["version"] = *pkg.Version
-	} else {
-		values["version"] = ""
-	}
-	if pkg.Subpath != nil {
-		values["subpath"] = *pkg.Subpath
-	} else {
-		values["subpath"] = ""
-	}
-
-	// To ensure consistency, always sort the qualifiers by key
-	qualifiersMap := map[string]string{}
-	keys := []string{}
-	for _, kv := range pkg.Qualifiers {
-		qualifiersMap[kv.Key] = kv.Value
-		keys = append(keys, kv.Key)
-	}
-	sort.Strings(keys)
-	qualifiers := []string{}
-	for _, k := range keys {
-		qualifiers = append(qualifiers, k, qualifiersMap[k])
-	}
-	values["qualifier"] = qualifiers
-	values["typeID"] = c.pkgTypeMap[pkg.Type].Id
-	values["typeKey"] = c.pkgTypeMap[pkg.Type].Key
-	values["typeValue"] = c.pkgTypeMap[pkg.Type].PkgType
-
-	guacIds := guacPkgId(pkg)
-	values["guacNsKey"] = guacIds.NamespaceId
-	values["guacNameKey"] = guacIds.NameId
-	values["guacVersionKey"] = guacIds.VersionId
-
 	query := `	  
 	  LET ns = FIRST(
 		UPSERT { namespace: @namespace, _parent: @typeID , guacKey: @guacNsKey}
@@ -326,138 +256,32 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 	  )
 		
 	RETURN {
-    "type": @typeValue,
-    "namespace": ns.namespace,
-    "name": name.name,
-    "version": pkgVersionObj.version,
-    "subpath": pkgVersionObj.subpath,
-    "qualifier_list": pkgVersionObj.qualifier_list
+	  "type_id": @typeID,
+	  "type": @typeValue,
+	  "namespace_id": ns._id,
+	  "namespace": ns.namespace,
+	  "name_id": name._id,
+	  "name": name.name,
+	  "version_id": pkgVersionObj._id,
+	  "version": pkgVersionObj.version,
+	  "subpath": pkgVersionObj.subpath,
+	  "qualifier_list": pkgVersionObj.qualifier_list
   }`
 
-	cursor, err := executeQueryWithRetry(ctx, c.db, query, values, "IngestPackage")
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, getPackageQueryValues(c, &pkg), "IngestPackage")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w, values: %v", err, values)
+		return nil, fmt.Errorf("failed to ingest package: %w", err)
 	}
 
-	type collectedData struct {
-		PkgType       string      `json:"type"`
-		Namespace     string      `json:"namespace"`
-		Name          string      `json:"name"`
-		Version       string      `json:"version"`
-		Subpath       string      `json:"subpath"`
-		QualifierList interface{} `json:"qualifier_list"`
+	createdPackages, err := getPackages(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get packages from arango cursor: %w", err)
 	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				cursor.Close()
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest package: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-	if len(createdValues) == 1 {
-		return generateModelPackage(createdValues[0].PkgType, createdValues[0].Namespace,
-			createdValues[0].Name, createdValues[0].Version, createdValues[0].Subpath, createdValues[0].QualifierList)
+	if len(createdPackages) == 1 {
+		return createdPackages[0], nil
 	} else {
-		return nil, fmt.Errorf("number of hashEqual ingested is greater than one")
+		return nil, fmt.Errorf("number of packages ingested is greater than one")
 	}
-}
-
-func getCollectedPackageQualifiers(qualifierList []interface{}) ([]*model.PackageQualifier, error) {
-	qualifiers := []*model.PackageQualifier{}
-	for i := range qualifierList {
-		if i%2 == 0 {
-			key, ok := qualifierList[i].(string)
-			if !ok {
-				return nil, fmt.Errorf("failed to assert string value for pkg qualifier's key")
-			}
-			value, ok := qualifierList[i+1].(string)
-			if !ok {
-				return nil, fmt.Errorf("failed to assert string value for pkg qualifier's value")
-			}
-			qualifier := &model.PackageQualifier{
-				Key:   key,
-				Value: value,
-			}
-			qualifiers = append(qualifiers, qualifier)
-		}
-	}
-	return qualifiers, nil
-}
-
-func generateModelPackage(pkgType, namespaceStr, nameStr string, versionValue, subPathValue, qualifiersValue interface{}) (*model.Package, error) {
-	var version *model.PackageVersion = nil
-	if versionValue != nil && subPathValue != nil && qualifiersValue != nil {
-		qualifiersList, ok := qualifiersValue.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failed to assert slice for pkg qualifiers")
-		}
-		subPathString, ok := subPathValue.(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to assert string value for pkg subpath")
-		}
-		versionString, ok := versionValue.(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to assert string value for pkg version")
-		}
-		qualifiers, err := getCollectedPackageQualifiers(qualifiersList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get qualifiers with error: %w", err)
-		}
-		version = &model.PackageVersion{
-			Version:    versionString,
-			Subpath:    subPathString,
-			Qualifiers: qualifiers,
-		}
-	}
-
-	versions := []*model.PackageVersion{}
-	if version != nil {
-		versions = append(versions, version)
-	}
-	name := &model.PackageName{
-		Name:     nameStr,
-		Versions: versions,
-	}
-	namespace := &model.PackageNamespace{
-		Namespace: namespaceStr,
-		Names:     []*model.PackageName{name},
-	}
-	pkg := model.Package{
-		Type:       pkgType,
-		Namespaces: []*model.PackageNamespace{namespace},
-	}
-	return &pkg, nil
-}
-
-func getQualifiers(qualifiersSpec []*model.PackageQualifierSpec) []string {
-	qualifiersMap := map[string]string{}
-	keys := []string{}
-	for _, kv := range qualifiersSpec {
-		key := removeInvalidCharFromProperty(kv.Key)
-		qualifiersMap[key] = *kv.Value
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	qualifiers := []string{}
-	for _, k := range keys {
-		qualifiers = append(qualifiers, k, qualifiersMap[k])
-	}
-	return qualifiers
-}
-
-func removeInvalidCharFromProperty(key string) string {
-	// neo4j does not accept "." in its properties. If the qualifier contains a "." that must
-	// be replaced by an "-"
-	return strings.ReplaceAll(key, ".", "_")
 }
 
 func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
@@ -540,104 +364,11 @@ func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "Packages")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w, values: %v", err, values)
+		return nil, fmt.Errorf("failed to query for packages: %w", err)
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID        string        `json:"type_id"`
-		PkgType       string        `json:"type"`
-		NamespaceID   string        `json:"namespace_id"`
-		Namespace     string        `json:"namespace"`
-		NameID        string        `json:"name_id"`
-		Name          string        `json:"name"`
-		VersionID     string        `json:"version_id"`
-		Version       string        `json:"version"`
-		Subpath       string        `json:"subpath"`
-		QualifierList []interface{} `json:"qualifier_list"`
-	}
-
-	pkgTypes := map[string]map[string]map[string][]*model.PackageVersion{}
-	var doc collectedData
-	for {
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to query packages: %w", err)
-			}
-		} else {
-			var pkgQualifiers []*model.PackageQualifier
-			if doc.QualifierList != nil {
-				pkgQualifiers, err = getCollectedPackageQualifiers(doc.QualifierList)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get package qualifiers with error: %w", err)
-				}
-			}
-
-			subPathString := doc.Subpath
-			versionString := doc.Version
-			nameString := doc.Name + "," + doc.NameID
-			namespaceString := doc.Namespace + "," + doc.NamespaceID
-			typeString := doc.PkgType + "," + doc.TypeID
-
-			pkgVersion := &model.PackageVersion{
-				ID:         doc.VersionID,
-				Version:    versionString,
-				Subpath:    subPathString,
-				Qualifiers: pkgQualifiers,
-			}
-
-			if pkgNamespaces, ok := pkgTypes[typeString]; ok {
-				if pkgNames, ok := pkgNamespaces[namespaceString]; ok {
-					pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
-				} else {
-					pkgNames := map[string][]*model.PackageVersion{}
-					pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
-					pkgNamespaces[namespaceString] = pkgNames
-					pkgTypes[typeString] = pkgNamespaces
-				}
-			} else {
-				pkgNames := map[string][]*model.PackageVersion{}
-				pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
-				pkgNamespaces := map[string]map[string][]*model.PackageVersion{}
-				pkgNamespaces[namespaceString] = pkgNames
-				pkgTypes[typeString] = pkgNamespaces
-			}
-		}
-	}
-	var packages []*model.Package
-	for pkgType, pkgNamespaces := range pkgTypes {
-		collectedPkgNamespaces := []*model.PackageNamespace{}
-		for namespace, pkgNames := range pkgNamespaces {
-			collectedPkgNames := []*model.PackageName{}
-			for name, versions := range pkgNames {
-				nameValues := strings.Split(name, ",")
-				pkgName := &model.PackageName{
-					ID:       nameValues[1],
-					Name:     nameValues[0],
-					Versions: versions,
-				}
-				collectedPkgNames = append(collectedPkgNames, pkgName)
-			}
-			namespaceValues := strings.Split(namespace, ",")
-			pkgNamespace := &model.PackageNamespace{
-				ID:        namespaceValues[1],
-				Namespace: namespaceValues[0],
-				Names:     collectedPkgNames,
-			}
-			collectedPkgNamespaces = append(collectedPkgNamespaces, pkgNamespace)
-		}
-		typeValues := strings.Split(pkgType, ",")
-		collectedPackage := &model.Package{
-			ID:         typeValues[1],
-			Type:       typeValues[0],
-			Namespaces: collectedPkgNamespaces,
-		}
-		packages = append(packages, collectedPackage)
-	}
-	return packages, nil
+	return getPackages(ctx, cursor)
 }
 
 func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
@@ -662,7 +393,7 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "packagesType")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w, values: %v", err, values)
+		return nil, fmt.Errorf("failed to query for package types: %w, values: %v", err, values)
 	}
 	defer cursor.Close()
 
@@ -715,14 +446,14 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 		"type_id": pType._id,
 		"type": pType.type,
 		"namespace_id": pNs._id,
-		"namespace": pNs.namespace,
+		"namespace": pNs.namespace
 	  }`)
 
 	fmt.Println(arangoQueryBuilder.string())
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "packagesNamespace")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w, values: %v", err, values)
+		return nil, fmt.Errorf("failed to query for package namespaces: %w, values: %v", err, values)
 	}
 	defer cursor.Close()
 
@@ -797,14 +528,14 @@ func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec)
 		"namespace_id": pNs._id,
 		"namespace": pNs.namespace,
 		"name_id": pName._id,
-		"name": pName.name,
+		"name": pName.name
 	  }`)
 
 	fmt.Println(arangoQueryBuilder.string())
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "packagesName")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w, values: %v", err, values)
+		return nil, fmt.Errorf("failed to query for package names: %w, values: %v", err, values)
 	}
 	defer cursor.Close()
 
@@ -869,4 +600,186 @@ func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec)
 	}
 
 	return packages, nil
+}
+
+func getPackages(ctx context.Context, cursor driver.Cursor) ([]*model.Package, error) {
+	type collectedData struct {
+		TypeID        string        `json:"type_id"`
+		PkgType       string        `json:"type"`
+		NamespaceID   string        `json:"namespace_id"`
+		Namespace     string        `json:"namespace"`
+		NameID        string        `json:"name_id"`
+		Name          string        `json:"name"`
+		VersionID     string        `json:"version_id"`
+		Version       string        `json:"version"`
+		Subpath       string        `json:"subpath"`
+		QualifierList []interface{} `json:"qualifier_list"`
+	}
+
+	pkgTypes := map[string]map[string]map[string][]*model.PackageVersion{}
+	var doc collectedData
+	for {
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to get packages from cursor: %w", err)
+			}
+		} else {
+			var pkgQualifiers []*model.PackageQualifier
+			if doc.QualifierList != nil {
+				pkgQualifiers, err = getCollectedPackageQualifiers(doc.QualifierList)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get package qualifiers with error: %w", err)
+				}
+			}
+
+			subPathString := doc.Subpath
+			versionString := doc.Version
+			nameString := doc.Name + "," + doc.NameID
+			namespaceString := doc.Namespace + "," + doc.NamespaceID
+			typeString := doc.PkgType + "," + doc.TypeID
+
+			pkgVersion := &model.PackageVersion{
+				ID:         doc.VersionID,
+				Version:    versionString,
+				Subpath:    subPathString,
+				Qualifiers: pkgQualifiers,
+			}
+
+			if pkgNamespaces, ok := pkgTypes[typeString]; ok {
+				if pkgNames, ok := pkgNamespaces[namespaceString]; ok {
+					pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
+				} else {
+					pkgNames := map[string][]*model.PackageVersion{}
+					pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
+					pkgNamespaces[namespaceString] = pkgNames
+					pkgTypes[typeString] = pkgNamespaces
+				}
+			} else {
+				pkgNames := map[string][]*model.PackageVersion{}
+				pkgNames[nameString] = append(pkgNames[nameString], pkgVersion)
+				pkgNamespaces := map[string]map[string][]*model.PackageVersion{}
+				pkgNamespaces[namespaceString] = pkgNames
+				pkgTypes[typeString] = pkgNamespaces
+			}
+		}
+	}
+	var packages []*model.Package
+	for pkgType, pkgNamespaces := range pkgTypes {
+		collectedPkgNamespaces := []*model.PackageNamespace{}
+		for namespace, pkgNames := range pkgNamespaces {
+			collectedPkgNames := []*model.PackageName{}
+			for name, versions := range pkgNames {
+				nameValues := strings.Split(name, ",")
+				pkgName := &model.PackageName{
+					ID:       nameValues[1],
+					Name:     nameValues[0],
+					Versions: versions,
+				}
+				collectedPkgNames = append(collectedPkgNames, pkgName)
+			}
+			namespaceValues := strings.Split(namespace, ",")
+			pkgNamespace := &model.PackageNamespace{
+				ID:        namespaceValues[1],
+				Namespace: namespaceValues[0],
+				Names:     collectedPkgNames,
+			}
+			collectedPkgNamespaces = append(collectedPkgNamespaces, pkgNamespace)
+		}
+		typeValues := strings.Split(pkgType, ",")
+		collectedPackage := &model.Package{
+			ID:         typeValues[1],
+			Type:       typeValues[0],
+			Namespaces: collectedPkgNamespaces,
+		}
+		packages = append(packages, collectedPackage)
+	}
+	return packages, nil
+}
+
+func getCollectedPackageQualifiers(qualifierList []interface{}) ([]*model.PackageQualifier, error) {
+	qualifiers := []*model.PackageQualifier{}
+	for i := range qualifierList {
+		if i%2 == 0 {
+			key, ok := qualifierList[i].(string)
+			if !ok {
+				return nil, fmt.Errorf("failed to assert string value for pkg qualifier's key")
+			}
+			value, ok := qualifierList[i+1].(string)
+			if !ok {
+				return nil, fmt.Errorf("failed to assert string value for pkg qualifier's value")
+			}
+			qualifier := &model.PackageQualifier{
+				Key:   key,
+				Value: value,
+			}
+			qualifiers = append(qualifiers, qualifier)
+		}
+	}
+	return qualifiers, nil
+}
+
+func generateModelPackage(pkgTypeID, pkgType, namespaceID, namespaceStr, nameID, nameStr string, versionID, versionValue, subPathValue *string, qualifiersValue interface{}) (*model.Package, error) {
+	var version *model.PackageVersion = nil
+	if versionValue != nil && subPathValue != nil && qualifiersValue != nil {
+		qualifiersList, ok := qualifiersValue.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed to assert slice for pkg qualifiers")
+		}
+		qualifiers, err := getCollectedPackageQualifiers(qualifiersList)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get qualifiers with error: %w", err)
+		}
+		version = &model.PackageVersion{
+			ID:         *versionID,
+			Version:    *versionValue,
+			Subpath:    *subPathValue,
+			Qualifiers: qualifiers,
+		}
+	}
+
+	versions := []*model.PackageVersion{}
+	if version != nil {
+		versions = append(versions, version)
+	}
+	name := &model.PackageName{
+		ID:       nameID,
+		Name:     nameStr,
+		Versions: versions,
+	}
+	namespace := &model.PackageNamespace{
+		ID:        namespaceID,
+		Namespace: namespaceStr,
+		Names:     []*model.PackageName{name},
+	}
+	pkg := model.Package{
+		ID:         pkgTypeID,
+		Type:       pkgType,
+		Namespaces: []*model.PackageNamespace{namespace},
+	}
+	return &pkg, nil
+}
+
+func getQualifiers(qualifiersSpec []*model.PackageQualifierSpec) []string {
+	qualifiersMap := map[string]string{}
+	keys := []string{}
+	for _, kv := range qualifiersSpec {
+		key := removeInvalidCharFromProperty(kv.Key)
+		qualifiersMap[key] = *kv.Value
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	qualifiers := []string{}
+	for _, k := range keys {
+		qualifiers = append(qualifiers, k, qualifiersMap[k])
+	}
+	return qualifiers
+}
+
+func removeInvalidCharFromProperty(key string) string {
+	// neo4j does not accept "." in its properties. If the qualifier contains a "." that must
+	// be replaced by an "-"
+	return strings.ReplaceAll(key, ".", "_")
 }

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -34,13 +34,13 @@ FOR doc in GuacSearch
 SEARCH PHRASE(doc.guacKey, @searchText, "text_en") || PHRASE(doc.guacKey, @searchText, "customgram") || doc.digest == @searchText
 
 LET parsedDoc =
-    IS_SAME_COLLECTION(doc, "PkgNames") ?
-    // PkgNames case
+    IS_SAME_COLLECTION(doc, "pkgNames") ?
+    // pkgNames case
     (
-        FOR pNs in PkgNamespaces
+        FOR pNs in pkgNamespaces
           FILTER pNs._id == doc._parent
 
-        FOR pType in PkgTypes
+        FOR pType in pkgTypes
           FILTER pType._id == pNs._parent
 
         RETURN {
@@ -52,14 +52,14 @@ LET parsedDoc =
               'name': doc.name
           }
         }
-    ) : IS_SAME_COLLECTION(doc, "PkgVersions") ?
-    // PkgVersions case
+    ) : IS_SAME_COLLECTION(doc, "pkgVersions") ?
+    // pkgVersions case
     (
-        FOR pName in PkgNames
+        FOR pName in pkgNames
           FILTER pName._id == doc._parent
-        FOR pNs in PkgNamespaces
+        FOR pNs in pkgNamespaces
           FILTER pNs._id == pName._parent
-        FOR pType in PkgTypes
+        FOR pType in pkgTypes
           FILTER pType._id == pNs._parent
 
         RETURN {
@@ -74,12 +74,12 @@ LET parsedDoc =
               'qualifier_list': doc.qualifier_list
           }
         }
-    ) : IS_SAME_COLLECTION(doc, "SrcNames") ?
-    // SrcNames case
+    ) : IS_SAME_COLLECTION(doc, "srcNames") ?
+    // srcNames case
     (
-        FOR sNs in SrcNamespaces
+        FOR sNs in srcNamespaces
           FILTER sNs._id == doc._parent
-        FOR sType in SrcTypes
+        FOR sType in srcTypes
           FILTER sType._id == sNs._parent
 
         RETURN {

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -45,11 +45,13 @@ LET parsedDoc =
 
         RETURN {
           'nodeType': 'pkgName',
-          'id': doc._id,
           'pkgName': {
-              'type': pType.type,
-              'namespace': pNs.namespace,
-              'name': doc.name
+		    'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': doc._id,
+			'name': doc.name
           }
         }
     ) : IS_SAME_COLLECTION(doc, "pkgVersions") ?
@@ -64,14 +66,17 @@ LET parsedDoc =
 
         RETURN {
           'nodeType': 'pkgVersion',
-          'id': doc._id,
           'pkgVersion': {
-              'type': pType.type,
-              'namespace': pNs.namespace,
-              'name': pName.name,
-              'version': doc.version,
-              'subpath': doc.subpath,
-              'qualifier_list': doc.qualifier_list
+			'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': pName._id,
+			'name': pName.name,
+			'version_id': doc._id,
+			'version': doc.version,
+			'subpath': doc.subpath,
+			'qualifier_list': doc.qualifier_list
           }
         }
     ) : IS_SAME_COLLECTION(doc, "srcNames") ?
@@ -84,13 +89,15 @@ LET parsedDoc =
 
         RETURN {
           'nodeType': 'SrcName',
-          'id': doc._id,
           'srcName': {
-              'type': sType.type,
-              'namespace': sNs.namespace,
-              'name': doc.name,
-              'commit': doc.commit,
-              'tag': doc.tag
+			"type_id": sType._id,
+			"type": sType.type,
+			"namespace_id": sNs._id,
+			"namespace": sNs.namespace,
+			"name_id": doc._id,
+			"name": doc.name,
+			"commit": doc.commit,
+			"tag": doc.tag
           }
         }
     )
@@ -98,13 +105,12 @@ LET parsedDoc =
     // Artifact case
     (RETURN {
         'nodeType': 'artifact',
-         'id': doc._id,
          'artifact': {
+			'id': doc._id,
             'algorithm': doc.algorithm,
             'digest': doc.digest
          }
     })
-
 
 RETURN {
 "parsedDoc": parsedDoc
@@ -114,32 +120,42 @@ RETURN {
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, query, queryValues, "FindSoftware")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vertex documents: %w", err)
+		return nil, fmt.Errorf("failed to query FindSoftware: %w", err)
 	}
 	defer cursor.Close()
 
 	type parsedDoc struct {
 		NodeType string `json:"nodeType"`
-		Id       string `json:"id"`
-		PkgName  *struct {
-			PkgType   string `json:"type"`
-			Namespace string `json:"namespace"`
-			Name      string `json:"name"`
+
+		PkgName *struct {
+			TypeID      string `json:"type_id"`
+			PkgType     string `json:"type"`
+			NamespaceID string `json:"namespace_id"`
+			Namespace   string `json:"namespace"`
+			NameID      string `json:"name_id"`
+			Name        string `json:"name"`
 		} `json:"pkgName,omitempty"`
 		PkgVersion *struct {
-			PkgType       string      `json:"type"`
-			Namespace     string      `json:"namespace"`
-			Name          string      `json:"name"`
-			Version       string      `json:"version"`
-			Subpath       string      `json:"subpath"`
-			QualifierList interface{} `json:"qualifier_list"`
+			TypeID        string        `json:"type_id"`
+			PkgType       string        `json:"type"`
+			NamespaceID   string        `json:"namespace_id"`
+			Namespace     string        `json:"namespace"`
+			NameID        string        `json:"name_id"`
+			Name          string        `json:"name"`
+			VersionID     string        `json:"version_id"`
+			Version       string        `json:"version"`
+			Subpath       string        `json:"subpath"`
+			QualifierList []interface{} `json:"qualifier_list"`
 		} `json:"pkgVersion,omitempty"`
 		SrcName *struct {
-			SrcType   string `json:"type"`
-			Namespace string `json:"namespace"`
-			Name      string `json:"name"`
-			Commit    string `json:"commit"`
-			Tag       string `json:"tag"`
+			TypeID      string `json:"type_id"`
+			SrcType     string `json:"type"`
+			NamespaceID string `json:"namespace_id"`
+			Namespace   string `json:"namespace"`
+			NameID      string `json:"name_id"`
+			Name        string `json:"name"`
+			Commit      string `json:"commit"`
+			Tag         string `json:"tag"`
 		} `json:"srcName,omitempty"`
 		Artifact *model.Artifact `json:"artifact,omitempty"`
 	}
@@ -178,7 +194,7 @@ RETURN {
 				if p == nil {
 					return nil, fmt.Errorf("failed to parse result of pkgVersion, got nil when expected non-nil")
 				}
-				pkg, err := generateModelPackage(p.PkgType, p.Namespace, p.Name, p.Version, p.Subpath, p.QualifierList)
+				pkg, err := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, &p.VersionID, &p.Version, &p.Subpath, p.QualifierList)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
 				}
@@ -188,12 +204,21 @@ RETURN {
 				if p == nil {
 					return nil, fmt.Errorf("failed to parse result of pkgName, got nil when expected non-nil")
 				}
-				pkg, err := generateModelPackage(p.PkgType, p.Namespace, p.Name, nil, nil, nil)
+				pkg, err := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, nil, nil, nil, nil)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
 				}
 				results = append(results, pkg)
+			case "SrcName":
+				s := d.SrcName
+				if s == nil {
+					return nil, fmt.Errorf("failed to parse result of SrcName, got nil when expected non-nil")
+				}
+				src := generateModelSource(s.TypeID, s.SrcType, s.NamespaceID, s.Namespace, s.NameID, s.Name, &s.Commit, &s.Tag)
+
+				results = append(results, src)
 			}
+
 		}
 	}
 	return results, nil

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -126,7 +126,7 @@ func (c *arangoClient) IngestSources(ctx context.Context, sources []*model.Sourc
 	  UPSERT { namespace: doc.namespace, _parent: doc.typeID , guacKey: doc.guacNsKey}
 	  INSERT { namespace: doc.namespace, _parent: doc.typeID , guacKey: doc.guacNsKey}
 	  UPDATE {}
-	  IN SrcNamespaces OPTIONS { indexHint: "byNsGuacKey" }
+	  IN srcNamespaces OPTIONS { indexHint: "byNsGuacKey" }
 	  RETURN NEW
 	)
 	
@@ -134,16 +134,16 @@ func (c *arangoClient) IngestSources(ctx context.Context, sources []*model.Sourc
 	  UPSERT { name: doc.name, commit: doc.commit, tag: doc.tag, _parent: ns._id, guacKey: doc.guacNameKey}
 	  INSERT { name: doc.name, commit: doc.commit, tag: doc.tag, _parent: ns._id, guacKey: doc.guacNameKey}
 	  UPDATE {}
-	  IN SrcNames OPTIONS { indexHint: "byNameGuacKey" }
+	  IN srcNames OPTIONS { indexHint: "byNameGuacKey" }
 	  RETURN NEW
 	)
   
 	LET pkgHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("srcHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "SrcHasNamespace"} INTO SrcHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "srcHasNamespace"} INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasNameCollection = (
-	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "SrcHasName"} INTO SrcHasName OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "srcHasName"} INTO srcHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	  
     RETURN {
@@ -225,7 +225,7 @@ func (c *arangoClient) IngestSource(ctx context.Context, source model.SourceInpu
 	  UPSERT { namespace: @namespace, _parent: @typeID , guacKey: @guacNsKey}
 	  INSERT { namespace: @namespace, _parent: @typeID , guacKey: @guacNsKey}
 	  UPDATE {}
-	  IN SrcNamespaces OPTIONS { indexHint: "byNsGuacKey" }
+	  IN srcNamespaces OPTIONS { indexHint: "byNsGuacKey" }
 	  RETURN NEW
 	)
 	
@@ -233,16 +233,16 @@ func (c *arangoClient) IngestSource(ctx context.Context, source model.SourceInpu
 	  UPSERT { name: @name, commit: @commit, tag: @tag, _parent: ns._id, guacKey: @guacNameKey}
 	  INSERT { name: @name, commit: @commit, tag: @tag, _parent: ns._id, guacKey: @guacNameKey}
 	  UPDATE {}
-	  IN SrcNames OPTIONS { indexHint: "byNameGuacKey" }
+	  IN srcNames OPTIONS { indexHint: "byNameGuacKey" }
 	  RETURN NEW
 	)
   
 	LET pkgHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("srcHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "SrcHasNamespace"} INTO SrcHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "srcHasNamespace"} INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasNameCollection = (
-	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "SrcHasName"} INTO SrcHasName OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "srcHasName"} INTO srcHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	  
     RETURN {
@@ -312,20 +312,20 @@ func (c *arangoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("SrcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("SrcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("SrcHasNamespace", "sNs", "sType")
+	arangoQueryBuilder.ForOutBound("srcHasNamespace", "sNs", "sType")
 	if sourceSpec.Namespace != nil {
 		arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 		values["namespace"] = *sourceSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("SrcHasName", "sName", "sNs")
+	arangoQueryBuilder.ForOutBound("srcHasName", "sName", "sNs")
 	if sourceSpec.Name != nil {
 		arangoQueryBuilder.filter("sName", "name", "==", "@name")
 		values["name"] = *sourceSpec.Name
@@ -429,10 +429,10 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("SrcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("SrcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
@@ -482,15 +482,15 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("SrcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("SrcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("SrcHasNamespace", "sNs", "sType")
+	arangoQueryBuilder.ForOutBound("srcHasNamespace", "sNs", "sType")
 	if sourceSpec.Namespace != nil {
 		arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 		values["namespace"] = *sourceSpec.Namespace

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -246,20 +246,20 @@ func (c *arangoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery(srcRootsStr, "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("srcHasNamespace", "sNs", "sType")
+	arangoQueryBuilder.ForOutBound(srcHasNamespaceStr, "sNs", "sType")
 	if sourceSpec.Namespace != nil {
 		arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 		values["namespace"] = *sourceSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound("srcHasName", "sName", "sNs")
+	arangoQueryBuilder.ForOutBound(srcHasNameStr, "sName", "sNs")
 	if sourceSpec.Name != nil {
 		arangoQueryBuilder.filter("sName", "name", "==", "@name")
 		values["name"] = *sourceSpec.Name
@@ -300,10 +300,10 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery(srcRootsStr, "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
@@ -353,15 +353,15 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery("srcRoots", "sRoot")
+	arangoQueryBuilder := newForQuery(srcRootsStr, "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound("srcHasType", "sType", "sRoot")
+	arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound("srcHasNamespace", "sNs", "sType")
+	arangoQueryBuilder.ForOutBound(srcHasNamespaceStr, "sNs", "sType")
 	if sourceSpec.Namespace != nil {
 		arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 		values["namespace"] = *sourceSpec.Namespace

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -55,6 +55,7 @@ type Backend interface {
 	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error)
 	IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]*model.Artifact, error)
 	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error)
+	IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error)
 	IngestCve(ctx context.Context, cve *model.CVEInputSpec) (*model.Cve, error)
 	IngestGhsa(ctx context.Context, ghsa *model.GHSAInputSpec) (*model.Ghsa, error)
 	IngestMaterials(ctx context.Context, materials []*model.ArtifactInputSpec) ([]*model.Artifact, error)

--- a/pkg/assembler/backends/inmem/builder.go
+++ b/pkg/assembler/backends/inmem/builder.go
@@ -54,7 +54,22 @@ func (c *demoClient) builderByKey(uri string) (*builderStruct, error) {
 	return nil, errors.New("builder not found")
 }
 
+// Ingest Builders
+
+func (c *demoClient) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
+	var modelBuilders []*model.Builder
+	for _, build := range builders {
+		modelBuild, err := c.IngestBuilder(ctx, build)
+		if err != nil {
+			return nil, gqlerror.Errorf("IngestBuilder failed with err: %v", err)
+		}
+		modelBuilders = append(modelBuilders, modelBuild)
+	}
+	return modelBuilders, nil
+}
+
 // Ingest Builder
+
 func (c *demoClient) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {
 	return c.ingestBuilder(ctx, builder, true)
 }

--- a/pkg/assembler/backends/inmem/builder_test.go
+++ b/pkg/assembler/backends/inmem/builder_test.go
@@ -185,6 +185,53 @@ func Test_demoClient_IngestBuilder(t *testing.T) {
 	}
 }
 
+func Test_demoClient_IngestBuilders(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name          string
+		builderInputs []*model.BuilderInputSpec
+		want          []*model.Builder
+		wantErr       bool
+	}{{
+		name: "HubHostedActions",
+		builderInputs: []*model.BuilderInputSpec{
+			{
+				URI: "https://github.com/CreateFork/HubHostedActions@v1",
+			},
+			{
+				URI: "https://tekton.dev/chains/v2",
+			}},
+		want: []*model.Builder{
+			{
+				URI: "https://github.com/CreateFork/HubHostedActions@v1",
+			},
+			{
+				URI: "https://tekton.dev/chains/v2",
+			}},
+		wantErr: false,
+	}}
+
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &demoClient{
+				builders: builderMap{},
+				index:    indexType{},
+			}
+			got, err := c.IngestBuilders(ctx, tt.builderInputs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("demoClient.IngestBuilder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_demoClient_Builders(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {

--- a/pkg/assembler/backends/inmem/src_test.go
+++ b/pkg/assembler/backends/inmem/src_test.go
@@ -61,6 +61,40 @@ var s2out = &model.Source{
 	}},
 }
 
+func Test_demoClient_IngestSources(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		srcInputs []*model.SourceInputSpec
+		want      []*model.Source
+		wantErr   bool
+	}{{
+		name:      "test batch source intestion",
+		srcInputs: []*model.SourceInputSpec{s1, s2},
+		want:      []*model.Source{s1out, s2out},
+		wantErr:   false,
+	}}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &demoClient{
+				sources: srcTypeMap{},
+				index:   indexType{},
+			}
+			got, err := c.IngestSources(ctx, tt.srcInputs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("demoClient.IngestSources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_demoClient_Sources(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {

--- a/pkg/assembler/backends/neo4j/builder.go
+++ b/pkg/assembler/backends/neo4j/builder.go
@@ -17,6 +17,7 @@ package neo4j
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -83,6 +84,10 @@ func (c *neo4jClient) Builders(ctx context.Context, builderSpec *model.BuilderSp
 	}
 
 	return result.([]*model.Builder), nil
+}
+
+func (c *neo4jClient) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
+	return []*model.Builder{}, fmt.Errorf("not implemented: IngestBuilders")
 }
 
 func (c *neo4jClient) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5346,6 +5346,30 @@ type IngestBuilderResponse struct {
 // GetIngestBuilder returns IngestBuilderResponse.IngestBuilder, and is useful for accessing the field via an interface.
 func (v *IngestBuilderResponse) GetIngestBuilder() IngestBuilderIngestBuilder { return v.IngestBuilder }
 
+// IngestBuildersIngestBuildersBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder (e.g., FRSCA or GitHub Actions).
+//
+// Currently builders are identified by the uri field.
+type IngestBuildersIngestBuildersBuilder struct {
+	Uri string `json:"uri"`
+}
+
+// GetUri returns IngestBuildersIngestBuildersBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *IngestBuildersIngestBuildersBuilder) GetUri() string { return v.Uri }
+
+// IngestBuildersResponse is returned by IngestBuilders on success.
+type IngestBuildersResponse struct {
+	// Bulk ingests new builders and returns a list of them.
+	IngestBuilders []IngestBuildersIngestBuildersBuilder `json:"ingestBuilders"`
+}
+
+// GetIngestBuilders returns IngestBuildersResponse.IngestBuilders, and is useful for accessing the field via an interface.
+func (v *IngestBuildersResponse) GetIngestBuilders() []IngestBuildersIngestBuildersBuilder {
+	return v.IngestBuilders
+}
+
 // IngestCVEIngestCVE includes the requested fields of the GraphQL type CVE.
 // The GraphQL type's documentation follows.
 //
@@ -19868,6 +19892,14 @@ type __IngestBuilderInput struct {
 // GetBuilder returns __IngestBuilderInput.Builder, and is useful for accessing the field via an interface.
 func (v *__IngestBuilderInput) GetBuilder() BuilderInputSpec { return v.Builder }
 
+// __IngestBuildersInput is used internally by genqlient
+type __IngestBuildersInput struct {
+	Builders []BuilderInputSpec `json:"builders"`
+}
+
+// GetBuilders returns __IngestBuildersInput.Builders, and is useful for accessing the field via an interface.
+func (v *__IngestBuildersInput) GetBuilders() []BuilderInputSpec { return v.Builders }
+
 // __IngestCVEInput is used internally by genqlient
 type __IngestCVEInput struct {
 	Cve CVEInputSpec `json:"cve"`
@@ -26773,6 +26805,42 @@ func IngestBuilder(
 	var err error
 
 	var data IngestBuilderResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IngestBuilders.
+const IngestBuilders_Operation = `
+# Bulk Ingest Builder
+mutation IngestBuilders ($builders: [BuilderInputSpec!]!) {
+	ingestBuilders(builders: $builders) {
+		uri
+	}
+}
+`
+
+func IngestBuilders(
+	ctx context.Context,
+	client graphql.Client,
+	builders []BuilderInputSpec,
+) (*IngestBuildersResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestBuilders",
+		Query:  IngestBuilders_Operation,
+		Variables: &__IngestBuildersInput{
+			Builders: builders,
+		},
+	}
+	var err error
+
+	var data IngestBuildersResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -291,7 +291,6 @@ func ingestIsOccurrences(ctx context.Context, client graphql.Client, v []assembl
 		if err != nil {
 			return fmt.Errorf("isOccurrencesSrc failed with error: %w", err)
 		}
-
 	}
 	if len(pkgs) > 0 {
 		_, err := model.IsOccurrencesPkg(ctx, client, pkgs, pkgArtifacts, pkgOccurrences)

--- a/pkg/assembler/clients/operations/builder.graphql
+++ b/pkg/assembler/clients/operations/builder.graphql
@@ -22,3 +22,11 @@ mutation IngestBuilder($builder: BuilderInputSpec!) {
     uri
   }
 }
+
+# Bulk Ingest Builder
+
+mutation IngestBuilders($builders: [BuilderInputSpec!]!) {
+  ingestBuilders(builders: $builders) {
+    uri
+  }
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -22,6 +22,7 @@ type MutationResolver interface {
 	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error)
 	IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]*model.Artifact, error)
 	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error)
+	IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error)
 	IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error)
 	IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error)
 	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
@@ -148,6 +149,21 @@ func (ec *executionContext) field_Mutation_ingestBuilder_args(ctx context.Contex
 		}
 	}
 	args["builder"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestBuilders_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.BuilderInputSpec
+	if tmp, ok := rawArgs["builders"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("builders"))
+		arg0, err = ec.unmarshalNBuilderInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["builders"] = arg0
 	return args, nil
 }
 
@@ -1585,6 +1601,67 @@ func (ec *executionContext) fieldContext_Mutation_ingestBuilder(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestBuilder_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestBuilders(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestBuilders(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestBuilders(rctx, fc.Args["builders"].([]*model.BuilderInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Builder)
+	fc.Result = res
+	return ec.marshalNBuilder2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestBuilders(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Builder_id(ctx, field)
+			case "uri":
+				return ec.fieldContext_Builder_uri(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Builder", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestBuilders_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5328,6 +5405,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "ingestBuilder":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestBuilder(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ingestBuilders":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestBuilders(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/builder.generated.go
+++ b/pkg/assembler/graphql/generated/builder.generated.go
@@ -306,6 +306,28 @@ func (ec *executionContext) unmarshalNBuilderInputSpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNBuilderInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.BuilderInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.BuilderInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx context.Context, v interface{}) (*model.BuilderInputSpec, error) {
+	res, err := ec.unmarshalInputBuilderInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOBuilderInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderInputSpec(ctx context.Context, v interface{}) (*model.BuilderInputSpec, error) {
 	if v == nil {
 		return nil, nil

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -183,6 +183,7 @@ type ComplexityRoot struct {
 		IngestArtifact        func(childComplexity int, artifact *model.ArtifactInputSpec) int
 		IngestArtifacts       func(childComplexity int, artifacts []*model.ArtifactInputSpec) int
 		IngestBuilder         func(childComplexity int, builder *model.BuilderInputSpec) int
+		IngestBuilders        func(childComplexity int, builders []*model.BuilderInputSpec) int
 		IngestCertifyBad      func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) int
 		IngestCertifyGood     func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) int
 		IngestCve             func(childComplexity int, cve *model.CVEInputSpec) int
@@ -1037,6 +1038,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestBuilder(childComplexity, args["builder"].(*model.BuilderInputSpec)), true
+
+	case "Mutation.ingestBuilders":
+		if e.complexity.Mutation.IngestBuilders == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestBuilders_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestBuilders(childComplexity, args["builders"].([]*model.BuilderInputSpec)), true
 
 	case "Mutation.ingestCertifyBad":
 		if e.complexity.Mutation.IngestCertifyBad == nil {
@@ -2409,6 +2422,8 @@ extend type Query {
 extend type Mutation {
   "Ingests a new builder and returns it."
   ingestBuilder(builder: BuilderInputSpec): Builder!
+  "Bulk ingests new builders and returns a list of them."
+  ingestBuilders(builders: [BuilderInputSpec!]!): [Builder!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyBad.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/builder.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/builder.resolvers.go
@@ -15,6 +15,11 @@ func (r *mutationResolver) IngestBuilder(ctx context.Context, builder *model.Bui
 	return r.Backend.IngestBuilder(ctx, builder)
 }
 
+// IngestBuilders is the resolver for the ingestBuilders field.
+func (r *mutationResolver) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
+	return r.Backend.IngestBuilders(ctx, builders)
+}
+
 // Builders is the resolver for the builders field.
 func (r *queryResolver) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
 	return r.Backend.Builders(ctx, builderSpec)

--- a/pkg/assembler/graphql/schema/builder.graphql
+++ b/pkg/assembler/graphql/schema/builder.graphql
@@ -46,4 +46,6 @@ extend type Query {
 extend type Mutation {
   "Ingests a new builder and returns it."
   ingestBuilder(builder: BuilderInputSpec): Builder!
+  "Bulk ingests new builders and returns a list of them."
+  ingestBuilders(builders: [BuilderInputSpec!]!): [Builder!]!
 }


### PR DESCRIPTION
# Description of the PR

- cleanup arango backend to remove code duplication
- add ingestion and query of builder (including bulk)
- add support for source ingestion for Occurrences
- return IDs during ingestion and query

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
