### PR TITLE
fix PURL NPE and add OCI heuristic

### DIFF
--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -54,7 +54,21 @@ func PkgInputSpecToPurl(currentPkg *model.PkgInputSpec) string {
 	for _, k := range keys {
 		qualifiers = append(qualifiers, k, qualifiersMap[k])
 	}
-	return PkgToPurl(currentPkg.Type, *currentPkg.Namespace, currentPkg.Name, *currentPkg.Version, *currentPkg.Subpath, qualifiers)
+
+	var ns, ver, subpath string
+
+	if currentPkg.Namespace != nil {
+		ns = *currentPkg.Namespace
+	}
+
+	if currentPkg.Version != nil {
+		ver = *currentPkg.Version
+	}
+
+	if currentPkg.Subpath != nil {
+		subpath = *currentPkg.Subpath
+	}
+	return PkgToPurl(currentPkg.Type, ns, currentPkg.Name, ver, subpath, qualifiers)
 }
 
 func PkgToPurl(purlType, namespace, name, version, subpath string, qualifiersList []string) string {
@@ -111,7 +125,10 @@ func purlConvert(p purl.PackageURL) (*model.PkgInputSpec, error) {
 		//
 		// Ref: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci
 		qs := p.Qualifiers.Map()
-		var ns string
+
+		// Not technically part of the spec but some PURLs still include the namespace
+		// as part of the PURL
+		var ns string = p.Namespace
 		for k, v := range qs {
 			if k == "repository_url" {
 				ns = v

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -94,6 +94,12 @@ func TestPurlConvert(t *testing.T) {
 			purlUri:  "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&tag=latest&repository_url=docker.io%2Flibrary",
 			expected: pkg("oci", "docker.io/library", "debian", "sha256:244fd47e07d10", "", map[string]string{"arch": "amd64", "tag": "latest"}),
 		}, {
+			// test case based on OCI PURLs that may not include repository_url.
+			purlUri:  "pkg:oci/docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+			expected: pkg("oci", "docker.io/library", "alpine", "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870", "", map[string]string{}),
+		},
+
+		{
 			purlUri:  "pkg:docker/smartentry/debian@dc437cc87d10",
 			expected: pkg("docker", "smartentry", "debian", "dc437cc87d10", "", map[string]string{}),
 		}, {


### PR DESCRIPTION
# Description of the PR

- fix PURL NPE
- add OCI heuristic where `repository_url` is not present

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
