### PR TITLE
arango ingest/query scorecard and bulk ingestion

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -88,7 +88,7 @@ func ingestScorecards(ctx context.Context, client graphql.Client) {
 	if _, err := model.IngestSource(ctx, client, source); err != nil {
 		logger.Errorf("Error in ingesting source: %v\n", err)
 	}
-	if _, err := model.Scorecard(ctx, client, source, scorecard); err != nil {
+	if _, err := model.CertifyScorecard(ctx, client, source, scorecard); err != nil {
 		logger.Errorf("Error in ingesting: %v\n", err)
 	}
 }

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -110,6 +110,11 @@ const (
 
 	certifyVulnEdgesStr string = "certifyVulnEdges"
 	certifyVulnsStr     string = "certifyVulns"
+
+	// certifyScorecard collection
+
+	scorecardEdgesStr string = "scorecardEdges"
+	scorecardStr      string = "scorecards"
 )
 
 type ArangoConfig struct {
@@ -325,10 +330,19 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		// repeat this for the collections where an edge is going into
 		certifyVulnEdges.To = []string{certifyVulnsStr, cvesStr, ghsasStr, osvsStr}
 
+		var certifyScorecardEdges driver.EdgeDefinition
+		certifyScorecardEdges.Collection = scorecardEdgesStr
+		// define a set of collections where an edge is going out...
+		certifyScorecardEdges.From = []string{srcNamesStr}
+
+		// repeat this for the collections where an edge is going into
+		certifyScorecardEdges.To = []string{scorecardStr}
+
 		// A graph can contain additional vertex collections, defined in the set of orphan collections
 		var options driver.CreateGraphOptions
 		options.EdgeDefinitions = []driver.EdgeDefinition{hashEqualsEdges, pkgHasType, pkgHasNamespace, pkgHasName,
-			pkgHasVersion, srcHasType, srcHasNamespace, srcHasName, isDependencyEdges, isOccurrencesEdges, hasSBOMEdges, hasSLSAEdges, certifyVulnEdges}
+			pkgHasVersion, srcHasType, srcHasNamespace, srcHasName, isDependencyEdges, isOccurrencesEdges, hasSBOMEdges,
+			hasSLSAEdges, certifyVulnEdges, certifyScorecardEdges}
 
 		// create a graph
 		graph, err = db.CreateGraphV2(ctx, "guac", &options)

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -723,7 +723,7 @@ func getPreloads(ctx context.Context) []string {
 }
 
 func getNestedPreloads(ctx *graphql.OperationContext, fields []graphql.CollectedField, prefix string, visited map[string]bool) []string {
-	preloads := []string{}
+	var preloads []string
 	for _, column := range fields {
 		prefixColumn := getPreloadString(prefix, column.Name)
 		if visited[prefixColumn] {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -756,9 +756,6 @@ func (c *arangoClient) IsVulnerability(ctx context.Context, isVulnerabilitySpec 
 func (c *arangoClient) PkgEqual(ctx context.Context, pkgEqualSpec *model.PkgEqualSpec) ([]*model.PkgEqual, error) {
 	panic(fmt.Errorf("not implemented: PkgEqual - PkgEqual"))
 }
-func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *model.CertifyScorecardSpec) ([]*model.CertifyScorecard, error) {
-	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
-}
 
 // Mutations for software trees (read-write queries)
 
@@ -767,9 +764,6 @@ func (c *arangoClient) IngestMaterials(ctx context.Context, materials []*model.A
 }
 
 // Mutations for evidence trees (read-write queries, assume software trees ingested)
-func (c *arangoClient) CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
-	return &model.CertifyScorecard{}, nil
-}
 func (c *arangoClient) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error) {
 	panic(fmt.Errorf("not implemented: IngestCertifyBad - IngestCertifyBad"))
 }

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -17,9 +17,23 @@ package arangodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+const (
+	timeScannedStr      string = "timeScanned"
+	aggregateScoreStr   string = "aggregateScore"
+	checksStr           string = "checks"
+	scorecardVersionStr string = "scorecardVersion"
+	scorecardCommitStr  string = "scorecardCommit"
 )
 
 // Query Scorecards
@@ -28,17 +42,273 @@ func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *mod
 	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
 }
 
+func getScorecardValues(src *model.SourceInputSpec, scorecard *model.ScorecardInputSpec) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	source := guacSrcId(*src)
+	values["srcNameGuacKey"] = source.NameId
+
+	// To ensure consistency, always sort the checks by key
+	checksMap := map[string]int{}
+	var keys []string
+	for _, kv := range scorecard.Checks {
+		checksMap[kv.Check] = kv.Score
+		keys = append(keys, kv.Check)
+	}
+	sort.Strings(keys)
+	checks := []string{}
+	for _, k := range keys {
+		checks = append(checks, k, strconv.Itoa(checksMap[k]))
+	}
+	values[checksStr] = checks
+	values[aggregateScoreStr] = scorecard.AggregateScore
+	values[timeScannedStr] = scorecard.TimeScanned.UTC()
+	values[scorecardVersionStr] = scorecard.ScorecardVersion
+	values[scorecardCommitStr] = scorecard.ScorecardCommit
+	values[origin] = scorecard.Origin
+	values[collector] = scorecard.Collector
+
+	return values
+}
+
 // Ingest Scorecards
 
 func (c *arangoClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
 	if len(sources) != len(scorecards) {
 		return nil, fmt.Errorf("uneven source and scorecards for ingestion")
 	}
-	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
+
+	listOfValues := []map[string]any{}
+
+	for i := range sources {
+		listOfValues = append(listOfValues, getScorecardValues(sources[i], scorecards[i]))
+	}
+
+	var documents []string
+	for _, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		documents = append(documents, string(bs))
+	}
+
+	queryValues := map[string]any{}
+	queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+	var sb strings.Builder
+
+	sb.WriteString("for doc in [")
+	for i, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		if i == len(listOfValues)-1 {
+			sb.WriteString(string(bs))
+		} else {
+			sb.WriteString(string(bs) + ",")
+		}
+	}
+	sb.WriteString("]")
+
+	query := `
+	LET firstSrc = FIRST(
+		FOR sName in srcNames
+		  FILTER sName.guacKey == doc.srcNameGuacKey
+		FOR sNs in srcNamespaces
+		  FILTER sNs._id == sName._parent
+		FOR sType in srcTypes
+		  FILTER sType._id == sNs._parent
+
+		RETURN {
+		  'typeID': sType._id,
+		  'type': sType.type,
+		  'namespace_id': sNs._id,
+		  'namespace': sNs.namespace,
+		  'name_id': sName._id,
+		  'name': sName.name,
+		  'commit': sName.commit,
+		  'tag': sName.tag,
+		  'nameDoc': sName
+		}
+	)
+	  	  
+	LET scorecard = FIRST(
+		UPSERT { sourceID:firstSrc.name_id, checks:doc.checks, aggregateScore:doc.aggregateScore, timeScanned:doc.timeScanned, scorecardVersion:doc.scorecardVersion, scorecardCommit:doc.scorecardCommit, collector:doc.collector, origin:doc.origin } 
+			INSERT { sourceID:firstSrc.name_id, checks:doc.checks, aggregateScore:doc.aggregateScore, timeScanned:doc.timeScanned, scorecardVersion:doc.scorecardVersion, scorecardCommit:doc.scorecardCommit, collector:doc.collector, origin:doc.origin } 
+			UPDATE {} IN scorecards
+			RETURN NEW
+	)
+	
+	LET edgeCollection = (
+	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id, label : "certifyScorecard" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
+	)
+	  
+	  RETURN {
+		'srcName': {
+			'type_id': firstSrc.typeID,
+			'type': firstSrc.type,
+			'namespace_id': firstSrc.namespace_id,
+			'namespace': firstSrc.namespace,
+			'name_id': firstSrc.name_id,
+			'name': firstSrc.name,
+			'commit': firstSrc.commit,
+			'tag': firstSrc.tag
+		},
+		'scorecard_id': scorecard._id,
+		'checks': scorecard.checks,
+		'aggregateScore': scorecard.aggregateScore,
+		'timeScanned': scorecard.timeScanned,
+		'scorecardVersion': scorecard.scorecardVersion,
+		'scorecardCommit': scorecard.scorecardCommit,
+		'collector': isOccurrence.collector,
+		'origin': isOccurrence.origin
+	  }`
+
+	sb.WriteString(query)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestScorecards")
+	if err != nil {
+		return nil, fmt.Errorf("failed to ingest scorecard: %w", err)
+	}
+	defer cursor.Close()
+	scorecardList, err := getCertifyScorecard(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scorecard from arango cursor: %w", err)
+	}
+
+	return scorecardList, nil
+
 }
 
 // Ingest Scorecard
 
 func (c *arangoClient) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
-	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
+	query := `
+	LET firstSrc = FIRST(
+		FOR sName in srcNames
+		  FILTER sName.guacKey == @srcNameGuacKey
+		FOR sNs in srcNamespaces
+		  FILTER sNs._id == sName._parent
+		FOR sType in srcTypes
+		  FILTER sType._id == sNs._parent
+
+		RETURN {
+		  'typeID': sType._id,
+		  'type': sType.type,
+		  'namespace_id': sNs._id,
+		  'namespace': sNs.namespace,
+		  'name_id': sName._id,
+		  'name': sName.name,
+		  'commit': sName.commit,
+		  'tag': sName.tag,
+		  'nameDoc': sName
+		}
+	)
+	  	  
+	LET scorecard = FIRST(
+		UPSERT { sourceID:firstSrc.name_id, checks:@checks, aggregateScore:@aggregateScore, timeScanned:@timeScanned, scorecardVersion:@scorecardVersion, scorecardCommit:@scorecardCommit, collector:@collector, origin:@origin } 
+			INSERT { sourceID:firstSrc.name_id, checks:@checks, aggregateScore:@aggregateScore, timeScanned:@timeScanned, scorecardVersion:@scorecardVersion, scorecardCommit:@scorecardCommit, collector:@collector, origin:@origin } 
+			UPDATE {} IN scorecards
+			RETURN NEW
+	)
+	
+	LET edgeCollection = (
+	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id, label : "certifyScorecard" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
+	)
+	  
+	  RETURN {
+		'srcName': {
+			'type_id': firstSrc.typeID,
+			'type': firstSrc.type,
+			'namespace_id': firstSrc.namespace_id,
+			'namespace': firstSrc.namespace,
+			'name_id': firstSrc.name_id,
+			'name': firstSrc.name,
+			'commit': firstSrc.commit,
+			'tag': firstSrc.tag
+		},
+		'scorecard_id': scorecard._id,
+		'checks': scorecard.checks,
+		'aggregateScore': scorecard.aggregateScore,
+		'timeScanned': scorecard.timeScanned,
+		'scorecardVersion': scorecard.scorecardVersion,
+		'scorecardCommit': scorecard.scorecardCommit,
+		'collector': isOccurrence.collector,
+		'origin': isOccurrence.origin
+	  }`
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, getScorecardValues(&source, &scorecard), "IngestScorecard")
+	if err != nil {
+		return nil, fmt.Errorf("failed to ingest source occurrence: %w", err)
+	}
+	defer cursor.Close()
+
+	scorecardList, err := getCertifyScorecard(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scorecard from arango cursor: %w", err)
+	}
+
+	if len(scorecardList) == 1 {
+		return scorecardList[0], nil
+	} else {
+		return nil, fmt.Errorf("number of scorecard ingested is greater than one")
+	}
+
+}
+
+func getCertifyScorecard(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyScorecard, error) {
+	type collectedData struct {
+		SrcName struct {
+			TypeID      string `json:"type_id"`
+			SrcType     string `json:"type"`
+			NamespaceID string `json:"namespace_id"`
+			Namespace   string `json:"namespace"`
+			NameID      string `json:"name_id"`
+			Name        string `json:"name"`
+			Commit      string `json:"commit"`
+			Tag         string `json:"tag"`
+		} `json:"srcName"`
+		ScorecardID      string    `json:"scorecard_id"`
+		Checks           []string  `json:"checks"`
+		AggregateScore   float64   `json:"aggregateScore"`
+		TimeScanned      time.Time `json:"timeScanned"`
+		ScorecardVersion string    `json:"scorecardVersion"`
+		ScorecardCommit  string    `json:"scorecardCommit"`
+		Collector        string    `json:"collector"`
+		Origin           string    `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to get scorecard from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyScorecardList []*model.CertifyScorecard
+	for _, createdValue := range createdValues {
+		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+			createdValue.SrcName.NameID, createdValue.SrcName.Name, &createdValue.SrcName.Commit, &createdValue.SrcName.Tag)
+
+		scorecard := &model.Scorecard{
+			AggregateScore:   createdValue.AggregateScore,
+			TimeScanned:      createdValue.TimeScanned,
+			ScorecardVersion: createdValue.ScorecardVersion,
+			ScorecardCommit:  createdValue.ScorecardCommit,
+			Origin:           createdValue.Origin,
+			Collector:        createdValue.Collector,
+		}
+
+		certifyScorecard := &model.CertifyScorecard{
+			ID:        createdValue.ScorecardID,
+			Source:    src,
+			Scorecard: scorecard,
+		}
+		certifyScorecardList = append(certifyScorecardList, certifyScorecard)
+	}
+	return certifyScorecardList, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -358,16 +358,7 @@ func getCollectedScorecardChecks(checksList []string) ([]*model.ScorecardCheck, 
 
 func getCertifyScorecard(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyScorecard, error) {
 	type collectedData struct {
-		SrcName struct {
-			TypeID      string `json:"type_id"`
-			SrcType     string `json:"type"`
-			NamespaceID string `json:"namespace_id"`
-			Namespace   string `json:"namespace"`
-			NameID      string `json:"name_id"`
-			Name        string `json:"name"`
-			Commit      string `json:"commit"`
-			Tag         string `json:"tag"`
-		} `json:"srcName"`
+		SrcName          dbSrcName `json:"srcName"`
 		ScorecardID      string    `json:"scorecard_id"`
 		Checks           []string  `json:"checks"`
 		AggregateScore   float64   `json:"aggregateScore"`

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+// Query Scorecards
+
+func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *model.CertifyScorecardSpec) ([]*model.CertifyScorecard, error) {
+	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
+}
+
+// Ingest Scorecards
+
+func (c *arangoClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
+	if len(sources) != len(scorecards) {
+		return nil, fmt.Errorf("uneven source and scorecards for ingestion")
+	}
+	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
+}
+
+// Ingest Scorecard
+
+func (c *arangoClient) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
+	panic(fmt.Errorf("not implemented: Scorecards - Scorecards"))
+}

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -122,14 +122,14 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 		)
 		  
 		  LET hasSBOM = FIRST(
-			  UPSERT { uri:@uri, algorithm:@algorithm, digest:@digest, downloadLocation:@downloadLocation, collector:@collector, origin:@origin } 
-				  INSERT { uri:@uri, algorithm:@algorithm, digest:@digest, downloadLocation:@downloadLocation, collector:@collector, origin:@origin } 
+			  UPSERT {  packageID:firstPkg.version_id, uri:@uri, algorithm:@algorithm, digest:@digest, downloadLocation:@downloadLocation, collector:@collector, origin:@origin } 
+				  INSERT {  packageID:firstPkg.version_id, uri:@uri, algorithm:@algorithm, digest:@digest, downloadLocation:@downloadLocation, collector:@collector, origin:@origin } 
 				  UPDATE {} IN hasSBOMs
 				  RETURN NEW
 		  )
 		  
 		  LET edgeCollection = (
-			INSERT {  _key: CONCAT("hasSBOMEdges", firstPkg.versionDoc._key, hasSBOM._key), _from: firstPkg.versionDoc._id, _to: hasSBOM._id, label : "hasSBOM" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
+			INSERT {  _key: CONCAT("hasSBOMEdges", firstPkg.versionDoc._key, hasSBOM._key), _from: firstPkg.version_id, _to: hasSBOM._id, label : "hasSBOM" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
 		  )
 		  
 		  RETURN {

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -176,16 +176,16 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 func getPkgHasSBOM(ctx context.Context, cursor driver.Cursor) ([]*model.HasSbom, error) {
 	type collectedData struct {
 		PkgVersion struct {
-			TypeID        string        `json:"type_id"`
-			PkgType       string        `json:"type"`
-			NamespaceID   string        `json:"namespace_id"`
-			Namespace     string        `json:"namespace"`
-			NameID        string        `json:"name_id"`
-			Name          string        `json:"name"`
-			VersionID     string        `json:"version_id"`
-			Version       string        `json:"version"`
-			Subpath       string        `json:"subpath"`
-			QualifierList []interface{} `json:"qualifier_list"`
+			TypeID        string   `json:"type_id"`
+			PkgType       string   `json:"type"`
+			NamespaceID   string   `json:"namespace_id"`
+			Namespace     string   `json:"namespace"`
+			NameID        string   `json:"name_id"`
+			Name          string   `json:"name"`
+			VersionID     string   `json:"version_id"`
+			Version       string   `json:"version"`
+			Subpath       string   `json:"subpath"`
+			QualifierList []string `json:"qualifier_list"`
 		} `json:"pkgVersion"`
 		HasSBOMId        string `json:"hasSBOM_id"`
 		Uri              string `json:"uri"`
@@ -213,11 +213,8 @@ func getPkgHasSBOM(ctx context.Context, cursor driver.Cursor) ([]*model.HasSbom,
 
 	var hasSBOMList []*model.HasSbom
 	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
 			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
 
 		hasSBOM := &model.HasSbom{
 			ID:               createdValue.HasSBOMId,

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -175,25 +175,14 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 
 func getPkgHasSBOM(ctx context.Context, cursor driver.Cursor) ([]*model.HasSbom, error) {
 	type collectedData struct {
-		PkgVersion struct {
-			TypeID        string   `json:"type_id"`
-			PkgType       string   `json:"type"`
-			NamespaceID   string   `json:"namespace_id"`
-			Namespace     string   `json:"namespace"`
-			NameID        string   `json:"name_id"`
-			Name          string   `json:"name"`
-			VersionID     string   `json:"version_id"`
-			Version       string   `json:"version"`
-			Subpath       string   `json:"subpath"`
-			QualifierList []string `json:"qualifier_list"`
-		} `json:"pkgVersion"`
-		HasSBOMId        string `json:"hasSBOM_id"`
-		Uri              string `json:"uri"`
-		Algorithm        string `json:"algorithm"`
-		Digest           string `json:"digest"`
-		DownloadLocation string `json:"downloadLocation"`
-		Collector        string `json:"collector"`
-		Origin           string `json:"origin"`
+		PkgVersion       dbPkgVersion `json:"pkgVersion"`
+		HasSBOMId        string       `json:"hasSBOM_id"`
+		Uri              string       `json:"uri"`
+		Algorithm        string       `json:"algorithm"`
+		Digest           string       `json:"digest"`
+		DownloadLocation string       `json:"downloadLocation"`
+		Collector        string       `json:"collector"`
+		Origin           string       `json:"origin"`
 	}
 
 	var createdValues []collectedData

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -316,16 +316,16 @@ func convertDependencyTypeToEnum(status string) (model.DependencyType, error) {
 func getIsDependency(ctx context.Context, cursor driver.Cursor) ([]*model.IsDependency, error) {
 	type collectedData struct {
 		PkgVersion struct {
-			TypeID        string        `json:"type_id"`
-			PkgType       string        `json:"type"`
-			NamespaceID   string        `json:"namespace_id"`
-			Namespace     string        `json:"namespace"`
-			NameID        string        `json:"name_id"`
-			Name          string        `json:"name"`
-			VersionID     string        `json:"version_id"`
-			Version       string        `json:"version"`
-			Subpath       string        `json:"subpath"`
-			QualifierList []interface{} `json:"qualifier_list"`
+			TypeID        string   `json:"type_id"`
+			PkgType       string   `json:"type"`
+			NamespaceID   string   `json:"namespace_id"`
+			Namespace     string   `json:"namespace"`
+			NameID        string   `json:"name_id"`
+			Name          string   `json:"name"`
+			VersionID     string   `json:"version_id"`
+			Version       string   `json:"version"`
+			Subpath       string   `json:"subpath"`
+			QualifierList []string `json:"qualifier_list"`
 		} `json:"pkgVersion"`
 		DepPkg struct {
 			TypeID      string `json:"type_id"`
@@ -360,16 +360,12 @@ func getIsDependency(ctx context.Context, cursor driver.Cursor) ([]*model.IsDepe
 
 	var isDependencyList []*model.IsDependency
 	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
 			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
-		depPkg, err := generateModelPackage(createdValue.DepPkg.TypeID, createdValue.DepPkg.PkgType, createdValue.DepPkg.NamespaceID, createdValue.DepPkg.Namespace, createdValue.DepPkg.NameID,
+
+		depPkg := generateModelPackage(createdValue.DepPkg.TypeID, createdValue.DepPkg.PkgType, createdValue.DepPkg.NamespaceID, createdValue.DepPkg.Namespace, createdValue.DepPkg.NameID,
 			createdValue.DepPkg.Name, nil, nil, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get dependent model.package with err: %w", err)
-		}
+
 		dependencyTypeEnum, err := convertDependencyTypeToEnum(createdValue.DependencyType)
 		if err != nil {
 			return nil, fmt.Errorf("convertDependencyTypeToEnum failed with error: %w", err)

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -140,15 +140,15 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.Pkg
     )
 		
 	LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.versionDoc._id, depPackageID:secondPkg.nameDoc._id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			INSERT { packageID:firstPkg.versionDoc._id, depPackageID:secondPkg.nameDoc._id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin }
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin }
 			UPDATE {} IN isDependencies
 			RETURN NEW
 		)
 		
 	LET edgeCollection = (FOR edgeData IN [
-		{fromKey: isDependency._key, toKey: secondPkg.nameDoc._key, from: isDependency._id, to: secondPkg.nameDoc._id, label: 'dependency'}, 
-		{fromKey: firstPkg.versionDoc._key, toKey: isDependency._key, from: firstPkg.versionDoc._id, to: isDependency._id, label: 'subject'}]
+		{fromKey: isDependency._key, toKey: secondPkg.nameDoc._key, from: isDependency._id, to: secondPkg.name_id, label: 'dependency'}, 
+		{fromKey: firstPkg.versionDoc._key, toKey: isDependency._key, from: firstPkg.version_id, to: isDependency._id, label: 'subject'}]
 	  
 		INSERT { _key: CONCAT('isDependencyEdges', edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isDependencyEdges OPTIONS { overwriteMode: 'ignore' }
 		)
@@ -240,15 +240,15 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
     )
 	  
 	  LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.versionDoc._id, depPackageID:secondPkg.nameDoc._id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
-			  INSERT { packageID:firstPkg.versionDoc._id, depPackageID:secondPkg.nameDoc._id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
+			  INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
 			  UPDATE {} IN isDependencies
 			  RETURN NEW
 	  )
 	  
 	  LET edgeCollection = (FOR edgeData IN [
-		{fromKey: isDependency._key, toKey: secondPkg.nameDoc._key, from: isDependency._id, to: secondPkg.nameDoc._id, label: "dependency"}, 
-		{fromKey: firstPkg.versionDoc._key, toKey: isDependency._key, from: firstPkg.versionDoc._id, to: isDependency._id, label: "subject"}]
+		{fromKey: isDependency._key, toKey: secondPkg.nameDoc._key, from: isDependency._id, to: secondPkg.name_id, label: "dependency"}, 
+		{fromKey: firstPkg.versionDoc._key, toKey: isDependency._key, from: firstPkg.version_id, to: isDependency._id, label: "subject"}]
 	
 		INSERT { _key: CONCAT("isDependencyEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isDependencyEdges OPTIONS { overwriteMode: "ignore" }
 	  )

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -315,32 +315,14 @@ func convertDependencyTypeToEnum(status string) (model.DependencyType, error) {
 
 func getIsDependency(ctx context.Context, cursor driver.Cursor) ([]*model.IsDependency, error) {
 	type collectedData struct {
-		PkgVersion struct {
-			TypeID        string   `json:"type_id"`
-			PkgType       string   `json:"type"`
-			NamespaceID   string   `json:"namespace_id"`
-			Namespace     string   `json:"namespace"`
-			NameID        string   `json:"name_id"`
-			Name          string   `json:"name"`
-			VersionID     string   `json:"version_id"`
-			Version       string   `json:"version"`
-			Subpath       string   `json:"subpath"`
-			QualifierList []string `json:"qualifier_list"`
-		} `json:"pkgVersion"`
-		DepPkg struct {
-			TypeID      string `json:"type_id"`
-			PkgType     string `json:"type"`
-			NamespaceID string `json:"namespace_id"`
-			Namespace   string `json:"namespace"`
-			NameID      string `json:"name_id"`
-			Name        string `json:"name"`
-		} `json:"depPkg"`
-		IsDependencyID string `json:"isDependency_id"`
-		VersionRange   string `json:"versionRange"`
-		DependencyType string `json:"dependencyType"`
-		Justification  string `json:"justification"`
-		Collector      string `json:"collector"`
-		Origin         string `json:"origin"`
+		PkgVersion     dbPkgVersion `json:"pkgVersion"`
+		DepPkg         dbPkgName    `json:"depPkg"`
+		IsDependencyID string       `json:"isDependency_id"`
+		VersionRange   string       `json:"versionRange"`
+		DependencyType string       `json:"dependencyType"`
+		Justification  string       `json:"justification"`
+		Collector      string       `json:"collector"`
+		Origin         string       `json:"origin"`
 	}
 
 	var createdValues []collectedData

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -452,18 +452,7 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 
 func getPkgIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsOccurrence, error) {
 	type collectedData struct {
-		PkgVersion struct {
-			TypeID        string   `json:"type_id"`
-			PkgType       string   `json:"type"`
-			NamespaceID   string   `json:"namespace_id"`
-			Namespace     string   `json:"namespace"`
-			NameID        string   `json:"name_id"`
-			Name          string   `json:"name"`
-			VersionID     string   `json:"version_id"`
-			Version       string   `json:"version"`
-			Subpath       string   `json:"subpath"`
-			QualifierList []string `json:"qualifier_list"`
-		} `json:"pkgVersion"`
+		PkgVersion     dbPkgVersion   `json:"pkgVersion"`
 		Artifact       model.Artifact `json:"artifact"`
 		IsOccurrenceID string         `json:"isOccurrence_id"`
 		Justification  string         `json:"justification"`
@@ -505,16 +494,7 @@ func getPkgIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsO
 
 func getSrcIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsOccurrence, error) {
 	type collectedData struct {
-		SrcName struct {
-			TypeID      string `json:"type_id"`
-			SrcType     string `json:"type"`
-			NamespaceID string `json:"namespace_id"`
-			Namespace   string `json:"namespace"`
-			NameID      string `json:"name_id"`
-			Name        string `json:"name"`
-			Commit      string `json:"commit"`
-			Tag         string `json:"tag"`
-		} `json:"srcName"`
+		SrcName        dbSrcName      `json:"srcName"`
 		Artifact       model.Artifact `json:"artifact"`
 		IsOccurrenceID string         `json:"isOccurrence_id"`
 		Justification  string         `json:"justification"`

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -453,16 +453,16 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 func getPkgIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsOccurrence, error) {
 	type collectedData struct {
 		PkgVersion struct {
-			TypeID        string        `json:"type_id"`
-			PkgType       string        `json:"type"`
-			NamespaceID   string        `json:"namespace_id"`
-			Namespace     string        `json:"namespace"`
-			NameID        string        `json:"name_id"`
-			Name          string        `json:"name"`
-			VersionID     string        `json:"version_id"`
-			Version       string        `json:"version"`
-			Subpath       string        `json:"subpath"`
-			QualifierList []interface{} `json:"qualifier_list"`
+			TypeID        string   `json:"type_id"`
+			PkgType       string   `json:"type"`
+			NamespaceID   string   `json:"namespace_id"`
+			Namespace     string   `json:"namespace"`
+			NameID        string   `json:"name_id"`
+			Name          string   `json:"name"`
+			VersionID     string   `json:"version_id"`
+			Version       string   `json:"version"`
+			Subpath       string   `json:"subpath"`
+			QualifierList []string `json:"qualifier_list"`
 		} `json:"pkgVersion"`
 		Artifact       model.Artifact `json:"artifact"`
 		IsOccurrenceID string         `json:"isOccurrence_id"`
@@ -488,11 +488,8 @@ func getPkgIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsO
 
 	var isOccurrenceList []*model.IsOccurrence
 	for _, createdValue := range createdValues {
-		pkg, err := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
 			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-		}
 
 		isOccurrence := &model.IsOccurrence{
 			ID:        createdValue.IsOccurrenceID,

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -228,15 +228,15 @@ func (c *arangoClient) IngestOccurrences(ctx context.Context, subjects model.Pac
 		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 		  
 		  LET isOccurrence = FIRST(
-			  UPSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				  INSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			  UPSERT { sourceID:firstSrc.name_id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT { sourceID:firstSrc.name_id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
 				  UPDATE {} IN isOccurrences
 				  RETURN NEW
 		  )
 		  
 		  LET edgeCollection = (FOR edgeData IN [
 			{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
-			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.nameDoc._id, to: isOccurrence._id, label: "subject"}]
+			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.name_id, to: isOccurrence._id, label: "subject"}]
 		
 		  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
 		  )
@@ -393,15 +393,15 @@ func (c *arangoClient) IngestOccurrence(ctx context.Context, subject model.Packa
 		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
 		  
 		  LET isOccurrence = FIRST(
-			  UPSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
-				  INSERT { sourceID:firstSrc.nameDoc._id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
+			  UPSERT { sourceID:firstSrc.name_id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
+				  INSERT { sourceID:firstSrc.name_id, artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin } 
 				  UPDATE {} IN isOccurrences
 				  RETURN NEW
 		  )
 		  
 		  LET edgeCollection = (FOR edgeData IN [
 			{fromKey: isOccurrence._key, toKey: artifact._key, from: isOccurrence._id, to: artifact._id, label: "has_occurrence"}, 
-			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.nameDoc._id, to: isOccurrence._id, label: "subject"}]
+			{fromKey: firstSrc.nameDoc._key, toKey: isOccurrence._key, from: firstSrc.name_id, to: isOccurrence._id, label: "subject"}]
 		
 		  INSERT { _key: CONCAT("isOccurrencesEdges", edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isOccurrencesEdges OPTIONS { overwriteMode: "ignore" }
 		  )

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -540,7 +540,7 @@ func getSrcIsOccurrence(ctx context.Context, cursor driver.Cursor) ([]*model.IsO
 	var isOccurrenceList []*model.IsOccurrence
 	for _, createdValue := range createdValues {
 		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
-			createdValue.SrcName.NameID, createdValue.SrcName.Name, &createdValue.SrcName.Commit, &createdValue.SrcName.Tag)
+			createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
 
 		isOccurrence := &model.IsOccurrence{
 			ID:        createdValue.IsOccurrenceID,

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -26,6 +26,40 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+type dbPkgVersion struct {
+	TypeID        string   `json:"type_id"`
+	PkgType       string   `json:"type"`
+	NamespaceID   string   `json:"namespace_id"`
+	Namespace     string   `json:"namespace"`
+	NameID        string   `json:"name_id"`
+	Name          string   `json:"name"`
+	VersionID     string   `json:"version_id"`
+	Version       string   `json:"version"`
+	Subpath       string   `json:"subpath"`
+	QualifierList []string `json:"qualifier_list"`
+}
+
+type dbPkgName struct {
+	TypeID      string `json:"type_id"`
+	PkgType     string `json:"type"`
+	NamespaceID string `json:"namespace_id"`
+	Namespace   string `json:"namespace"`
+	NameID      string `json:"name_id"`
+	Name        string `json:"name"`
+}
+
+type dbPkgNamespace struct {
+	TypeID      string `json:"type_id"`
+	PkgType     string `json:"type"`
+	NamespaceID string `json:"namespace_id"`
+	Namespace   string `json:"namespace"`
+}
+
+type dbPkgType struct {
+	TypeID  string `json:"type_id"`
+	PkgType string `json:"type"`
+}
+
 type PkgIds struct {
 	TypeId      string
 	NamespaceId string
@@ -421,14 +455,9 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID  string `json:"type_id"`
-		PkgType string `json:"type"`
-	}
-
 	var packages []*model.Package
 	for {
-		var doc collectedData
+		var doc dbPkgType
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {
 			if driver.IsNoMoreDocuments(err) {
@@ -481,16 +510,9 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID      string `json:"type_id"`
-		PkgType     string `json:"type"`
-		NamespaceID string `json:"namespace_id"`
-		Namespace   string `json:"namespace"`
-	}
-
 	pkgTypes := map[string][]*model.PackageNamespace{}
 	for {
-		var doc collectedData
+		var doc dbPkgNamespace
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {
 			if driver.IsNoMoreDocuments(err) {
@@ -563,18 +585,9 @@ func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec)
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID      string `json:"type_id"`
-		PkgType     string `json:"type"`
-		NamespaceID string `json:"namespace_id"`
-		Namespace   string `json:"namespace"`
-		NameID      string `json:"name_id"`
-		Name        string `json:"name"`
-	}
-
 	pkgTypes := map[string]map[string][]*model.PackageName{}
 	for {
-		var doc collectedData
+		var doc dbPkgName
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {
 			if driver.IsNoMoreDocuments(err) {
@@ -627,21 +640,9 @@ func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec)
 }
 
 func getPackages(ctx context.Context, cursor driver.Cursor) ([]*model.Package, error) {
-	type collectedData struct {
-		TypeID        string   `json:"type_id"`
-		PkgType       string   `json:"type"`
-		NamespaceID   string   `json:"namespace_id"`
-		Namespace     string   `json:"namespace"`
-		NameID        string   `json:"name_id"`
-		Name          string   `json:"name"`
-		VersionID     string   `json:"version_id"`
-		Version       string   `json:"version"`
-		Subpath       string   `json:"subpath"`
-		QualifierList []string `json:"qualifier_list"`
-	}
 
 	pkgTypes := map[string]map[string]map[string][]*model.PackageVersion{}
-	var doc collectedData
+	var doc dbPkgVersion
 	for {
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -285,8 +285,9 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 }
 
 func setPkgMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *arangoQueryBuilder {
+	var arangoQueryBuilder *arangoQueryBuilder
 	if pkgSpec != nil {
-		arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
+		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
 		arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 		queryValues["pkg"] = "pkg"
 		arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
@@ -317,7 +318,6 @@ func setPkgMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *aran
 			arangoQueryBuilder.filter("pVersion", "qualifier_list", "==", "@qualifier")
 			queryValues["qualifier"] = getQualifiers(pkgSpec.Qualifiers)
 		}
-
 		if !*pkgSpec.MatchOnlyEmptyQualifiers {
 			if len(pkgSpec.Qualifiers) > 0 {
 				arangoQueryBuilder.filter("pVersion", "qualifier_list", "==", "@qualifier")
@@ -327,8 +327,15 @@ func setPkgMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *aran
 			arangoQueryBuilder.filter("pVersion", "qualifier_list", "==", "@qualifier")
 			queryValues["objPkgQualifierList"] = []string{}
 		}
+
+	} else {
+		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
+		arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
+		arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
+		arangoQueryBuilder.ForOutBound(pkgHasVersionStr, "pVersion", "pName")
 	}
-	return nil
+	return arangoQueryBuilder
 }
 
 func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -115,7 +115,7 @@ func getPackageQueryValues(c *arangoClient, pkg *model.PkgInputSpec) map[string]
 
 	// To ensure consistency, always sort the qualifiers by key
 	qualifiersMap := map[string]string{}
-	keys := []string{}
+	var keys []string
 	for _, kv := range pkg.Qualifiers {
 		qualifiersMap[kv.Key] = kv.Value
 		keys = append(keys, kv.Key)

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -136,16 +136,16 @@ RETURN {
 			Name        string `json:"name"`
 		} `json:"pkgName,omitempty"`
 		PkgVersion *struct {
-			TypeID        string        `json:"type_id"`
-			PkgType       string        `json:"type"`
-			NamespaceID   string        `json:"namespace_id"`
-			Namespace     string        `json:"namespace"`
-			NameID        string        `json:"name_id"`
-			Name          string        `json:"name"`
-			VersionID     string        `json:"version_id"`
-			Version       string        `json:"version"`
-			Subpath       string        `json:"subpath"`
-			QualifierList []interface{} `json:"qualifier_list"`
+			TypeID        string   `json:"type_id"`
+			PkgType       string   `json:"type"`
+			NamespaceID   string   `json:"namespace_id"`
+			Namespace     string   `json:"namespace"`
+			NameID        string   `json:"name_id"`
+			Name          string   `json:"name"`
+			VersionID     string   `json:"version_id"`
+			Version       string   `json:"version"`
+			Subpath       string   `json:"subpath"`
+			QualifierList []string `json:"qualifier_list"`
 		} `json:"pkgVersion,omitempty"`
 		SrcName *struct {
 			TypeID      string `json:"type_id"`
@@ -194,20 +194,14 @@ RETURN {
 				if p == nil {
 					return nil, fmt.Errorf("failed to parse result of pkgVersion, got nil when expected non-nil")
 				}
-				pkg, err := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, &p.VersionID, &p.Version, &p.Subpath, p.QualifierList)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-				}
+				pkg := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, &p.VersionID, &p.Version, &p.Subpath, p.QualifierList)
 				results = append(results, pkg)
 			case "pkgName":
 				p := d.PkgName
 				if p == nil {
 					return nil, fmt.Errorf("failed to parse result of pkgName, got nil when expected non-nil")
 				}
-				pkg, err := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, nil, nil, nil, nil)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get model.package with err: %w", err)
-				}
+				pkg := generateModelPackage(p.TypeID, p.PkgType, p.NamespaceID, p.Namespace, p.NameID, p.Name, nil, nil, nil, nil)
 				results = append(results, pkg)
 			case "SrcName":
 				s := d.SrcName

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -208,7 +208,7 @@ RETURN {
 				if s == nil {
 					return nil, fmt.Errorf("failed to parse result of SrcName, got nil when expected non-nil")
 				}
-				src := generateModelSource(s.TypeID, s.SrcType, s.NamespaceID, s.Namespace, s.NameID, s.Name, &s.Commit, &s.Tag)
+				src := generateModelSource(s.TypeID, s.SrcType, s.NamespaceID, s.Namespace, s.NameID, s.Name, s.Commit, s.Tag)
 
 				results = append(results, src)
 			}

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -127,27 +127,9 @@ RETURN {
 	type parsedDoc struct {
 		NodeType string `json:"nodeType"`
 
-		PkgName *struct {
-			TypeID      string `json:"type_id"`
-			PkgType     string `json:"type"`
-			NamespaceID string `json:"namespace_id"`
-			Namespace   string `json:"namespace"`
-			NameID      string `json:"name_id"`
-			Name        string `json:"name"`
-		} `json:"pkgName,omitempty"`
-		PkgVersion *struct {
-			TypeID        string   `json:"type_id"`
-			PkgType       string   `json:"type"`
-			NamespaceID   string   `json:"namespace_id"`
-			Namespace     string   `json:"namespace"`
-			NameID        string   `json:"name_id"`
-			Name          string   `json:"name"`
-			VersionID     string   `json:"version_id"`
-			Version       string   `json:"version"`
-			Subpath       string   `json:"subpath"`
-			QualifierList []string `json:"qualifier_list"`
-		} `json:"pkgVersion,omitempty"`
-		SrcName *struct {
+		PkgName    *dbPkgName    `json:"pkgName,omitempty"`
+		PkgVersion *dbPkgVersion `json:"pkgVersion,omitempty"`
+		SrcName    *struct {
 			TypeID      string `json:"type_id"`
 			SrcType     string `json:"type"`
 			NamespaceID string `json:"namespace_id"`

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -411,7 +411,7 @@ func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.S
 			srcTypes[typeString] = append(srcTypes[typeString], srcNamespace)
 		}
 	}
-	sources := []*model.Source{}
+	var sources []*model.Source
 	for pkgType, namespaces := range srcTypes {
 		typeValues := strings.Split(pkgType, ",")
 		collectedSource := &model.Source{
@@ -469,9 +469,9 @@ func getSources(ctx context.Context, cursor driver.Cursor) ([]*model.Source, err
 			}
 		}
 	}
-	sources := []*model.Source{}
+	var sources []*model.Source
 	for srcType, namespaces := range srcTypes {
-		sourceNamespaces := []*model.SourceNamespace{}
+		var sourceNamespaces []*model.SourceNamespace
 		for namespace, sourceNames := range namespaces {
 			namespaceValues := strings.Split(namespace, ",")
 			srcNamespace := &model.SourceNamespace{

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -25,6 +25,29 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+type dbSrcName struct {
+	TypeID      string `json:"type_id"`
+	SrcType     string `json:"type"`
+	NamespaceID string `json:"namespace_id"`
+	Namespace   string `json:"namespace"`
+	NameID      string `json:"name_id"`
+	Name        string `json:"name"`
+	Commit      string `json:"commit"`
+	Tag         string `json:"tag"`
+}
+
+type dbSrcNamespace struct {
+	TypeID      string `json:"type_id"`
+	SrcType     string `json:"type"`
+	NamespaceID string `json:"namespace_id"`
+	Namespace   string `json:"namespace"`
+}
+
+type dbSrcType struct {
+	TypeID  string `json:"type_id"`
+	SrcType string `json:"type"`
+}
+
 type SrcIds struct {
 	TypeId      string
 	NamespaceId string
@@ -335,14 +358,9 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID  string `json:"type_id"`
-		SrcType string `json:"type"`
-	}
-
 	var sources []*model.Source
 	for {
-		var doc collectedData
+		var doc dbSrcType
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {
 			if driver.IsNoMoreDocuments(err) {
@@ -395,16 +413,9 @@ func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.S
 	}
 	defer cursor.Close()
 
-	type collectedData struct {
-		TypeID      string `json:"type_id"`
-		SrcType     string `json:"type"`
-		NamespaceID string `json:"namespace_id"`
-		Namespace   string `json:"namespace"`
-	}
-
 	srcTypes := map[string][]*model.SourceNamespace{}
 	for {
-		var doc collectedData
+		var doc dbSrcNamespace
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {
 			if driver.IsNoMoreDocuments(err) {
@@ -439,19 +450,8 @@ func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.S
 }
 
 func getSources(ctx context.Context, cursor driver.Cursor) ([]*model.Source, error) {
-	type ingestedSource struct {
-		TypeID      string `json:"type_id"`
-		SrcType     string `json:"type"`
-		NamespaceID string `json:"namespace_id"`
-		Namespace   string `json:"namespace"`
-		NameID      string `json:"name_id"`
-		Name        string `json:"name"`
-		Commit      string `json:"commit"`
-		Tag         string `json:"tag"`
-	}
-
 	srcTypes := map[string]map[string][]*model.SourceName{}
-	var doc ingestedSource
+	var doc dbSrcName
 	for {
 		_, err := cursor.ReadDocument(ctx, &doc)
 		if err != nil {

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -69,7 +69,8 @@ type Backend interface {
 	IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]*model.Source, error)
 
 	// Mutations for evidence trees (read-write queries, assume software trees ingested)
-	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
+	IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
+	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error)
 	IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error)
 	IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error)
 	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -53,8 +53,25 @@ func (n *scorecardLink) BuildModelNode(c *demoClient) (model.Node, error) {
 	return c.buildScorecard(n, nil, true)
 }
 
+// Ingest Scorecards
+
+func (c *demoClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
+	if len(sources) != len(scorecards) {
+		return nil, gqlerror.Errorf("uneven source and scorecards for ingestion")
+	}
+	var modelCertifyScorecards []*model.CertifyScorecard
+	for i := range scorecards {
+		scorecard, err := c.IngestScorecard(ctx, *sources[i], *scorecards[i])
+		if err != nil {
+			return nil, gqlerror.Errorf("IngestScorecard failed with err: %v", err)
+		}
+		modelCertifyScorecards = append(modelCertifyScorecards, scorecard)
+	}
+	return modelCertifyScorecards, nil
+}
+
 // Ingest CertifyScorecard
-func (c *demoClient) CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
+func (c *demoClient) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
 	return c.certifyScorecard(ctx, source, scorecard, true)
 }
 

--- a/pkg/assembler/backends/inmem/certifyScorecard_test.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard_test.go
@@ -419,7 +419,7 @@ func TestCertifyScorecard(t *testing.T) {
 				}
 			}
 			for _, o := range test.Calls {
-				_, err := b.CertifyScorecard(ctx, *o.Src, *o.SC)
+				_, err := b.IngestScorecard(ctx, *o.Src, *o.SC)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
@@ -514,7 +514,7 @@ func TestCertifyScorecardNeighbors(t *testing.T) {
 				}
 			}
 			for _, o := range test.Calls {
-				if _, err := b.CertifyScorecard(ctx, *o.Src, *o.SC); err != nil {
+				if _, err := b.IngestScorecard(ctx, *o.Src, *o.SC); err != nil {
 					t.Fatalf("Could not ingest CertifyScorecard: %v", err)
 				}
 			}

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -53,7 +53,6 @@ func (n *isDependencyLink) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest IngestDependencies
 
 func (c *demoClient) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
-
 	if len(pkgs) != len(depPkgs) {
 		return nil, gqlerror.Errorf("uneven packages and dependent packages for ingestion")
 	}

--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -17,6 +17,7 @@ package neo4j
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -189,7 +190,13 @@ func setCertifyScorecardValues(sb *strings.Builder, certifyScorecardSpec *model.
 
 // Ingest Scorecards
 
-func (c *neo4jClient) CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
+func (c *neo4jClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
+	return []*model.CertifyScorecard{}, fmt.Errorf("not implemented: IngestDependencies")
+}
+
+// Ingest Scorecard
+
+func (c *neo4jClient) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 

--- a/pkg/assembler/backends/neo4j/certifyScorecard.go
+++ b/pkg/assembler/backends/neo4j/certifyScorecard.go
@@ -191,7 +191,7 @@ func setCertifyScorecardValues(sb *strings.Builder, certifyScorecardSpec *model.
 // Ingest Scorecards
 
 func (c *neo4jClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
-	return []*model.CertifyScorecard{}, fmt.Errorf("not implemented: IngestDependencies")
+	return []*model.CertifyScorecard{}, fmt.Errorf("not implemented: IngestScorecards")
 }
 
 // Ingest Scorecard

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -3557,6 +3557,176 @@ func (v *CertifyOSVResponse) GetIngestVulnerability() CertifyOSVIngestVulnerabil
 	return v.IngestVulnerability
 }
 
+// CertifyScorecardIngestScorecardCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
+// The GraphQL type's documentation follows.
+//
+// CertifyScorecard is an attestation to attach a Scorecard analysis to a
+// particular source repository.
+type CertifyScorecardIngestScorecardCertifyScorecard struct {
+	AllCertifyScorecard `json:"-"`
+}
+
+// GetId returns CertifyScorecardIngestScorecardCertifyScorecard.Id, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetId() string {
+	return v.AllCertifyScorecard.Id
+}
+
+// GetSource returns CertifyScorecardIngestScorecardCertifyScorecard.Source, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetSource() AllCertifyScorecardSource {
+	return v.AllCertifyScorecard.Source
+}
+
+// GetScorecard returns CertifyScorecardIngestScorecardCertifyScorecard.Scorecard, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetScorecard() AllCertifyScorecardScorecard {
+	return v.AllCertifyScorecard.Scorecard
+}
+
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CertifyScorecardIngestScorecardCertifyScorecard
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CertifyScorecardIngestScorecardCertifyScorecard = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCertifyScorecard)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalCertifyScorecardIngestScorecardCertifyScorecard struct {
+	Id string `json:"id"`
+
+	Source AllCertifyScorecardSource `json:"source"`
+
+	Scorecard AllCertifyScorecardScorecard `json:"scorecard"`
+}
+
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CertifyScorecardIngestScorecardCertifyScorecard) __premarshalJSON() (*__premarshalCertifyScorecardIngestScorecardCertifyScorecard, error) {
+	var retval __premarshalCertifyScorecardIngestScorecardCertifyScorecard
+
+	retval.Id = v.AllCertifyScorecard.Id
+	retval.Source = v.AllCertifyScorecard.Source
+	retval.Scorecard = v.AllCertifyScorecard.Scorecard
+	return &retval, nil
+}
+
+// CertifyScorecardResponse is returned by CertifyScorecard on success.
+type CertifyScorecardResponse struct {
+	// Adds a certification that a source repository has a Scorecard.
+	IngestScorecard CertifyScorecardIngestScorecardCertifyScorecard `json:"ingestScorecard"`
+}
+
+// GetIngestScorecard returns CertifyScorecardResponse.IngestScorecard, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardResponse) GetIngestScorecard() CertifyScorecardIngestScorecardCertifyScorecard {
+	return v.IngestScorecard
+}
+
+// CertifyScorecardsIngestScorecardsCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
+// The GraphQL type's documentation follows.
+//
+// CertifyScorecard is an attestation to attach a Scorecard analysis to a
+// particular source repository.
+type CertifyScorecardsIngestScorecardsCertifyScorecard struct {
+	AllCertifyScorecard `json:"-"`
+}
+
+// GetId returns CertifyScorecardsIngestScorecardsCertifyScorecard.Id, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetId() string {
+	return v.AllCertifyScorecard.Id
+}
+
+// GetSource returns CertifyScorecardsIngestScorecardsCertifyScorecard.Source, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetSource() AllCertifyScorecardSource {
+	return v.AllCertifyScorecard.Source
+}
+
+// GetScorecard returns CertifyScorecardsIngestScorecardsCertifyScorecard.Scorecard, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetScorecard() AllCertifyScorecardScorecard {
+	return v.AllCertifyScorecard.Scorecard
+}
+
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CertifyScorecardsIngestScorecardsCertifyScorecard
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CertifyScorecardsIngestScorecardsCertifyScorecard = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCertifyScorecard)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalCertifyScorecardsIngestScorecardsCertifyScorecard struct {
+	Id string `json:"id"`
+
+	Source AllCertifyScorecardSource `json:"source"`
+
+	Scorecard AllCertifyScorecardScorecard `json:"scorecard"`
+}
+
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) __premarshalJSON() (*__premarshalCertifyScorecardsIngestScorecardsCertifyScorecard, error) {
+	var retval __premarshalCertifyScorecardsIngestScorecardsCertifyScorecard
+
+	retval.Id = v.AllCertifyScorecard.Id
+	retval.Source = v.AllCertifyScorecard.Source
+	retval.Scorecard = v.AllCertifyScorecard.Scorecard
+	return &retval, nil
+}
+
+// CertifyScorecardsResponse is returned by CertifyScorecards on success.
+type CertifyScorecardsResponse struct {
+	// Adds bulk certifications that a source repository has a Scorecard.
+	IngestScorecards []CertifyScorecardsIngestScorecardsCertifyScorecard `json:"ingestScorecards"`
+}
+
+// GetIngestScorecards returns CertifyScorecardsResponse.IngestScorecards, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardsResponse) GetIngestScorecards() []CertifyScorecardsIngestScorecardsCertifyScorecard {
+	return v.IngestScorecards
+}
+
 // DependencyType determines the type of the dependency.
 type DependencyType string
 
@@ -18242,78 +18412,6 @@ func (v *SLSAPredicateInputSpec) GetKey() string { return v.Key }
 // GetValue returns SLSAPredicateInputSpec.Value, and is useful for accessing the field via an interface.
 func (v *SLSAPredicateInputSpec) GetValue() string { return v.Value }
 
-// ScorecardCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
-// The GraphQL type's documentation follows.
-//
-// CertifyScorecard is an attestation to attach a Scorecard analysis to a
-// particular source repository.
-type ScorecardCertifyScorecard struct {
-	AllCertifyScorecard `json:"-"`
-}
-
-// GetId returns ScorecardCertifyScorecard.Id, and is useful for accessing the field via an interface.
-func (v *ScorecardCertifyScorecard) GetId() string { return v.AllCertifyScorecard.Id }
-
-// GetSource returns ScorecardCertifyScorecard.Source, and is useful for accessing the field via an interface.
-func (v *ScorecardCertifyScorecard) GetSource() AllCertifyScorecardSource {
-	return v.AllCertifyScorecard.Source
-}
-
-// GetScorecard returns ScorecardCertifyScorecard.Scorecard, and is useful for accessing the field via an interface.
-func (v *ScorecardCertifyScorecard) GetScorecard() AllCertifyScorecardScorecard {
-	return v.AllCertifyScorecard.Scorecard
-}
-
-func (v *ScorecardCertifyScorecard) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*ScorecardCertifyScorecard
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.ScorecardCertifyScorecard = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyScorecard)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalScorecardCertifyScorecard struct {
-	Id string `json:"id"`
-
-	Source AllCertifyScorecardSource `json:"source"`
-
-	Scorecard AllCertifyScorecardScorecard `json:"scorecard"`
-}
-
-func (v *ScorecardCertifyScorecard) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *ScorecardCertifyScorecard) __premarshalJSON() (*__premarshalScorecardCertifyScorecard, error) {
-	var retval __premarshalScorecardCertifyScorecard
-
-	retval.Id = v.AllCertifyScorecard.Id
-	retval.Source = v.AllCertifyScorecard.Source
-	retval.Scorecard = v.AllCertifyScorecard.Scorecard
-	return &retval, nil
-}
-
 // ScorecardCheckInputSpec represents the mutation input for a Scorecard check.
 type ScorecardCheckInputSpec struct {
 	Check string `json:"check"`
@@ -18357,17 +18455,6 @@ func (v *ScorecardInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns ScorecardInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *ScorecardInputSpec) GetCollector() string { return v.Collector }
-
-// ScorecardResponse is returned by Scorecard on success.
-type ScorecardResponse struct {
-	// Adds a certification that a source repository has a Scorecard.
-	CertifyScorecard ScorecardCertifyScorecard `json:"certifyScorecard"`
-}
-
-// GetCertifyScorecard returns ScorecardResponse.CertifyScorecard, and is useful for accessing the field via an interface.
-func (v *ScorecardResponse) GetCertifyScorecard() ScorecardCertifyScorecard {
-	return v.CertifyScorecard
-}
 
 // SourceInputSpec specifies a source for mutations.
 //
@@ -19752,6 +19839,30 @@ func (v *__CertifyOSVInput) GetOsv() OSVInputSpec { return v.Osv }
 // GetCertifyVuln returns __CertifyOSVInput.CertifyVuln, and is useful for accessing the field via an interface.
 func (v *__CertifyOSVInput) GetCertifyVuln() VulnerabilityMetaDataInput { return v.CertifyVuln }
 
+// __CertifyScorecardInput is used internally by genqlient
+type __CertifyScorecardInput struct {
+	Source    SourceInputSpec    `json:"source"`
+	Scorecard ScorecardInputSpec `json:"scorecard"`
+}
+
+// GetSource returns __CertifyScorecardInput.Source, and is useful for accessing the field via an interface.
+func (v *__CertifyScorecardInput) GetSource() SourceInputSpec { return v.Source }
+
+// GetScorecard returns __CertifyScorecardInput.Scorecard, and is useful for accessing the field via an interface.
+func (v *__CertifyScorecardInput) GetScorecard() ScorecardInputSpec { return v.Scorecard }
+
+// __CertifyScorecardsInput is used internally by genqlient
+type __CertifyScorecardsInput struct {
+	Sources    []SourceInputSpec    `json:"sources"`
+	Scorecards []ScorecardInputSpec `json:"scorecards"`
+}
+
+// GetSources returns __CertifyScorecardsInput.Sources, and is useful for accessing the field via an interface.
+func (v *__CertifyScorecardsInput) GetSources() []SourceInputSpec { return v.Sources }
+
+// GetScorecards returns __CertifyScorecardsInput.Scorecards, and is useful for accessing the field via an interface.
+func (v *__CertifyScorecardsInput) GetScorecards() []ScorecardInputSpec { return v.Scorecards }
+
 // __FindSoftwareInput is used internally by genqlient
 type __FindSoftwareInput struct {
 	SearchText string `json:"searchText"`
@@ -20241,18 +20352,6 @@ func (v *__SLSAForArtifactInput) GetBuilder() BuilderInputSpec { return v.Builde
 
 // GetSlsa returns __SLSAForArtifactInput.Slsa, and is useful for accessing the field via an interface.
 func (v *__SLSAForArtifactInput) GetSlsa() SLSAInputSpec { return v.Slsa }
-
-// __ScorecardInput is used internally by genqlient
-type __ScorecardInput struct {
-	Source    SourceInputSpec    `json:"source"`
-	Scorecard ScorecardInputSpec `json:"scorecard"`
-}
-
-// GetSource returns __ScorecardInput.Source, and is useful for accessing the field via an interface.
-func (v *__ScorecardInput) GetSource() SourceInputSpec { return v.Source }
-
-// GetScorecard returns __ScorecardInput.Scorecard, and is useful for accessing the field via an interface.
-func (v *__ScorecardInput) GetScorecard() ScorecardInputSpec { return v.Scorecard }
 
 // __SourcesInput is used internally by genqlient
 type __SourcesInput struct {
@@ -25509,6 +25608,144 @@ func CertifyOSV(
 	return &data, err
 }
 
+// The query or mutation executed by CertifyScorecard.
+const CertifyScorecard_Operation = `
+mutation CertifyScorecard ($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
+	ingestScorecard(source: $source, scorecard: $scorecard) {
+		... AllCertifyScorecard
+	}
+}
+fragment AllCertifyScorecard on CertifyScorecard {
+	id
+	source {
+		... AllSourceTree
+	}
+	scorecard {
+		timeScanned
+		aggregateScore
+		checks {
+			check
+			score
+		}
+		scorecardVersion
+		scorecardCommit
+		origin
+		collector
+	}
+}
+fragment AllSourceTree on Source {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			tag
+			commit
+		}
+	}
+}
+`
+
+func CertifyScorecard(
+	ctx context.Context,
+	client graphql.Client,
+	source SourceInputSpec,
+	scorecard ScorecardInputSpec,
+) (*CertifyScorecardResponse, error) {
+	req := &graphql.Request{
+		OpName: "CertifyScorecard",
+		Query:  CertifyScorecard_Operation,
+		Variables: &__CertifyScorecardInput{
+			Source:    source,
+			Scorecard: scorecard,
+		},
+	}
+	var err error
+
+	var data CertifyScorecardResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by CertifyScorecards.
+const CertifyScorecards_Operation = `
+mutation CertifyScorecards ($sources: [SourceInputSpec!]!, $scorecards: [ScorecardInputSpec!]!) {
+	ingestScorecards(sources: $sources, scorecards: $scorecards) {
+		... AllCertifyScorecard
+	}
+}
+fragment AllCertifyScorecard on CertifyScorecard {
+	id
+	source {
+		... AllSourceTree
+	}
+	scorecard {
+		timeScanned
+		aggregateScore
+		checks {
+			check
+			score
+		}
+		scorecardVersion
+		scorecardCommit
+		origin
+		collector
+	}
+}
+fragment AllSourceTree on Source {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			tag
+			commit
+		}
+	}
+}
+`
+
+func CertifyScorecards(
+	ctx context.Context,
+	client graphql.Client,
+	sources []SourceInputSpec,
+	scorecards []ScorecardInputSpec,
+) (*CertifyScorecardsResponse, error) {
+	req := &graphql.Request{
+		OpName: "CertifyScorecards",
+		Query:  CertifyScorecards_Operation,
+		Variables: &__CertifyScorecardsInput{
+			Sources:    sources,
+			Scorecards: scorecards,
+		},
+	}
+	var err error
+
+	var data CertifyScorecardsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by FindSoftware.
 const FindSoftware_Operation = `
 query FindSoftware ($searchText: String!) {
@@ -29548,75 +29785,6 @@ func SLSAForArtifact(
 	var err error
 
 	var data SLSAForArtifactResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
-// The query or mutation executed by Scorecard.
-const Scorecard_Operation = `
-mutation Scorecard ($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
-	certifyScorecard(source: $source, scorecard: $scorecard) {
-		... AllCertifyScorecard
-	}
-}
-fragment AllCertifyScorecard on CertifyScorecard {
-	id
-	source {
-		... AllSourceTree
-	}
-	scorecard {
-		timeScanned
-		aggregateScore
-		checks {
-			check
-			score
-		}
-		scorecardVersion
-		scorecardCommit
-		origin
-		collector
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-`
-
-func Scorecard(
-	ctx context.Context,
-	client graphql.Client,
-	source SourceInputSpec,
-	scorecard ScorecardInputSpec,
-) (*ScorecardResponse, error) {
-	req := &graphql.Request{
-		OpName: "Scorecard",
-		Query:  Scorecard_Operation,
-		Variables: &__ScorecardInput{
-			Source:    source,
-			Scorecard: scorecard,
-		},
-	}
-	var err error
-
-	var data ScorecardResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5625,6 +5625,91 @@ type IngestCVEResponse struct {
 // GetIngestCVE returns IngestCVEResponse.IngestCVE, and is useful for accessing the field via an interface.
 func (v *IngestCVEResponse) GetIngestCVE() IngestCVEIngestCVE { return v.IngestCVE }
 
+// IngestCVEsIngestCVEsCVE includes the requested fields of the GraphQL type CVE.
+// The GraphQL type's documentation follows.
+//
+// CVE represents a vulnerability in the Common Vulnerabilities and Exposures
+// schema.
+//
+// The vulnerability identifier contains a year field, so we are extracting that
+// to allow matching for vulnerabilities found in a given year.
+//
+// The vulnerability identifier field is mandatory and canonicalized to be
+// lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type IngestCVEsIngestCVEsCVE struct {
+	AllCveTree `json:"-"`
+}
+
+// GetId returns IngestCVEsIngestCVEsCVE.Id, and is useful for accessing the field via an interface.
+func (v *IngestCVEsIngestCVEsCVE) GetId() string { return v.AllCveTree.Id }
+
+// GetYear returns IngestCVEsIngestCVEsCVE.Year, and is useful for accessing the field via an interface.
+func (v *IngestCVEsIngestCVEsCVE) GetYear() int { return v.AllCveTree.Year }
+
+// GetCveId returns IngestCVEsIngestCVEsCVE.CveId, and is useful for accessing the field via an interface.
+func (v *IngestCVEsIngestCVEsCVE) GetCveId() string { return v.AllCveTree.CveId }
+
+func (v *IngestCVEsIngestCVEsCVE) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IngestCVEsIngestCVEsCVE
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IngestCVEsIngestCVEsCVE = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCveTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIngestCVEsIngestCVEsCVE struct {
+	Id string `json:"id"`
+
+	Year int `json:"year"`
+
+	CveId string `json:"cveId"`
+}
+
+func (v *IngestCVEsIngestCVEsCVE) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IngestCVEsIngestCVEsCVE) __premarshalJSON() (*__premarshalIngestCVEsIngestCVEsCVE, error) {
+	var retval __premarshalIngestCVEsIngestCVEsCVE
+
+	retval.Id = v.AllCveTree.Id
+	retval.Year = v.AllCveTree.Year
+	retval.CveId = v.AllCveTree.CveId
+	return &retval, nil
+}
+
+// IngestCVEsResponse is returned by IngestCVEs on success.
+type IngestCVEsResponse struct {
+	// Bulk ingests new CVEs and returns a list of them.
+	IngestCVEs []IngestCVEsIngestCVEsCVE `json:"ingestCVEs"`
+}
+
+// GetIngestCVEs returns IngestCVEsResponse.IngestCVEs, and is useful for accessing the field via an interface.
+func (v *IngestCVEsResponse) GetIngestCVEs() []IngestCVEsIngestCVEsCVE { return v.IngestCVEs }
+
 // IngestGHSAIngestGHSA includes the requested fields of the GraphQL type GHSA.
 // The GraphQL type's documentation follows.
 //
@@ -5698,6 +5783,80 @@ type IngestGHSAResponse struct {
 
 // GetIngestGHSA returns IngestGHSAResponse.IngestGHSA, and is useful for accessing the field via an interface.
 func (v *IngestGHSAResponse) GetIngestGHSA() IngestGHSAIngestGHSA { return v.IngestGHSA }
+
+// IngestGHSAsIngestGHSAsGHSA includes the requested fields of the GraphQL type GHSA.
+// The GraphQL type's documentation follows.
+//
+// GHSA represents GitHub security advisories.
+//
+// The advisory id field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type IngestGHSAsIngestGHSAsGHSA struct {
+	AllGHSATree `json:"-"`
+}
+
+// GetId returns IngestGHSAsIngestGHSAsGHSA.Id, and is useful for accessing the field via an interface.
+func (v *IngestGHSAsIngestGHSAsGHSA) GetId() string { return v.AllGHSATree.Id }
+
+// GetGhsaId returns IngestGHSAsIngestGHSAsGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *IngestGHSAsIngestGHSAsGHSA) GetGhsaId() string { return v.AllGHSATree.GhsaId }
+
+func (v *IngestGHSAsIngestGHSAsGHSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IngestGHSAsIngestGHSAsGHSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IngestGHSAsIngestGHSAsGHSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllGHSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIngestGHSAsIngestGHSAsGHSA struct {
+	Id string `json:"id"`
+
+	GhsaId string `json:"ghsaId"`
+}
+
+func (v *IngestGHSAsIngestGHSAsGHSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IngestGHSAsIngestGHSAsGHSA) __premarshalJSON() (*__premarshalIngestGHSAsIngestGHSAsGHSA, error) {
+	var retval __premarshalIngestGHSAsIngestGHSAsGHSA
+
+	retval.Id = v.AllGHSATree.Id
+	retval.GhsaId = v.AllGHSATree.GhsaId
+	return &retval, nil
+}
+
+// IngestGHSAsResponse is returned by IngestGHSAs on success.
+type IngestGHSAsResponse struct {
+	// Bulk ingests new GHSAs and returns a list of them.
+	IngestGHSAs []IngestGHSAsIngestGHSAsGHSA `json:"ingestGHSAs"`
+}
+
+// GetIngestGHSAs returns IngestGHSAsResponse.IngestGHSAs, and is useful for accessing the field via an interface.
+func (v *IngestGHSAsResponse) GetIngestGHSAs() []IngestGHSAsIngestGHSAsGHSA { return v.IngestGHSAs }
 
 // IngestMaterialsIngestMaterialsArtifact includes the requested fields of the GraphQL type Artifact.
 // The GraphQL type's documentation follows.
@@ -5861,6 +6020,83 @@ type IngestOSVResponse struct {
 
 // GetIngestOSV returns IngestOSVResponse.IngestOSV, and is useful for accessing the field via an interface.
 func (v *IngestOSVResponse) GetIngestOSV() IngestOSVIngestOSV { return v.IngestOSV }
+
+// IngestOSVsIngestOSVsOSV includes the requested fields of the GraphQL type OSV.
+// The GraphQL type's documentation follows.
+//
+// OSV represents an Open Source Vulnerability.
+//
+// The osvId field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
+type IngestOSVsIngestOSVsOSV struct {
+	AllOSVTree `json:"-"`
+}
+
+// GetId returns IngestOSVsIngestOSVsOSV.Id, and is useful for accessing the field via an interface.
+func (v *IngestOSVsIngestOSVsOSV) GetId() string { return v.AllOSVTree.Id }
+
+// GetOsvId returns IngestOSVsIngestOSVsOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *IngestOSVsIngestOSVsOSV) GetOsvId() string { return v.AllOSVTree.OsvId }
+
+func (v *IngestOSVsIngestOSVsOSV) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*IngestOSVsIngestOSVsOSV
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.IngestOSVsIngestOSVsOSV = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllOSVTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalIngestOSVsIngestOSVsOSV struct {
+	Id string `json:"id"`
+
+	OsvId string `json:"osvId"`
+}
+
+func (v *IngestOSVsIngestOSVsOSV) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *IngestOSVsIngestOSVsOSV) __premarshalJSON() (*__premarshalIngestOSVsIngestOSVsOSV, error) {
+	var retval __premarshalIngestOSVsIngestOSVsOSV
+
+	retval.Id = v.AllOSVTree.Id
+	retval.OsvId = v.AllOSVTree.OsvId
+	return &retval, nil
+}
+
+// IngestOSVsResponse is returned by IngestOSVs on success.
+type IngestOSVsResponse struct {
+	// Bulk ingests new OSVs and returns a list of them.
+	IngestOSVs []IngestOSVsIngestOSVsOSV `json:"ingestOSVs"`
+}
+
+// GetIngestOSVs returns IngestOSVsResponse.IngestOSVs, and is useful for accessing the field via an interface.
+func (v *IngestOSVsResponse) GetIngestOSVs() []IngestOSVsIngestOSVsOSV { return v.IngestOSVs }
 
 // IngestPackageIngestPackage includes the requested fields of the GraphQL type Package.
 // The GraphQL type's documentation follows.
@@ -20019,6 +20255,14 @@ type __IngestCVEInput struct {
 // GetCve returns __IngestCVEInput.Cve, and is useful for accessing the field via an interface.
 func (v *__IngestCVEInput) GetCve() CVEInputSpec { return v.Cve }
 
+// __IngestCVEsInput is used internally by genqlient
+type __IngestCVEsInput struct {
+	Cves []CVEInputSpec `json:"cves"`
+}
+
+// GetCves returns __IngestCVEsInput.Cves, and is useful for accessing the field via an interface.
+func (v *__IngestCVEsInput) GetCves() []CVEInputSpec { return v.Cves }
+
 // __IngestGHSAInput is used internally by genqlient
 type __IngestGHSAInput struct {
 	Ghsa GHSAInputSpec `json:"ghsa"`
@@ -20026,6 +20270,14 @@ type __IngestGHSAInput struct {
 
 // GetGhsa returns __IngestGHSAInput.Ghsa, and is useful for accessing the field via an interface.
 func (v *__IngestGHSAInput) GetGhsa() GHSAInputSpec { return v.Ghsa }
+
+// __IngestGHSAsInput is used internally by genqlient
+type __IngestGHSAsInput struct {
+	Ghsas []GHSAInputSpec `json:"ghsas"`
+}
+
+// GetGhsas returns __IngestGHSAsInput.Ghsas, and is useful for accessing the field via an interface.
+func (v *__IngestGHSAsInput) GetGhsas() []GHSAInputSpec { return v.Ghsas }
 
 // __IngestMaterialsInput is used internally by genqlient
 type __IngestMaterialsInput struct {
@@ -20042,6 +20294,14 @@ type __IngestOSVInput struct {
 
 // GetOsv returns __IngestOSVInput.Osv, and is useful for accessing the field via an interface.
 func (v *__IngestOSVInput) GetOsv() OSVInputSpec { return v.Osv }
+
+// __IngestOSVsInput is used internally by genqlient
+type __IngestOSVsInput struct {
+	Osvs []OSVInputSpec `json:"osvs"`
+}
+
+// GetOsvs returns __IngestOSVsInput.Osvs, and is useful for accessing the field via an interface.
+func (v *__IngestOSVsInput) GetOsvs() []OSVInputSpec { return v.Osvs }
 
 // __IngestPackageInput is used internally by genqlient
 type __IngestPackageInput struct {
@@ -26659,6 +26919,46 @@ func IngestCVE(
 	return &data, err
 }
 
+// The query or mutation executed by IngestCVEs.
+const IngestCVEs_Operation = `
+mutation IngestCVEs ($cves: [CVEInputSpec!]!) {
+	ingestCVEs(cves: $cves) {
+		... AllCveTree
+	}
+}
+fragment AllCveTree on CVE {
+	id
+	year
+	cveId
+}
+`
+
+func IngestCVEs(
+	ctx context.Context,
+	client graphql.Client,
+	cves []CVEInputSpec,
+) (*IngestCVEsResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestCVEs",
+		Query:  IngestCVEs_Operation,
+		Variables: &__IngestCVEsInput{
+			Cves: cves,
+		},
+	}
+	var err error
+
+	var data IngestCVEsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by IngestGHSA.
 const IngestGHSA_Operation = `
 mutation IngestGHSA ($ghsa: GHSAInputSpec!) {
@@ -26687,6 +26987,45 @@ func IngestGHSA(
 	var err error
 
 	var data IngestGHSAResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IngestGHSAs.
+const IngestGHSAs_Operation = `
+mutation IngestGHSAs ($ghsas: [GHSAInputSpec!]!) {
+	ingestGHSAs(ghsas: $ghsas) {
+		... AllGHSATree
+	}
+}
+fragment AllGHSATree on GHSA {
+	id
+	ghsaId
+}
+`
+
+func IngestGHSAs(
+	ctx context.Context,
+	client graphql.Client,
+	ghsas []GHSAInputSpec,
+) (*IngestGHSAsResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestGHSAs",
+		Query:  IngestGHSAs_Operation,
+		Variables: &__IngestGHSAsInput{
+			Ghsas: ghsas,
+		},
+	}
+	var err error
+
+	var data IngestGHSAsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
@@ -26766,6 +27105,45 @@ func IngestOSV(
 	var err error
 
 	var data IngestOSVResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IngestOSVs.
+const IngestOSVs_Operation = `
+mutation IngestOSVs ($osvs: [OSVInputSpec!]!) {
+	ingestOSVs(osvs: $osvs) {
+		... AllOSVTree
+	}
+}
+fragment AllOSVTree on OSV {
+	id
+	osvId
+}
+`
+
+func IngestOSVs(
+	ctx context.Context,
+	client graphql.Client,
+	osvs []OSVInputSpec,
+) (*IngestOSVsResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestOSVs",
+		Query:  IngestOSVs_Operation,
+		Variables: &__IngestOSVsInput{
+			Osvs: osvs,
+		},
+	}
+	var err error
+
+	var data IngestOSVsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -94,7 +94,7 @@ func GetAssembler(ctx context.Context, gqlclient graphql.Client) func([]assemble
 
 			logger.Infof("assembling CertifyScorecard: %v", len(p.CertifyScorecard))
 			for _, v := range p.CertifyScorecard {
-				if err := ingestCertifyScorecards(ctx, gqlclient, v); err != nil {
+				if err := ingestCertifyScorecard(ctx, gqlclient, v); err != nil {
 					return err
 				}
 			}
@@ -227,7 +227,7 @@ func ingestGHSA(ctx context.Context, client graphql.Client, v *model.GHSAInputSp
 	return err
 }
 
-func ingestCertifyScorecards(ctx context.Context, client graphql.Client, v assembler.CertifyScorecardIngest) error {
+func ingestCertifyScorecard(ctx context.Context, client graphql.Client, v assembler.CertifyScorecardIngest) error {
 	_, err := model.CertifyScorecard(ctx, client, *v.Source, *v.Scorecard)
 	return err
 }

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -228,7 +228,7 @@ func ingestGHSA(ctx context.Context, client graphql.Client, v *model.GHSAInputSp
 }
 
 func ingestCertifyScorecards(ctx context.Context, client graphql.Client, v assembler.CertifyScorecardIngest) error {
-	_, err := model.Scorecard(ctx, client, *v.Source, *v.Scorecard)
+	_, err := model.CertifyScorecard(ctx, client, *v.Source, *v.Scorecard)
 	return err
 }
 

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -41,7 +41,6 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				return fmt.Errorf("ingestPackages failed with error: %w", err)
 			}
 
-			// TODO(pxp928): add bulk ingestion for sources
 			sources := p.GetSources(ctx)
 			logger.Infof("assembling Source: %v", len(sources))
 
@@ -65,13 +64,15 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				return fmt.Errorf("ingestArtifacts failed with error: %w", err)
 			}
 
-			// TODO(pxp928): add bulk ingestion for builders
 			builders := p.GetBuilders(ctx)
 			logger.Infof("assembling Builder: %v", len(builders))
+			var collectedBuilders []model.BuilderInputSpec
+			collectedBuilders = make([]model.BuilderInputSpec, 0)
 			for _, v := range builders {
-				if err := ingestBuilder(ctx, gqlclient, v); err != nil {
-					return fmt.Errorf("ingestBuilder failed with error: %w", err)
-				}
+				collectedBuilders = append(collectedBuilders, *v)
+			}
+			if err := ingestBuilders(ctx, gqlclient, collectedBuilders); err != nil {
+				return fmt.Errorf("ingestBuilders failed with error: %w", err)
 			}
 
 			// TODO(pxp928): add bulk ingestion for materials
@@ -81,39 +82,43 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				return fmt.Errorf("ingestMaterials failed with error: %w", err)
 			}
 
-			// TODO(pxp928): add bulk ingestion for cves
 			cves := p.GetCVEs(ctx)
 			logger.Infof("assembling CVE: %v", len(cves))
+			var collectedCVEs []model.CVEInputSpec
+			collectedCVEs = make([]model.CVEInputSpec, 0)
 			for _, v := range cves {
-				if err := ingestCVE(ctx, gqlclient, v); err != nil {
-					return fmt.Errorf("ingestCVE failed with error: %w", err)
-				}
+				collectedCVEs = append(collectedCVEs, *v)
+			}
+			if err := ingestCVEs(ctx, gqlclient, collectedCVEs); err != nil {
+				return fmt.Errorf("ingestCVEs failed with error: %w", err)
 			}
 
-			// TODO(pxp928): add bulk ingestion for osvs
 			osvs := p.GetOSVs(ctx)
 			logger.Infof("assembling OSV: %v", len(osvs))
+			var collectedOSVs []model.OSVInputSpec
+			collectedOSVs = make([]model.OSVInputSpec, 0)
 			for _, v := range osvs {
-				if err := ingestOSV(ctx, gqlclient, v); err != nil {
-					return fmt.Errorf("ingestOSV failed with error: %w", err)
-				}
+				collectedOSVs = append(collectedOSVs, *v)
+			}
+			if err := ingestOSVs(ctx, gqlclient, collectedOSVs); err != nil {
+				return fmt.Errorf("ingestOSVs failed with error: %w", err)
 			}
 
 			// TODO(pxp928): add bulk ingestion for ghsas
 			ghsas := p.GetGHSAs(ctx)
 			logger.Infof("assembling GHSA: %v", len(ghsas))
+			var collectedGHSAs []model.GHSAInputSpec
+			collectedGHSAs = make([]model.GHSAInputSpec, 0)
 			for _, v := range ghsas {
-				if err := ingestGHSA(ctx, gqlclient, v); err != nil {
-					return fmt.Errorf("ingestGHSA failed with error: %w", err)
-				}
+				collectedGHSAs = append(collectedGHSAs, *v)
+			}
+			if err := ingestGHSAs(ctx, gqlclient, collectedGHSAs); err != nil {
+				return fmt.Errorf("ingestGHSAs failed with error: %w", err)
 			}
 
-			// TODO(pxp928): add bulk ingestion for CertifyScorecard
 			logger.Infof("assembling CertifyScorecard: %v", len(p.CertifyScorecard))
-			for _, v := range p.CertifyScorecard {
-				if err := ingestCertifyScorecards(ctx, gqlclient, v); err != nil {
-					return fmt.Errorf("ingestCertifyScorecards failed with error: %w", err)
-				}
+			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
+				return fmt.Errorf("ingestCertifyScorecards failed with error: %w", err)
 			}
 
 			logger.Infof("assembling IsDependency: %v", len(p.IsDependency))
@@ -238,6 +243,54 @@ func ingestArtifacts(ctx context.Context, client graphql.Client, v []model.Artif
 	_, err := model.IngestArtifacts(ctx, client, v)
 	if err != nil {
 		return fmt.Errorf("ingestArtifacts failed with error: %w", err)
+	}
+	return nil
+}
+
+func ingestBuilders(ctx context.Context, client graphql.Client, v []model.BuilderInputSpec) error {
+	_, err := model.IngestBuilders(ctx, client, v)
+	if err != nil {
+		return fmt.Errorf("ingestBuilders failed with error: %w", err)
+	}
+	return nil
+}
+
+func ingestCVEs(ctx context.Context, client graphql.Client, v []model.CVEInputSpec) error {
+	_, err := model.IngestCVEs(ctx, client, v)
+	if err != nil {
+		return fmt.Errorf("ingestCVEs failed with error: %w", err)
+	}
+	return nil
+}
+
+func ingestOSVs(ctx context.Context, client graphql.Client, v []model.OSVInputSpec) error {
+	_, err := model.IngestOSVs(ctx, client, v)
+	if err != nil {
+		return fmt.Errorf("ingestOSVs failed with error: %w", err)
+	}
+	return nil
+}
+
+func ingestGHSAs(ctx context.Context, client graphql.Client, v []model.GHSAInputSpec) error {
+	_, err := model.IngestGHSAs(ctx, client, v)
+	if err != nil {
+		return fmt.Errorf("ingestGHSAs failed with error: %w", err)
+	}
+	return nil
+}
+
+func ingestCertifyScorecards(ctx context.Context, client graphql.Client, v []assembler.CertifyScorecardIngest) error {
+	var srcs []model.SourceInputSpec
+	var scorecards []model.ScorecardInputSpec
+	for _, ingest := range v {
+		srcs = append(srcs, *ingest.Source)
+		scorecards = append(scorecards, *ingest.Scorecard)
+	}
+	if len(v) > 0 {
+		_, err := model.CertifyScorecards(ctx, client, srcs, scorecards)
+		if err != nil {
+			return fmt.Errorf("certifyScorecards failed with error: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/assembler/clients/helpers/parallel.go
+++ b/pkg/assembler/clients/helpers/parallel.go
@@ -131,7 +131,7 @@ func GetParallelAssembler(ctx context.Context, gqlclient graphql.Client) func([]
 					break
 				}
 				v := v
-				verbs.Go(func() error { return ingestCertifyScorecards(errGroupVerbCtx, gqlclient, v) })
+				verbs.Go(func() error { return ingestCertifyScorecard(errGroupVerbCtx, gqlclient, v) })
 			}
 
 			logger.Infof("assembling IsDependency: %v", len(p.IsDependency))

--- a/pkg/assembler/clients/operations/certifyScorecard.graphql
+++ b/pkg/assembler/clients/operations/certifyScorecard.graphql
@@ -17,8 +17,16 @@
 
 # Defines the GraphQL operations to ingest a Scorecard certification into GUAC
 
-mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
-  certifyScorecard(source: $source, scorecard: $scorecard) {
+mutation CertifyScorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
+  ingestScorecard(source: $source, scorecard: $scorecard) {
+    ...AllCertifyScorecard
+  }
+}
+
+# Defines the GraphQL operations to bulk ingest Scorecard certifications into GUAC
+
+mutation CertifyScorecards($sources: [SourceInputSpec!]!, $scorecards: [ScorecardInputSpec!]!) {
+  ingestScorecards(sources: $sources, scorecards: $scorecards) {
     ...AllCertifyScorecard
   }
 }

--- a/pkg/assembler/clients/operations/cve.graphql
+++ b/pkg/assembler/clients/operations/cve.graphql
@@ -23,6 +23,14 @@ mutation IngestCVE($cve: CVEInputSpec!) {
   }
 }
 
+# Bulk Ingest CVE
+
+mutation IngestCVEs($cves: [CVEInputSpec!]!) {
+  ingestCVEs(cves: $cves) {
+    ...AllCveTree
+  }
+}
+
 # Exposes GraphQL queries to retrieve GUAC CVEs
 
 query CVEs($filter: CVESpec) {

--- a/pkg/assembler/clients/operations/ghsa.graphql
+++ b/pkg/assembler/clients/operations/ghsa.graphql
@@ -23,6 +23,14 @@ mutation IngestGHSA($ghsa: GHSAInputSpec!) {
   }
 }
 
+# Bulk Ingest GHSA
+
+mutation IngestGHSAs($ghsas: [GHSAInputSpec!]!) {
+  ingestGHSAs(ghsas: $ghsas) {
+    ...AllGHSATree
+  }
+}
+
 # Exposes GraphQL queries to retrieve GUAC GHSAs
 
 query GHSAs($filter: GHSASpec) {

--- a/pkg/assembler/clients/operations/osv.graphql
+++ b/pkg/assembler/clients/operations/osv.graphql
@@ -23,6 +23,14 @@ mutation IngestOSV($osv: OSVInputSpec!) {
   }
 }
 
+# Bulk Ingest OSV
+
+mutation IngestOSVs($osvs: [OSVInputSpec!]!) {
+  ingestOSVs(osvs: $osvs) {
+    ...AllOSVTree
+  }
+}
+
 # Exposes GraphQL queries to retrieve GUAC OSVs
 
 query OSVs($filter: OSVSpec) {

--- a/pkg/assembler/graphql/examples/certify_scorecard.gql
+++ b/pkg/assembler/graphql/examples/certify_scorecard.gql
@@ -62,7 +62,7 @@ mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
   ingestSource(source: $source) {
     ...allSrcTree
   }
-  certifyScorecard(source: $source, scorecard: $scorecard) {
+  ingestScorecard(source: $source, scorecard: $scorecard) {
     ...allCertifyScorecardTree
   }
 }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -25,7 +25,8 @@ type MutationResolver interface {
 	IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error)
 	IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error)
 	IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error)
-	CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
+	IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
+	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInput, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
 	IngestVulnerability(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInput, certifyVuln model.VulnerabilityMetaDataInput) (*model.CertifyVuln, error)
 	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (*model.PointOfContact, error)
@@ -85,30 +86,6 @@ type QueryResolver interface {
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
-
-func (ec *executionContext) field_Mutation_certifyScorecard_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 model.SourceInputSpec
-	if tmp, ok := rawArgs["source"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
-		arg0, err = ec.unmarshalNSourceInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpec(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["source"] = arg0
-	var arg1 model.ScorecardInputSpec
-	if tmp, ok := rawArgs["scorecard"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scorecard"))
-		arg1, err = ec.unmarshalNScorecardInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpec(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["scorecard"] = arg1
-	return args, nil
-}
 
 func (ec *executionContext) field_Mutation_ingestArtifact_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -773,6 +750,54 @@ func (ec *executionContext) field_Mutation_ingestSLSA_args(ctx context.Context, 
 		}
 	}
 	args["slsa"] = arg3
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestScorecard_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.SourceInputSpec
+	if tmp, ok := rawArgs["source"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+		arg0, err = ec.unmarshalNSourceInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["source"] = arg0
+	var arg1 model.ScorecardInputSpec
+	if tmp, ok := rawArgs["scorecard"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scorecard"))
+		arg1, err = ec.unmarshalNScorecardInputSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpec(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["scorecard"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestScorecards_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.SourceInputSpec
+	if tmp, ok := rawArgs["sources"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sources"))
+		arg0, err = ec.unmarshalNSourceInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["sources"] = arg0
+	var arg1 []*model.ScorecardInputSpec
+	if tmp, ok := rawArgs["scorecards"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scorecards"))
+		arg1, err = ec.unmarshalNScorecardInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["scorecards"] = arg1
 	return args, nil
 }
 
@@ -1850,8 +1875,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyGood(ctx context.
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_certifyScorecard(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_certifyScorecard(ctx, field)
+func (ec *executionContext) _Mutation_ingestScorecard(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestScorecard(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -1864,7 +1889,7 @@ func (ec *executionContext) _Mutation_certifyScorecard(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CertifyScorecard(rctx, fc.Args["source"].(model.SourceInputSpec), fc.Args["scorecard"].(model.ScorecardInputSpec))
+		return ec.resolvers.Mutation().IngestScorecard(rctx, fc.Args["source"].(model.SourceInputSpec), fc.Args["scorecard"].(model.ScorecardInputSpec))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -1881,7 +1906,7 @@ func (ec *executionContext) _Mutation_certifyScorecard(ctx context.Context, fiel
 	return ec.marshalNCertifyScorecard2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecard(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_certifyScorecard(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_ingestScorecard(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -1906,7 +1931,70 @@ func (ec *executionContext) fieldContext_Mutation_certifyScorecard(ctx context.C
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_certifyScorecard_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_ingestScorecard_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestScorecards(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestScorecards(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestScorecards(rctx, fc.Args["sources"].([]*model.SourceInputSpec), fc.Args["scorecards"].([]*model.ScorecardInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CertifyScorecard)
+	fc.Result = res
+	return ec.marshalNCertifyScorecard2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecardᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestScorecards(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyScorecard_id(ctx, field)
+			case "source":
+				return ec.fieldContext_CertifyScorecard_source(ctx, field)
+			case "scorecard":
+				return ec.fieldContext_CertifyScorecard_scorecard(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyScorecard", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestScorecards_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5663,9 +5751,16 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "certifyScorecard":
+		case "ingestScorecard":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_certifyScorecard(ctx, field)
+				return ec._Mutation_ingestScorecard(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ingestScorecards":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestScorecards(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -1184,6 +1184,28 @@ func (ec *executionContext) unmarshalNScorecardInputSpec2githubᚗcomᚋguacsec�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNScorecardInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.ScorecardInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.ScorecardInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNScorecardInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNScorecardInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScorecardInputSpec(ctx context.Context, v interface{}) (*model.ScorecardInputSpec, error) {
+	res, err := ec.unmarshalInputScorecardInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
 	res, err := graphql.UnmarshalTime(v)
 	return res, graphql.ErrorOnPath(ctx, err)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -179,7 +179,6 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CertifyScorecard      func(childComplexity int, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) int
 		IngestArtifact        func(childComplexity int, artifact *model.ArtifactInputSpec) int
 		IngestArtifacts       func(childComplexity int, artifacts []*model.ArtifactInputSpec) int
 		IngestBuilder         func(childComplexity int, builder *model.BuilderInputSpec) int
@@ -206,6 +205,8 @@ type ComplexityRoot struct {
 		IngestPackages        func(childComplexity int, pkgs []*model.PkgInputSpec) int
 		IngestPkgEqual        func(childComplexity int, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) int
 		IngestPointOfContact  func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, pointOfContact model.PointOfContactInputSpec) int
+		IngestScorecard       func(childComplexity int, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) int
+		IngestScorecards      func(childComplexity int, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) int
 		IngestSlsa            func(childComplexity int, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) int
 		IngestSource          func(childComplexity int, source model.SourceInputSpec) int
 		IngestSources         func(childComplexity int, sources []*model.SourceInputSpec) int
@@ -994,18 +995,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IsVulnerability.Vulnerability(childComplexity), true
 
-	case "Mutation.certifyScorecard":
-		if e.complexity.Mutation.CertifyScorecard == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_certifyScorecard_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CertifyScorecard(childComplexity, args["source"].(model.SourceInputSpec), args["scorecard"].(model.ScorecardInputSpec)), true
-
 	case "Mutation.ingestArtifact":
 		if e.complexity.Mutation.IngestArtifact == nil {
 			break
@@ -1317,6 +1306,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestPointOfContact(childComplexity, args["subject"].(model.PackageSourceOrArtifactInput), args["pkgMatchType"].(*model.MatchFlags), args["pointOfContact"].(model.PointOfContactInputSpec)), true
+
+	case "Mutation.ingestScorecard":
+		if e.complexity.Mutation.IngestScorecard == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestScorecard_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestScorecard(childComplexity, args["source"].(model.SourceInputSpec), args["scorecard"].(model.ScorecardInputSpec)), true
+
+	case "Mutation.ingestScorecards":
+		if e.complexity.Mutation.IngestScorecards == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestScorecards_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestScorecards(childComplexity, args["sources"].([]*model.SourceInputSpec), args["scorecards"].([]*model.ScorecardInputSpec)), true
 
 	case "Mutation.ingestSLSA":
 		if e.complexity.Mutation.IngestSlsa == nil {
@@ -2791,7 +2804,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
-  certifyScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  "Adds bulk certifications that a source repository has a Scorecard."
+  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [CertifyScorecard!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVEXStatement.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
@@ -10,9 +10,14 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-// CertifyScorecard is the resolver for the certifyScorecard field.
-func (r *mutationResolver) CertifyScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
-	return r.Backend.CertifyScorecard(ctx, source, scorecard)
+// IngestScorecard is the resolver for the ingestScorecard field.
+func (r *mutationResolver) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
+	return r.Backend.IngestScorecard(ctx, source, scorecard)
+}
+
+// IngestScorecards is the resolver for the ingestScorecards field.
+func (r *mutationResolver) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
+	return r.Backend.IngestScorecards(ctx, sources, scorecards)
 }
 
 // Scorecards is the resolver for the scorecards field.

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -126,5 +126,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
-  certifyScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  "Adds bulk certifications that a source repository has a Scorecard."
+  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [CertifyScorecard!]!
 }


### PR DESCRIPTION
# Description of the PR

- change `CertifyScorecard` to `IngestScorecard` for consistency
- implemented bulk ingestion for inmem backend
- implemented ingestion and query for arangoDB backend
- update bulk assembler for bulk ingestion of vulnerabilities, builder and scorecard
- code reuse cleanup and example update

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
