### PR TITLE
feat: allow filtering of CertifyVuln query results based on whether they have vulnerabilities

### DIFF
--- a/pkg/assembler/backends/helper/validation.go
+++ b/pkg/assembler/backends/helper/validation.go
@@ -57,7 +57,7 @@ func ValidateVulnerabilityQueryFilter(vulnerability *model.VulnerabilitySpec, no
 		if vulnerability.Cve != nil {
 			vulnDefined = vulnDefined + 1
 		}
-		if noVulnAllowed && vulnerability.NoVuln != nil && *vulnerability.NoVuln {
+		if noVulnAllowed && vulnerability.NoVuln != nil {
 			if vulnDefined != 0 {
 				return gqlerror.Errorf("Since NoVuln is set, no other vulnerability type is allowed")
 			}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2922,11 +2922,11 @@ union Vulnerability = OSV | CVE | GHSA | NoVuln
 VulnerabilitySpec allows using Vulnerability union as input type to be used in
 read queries.
 
-Either noVuln must be set to true or exactly one of osv, cve or ghsa
-must be set to non-nil. Setting noVuln to true means retrieving nodes where
-there is no vulnerability attached (thus, the special NoVuln node). Setting one
-of the other fields means retrieving certifications for the corresponding
-vulnerability types.
+Either noVuln must be set or exactly one of osv, cve or ghsa
+must be set to non-nil. Setting noVuln to true means retrieving only nodes where
+there is no vulnerability attached. Setting it to false means retrieving only nodes
+with identified vulnerabilities. Setting one of the other fields means retrieving
+certifications for the corresponding vulnerability types.
 """
 input VulnerabilitySpec {
   osv: OSVSpec

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1358,11 +1358,11 @@ type VulnerabilityMetaDataInput struct {
 // VulnerabilitySpec allows using Vulnerability union as input type to be used in
 // read queries.
 //
-// Either noVuln must be set to true or exactly one of osv, cve or ghsa
-// must be set to non-nil. Setting noVuln to true means retrieving nodes where
-// there is no vulnerability attached (thus, the special NoVuln node). Setting one
-// of the other fields means retrieving certifications for the corresponding
-// vulnerability types.
+// Either noVuln must be set or exactly one of osv, cve or ghsa
+// must be set to non-nil. Setting noVuln to true means retrieving only nodes where
+// there is no vulnerability attached. Setting it to false means retrieving only nodes
+// with identified vulnerabilities. Setting one of the other fields means retrieving
+// certifications for the corresponding vulnerability types.
 type VulnerabilitySpec struct {
 	Osv    *OSVSpec  `json:"osv,omitempty"`
 	Cve    *CVESpec  `json:"cve,omitempty"`

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -34,11 +34,11 @@ union Vulnerability = OSV | CVE | GHSA | NoVuln
 VulnerabilitySpec allows using Vulnerability union as input type to be used in
 read queries.
 
-Either noVuln must be set to true or exactly one of osv, cve or ghsa
-must be set to non-nil. Setting noVuln to true means retrieving nodes where
-there is no vulnerability attached (thus, the special NoVuln node). Setting one
-of the other fields means retrieving certifications for the corresponding
-vulnerability types.
+Either noVuln must be set or exactly one of osv, cve or ghsa
+must be set to non-nil. Setting noVuln to true means retrieving only nodes where
+there is no vulnerability attached. Setting it to false means retrieving only nodes
+with identified vulnerabilities. Setting one of the other fields means retrieving
+certifications for the corresponding vulnerability types.
 """
 input VulnerabilitySpec {
   osv: OSVSpec


### PR DESCRIPTION
# Description of the PR

This is an attempt to fix #1044 and allow `CertifyVuln` queries to return only results that include packages with or without vulnerabilities.

For that I changed the semantics of the `NoVuln` attribute to allow this filtering. This filter could be then used in combination with `package` filtering.

Some examples of valid queries with this change

1. return all packages with vulnerabilities
```
query CertifyVuln {
  CertifyVuln(certifyVulnSpec: {
    vulnerability: {noVuln: false}
  }) {
    ...allCertifyVulnTree
  }
}
```

2. return all openssl packages that have no vulnerabilties
```
query CertifyNoVuln {
  CertifyVuln(certifyVulnSpec: {
    package: {name: "openssl"},
    vulnerability: {noVuln: true}
  }) {
    ...allCertifyVulnTree
  }
}
```

All other queries, using no filter, specific vulnerability or package filters should keep working the same

Fixes #1044

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
