### PR TITLE
Add Compose Tarball to Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,3 +150,28 @@ jobs:
       registry-username: ${{ github.actor }}
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  compose-tarball:
+    runs-on: ubuntu-latest
+    name: generate compose tarball
+    needs: [goreleaser]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3
+      - name: Create and publish compose tarball
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          mkdir guac-compose
+          cp .env guac-compose/
+          cp docker-compose.yml guac-compose/
+          cp -r container_files guac-compose/
+          sed -i s/local-organic-guac/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-compose/.env
+          tar -zcvf guac-compose-${{ github.ref_name }}.tar.gz guac-compose/
+          rm -rf guac-compose/
+          gh release upload ${{ github.ref_name }} guac-compose-${{ github.ref_name }}.tar.gz
+          rm guac-compose-${{ github.ref_name }}.tar.gz
+        shell: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,14 @@ services:
   #   restart: on-failure
 
   nats:
-    image: "nats:2.9.17-alpine"
+    image: "docker.io/library/nats:2.9.17-alpine"
     command: "--config /config/nats/js.conf -m 8222"
     ports:
       - "4222:4222"
       # monitoring port
       - "8222:8222"
     volumes:
-      - ./container_files/nats:/config/nats
+      - ./container_files/nats:/config/nats:z
     restart: on-failure
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:8222/healthz"]
@@ -43,7 +43,7 @@ services:
       nats:
         condition: service_healthy
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:2782"]
       interval: 10s
@@ -62,7 +62,7 @@ services:
     ports:
       - "$GUAC_API_PORT:8080"
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:8080"]
       interval: 10s
@@ -81,7 +81,7 @@ services:
       guac-graphql:
         condition: service_healthy
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z
 
   oci-collector:
     image: $GUAC_IMAGE
@@ -94,7 +94,7 @@ services:
       guac-graphql:
         condition: service_healthy
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z
 
   depsdev-collector:
     image: $GUAC_IMAGE
@@ -109,7 +109,7 @@ services:
       guac-graphql:
         condition: service_healthy
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z
 
   osv-certifier:
     image: $GUAC_IMAGE
@@ -122,4 +122,4 @@ services:
       guac-graphql:
         condition: service_healthy
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/guac:/guac:z


### PR DESCRIPTION
# Description of the PR

Add a job to the release workflow that creates a stand-alone compose tarball that can be downloaded, unzipped, and upped by itself. The .env is set to point to the guac container for the release. This job runs after the goreleaser step is done, so that the release already exists and the tarball is attached to the existing release with `gh release upload`.

Test release: https://github.com/jeffmendoza/guac/releases/tag/v0.1.1-jeff4

Tested with docker-compose and podman-compose. Some updates to the docker-compose.yml were needed for podman to work.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
