### PR TITLE
update client GQL fragments to public usable by go

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -36,6 +36,23 @@ func (v *AllArtifactTree) GetAlgorithm() string { return v.Algorithm }
 // GetDigest returns AllArtifactTree.Digest, and is useful for accessing the field via an interface.
 func (v *AllArtifactTree) GetDigest() string { return v.Digest }
 
+// AllBuilderTree includes the GraphQL fields of Builder requested by the fragment AllBuilderTree.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder (e.g., FRSCA or GitHub Actions).
+//
+// Currently builders are identified by the uri field.
+type AllBuilderTree struct {
+	Id  string `json:"id"`
+	Uri string `json:"uri"`
+}
+
+// GetId returns AllBuilderTree.Id, and is useful for accessing the field via an interface.
+func (v *AllBuilderTree) GetId() string { return v.Id }
+
+// GetUri returns AllBuilderTree.Uri, and is useful for accessing the field via an interface.
+func (v *AllBuilderTree) GetUri() string { return v.Uri }
+
 // AllCertifyBad includes the GraphQL fields of CertifyBad requested by the fragment AllCertifyBad.
 // The GraphQL type's documentation follows.
 //
@@ -505,6 +522,475 @@ func (v *AllCertifyBadSubjectSource) __premarshalJSON() (*__premarshalAllCertify
 	return &retval, nil
 }
 
+// AllCertifyGood includes the GraphQL fields of CertifyGood requested by the fragment AllCertifyGood.
+// The GraphQL type's documentation follows.
+//
+// CertifyGood is an attestation that a package, source, or artifact is considered
+// good.
+//
+// All evidence trees record a justification for the property they represent as
+// well as the document that contains the attestation (origin) and the collector
+// that collected the document (collector).
+//
+// The certification applies to a subject which is a package, source, or artifact.
+// If the attestation targets a package, it must target a PackageName or a
+// PackageVersion. If the attestation targets a source, it must target a
+// SourceName.
+type AllCertifyGood struct {
+	Id            string                                       `json:"id"`
+	Justification string                                       `json:"justification"`
+	Subject       AllCertifyGoodSubjectPackageSourceOrArtifact `json:"-"`
+	Origin        string                                       `json:"origin"`
+	Collector     string                                       `json:"collector"`
+}
+
+// GetId returns AllCertifyGood.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyGood) GetId() string { return v.Id }
+
+// GetJustification returns AllCertifyGood.Justification, and is useful for accessing the field via an interface.
+func (v *AllCertifyGood) GetJustification() string { return v.Justification }
+
+// GetSubject returns AllCertifyGood.Subject, and is useful for accessing the field via an interface.
+func (v *AllCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact { return v.Subject }
+
+// GetOrigin returns AllCertifyGood.Origin, and is useful for accessing the field via an interface.
+func (v *AllCertifyGood) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllCertifyGood.Collector, and is useful for accessing the field via an interface.
+func (v *AllCertifyGood) GetCollector() string { return v.Collector }
+
+func (v *AllCertifyGood) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyGood
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyGood = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllCertifyGoodSubjectPackageSourceOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllCertifyGood.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllCertifyGood struct {
+	Id string `json:"id"`
+
+	Justification string `json:"justification"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllCertifyGood) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyGood) __premarshalJSON() (*__premarshalAllCertifyGood, error) {
+	var retval __premarshalAllCertifyGood
+
+	retval.Id = v.Id
+	retval.Justification = v.Justification
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllCertifyGood.Subject: %w", err)
+		}
+	}
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllCertifyGoodSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllCertifyGoodSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyGoodSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyGoodSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllCertifyGoodSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllCertifyGoodSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllCertifyGoodSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyGoodSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyGoodSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyGoodSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllCertifyGoodSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyGoodSubjectArtifact) __premarshalJSON() (*__premarshalAllCertifyGoodSubjectArtifact, error) {
+	var retval __premarshalAllCertifyGoodSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllCertifyGoodSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllCertifyGoodSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyGoodSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyGoodSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllCertifyGoodSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllCertifyGoodSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllCertifyGoodSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyGoodSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyGoodSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyGoodSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllCertifyGoodSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyGoodSubjectPackage) __premarshalJSON() (*__premarshalAllCertifyGoodSubjectPackage, error) {
+	var retval __premarshalAllCertifyGoodSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllCertifyGoodSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// AllCertifyGoodSubjectPackageSourceOrArtifact is implemented by the following types:
+// AllCertifyGoodSubjectArtifact
+// AllCertifyGoodSubjectPackage
+// AllCertifyGoodSubjectSource
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type AllCertifyGoodSubjectPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceAllCertifyGoodSubjectPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllCertifyGoodSubjectArtifact) implementsGraphQLInterfaceAllCertifyGoodSubjectPackageSourceOrArtifact() {
+}
+func (v *AllCertifyGoodSubjectPackage) implementsGraphQLInterfaceAllCertifyGoodSubjectPackageSourceOrArtifact() {
+}
+func (v *AllCertifyGoodSubjectSource) implementsGraphQLInterfaceAllCertifyGoodSubjectPackageSourceOrArtifact() {
+}
+
+func __unmarshalAllCertifyGoodSubjectPackageSourceOrArtifact(b []byte, v *AllCertifyGoodSubjectPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllCertifyGoodSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllCertifyGoodSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(AllCertifyGoodSubjectSource)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllCertifyGoodSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(v *AllCertifyGoodSubjectPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllCertifyGoodSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyGoodSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllCertifyGoodSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyGoodSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllCertifyGoodSubjectSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyGoodSubjectSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllCertifyGoodSubjectPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// AllCertifyGoodSubjectSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type AllCertifyGoodSubjectSource struct {
+	Typename      *string `json:"__typename"`
+	AllSourceTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyGoodSubjectSource.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectSource) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyGoodSubjectSource.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectSource) GetId() string { return v.AllSourceTree.Id }
+
+// GetType returns AllCertifyGoodSubjectSource.Type, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectSource) GetType() string { return v.AllSourceTree.Type }
+
+// GetNamespaces returns AllCertifyGoodSubjectSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllCertifyGoodSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *AllCertifyGoodSubjectSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyGoodSubjectSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyGoodSubjectSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyGoodSubjectSource struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *AllCertifyGoodSubjectSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyGoodSubjectSource) __premarshalJSON() (*__premarshalAllCertifyGoodSubjectSource, error) {
+	var retval __premarshalAllCertifyGoodSubjectSource
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
 // AllCertifyScorecard includes the GraphQL fields of CertifyScorecard requested by the fragment AllCertifyScorecard.
 // The GraphQL type's documentation follows.
 //
@@ -679,6 +1165,797 @@ func (v *AllCertifyScorecardSource) __premarshalJSON() (*__premarshalAllCertifyS
 	retval.Id = v.AllSourceTree.Id
 	retval.Type = v.AllSourceTree.Type
 	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
+// AllCertifyVEXStatement includes the GraphQL fields of CertifyVEXStatement requested by the fragment AllCertifyVEXStatement.
+// The GraphQL type's documentation follows.
+//
+// CertifyVEXStatement is an attestation to attach VEX statements to a package or
+// artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
+type AllCertifyVEXStatement struct {
+	Id string `json:"id"`
+	// Subject of attestation
+	Subject AllCertifyVEXStatementSubjectPackageOrArtifact `json:"-"`
+	// Attested vulnerability
+	Vulnerability AllCertifyVEXStatementVulnerability `json:"-"`
+	// Status of the vulnerabilities with respect to the subject
+	Status VexStatus `json:"status"`
+	// Justification from VEX statement
+	VexJustification VexJustification `json:"vexJustification"`
+	// VEX statement: impact_statement or action_statement depending on status
+	Statement string `json:"statement"`
+	// statusNotes may convey information about how status was determined
+	StatusNotes string `json:"statusNotes"`
+	// Timestamp (exact time in RFC 3339 format) for the VEX statement
+	KnownSince time.Time `json:"knownSince"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetId() string { return v.Id }
+
+// GetSubject returns AllCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.Subject
+}
+
+// GetVulnerability returns AllCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.Vulnerability
+}
+
+// GetStatus returns AllCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetStatus() VexStatus { return v.Status }
+
+// GetVexJustification returns AllCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetVexJustification() VexJustification { return v.VexJustification }
+
+// GetStatement returns AllCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetStatement() string { return v.Statement }
+
+// GetStatusNotes returns AllCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetStatusNotes() string { return v.StatusNotes }
+
+// GetKnownSince returns AllCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetKnownSince() time.Time { return v.KnownSince }
+
+// GetOrigin returns AllCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatement) GetCollector() string { return v.Collector }
+
+func (v *AllCertifyVEXStatement) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatement
+		Subject       json.RawMessage `json:"subject"`
+		Vulnerability json.RawMessage `json:"vulnerability"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatement = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllCertifyVEXStatementSubjectPackageOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllCertifyVEXStatement.Subject: %w", err)
+			}
+		}
+	}
+
+	{
+		dst := &v.Vulnerability
+		src := firstPass.Vulnerability
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllCertifyVEXStatementVulnerability(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllCertifyVEXStatement.Vulnerability: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatement struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Vulnerability json.RawMessage `json:"vulnerability"`
+
+	Status VexStatus `json:"status"`
+
+	VexJustification VexJustification `json:"vexJustification"`
+
+	Statement string `json:"statement"`
+
+	StatusNotes string `json:"statusNotes"`
+
+	KnownSince time.Time `json:"knownSince"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllCertifyVEXStatement) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatement) __premarshalJSON() (*__premarshalAllCertifyVEXStatement, error) {
+	var retval __premarshalAllCertifyVEXStatement
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllCertifyVEXStatement.Subject: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.Vulnerability
+		src := v.Vulnerability
+		var err error
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllCertifyVEXStatement.Vulnerability: %w", err)
+		}
+	}
+	retval.Status = v.Status
+	retval.VexJustification = v.VexJustification
+	retval.Statement = v.Statement
+	retval.StatusNotes = v.StatusNotes
+	retval.KnownSince = v.KnownSince
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllCertifyVEXStatementSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllCertifyVEXStatementSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyVEXStatementSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyVEXStatementSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllCertifyVEXStatementSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectArtifact) GetAlgorithm() string {
+	return v.AllArtifactTree.Algorithm
+}
+
+// GetDigest returns AllCertifyVEXStatementSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllCertifyVEXStatementSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatementSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatementSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatementSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllCertifyVEXStatementSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatementSubjectArtifact) __premarshalJSON() (*__premarshalAllCertifyVEXStatementSubjectArtifact, error) {
+	var retval __premarshalAllCertifyVEXStatementSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllCertifyVEXStatementSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllCertifyVEXStatementSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyVEXStatementSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyVEXStatementSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllCertifyVEXStatementSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllCertifyVEXStatementSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllCertifyVEXStatementSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatementSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatementSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatementSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllCertifyVEXStatementSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatementSubjectPackage) __premarshalJSON() (*__premarshalAllCertifyVEXStatementSubjectPackage, error) {
+	var retval __premarshalAllCertifyVEXStatementSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllCertifyVEXStatementSubjectPackageOrArtifact includes the requested fields of the GraphQL interface PackageOrArtifact.
+//
+// AllCertifyVEXStatementSubjectPackageOrArtifact is implemented by the following types:
+// AllCertifyVEXStatementSubjectArtifact
+// AllCertifyVEXStatementSubjectPackage
+// The GraphQL type's documentation follows.
+//
+// PackageOrArtifact is a union of Package and Artifact.
+type AllCertifyVEXStatementSubjectPackageOrArtifact interface {
+	implementsGraphQLInterfaceAllCertifyVEXStatementSubjectPackageOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllCertifyVEXStatementSubjectArtifact) implementsGraphQLInterfaceAllCertifyVEXStatementSubjectPackageOrArtifact() {
+}
+func (v *AllCertifyVEXStatementSubjectPackage) implementsGraphQLInterfaceAllCertifyVEXStatementSubjectPackageOrArtifact() {
+}
+
+func __unmarshalAllCertifyVEXStatementSubjectPackageOrArtifact(b []byte, v *AllCertifyVEXStatementSubjectPackageOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllCertifyVEXStatementSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllCertifyVEXStatementSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllCertifyVEXStatementSubjectPackageOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(v *AllCertifyVEXStatementSubjectPackageOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllCertifyVEXStatementSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyVEXStatementSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllCertifyVEXStatementSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyVEXStatementSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllCertifyVEXStatementSubjectPackageOrArtifact: "%T"`, v)
+	}
+}
+
+// AllCertifyVEXStatementVulnerability includes the requested fields of the GraphQL interface Vulnerability.
+//
+// AllCertifyVEXStatementVulnerability is implemented by the following types:
+// AllCertifyVEXStatementVulnerabilityCVE
+// AllCertifyVEXStatementVulnerabilityGHSA
+// AllCertifyVEXStatementVulnerabilityNoVuln
+// AllCertifyVEXStatementVulnerabilityOSV
+// The GraphQL type's documentation follows.
+//
+// Vulnerability is a union of OSV, CVE, GHSA or the NoVuln node.
+type AllCertifyVEXStatementVulnerability interface {
+	implementsGraphQLInterfaceAllCertifyVEXStatementVulnerability()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityCVE) implementsGraphQLInterfaceAllCertifyVEXStatementVulnerability() {
+}
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) implementsGraphQLInterfaceAllCertifyVEXStatementVulnerability() {
+}
+func (v *AllCertifyVEXStatementVulnerabilityNoVuln) implementsGraphQLInterfaceAllCertifyVEXStatementVulnerability() {
+}
+func (v *AllCertifyVEXStatementVulnerabilityOSV) implementsGraphQLInterfaceAllCertifyVEXStatementVulnerability() {
+}
+
+func __unmarshalAllCertifyVEXStatementVulnerability(b []byte, v *AllCertifyVEXStatementVulnerability) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "CVE":
+		*v = new(AllCertifyVEXStatementVulnerabilityCVE)
+		return json.Unmarshal(b, *v)
+	case "GHSA":
+		*v = new(AllCertifyVEXStatementVulnerabilityGHSA)
+		return json.Unmarshal(b, *v)
+	case "NoVuln":
+		*v = new(AllCertifyVEXStatementVulnerabilityNoVuln)
+		return json.Unmarshal(b, *v)
+	case "OSV":
+		*v = new(AllCertifyVEXStatementVulnerabilityOSV)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing Vulnerability.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllCertifyVEXStatementVulnerability: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllCertifyVEXStatementVulnerability(v *AllCertifyVEXStatementVulnerability) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllCertifyVEXStatementVulnerabilityCVE:
+		typename = "CVE"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyVEXStatementVulnerabilityCVE
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllCertifyVEXStatementVulnerabilityGHSA:
+		typename = "GHSA"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyVEXStatementVulnerabilityGHSA
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllCertifyVEXStatementVulnerabilityNoVuln:
+		typename = "NoVuln"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AllCertifyVEXStatementVulnerabilityNoVuln
+		}{typename, v}
+		return json.Marshal(result)
+	case *AllCertifyVEXStatementVulnerabilityOSV:
+		typename = "OSV"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllCertifyVEXStatementVulnerabilityOSV
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllCertifyVEXStatementVulnerability: "%T"`, v)
+	}
+}
+
+// AllCertifyVEXStatementVulnerabilityCVE includes the requested fields of the GraphQL type CVE.
+// The GraphQL type's documentation follows.
+//
+// CVE represents a vulnerability in the Common Vulnerabilities and Exposures
+// schema.
+//
+// The vulnerability identifier contains a year field, so we are extracting that
+// to allow matching for vulnerabilities found in a given year.
+//
+// The vulnerability identifier field is mandatory and canonicalized to be
+// lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type AllCertifyVEXStatementVulnerabilityCVE struct {
+	Typename   *string `json:"__typename"`
+	AllCveTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyVEXStatementVulnerabilityCVE.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityCVE) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyVEXStatementVulnerabilityCVE.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityCVE) GetId() string { return v.AllCveTree.Id }
+
+// GetYear returns AllCertifyVEXStatementVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityCVE) GetYear() int { return v.AllCveTree.Year }
+
+// GetCveId returns AllCertifyVEXStatementVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityCVE) GetCveId() string { return v.AllCveTree.CveId }
+
+func (v *AllCertifyVEXStatementVulnerabilityCVE) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatementVulnerabilityCVE
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatementVulnerabilityCVE = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCveTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatementVulnerabilityCVE struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Year int `json:"year"`
+
+	CveId string `json:"cveId"`
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityCVE) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityCVE) __premarshalJSON() (*__premarshalAllCertifyVEXStatementVulnerabilityCVE, error) {
+	var retval __premarshalAllCertifyVEXStatementVulnerabilityCVE
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllCveTree.Id
+	retval.Year = v.AllCveTree.Year
+	retval.CveId = v.AllCveTree.CveId
+	return &retval, nil
+}
+
+// AllCertifyVEXStatementVulnerabilityGHSA includes the requested fields of the GraphQL type GHSA.
+// The GraphQL type's documentation follows.
+//
+// GHSA represents GitHub security advisories.
+//
+// The advisory id field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type AllCertifyVEXStatementVulnerabilityGHSA struct {
+	Typename    *string `json:"__typename"`
+	AllGHSATree `json:"-"`
+}
+
+// GetTypename returns AllCertifyVEXStatementVulnerabilityGHSA.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyVEXStatementVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) GetId() string { return v.AllGHSATree.Id }
+
+// GetGhsaId returns AllCertifyVEXStatementVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) GetGhsaId() string { return v.AllGHSATree.GhsaId }
+
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatementVulnerabilityGHSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatementVulnerabilityGHSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllGHSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatementVulnerabilityGHSA struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	GhsaId string `json:"ghsaId"`
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityGHSA) __premarshalJSON() (*__premarshalAllCertifyVEXStatementVulnerabilityGHSA, error) {
+	var retval __premarshalAllCertifyVEXStatementVulnerabilityGHSA
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllGHSATree.Id
+	retval.GhsaId = v.AllGHSATree.GhsaId
+	return &retval, nil
+}
+
+// AllCertifyVEXStatementVulnerabilityNoVuln includes the requested fields of the GraphQL type NoVuln.
+// The GraphQL type's documentation follows.
+//
+// NoVuln is a special vulnerability node to attest that no vulnerability has been
+// found during a vulnerability scan.
+//
+// Backends guarantee that this is a singleton node.
+type AllCertifyVEXStatementVulnerabilityNoVuln struct {
+	Typename *string `json:"__typename"`
+}
+
+// GetTypename returns AllCertifyVEXStatementVulnerabilityNoVuln.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityNoVuln) GetTypename() *string { return v.Typename }
+
+// AllCertifyVEXStatementVulnerabilityOSV includes the requested fields of the GraphQL type OSV.
+// The GraphQL type's documentation follows.
+//
+// OSV represents an Open Source Vulnerability.
+//
+// The osvId field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
+type AllCertifyVEXStatementVulnerabilityOSV struct {
+	Typename   *string `json:"__typename"`
+	AllOSVTree `json:"-"`
+}
+
+// GetTypename returns AllCertifyVEXStatementVulnerabilityOSV.Typename, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityOSV) GetTypename() *string { return v.Typename }
+
+// GetId returns AllCertifyVEXStatementVulnerabilityOSV.Id, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityOSV) GetId() string { return v.AllOSVTree.Id }
+
+// GetOsvId returns AllCertifyVEXStatementVulnerabilityOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *AllCertifyVEXStatementVulnerabilityOSV) GetOsvId() string { return v.AllOSVTree.OsvId }
+
+func (v *AllCertifyVEXStatementVulnerabilityOSV) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllCertifyVEXStatementVulnerabilityOSV
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllCertifyVEXStatementVulnerabilityOSV = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllOSVTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllCertifyVEXStatementVulnerabilityOSV struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	OsvId string `json:"osvId"`
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityOSV) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllCertifyVEXStatementVulnerabilityOSV) __premarshalJSON() (*__premarshalAllCertifyVEXStatementVulnerabilityOSV, error) {
+	var retval __premarshalAllCertifyVEXStatementVulnerabilityOSV
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllOSVTree.Id
+	retval.OsvId = v.AllOSVTree.OsvId
 	return &retval, nil
 }
 
@@ -1320,6 +2597,1397 @@ func (v *AllGHSATree) GetId() string { return v.Id }
 // GetGhsaId returns AllGHSATree.GhsaId, and is useful for accessing the field via an interface.
 func (v *AllGHSATree) GetGhsaId() string { return v.GhsaId }
 
+// AllHasMetadata includes the GraphQL fields of HasMetadata requested by the fragment AllHasMetadata.
+// The GraphQL type's documentation follows.
+//
+// HasMetadata is an attestation that a package, source, or artifact has a certain
+// attested property (key) with value (value). For example, a source may have
+// metadata "SourceRepo2FAEnabled=true".
+//
+// The intent of this evidence tree predicate is to allow extensibility of metadata
+// expressible within the GUAC ontology. Metadata that is commonly used will then
+// be promoted to a predicate on its own.
+//
+// Justification indicates how the metadata was determined.
+//
+// The metadata applies to a subject which is a package, source, or artifact.
+// If the attestation targets a package, it must target a PackageName or a
+// PackageVersion. If the attestation targets a source, it must target a
+// SourceName.
+type AllHasMetadata struct {
+	Id            string                                       `json:"id"`
+	Subject       AllHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
+	Key           string                                       `json:"key"`
+	Value         string                                       `json:"value"`
+	Timestamp     time.Time                                    `json:"timestamp"`
+	Justification string                                       `json:"justification"`
+	Origin        string                                       `json:"origin"`
+	Collector     string                                       `json:"collector"`
+}
+
+// GetId returns AllHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetId() string { return v.Id }
+
+// GetSubject returns AllHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact { return v.Subject }
+
+// GetKey returns AllHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetKey() string { return v.Key }
+
+// GetValue returns AllHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetValue() string { return v.Value }
+
+// GetTimestamp returns AllHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetTimestamp() time.Time { return v.Timestamp }
+
+// GetJustification returns AllHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetJustification() string { return v.Justification }
+
+// GetOrigin returns AllHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetCollector() string { return v.Collector }
+
+func (v *AllHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadata
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllHasMetadata.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadata struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadata) __premarshalJSON() (*__premarshalAllHasMetadata, error) {
+	var retval __premarshalAllHasMetadata
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.Key
+	retval.Value = v.Value
+	retval.Timestamp = v.Timestamp
+	retval.Justification = v.Justification
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllHasMetadataSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllHasMetadataSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllHasMetadataSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllHasMetadataSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllHasMetadataSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectArtifact) __premarshalJSON() (*__premarshalAllHasMetadataSubjectArtifact, error) {
+	var retval __premarshalAllHasMetadataSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllHasMetadataSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllHasMetadataSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllHasMetadataSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllHasMetadataSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllHasMetadataSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectPackage) __premarshalJSON() (*__premarshalAllHasMetadataSubjectPackage, error) {
+	var retval __premarshalAllHasMetadataSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// AllHasMetadataSubjectPackageSourceOrArtifact is implemented by the following types:
+// AllHasMetadataSubjectArtifact
+// AllHasMetadataSubjectPackage
+// AllHasMetadataSubjectSource
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type AllHasMetadataSubjectPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllHasMetadataSubjectArtifact) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+func (v *AllHasMetadataSubjectPackage) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+func (v *AllHasMetadataSubjectSource) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+
+func __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(b []byte, v *AllHasMetadataSubjectPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllHasMetadataSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllHasMetadataSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(AllHasMetadataSubjectSource)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllHasMetadataSubjectPackageSourceOrArtifact(v *AllHasMetadataSubjectPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllHasMetadataSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllHasMetadataSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllHasMetadataSubjectSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// AllHasMetadataSubjectSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type AllHasMetadataSubjectSource struct {
+	Typename      *string `json:"__typename"`
+	AllSourceTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectSource.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectSource.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetId() string { return v.AllSourceTree.Id }
+
+// GetType returns AllHasMetadataSubjectSource.Type, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetType() string { return v.AllSourceTree.Type }
+
+// GetNamespaces returns AllHasMetadataSubjectSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *AllHasMetadataSubjectSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectSource struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *AllHasMetadataSubjectSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectSource) __premarshalJSON() (*__premarshalAllHasMetadataSubjectSource, error) {
+	var retval __premarshalAllHasMetadataSubjectSource
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
+// AllHasSBOMTree includes the GraphQL fields of HasSBOM requested by the fragment AllHasSBOMTree.
+type AllHasSBOMTree struct {
+	Id string `json:"id"`
+	// SBOM subject
+	Subject AllHasSBOMTreeSubjectPackageOrArtifact `json:"-"`
+	// Identifier for the SBOM document
+	Uri string `json:"uri"`
+	// Algorithm by which SBOMs digest was computed
+	Algorithm string `json:"algorithm"`
+	// Digest of SBOM
+	Digest string `json:"digest"`
+	// Location from which the SBOM can be downloaded
+	DownloadLocation string `json:"downloadLocation"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllHasSBOMTree.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetId() string { return v.Id }
+
+// GetSubject returns AllHasSBOMTree.Subject, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact { return v.Subject }
+
+// GetUri returns AllHasSBOMTree.Uri, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetUri() string { return v.Uri }
+
+// GetAlgorithm returns AllHasSBOMTree.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetAlgorithm() string { return v.Algorithm }
+
+// GetDigest returns AllHasSBOMTree.Digest, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetDigest() string { return v.Digest }
+
+// GetDownloadLocation returns AllHasSBOMTree.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetDownloadLocation() string { return v.DownloadLocation }
+
+// GetOrigin returns AllHasSBOMTree.Origin, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllHasSBOMTree.Collector, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTree) GetCollector() string { return v.Collector }
+
+func (v *AllHasSBOMTree) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasSBOMTree
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasSBOMTree = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllHasSBOMTreeSubjectPackageOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllHasSBOMTree.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllHasSBOMTree struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Uri string `json:"uri"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllHasSBOMTree) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasSBOMTree) __premarshalJSON() (*__premarshalAllHasSBOMTree, error) {
+	var retval __premarshalAllHasSBOMTree
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllHasSBOMTree.Subject: %w", err)
+		}
+	}
+	retval.Uri = v.Uri
+	retval.Algorithm = v.Algorithm
+	retval.Digest = v.Digest
+	retval.DownloadLocation = v.DownloadLocation
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllHasSBOMTreeSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllHasSBOMTreeSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllHasSBOMTreeSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasSBOMTreeSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllHasSBOMTreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllHasSBOMTreeSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllHasSBOMTreeSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasSBOMTreeSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasSBOMTreeSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasSBOMTreeSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllHasSBOMTreeSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasSBOMTreeSubjectArtifact) __premarshalJSON() (*__premarshalAllHasSBOMTreeSubjectArtifact, error) {
+	var retval __premarshalAllHasSBOMTreeSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllHasSBOMTreeSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllHasSBOMTreeSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllHasSBOMTreeSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasSBOMTreeSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllHasSBOMTreeSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllHasSBOMTreeSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasSBOMTreeSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllHasSBOMTreeSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasSBOMTreeSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasSBOMTreeSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasSBOMTreeSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllHasSBOMTreeSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasSBOMTreeSubjectPackage) __premarshalJSON() (*__premarshalAllHasSBOMTreeSubjectPackage, error) {
+	var retval __premarshalAllHasSBOMTreeSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllHasSBOMTreeSubjectPackageOrArtifact includes the requested fields of the GraphQL interface PackageOrArtifact.
+//
+// AllHasSBOMTreeSubjectPackageOrArtifact is implemented by the following types:
+// AllHasSBOMTreeSubjectArtifact
+// AllHasSBOMTreeSubjectPackage
+// The GraphQL type's documentation follows.
+//
+// PackageOrArtifact is a union of Package and Artifact.
+type AllHasSBOMTreeSubjectPackageOrArtifact interface {
+	implementsGraphQLInterfaceAllHasSBOMTreeSubjectPackageOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllHasSBOMTreeSubjectArtifact) implementsGraphQLInterfaceAllHasSBOMTreeSubjectPackageOrArtifact() {
+}
+func (v *AllHasSBOMTreeSubjectPackage) implementsGraphQLInterfaceAllHasSBOMTreeSubjectPackageOrArtifact() {
+}
+
+func __unmarshalAllHasSBOMTreeSubjectPackageOrArtifact(b []byte, v *AllHasSBOMTreeSubjectPackageOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllHasSBOMTreeSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllHasSBOMTreeSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllHasSBOMTreeSubjectPackageOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllHasSBOMTreeSubjectPackageOrArtifact(v *AllHasSBOMTreeSubjectPackageOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllHasSBOMTreeSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasSBOMTreeSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllHasSBOMTreeSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasSBOMTreeSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllHasSBOMTreeSubjectPackageOrArtifact: "%T"`, v)
+	}
+}
+
+// AllHasSourceAt includes the GraphQL fields of HasSourceAt requested by the fragment AllHasSourceAt.
+// The GraphQL type's documentation follows.
+//
+// HasSourceAt records that a package's repository is a given source.
+type AllHasSourceAt struct {
+	Id string `json:"id"`
+	// Justification for the attested relationship
+	Justification string `json:"justification"`
+	// Timestamp since this link between package and source was certified
+	KnownSince time.Time `json:"knownSince"`
+	// The subject of the attestation: can be a PackageName or a PackageVersion
+	Package AllHasSourceAtPackage `json:"package"`
+	// Source repository from which the package is built
+	Source AllHasSourceAtSource `json:"source"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllHasSourceAt.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetId() string { return v.Id }
+
+// GetJustification returns AllHasSourceAt.Justification, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetJustification() string { return v.Justification }
+
+// GetKnownSince returns AllHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetKnownSince() time.Time { return v.KnownSince }
+
+// GetPackage returns AllHasSourceAt.Package, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetPackage() AllHasSourceAtPackage { return v.Package }
+
+// GetSource returns AllHasSourceAt.Source, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetSource() AllHasSourceAtSource { return v.Source }
+
+// GetOrigin returns AllHasSourceAt.Origin, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllHasSourceAt.Collector, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAt) GetCollector() string { return v.Collector }
+
+// AllHasSourceAtPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllHasSourceAtPackage struct {
+	AllPkgTree `json:"-"`
+}
+
+// GetId returns AllHasSourceAtPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllHasSourceAtPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllHasSourceAtPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllHasSourceAtPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasSourceAtPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasSourceAtPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasSourceAtPackage struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllHasSourceAtPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasSourceAtPackage) __premarshalJSON() (*__premarshalAllHasSourceAtPackage, error) {
+	var retval __premarshalAllHasSourceAtPackage
+
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllHasSourceAtSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type AllHasSourceAtSource struct {
+	AllSourceTree `json:"-"`
+}
+
+// GetId returns AllHasSourceAtSource.Id, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtSource) GetId() string { return v.AllSourceTree.Id }
+
+// GetType returns AllHasSourceAtSource.Type, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtSource) GetType() string { return v.AllSourceTree.Type }
+
+// GetNamespaces returns AllHasSourceAtSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasSourceAtSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *AllHasSourceAtSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasSourceAtSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasSourceAtSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasSourceAtSource struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *AllHasSourceAtSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasSourceAtSource) __premarshalJSON() (*__premarshalAllHasSourceAtSource, error) {
+	var retval __premarshalAllHasSourceAtSource
+
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
+// AllHashEqualTree includes the GraphQL fields of HashEqual requested by the fragment AllHashEqualTree.
+// The GraphQL type's documentation follows.
+//
+// HashEqual is an attestation that a set of artifacts are identical.
+type AllHashEqualTree struct {
+	Id string `json:"id"`
+	// Justification for the claim that the artifacts are similar
+	Justification string `json:"justification"`
+	// Collection of artifacts that are similar
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllHashEqualTree.Id, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTree) GetId() string { return v.Id }
+
+// GetJustification returns AllHashEqualTree.Justification, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTree) GetJustification() string { return v.Justification }
+
+// GetArtifacts returns AllHashEqualTree.Artifacts, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTree) GetArtifacts() []AllHashEqualTreeArtifactsArtifact { return v.Artifacts }
+
+// GetOrigin returns AllHashEqualTree.Origin, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTree) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllHashEqualTree.Collector, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTree) GetCollector() string { return v.Collector }
+
+// AllHashEqualTreeArtifactsArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllHashEqualTreeArtifactsArtifact struct {
+	AllArtifactTree `json:"-"`
+}
+
+// GetId returns AllHashEqualTreeArtifactsArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTreeArtifactsArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllHashEqualTreeArtifactsArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTreeArtifactsArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllHashEqualTreeArtifactsArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllHashEqualTreeArtifactsArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllHashEqualTreeArtifactsArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHashEqualTreeArtifactsArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHashEqualTreeArtifactsArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHashEqualTreeArtifactsArtifact struct {
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllHashEqualTreeArtifactsArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHashEqualTreeArtifactsArtifact) __premarshalJSON() (*__premarshalAllHashEqualTreeArtifactsArtifact, error) {
+	var retval __premarshalAllHashEqualTreeArtifactsArtifact
+
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllIsDependencyTree includes the GraphQL fields of IsDependency requested by the fragment AllIsDependencyTree.
+// The GraphQL type's documentation follows.
+//
+// IsDependency is an attestation to record that a package depends on another.
+type AllIsDependencyTree struct {
+	Id string `json:"id"`
+	// Justification for the attested relationship
+	Justification string `json:"justification"`
+	// Package that has the dependency
+	Package AllIsDependencyTreePackage `json:"package"`
+	// Package for the dependency; MUST BE PackageName, not PackageVersion
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	// Type of dependency
+	DependencyType DependencyType `json:"dependencyType"`
+	// Version range for the dependency link
+	VersionRange string `json:"versionRange"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllIsDependencyTree.Id, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetId() string { return v.Id }
+
+// GetJustification returns AllIsDependencyTree.Justification, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetJustification() string { return v.Justification }
+
+// GetPackage returns AllIsDependencyTree.Package, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetPackage() AllIsDependencyTreePackage { return v.Package }
+
+// GetDependentPackage returns AllIsDependencyTree.DependentPackage, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.DependentPackage
+}
+
+// GetDependencyType returns AllIsDependencyTree.DependencyType, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetDependencyType() DependencyType { return v.DependencyType }
+
+// GetVersionRange returns AllIsDependencyTree.VersionRange, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetVersionRange() string { return v.VersionRange }
+
+// GetOrigin returns AllIsDependencyTree.Origin, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllIsDependencyTree.Collector, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTree) GetCollector() string { return v.Collector }
+
+// AllIsDependencyTreeDependentPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllIsDependencyTreeDependentPackage struct {
+	AllPkgTree `json:"-"`
+}
+
+// GetId returns AllIsDependencyTreeDependentPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreeDependentPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllIsDependencyTreeDependentPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreeDependentPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllIsDependencyTreeDependentPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreeDependentPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllIsDependencyTreeDependentPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsDependencyTreeDependentPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsDependencyTreeDependentPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllIsDependencyTreeDependentPackage struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllIsDependencyTreeDependentPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsDependencyTreeDependentPackage) __premarshalJSON() (*__premarshalAllIsDependencyTreeDependentPackage, error) {
+	var retval __premarshalAllIsDependencyTreeDependentPackage
+
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllIsDependencyTreePackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllIsDependencyTreePackage struct {
+	AllPkgTree `json:"-"`
+}
+
+// GetId returns AllIsDependencyTreePackage.Id, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreePackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllIsDependencyTreePackage.Type, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreePackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllIsDependencyTreePackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllIsDependencyTreePackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllIsDependencyTreePackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsDependencyTreePackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsDependencyTreePackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllIsDependencyTreePackage struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllIsDependencyTreePackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsDependencyTreePackage) __premarshalJSON() (*__premarshalAllIsDependencyTreePackage, error) {
+	var retval __premarshalAllIsDependencyTreePackage
+
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
 // AllIsOccurrencesTree includes the GraphQL fields of IsOccurrence requested by the fragment AllIsOccurrencesTree.
 // The GraphQL type's documentation follows.
 //
@@ -1770,6 +4438,429 @@ func (v *AllIsOccurrencesTreeSubjectSource) __premarshalJSON() (*__premarshalAll
 	return &retval, nil
 }
 
+// AllIsVulnerability includes the GraphQL fields of IsVulnerability requested by the fragment AllIsVulnerability.
+// The GraphQL type's documentation follows.
+//
+// IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
+type AllIsVulnerability struct {
+	Id string `json:"id"`
+	// The OSV that encapsulates the vulnerability
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
+	// The upstream vulnerability information
+	Vulnerability AllIsVulnerabilityVulnerabilityCveOrGhsa `json:"-"`
+	// Justification for the attested relationship
+	Justification string `json:"justification"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllIsVulnerability.Id, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetId() string { return v.Id }
+
+// GetOsv returns AllIsVulnerability.Osv, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV { return v.Osv }
+
+// GetVulnerability returns AllIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.Vulnerability
+}
+
+// GetJustification returns AllIsVulnerability.Justification, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetJustification() string { return v.Justification }
+
+// GetOrigin returns AllIsVulnerability.Origin, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllIsVulnerability.Collector, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerability) GetCollector() string { return v.Collector }
+
+func (v *AllIsVulnerability) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsVulnerability
+		Vulnerability json.RawMessage `json:"vulnerability"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsVulnerability = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Vulnerability
+		src := firstPass.Vulnerability
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllIsVulnerability.Vulnerability: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllIsVulnerability struct {
+	Id string `json:"id"`
+
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
+
+	Vulnerability json.RawMessage `json:"vulnerability"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllIsVulnerability) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsVulnerability) __premarshalJSON() (*__premarshalAllIsVulnerability, error) {
+	var retval __premarshalAllIsVulnerability
+
+	retval.Id = v.Id
+	retval.Osv = v.Osv
+	{
+
+		dst := &retval.Vulnerability
+		src := v.Vulnerability
+		var err error
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllIsVulnerability.Vulnerability: %w", err)
+		}
+	}
+	retval.Justification = v.Justification
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllIsVulnerabilityOsvOSV includes the requested fields of the GraphQL type OSV.
+// The GraphQL type's documentation follows.
+//
+// OSV represents an Open Source Vulnerability.
+//
+// The osvId field is mandatory and canonicalized to be lowercase.
+//
+// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
+// CVE ID).
+//
+// This node can be referred to by other parts of GUAC.
+type AllIsVulnerabilityOsvOSV struct {
+	AllOSVTree `json:"-"`
+}
+
+// GetId returns AllIsVulnerabilityOsvOSV.Id, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityOsvOSV) GetId() string { return v.AllOSVTree.Id }
+
+// GetOsvId returns AllIsVulnerabilityOsvOSV.OsvId, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityOsvOSV) GetOsvId() string { return v.AllOSVTree.OsvId }
+
+func (v *AllIsVulnerabilityOsvOSV) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsVulnerabilityOsvOSV
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsVulnerabilityOsvOSV = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllOSVTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllIsVulnerabilityOsvOSV struct {
+	Id string `json:"id"`
+
+	OsvId string `json:"osvId"`
+}
+
+func (v *AllIsVulnerabilityOsvOSV) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsVulnerabilityOsvOSV) __premarshalJSON() (*__premarshalAllIsVulnerabilityOsvOSV, error) {
+	var retval __premarshalAllIsVulnerabilityOsvOSV
+
+	retval.Id = v.AllOSVTree.Id
+	retval.OsvId = v.AllOSVTree.OsvId
+	return &retval, nil
+}
+
+// AllIsVulnerabilityVulnerabilityCVE includes the requested fields of the GraphQL type CVE.
+// The GraphQL type's documentation follows.
+//
+// CVE represents a vulnerability in the Common Vulnerabilities and Exposures
+// schema.
+//
+// The vulnerability identifier contains a year field, so we are extracting that
+// to allow matching for vulnerabilities found in a given year.
+//
+// The vulnerability identifier field is mandatory and canonicalized to be
+// lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type AllIsVulnerabilityVulnerabilityCVE struct {
+	Typename   *string `json:"__typename"`
+	AllCveTree `json:"-"`
+}
+
+// GetTypename returns AllIsVulnerabilityVulnerabilityCVE.Typename, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityCVE) GetTypename() *string { return v.Typename }
+
+// GetId returns AllIsVulnerabilityVulnerabilityCVE.Id, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityCVE) GetId() string { return v.AllCveTree.Id }
+
+// GetYear returns AllIsVulnerabilityVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityCVE) GetYear() int { return v.AllCveTree.Year }
+
+// GetCveId returns AllIsVulnerabilityVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityCVE) GetCveId() string { return v.AllCveTree.CveId }
+
+func (v *AllIsVulnerabilityVulnerabilityCVE) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsVulnerabilityVulnerabilityCVE
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsVulnerabilityVulnerabilityCVE = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCveTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllIsVulnerabilityVulnerabilityCVE struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Year int `json:"year"`
+
+	CveId string `json:"cveId"`
+}
+
+func (v *AllIsVulnerabilityVulnerabilityCVE) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsVulnerabilityVulnerabilityCVE) __premarshalJSON() (*__premarshalAllIsVulnerabilityVulnerabilityCVE, error) {
+	var retval __premarshalAllIsVulnerabilityVulnerabilityCVE
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllCveTree.Id
+	retval.Year = v.AllCveTree.Year
+	retval.CveId = v.AllCveTree.CveId
+	return &retval, nil
+}
+
+// AllIsVulnerabilityVulnerabilityCveOrGhsa includes the requested fields of the GraphQL interface CveOrGhsa.
+//
+// AllIsVulnerabilityVulnerabilityCveOrGhsa is implemented by the following types:
+// AllIsVulnerabilityVulnerabilityCVE
+// AllIsVulnerabilityVulnerabilityGHSA
+// The GraphQL type's documentation follows.
+//
+// CveOrGhsa is a union of CVE and GHSA.
+type AllIsVulnerabilityVulnerabilityCveOrGhsa interface {
+	implementsGraphQLInterfaceAllIsVulnerabilityVulnerabilityCveOrGhsa()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllIsVulnerabilityVulnerabilityCVE) implementsGraphQLInterfaceAllIsVulnerabilityVulnerabilityCveOrGhsa() {
+}
+func (v *AllIsVulnerabilityVulnerabilityGHSA) implementsGraphQLInterfaceAllIsVulnerabilityVulnerabilityCveOrGhsa() {
+}
+
+func __unmarshalAllIsVulnerabilityVulnerabilityCveOrGhsa(b []byte, v *AllIsVulnerabilityVulnerabilityCveOrGhsa) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "CVE":
+		*v = new(AllIsVulnerabilityVulnerabilityCVE)
+		return json.Unmarshal(b, *v)
+	case "GHSA":
+		*v = new(AllIsVulnerabilityVulnerabilityGHSA)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing CveOrGhsa.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllIsVulnerabilityVulnerabilityCveOrGhsa: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(v *AllIsVulnerabilityVulnerabilityCveOrGhsa) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllIsVulnerabilityVulnerabilityCVE:
+		typename = "CVE"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllIsVulnerabilityVulnerabilityCVE
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllIsVulnerabilityVulnerabilityGHSA:
+		typename = "GHSA"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllIsVulnerabilityVulnerabilityGHSA
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllIsVulnerabilityVulnerabilityCveOrGhsa: "%T"`, v)
+	}
+}
+
+// AllIsVulnerabilityVulnerabilityGHSA includes the requested fields of the GraphQL type GHSA.
+// The GraphQL type's documentation follows.
+//
+// GHSA represents GitHub security advisories.
+//
+// The advisory id field is mandatory and canonicalized to be lowercase.
+//
+// This node can be referred to by other parts of GUAC.
+type AllIsVulnerabilityVulnerabilityGHSA struct {
+	Typename    *string `json:"__typename"`
+	AllGHSATree `json:"-"`
+}
+
+// GetTypename returns AllIsVulnerabilityVulnerabilityGHSA.Typename, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityGHSA) GetTypename() *string { return v.Typename }
+
+// GetId returns AllIsVulnerabilityVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityGHSA) GetId() string { return v.AllGHSATree.Id }
+
+// GetGhsaId returns AllIsVulnerabilityVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
+func (v *AllIsVulnerabilityVulnerabilityGHSA) GetGhsaId() string { return v.AllGHSATree.GhsaId }
+
+func (v *AllIsVulnerabilityVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllIsVulnerabilityVulnerabilityGHSA
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllIsVulnerabilityVulnerabilityGHSA = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllGHSATree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllIsVulnerabilityVulnerabilityGHSA struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	GhsaId string `json:"ghsaId"`
+}
+
+func (v *AllIsVulnerabilityVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllIsVulnerabilityVulnerabilityGHSA) __premarshalJSON() (*__premarshalAllIsVulnerabilityVulnerabilityGHSA, error) {
+	var retval __premarshalAllIsVulnerabilityVulnerabilityGHSA
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllGHSATree.Id
+	retval.GhsaId = v.AllGHSATree.GhsaId
+	return &retval, nil
+}
+
 // AllOSVTree includes the GraphQL fields of OSV requested by the fragment AllOSVTree.
 // The GraphQL type's documentation follows.
 //
@@ -1791,6 +4882,119 @@ func (v *AllOSVTree) GetId() string { return v.Id }
 
 // GetOsvId returns AllOSVTree.OsvId, and is useful for accessing the field via an interface.
 func (v *AllOSVTree) GetOsvId() string { return v.OsvId }
+
+// AllPkgEqual includes the GraphQL fields of PkgEqual requested by the fragment AllPkgEqual.
+// The GraphQL type's documentation follows.
+//
+// PkgEqual is an attestation that a set of packages are similar.
+type AllPkgEqual struct {
+	Id string `json:"id"`
+	// Justification for the claim that the packages are similar
+	Justification string `json:"justification"`
+	// Collection of packages that are similar
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetId returns AllPkgEqual.Id, and is useful for accessing the field via an interface.
+func (v *AllPkgEqual) GetId() string { return v.Id }
+
+// GetJustification returns AllPkgEqual.Justification, and is useful for accessing the field via an interface.
+func (v *AllPkgEqual) GetJustification() string { return v.Justification }
+
+// GetPackages returns AllPkgEqual.Packages, and is useful for accessing the field via an interface.
+func (v *AllPkgEqual) GetPackages() []AllPkgEqualPackagesPackage { return v.Packages }
+
+// GetOrigin returns AllPkgEqual.Origin, and is useful for accessing the field via an interface.
+func (v *AllPkgEqual) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllPkgEqual.Collector, and is useful for accessing the field via an interface.
+func (v *AllPkgEqual) GetCollector() string { return v.Collector }
+
+// AllPkgEqualPackagesPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllPkgEqualPackagesPackage struct {
+	AllPkgTree `json:"-"`
+}
+
+// GetId returns AllPkgEqualPackagesPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllPkgEqualPackagesPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllPkgEqualPackagesPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllPkgEqualPackagesPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllPkgEqualPackagesPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllPkgEqualPackagesPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllPkgEqualPackagesPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllPkgEqualPackagesPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllPkgEqualPackagesPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllPkgEqualPackagesPackage struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllPkgEqualPackagesPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllPkgEqualPackagesPackage) __premarshalJSON() (*__premarshalAllPkgEqualPackagesPackage, error) {
+	var retval __premarshalAllPkgEqualPackagesPackage
+
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
 
 // AllPkgTree includes the GraphQL fields of Package requested by the fragment AllPkgTree.
 // The GraphQL type's documentation follows.
@@ -1954,6 +5158,796 @@ func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVers
 // GetValue returns AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier.Value, and is useful for accessing the field via an interface.
 func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier) GetValue() string {
 	return v.Value
+}
+
+// AllPointOfContact includes the GraphQL fields of PointOfContact requested by the fragment AllPointOfContact.
+// The GraphQL type's documentation follows.
+//
+// PointOfContact is an attestation of how to get in touch with the person(s) responsible
+// for a package, source, or artifact.
+//
+// All evidence trees record a justification for the property they represent as
+// well as the document that contains the attestation (origin) and the collector
+// that collected the document (collector).
+//
+// The attestation applies to a subject which is a package, source, or artifact.
+// If the attestation targets a package, it must target a PackageName or a
+// PackageVersion. If the attestation targets a source, it must target a
+// SourceName.
+//
+// email is the email address (singular) of the point of contact.
+//
+// info is additional contact information other than email address. This is free
+// form.
+//
+// NOTE: the identifiers for point of contact should be part of software trees.
+// This will benefit from identifier look up and traversal as well as organization
+// hierarchy. However, until the use case arises, PointOfContact will be a flat
+// reference to the contact details.
+type AllPointOfContact struct {
+	Id            string                                          `json:"id"`
+	Subject       AllPointOfContactSubjectPackageSourceOrArtifact `json:"-"`
+	Email         string                                          `json:"email"`
+	Info          string                                          `json:"info"`
+	Since         time.Time                                       `json:"since"`
+	Justification string                                          `json:"justification"`
+	Origin        string                                          `json:"origin"`
+	Collector     string                                          `json:"collector"`
+}
+
+// GetId returns AllPointOfContact.Id, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetId() string { return v.Id }
+
+// GetSubject returns AllPointOfContact.Subject, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.Subject
+}
+
+// GetEmail returns AllPointOfContact.Email, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetEmail() string { return v.Email }
+
+// GetInfo returns AllPointOfContact.Info, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetInfo() string { return v.Info }
+
+// GetSince returns AllPointOfContact.Since, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetSince() time.Time { return v.Since }
+
+// GetJustification returns AllPointOfContact.Justification, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetJustification() string { return v.Justification }
+
+// GetOrigin returns AllPointOfContact.Origin, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllPointOfContact.Collector, and is useful for accessing the field via an interface.
+func (v *AllPointOfContact) GetCollector() string { return v.Collector }
+
+func (v *AllPointOfContact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllPointOfContact
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllPointOfContact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllPointOfContactSubjectPackageSourceOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllPointOfContact.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllPointOfContact struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Email string `json:"email"`
+
+	Info string `json:"info"`
+
+	Since time.Time `json:"since"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllPointOfContact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllPointOfContact) __premarshalJSON() (*__premarshalAllPointOfContact, error) {
+	var retval __premarshalAllPointOfContact
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllPointOfContact.Subject: %w", err)
+		}
+	}
+	retval.Email = v.Email
+	retval.Info = v.Info
+	retval.Since = v.Since
+	retval.Justification = v.Justification
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllPointOfContactSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllPointOfContactSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllPointOfContactSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllPointOfContactSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllPointOfContactSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllPointOfContactSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllPointOfContactSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllPointOfContactSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllPointOfContactSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllPointOfContactSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllPointOfContactSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllPointOfContactSubjectArtifact) __premarshalJSON() (*__premarshalAllPointOfContactSubjectArtifact, error) {
+	var retval __premarshalAllPointOfContactSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllPointOfContactSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllPointOfContactSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllPointOfContactSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllPointOfContactSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllPointOfContactSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllPointOfContactSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllPointOfContactSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllPointOfContactSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllPointOfContactSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllPointOfContactSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllPointOfContactSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllPointOfContactSubjectPackage) __premarshalJSON() (*__premarshalAllPointOfContactSubjectPackage, error) {
+	var retval __premarshalAllPointOfContactSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllPointOfContactSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// AllPointOfContactSubjectPackageSourceOrArtifact is implemented by the following types:
+// AllPointOfContactSubjectArtifact
+// AllPointOfContactSubjectPackage
+// AllPointOfContactSubjectSource
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type AllPointOfContactSubjectPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceAllPointOfContactSubjectPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllPointOfContactSubjectArtifact) implementsGraphQLInterfaceAllPointOfContactSubjectPackageSourceOrArtifact() {
+}
+func (v *AllPointOfContactSubjectPackage) implementsGraphQLInterfaceAllPointOfContactSubjectPackageSourceOrArtifact() {
+}
+func (v *AllPointOfContactSubjectSource) implementsGraphQLInterfaceAllPointOfContactSubjectPackageSourceOrArtifact() {
+}
+
+func __unmarshalAllPointOfContactSubjectPackageSourceOrArtifact(b []byte, v *AllPointOfContactSubjectPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllPointOfContactSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllPointOfContactSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(AllPointOfContactSubjectSource)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllPointOfContactSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllPointOfContactSubjectPackageSourceOrArtifact(v *AllPointOfContactSubjectPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllPointOfContactSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllPointOfContactSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllPointOfContactSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllPointOfContactSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllPointOfContactSubjectSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllPointOfContactSubjectSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllPointOfContactSubjectPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// AllPointOfContactSubjectSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type AllPointOfContactSubjectSource struct {
+	Typename      *string `json:"__typename"`
+	AllSourceTree `json:"-"`
+}
+
+// GetTypename returns AllPointOfContactSubjectSource.Typename, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectSource) GetTypename() *string { return v.Typename }
+
+// GetId returns AllPointOfContactSubjectSource.Id, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectSource) GetId() string { return v.AllSourceTree.Id }
+
+// GetType returns AllPointOfContactSubjectSource.Type, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectSource) GetType() string { return v.AllSourceTree.Type }
+
+// GetNamespaces returns AllPointOfContactSubjectSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllPointOfContactSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *AllPointOfContactSubjectSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllPointOfContactSubjectSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllPointOfContactSubjectSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllPointOfContactSubjectSource struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *AllPointOfContactSubjectSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllPointOfContactSubjectSource) __premarshalJSON() (*__premarshalAllPointOfContactSubjectSource, error) {
+	var retval __premarshalAllPointOfContactSubjectSource
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
+// AllSLSATree includes the GraphQL fields of HasSLSA requested by the fragment AllSLSATree.
+// The GraphQL type's documentation follows.
+//
+// HasSLSA records that a subject node has a SLSA attestation.
+type AllSLSATree struct {
+	Id string `json:"id"`
+	// The subject of SLSA attestation
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
+	// The SLSA attestation
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
+}
+
+// GetId returns AllSLSATree.Id, and is useful for accessing the field via an interface.
+func (v *AllSLSATree) GetId() string { return v.Id }
+
+// GetSubject returns AllSLSATree.Subject, and is useful for accessing the field via an interface.
+func (v *AllSLSATree) GetSubject() AllSLSATreeSubjectArtifact { return v.Subject }
+
+// GetSlsa returns AllSLSATree.Slsa, and is useful for accessing the field via an interface.
+func (v *AllSLSATree) GetSlsa() AllSLSATreeSlsaSLSA { return v.Slsa }
+
+// AllSLSATreeSlsaSLSA includes the requested fields of the GraphQL type SLSA.
+// The GraphQL type's documentation follows.
+//
+// SLSA contains all of the fields present in a SLSA attestation.
+//
+// The materials and builders are objects of the HasSLSA predicate, everything
+// else are properties extracted from the attestation.
+//
+// We also include fields to specify under what conditions the check was performed
+// (time of scan, version of scanners, etc.) as well as how this information got
+// included into GUAC (origin document and the collector for that document).
+type AllSLSATreeSlsaSLSA struct {
+	// Materials of the build resulting in subject
+	BuiltFrom []AllSLSATreeSlsaSLSABuiltFromArtifact `json:"builtFrom"`
+	// Builder performing the build
+	BuiltBy AllSLSATreeSlsaSLSABuiltByBuilder `json:"builtBy"`
+	// Type of the builder
+	BuildType string `json:"buildType"`
+	// Individual predicates found in the attestation
+	SlsaPredicate []AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate `json:"slsaPredicate"`
+	// Version of the SLSA predicate
+	SlsaVersion string `json:"slsaVersion"`
+	// Timestamp (RFC3339Nano format) of build start time
+	StartedOn *time.Time `json:"startedOn"`
+	// Timestamp (RFC3339Nano format) of build end time
+	FinishedOn *time.Time `json:"finishedOn"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+}
+
+// GetBuiltFrom returns AllSLSATreeSlsaSLSA.BuiltFrom, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetBuiltFrom() []AllSLSATreeSlsaSLSABuiltFromArtifact {
+	return v.BuiltFrom
+}
+
+// GetBuiltBy returns AllSLSATreeSlsaSLSA.BuiltBy, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetBuiltBy() AllSLSATreeSlsaSLSABuiltByBuilder { return v.BuiltBy }
+
+// GetBuildType returns AllSLSATreeSlsaSLSA.BuildType, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetBuildType() string { return v.BuildType }
+
+// GetSlsaPredicate returns AllSLSATreeSlsaSLSA.SlsaPredicate, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetSlsaPredicate() []AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate {
+	return v.SlsaPredicate
+}
+
+// GetSlsaVersion returns AllSLSATreeSlsaSLSA.SlsaVersion, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetSlsaVersion() string { return v.SlsaVersion }
+
+// GetStartedOn returns AllSLSATreeSlsaSLSA.StartedOn, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetStartedOn() *time.Time { return v.StartedOn }
+
+// GetFinishedOn returns AllSLSATreeSlsaSLSA.FinishedOn, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetFinishedOn() *time.Time { return v.FinishedOn }
+
+// GetOrigin returns AllSLSATreeSlsaSLSA.Origin, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllSLSATreeSlsaSLSA.Collector, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSA) GetCollector() string { return v.Collector }
+
+// AllSLSATreeSlsaSLSABuiltByBuilder includes the requested fields of the GraphQL type Builder.
+// The GraphQL type's documentation follows.
+//
+// Builder represents the builder (e.g., FRSCA or GitHub Actions).
+//
+// Currently builders are identified by the uri field.
+type AllSLSATreeSlsaSLSABuiltByBuilder struct {
+	Id  string `json:"id"`
+	Uri string `json:"uri"`
+}
+
+// GetId returns AllSLSATreeSlsaSLSABuiltByBuilder.Id, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSABuiltByBuilder) GetId() string { return v.Id }
+
+// GetUri returns AllSLSATreeSlsaSLSABuiltByBuilder.Uri, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSABuiltByBuilder) GetUri() string { return v.Uri }
+
+// AllSLSATreeSlsaSLSABuiltFromArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllSLSATreeSlsaSLSABuiltFromArtifact struct {
+	AllArtifactTree `json:"-"`
+}
+
+// GetId returns AllSLSATreeSlsaSLSABuiltFromArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllSLSATreeSlsaSLSABuiltFromArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) GetAlgorithm() string {
+	return v.AllArtifactTree.Algorithm
+}
+
+// GetDigest returns AllSLSATreeSlsaSLSABuiltFromArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllSLSATreeSlsaSLSABuiltFromArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllSLSATreeSlsaSLSABuiltFromArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllSLSATreeSlsaSLSABuiltFromArtifact struct {
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllSLSATreeSlsaSLSABuiltFromArtifact) __premarshalJSON() (*__premarshalAllSLSATreeSlsaSLSABuiltFromArtifact, error) {
+	var retval __premarshalAllSLSATreeSlsaSLSABuiltFromArtifact
+
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate includes the requested fields of the GraphQL type SLSAPredicate.
+// The GraphQL type's documentation follows.
+//
+// SLSAPredicate are the values from the SLSA predicate in key-value pair form.
+//
+// # For example, given the following predicate
+//
+// ```
+// "predicate": {
+// "buildDefinition": {
+// "externalParameters": {
+// "repository": "https://github.com/octocat/hello-world",
+// ...
+// },
+// ...
+// },
+// ...
+// }
+// ```
+//
+// we have
+//
+// ```
+// key   = "buildDefinition.externalParameters.repository"
+// value = "https://github.com/octocat/hello-world"
+// ```
+//
+// This node cannot be directly referred by other parts of GUAC.
+type AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetKey returns AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Key, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetKey() string { return v.Key }
+
+// GetValue returns AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Value, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetValue() string { return v.Value }
+
+// AllSLSATreeSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllSLSATreeSubjectArtifact struct {
+	AllArtifactTree `json:"-"`
+}
+
+// GetId returns AllSLSATreeSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllSLSATreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllSLSATreeSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllSLSATreeSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllSLSATreeSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllSLSATreeSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllSLSATreeSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllSLSATreeSubjectArtifact struct {
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllSLSATreeSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllSLSATreeSubjectArtifact) __premarshalJSON() (*__premarshalAllSLSATreeSubjectArtifact, error) {
+	var retval __premarshalAllSLSATreeSubjectArtifact
+
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
 }
 
 // AllSourceTree includes the GraphQL fields of Source requested by the fragment AllSourceTree.
@@ -3001,28 +6995,28 @@ func (v *CertifyGHSAResponse) GetIngestVulnerability() CertifyGHSAIngestVulnerab
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type CertifyGoodArtifactIngestCertifyGood struct {
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetId returns CertifyGoodArtifactIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *CertifyGoodArtifactIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns CertifyGoodArtifactIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyGoodArtifactIngestCertifyGood) GetJustification() string {
-	return v.allCertifyGood.Justification
+	return v.AllCertifyGood.Justification
 }
 
 // GetSubject returns CertifyGoodArtifactIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *CertifyGoodArtifactIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns CertifyGoodArtifactIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *CertifyGoodArtifactIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns CertifyGoodArtifactIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyGoodArtifactIngestCertifyGood) GetCollector() string {
-	return v.allCertifyGood.Collector
+	return v.AllCertifyGood.Collector
 }
 
 func (v *CertifyGoodArtifactIngestCertifyGood) UnmarshalJSON(b []byte) error {
@@ -3043,7 +7037,7 @@ func (v *CertifyGoodArtifactIngestCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -3073,22 +7067,22 @@ func (v *CertifyGoodArtifactIngestCertifyGood) MarshalJSON() ([]byte, error) {
 func (v *CertifyGoodArtifactIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodArtifactIngestCertifyGood, error) {
 	var retval __premarshalCertifyGoodArtifactIngestCertifyGood
 
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodArtifactIngestCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal CertifyGoodArtifactIngestCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -3134,27 +7128,27 @@ func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type CertifyGoodPkgIngestCertifyGood struct {
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetId returns CertifyGoodPkgIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *CertifyGoodPkgIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns CertifyGoodPkgIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyGoodPkgIngestCertifyGood) GetJustification() string {
-	return v.allCertifyGood.Justification
+	return v.AllCertifyGood.Justification
 }
 
 // GetSubject returns CertifyGoodPkgIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *CertifyGoodPkgIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns CertifyGoodPkgIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *CertifyGoodPkgIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns CertifyGoodPkgIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *CertifyGoodPkgIngestCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *CertifyGoodPkgIngestCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -3174,7 +7168,7 @@ func (v *CertifyGoodPkgIngestCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -3204,22 +7198,22 @@ func (v *CertifyGoodPkgIngestCertifyGood) MarshalJSON() ([]byte, error) {
 func (v *CertifyGoodPkgIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodPkgIngestCertifyGood, error) {
 	var retval __premarshalCertifyGoodPkgIngestCertifyGood
 
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodPkgIngestCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal CertifyGoodPkgIngestCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -3249,27 +7243,27 @@ func (v *CertifyGoodPkgResponse) GetIngestCertifyGood() CertifyGoodPkgIngestCert
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type CertifyGoodSrcIngestCertifyGood struct {
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetId returns CertifyGoodSrcIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *CertifyGoodSrcIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns CertifyGoodSrcIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyGoodSrcIngestCertifyGood) GetJustification() string {
-	return v.allCertifyGood.Justification
+	return v.AllCertifyGood.Justification
 }
 
 // GetSubject returns CertifyGoodSrcIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *CertifyGoodSrcIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns CertifyGoodSrcIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *CertifyGoodSrcIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns CertifyGoodSrcIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *CertifyGoodSrcIngestCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *CertifyGoodSrcIngestCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -3289,7 +7283,7 @@ func (v *CertifyGoodSrcIngestCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -3319,22 +7313,22 @@ func (v *CertifyGoodSrcIngestCertifyGood) MarshalJSON() ([]byte, error) {
 func (v *CertifyGoodSrcIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodSrcIngestCertifyGood, error) {
 	var retval __premarshalCertifyGoodSrcIngestCertifyGood
 
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodSrcIngestCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal CertifyGoodSrcIngestCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -4402,39 +8396,39 @@ func (v *GHSAsResponse) GetGhsa() []GHSAsGhsaGHSA { return v.Ghsa }
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type HasMetadataArtifactIngestHasMetadata struct {
-	allHasMetadata `json:"-"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetId returns HasMetadataArtifactIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetId() string { return v.allHasMetadata.Id }
+func (v *HasMetadataArtifactIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
 
 // GetSubject returns HasMetadataArtifactIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetSubject() allHasMetadataSubjectPackageSourceOrArtifact {
-	return v.allHasMetadata.Subject
+func (v *HasMetadataArtifactIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
 }
 
 // GetKey returns HasMetadataArtifactIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetKey() string { return v.allHasMetadata.Key }
+func (v *HasMetadataArtifactIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
 
 // GetValue returns HasMetadataArtifactIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetValue() string { return v.allHasMetadata.Value }
+func (v *HasMetadataArtifactIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
 
 // GetTimestamp returns HasMetadataArtifactIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
 func (v *HasMetadataArtifactIngestHasMetadata) GetTimestamp() time.Time {
-	return v.allHasMetadata.Timestamp
+	return v.AllHasMetadata.Timestamp
 }
 
 // GetJustification returns HasMetadataArtifactIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
 func (v *HasMetadataArtifactIngestHasMetadata) GetJustification() string {
-	return v.allHasMetadata.Justification
+	return v.AllHasMetadata.Justification
 }
 
 // GetOrigin returns HasMetadataArtifactIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetOrigin() string { return v.allHasMetadata.Origin }
+func (v *HasMetadataArtifactIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
 
 // GetCollector returns HasMetadataArtifactIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
 func (v *HasMetadataArtifactIngestHasMetadata) GetCollector() string {
-	return v.allHasMetadata.Collector
+	return v.AllHasMetadata.Collector
 }
 
 func (v *HasMetadataArtifactIngestHasMetadata) UnmarshalJSON(b []byte) error {
@@ -4455,7 +8449,7 @@ func (v *HasMetadataArtifactIngestHasMetadata) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasMetadata)
+		b, &v.AllHasMetadata)
 	if err != nil {
 		return err
 	}
@@ -4491,25 +8485,25 @@ func (v *HasMetadataArtifactIngestHasMetadata) MarshalJSON() ([]byte, error) {
 func (v *HasMetadataArtifactIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataArtifactIngestHasMetadata, error) {
 	var retval __premarshalHasMetadataArtifactIngestHasMetadata
 
-	retval.Id = v.allHasMetadata.Id
+	retval.Id = v.AllHasMetadata.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasMetadata.Subject
+		src := v.AllHasMetadata.Subject
 		var err error
-		*dst, err = __marshalallHasMetadataSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataArtifactIngestHasMetadata.allHasMetadata.Subject: %w", err)
+				"unable to marshal HasMetadataArtifactIngestHasMetadata.AllHasMetadata.Subject: %w", err)
 		}
 	}
-	retval.Key = v.allHasMetadata.Key
-	retval.Value = v.allHasMetadata.Value
-	retval.Timestamp = v.allHasMetadata.Timestamp
-	retval.Justification = v.allHasMetadata.Justification
-	retval.Origin = v.allHasMetadata.Origin
-	retval.Collector = v.allHasMetadata.Collector
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
 	return &retval, nil
 }
 
@@ -4570,36 +8564,36 @@ func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type HasMetadataPkgIngestHasMetadata struct {
-	allHasMetadata `json:"-"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetId returns HasMetadataPkgIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetId() string { return v.allHasMetadata.Id }
+func (v *HasMetadataPkgIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
 
 // GetSubject returns HasMetadataPkgIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetSubject() allHasMetadataSubjectPackageSourceOrArtifact {
-	return v.allHasMetadata.Subject
+func (v *HasMetadataPkgIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
 }
 
 // GetKey returns HasMetadataPkgIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetKey() string { return v.allHasMetadata.Key }
+func (v *HasMetadataPkgIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
 
 // GetValue returns HasMetadataPkgIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetValue() string { return v.allHasMetadata.Value }
+func (v *HasMetadataPkgIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
 
 // GetTimestamp returns HasMetadataPkgIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetTimestamp() time.Time { return v.allHasMetadata.Timestamp }
+func (v *HasMetadataPkgIngestHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
 
 // GetJustification returns HasMetadataPkgIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
 func (v *HasMetadataPkgIngestHasMetadata) GetJustification() string {
-	return v.allHasMetadata.Justification
+	return v.AllHasMetadata.Justification
 }
 
 // GetOrigin returns HasMetadataPkgIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetOrigin() string { return v.allHasMetadata.Origin }
+func (v *HasMetadataPkgIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
 
 // GetCollector returns HasMetadataPkgIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetCollector() string { return v.allHasMetadata.Collector }
+func (v *HasMetadataPkgIngestHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
 
 func (v *HasMetadataPkgIngestHasMetadata) UnmarshalJSON(b []byte) error {
 
@@ -4619,7 +8613,7 @@ func (v *HasMetadataPkgIngestHasMetadata) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasMetadata)
+		b, &v.AllHasMetadata)
 	if err != nil {
 		return err
 	}
@@ -4655,25 +8649,25 @@ func (v *HasMetadataPkgIngestHasMetadata) MarshalJSON() ([]byte, error) {
 func (v *HasMetadataPkgIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataPkgIngestHasMetadata, error) {
 	var retval __premarshalHasMetadataPkgIngestHasMetadata
 
-	retval.Id = v.allHasMetadata.Id
+	retval.Id = v.AllHasMetadata.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasMetadata.Subject
+		src := v.AllHasMetadata.Subject
 		var err error
-		*dst, err = __marshalallHasMetadataSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataPkgIngestHasMetadata.allHasMetadata.Subject: %w", err)
+				"unable to marshal HasMetadataPkgIngestHasMetadata.AllHasMetadata.Subject: %w", err)
 		}
 	}
-	retval.Key = v.allHasMetadata.Key
-	retval.Value = v.allHasMetadata.Value
-	retval.Timestamp = v.allHasMetadata.Timestamp
-	retval.Justification = v.allHasMetadata.Justification
-	retval.Origin = v.allHasMetadata.Origin
-	retval.Collector = v.allHasMetadata.Collector
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
 	return &retval, nil
 }
 
@@ -4706,36 +8700,36 @@ func (v *HasMetadataPkgResponse) GetIngestHasMetadata() HasMetadataPkgIngestHasM
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type HasMetadataSrcIngestHasMetadata struct {
-	allHasMetadata `json:"-"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetId returns HasMetadataSrcIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetId() string { return v.allHasMetadata.Id }
+func (v *HasMetadataSrcIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
 
 // GetSubject returns HasMetadataSrcIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetSubject() allHasMetadataSubjectPackageSourceOrArtifact {
-	return v.allHasMetadata.Subject
+func (v *HasMetadataSrcIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
 }
 
 // GetKey returns HasMetadataSrcIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetKey() string { return v.allHasMetadata.Key }
+func (v *HasMetadataSrcIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
 
 // GetValue returns HasMetadataSrcIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetValue() string { return v.allHasMetadata.Value }
+func (v *HasMetadataSrcIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
 
 // GetTimestamp returns HasMetadataSrcIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetTimestamp() time.Time { return v.allHasMetadata.Timestamp }
+func (v *HasMetadataSrcIngestHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
 
 // GetJustification returns HasMetadataSrcIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
 func (v *HasMetadataSrcIngestHasMetadata) GetJustification() string {
-	return v.allHasMetadata.Justification
+	return v.AllHasMetadata.Justification
 }
 
 // GetOrigin returns HasMetadataSrcIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetOrigin() string { return v.allHasMetadata.Origin }
+func (v *HasMetadataSrcIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
 
 // GetCollector returns HasMetadataSrcIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetCollector() string { return v.allHasMetadata.Collector }
+func (v *HasMetadataSrcIngestHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
 
 func (v *HasMetadataSrcIngestHasMetadata) UnmarshalJSON(b []byte) error {
 
@@ -4755,7 +8749,7 @@ func (v *HasMetadataSrcIngestHasMetadata) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasMetadata)
+		b, &v.AllHasMetadata)
 	if err != nil {
 		return err
 	}
@@ -4791,25 +8785,25 @@ func (v *HasMetadataSrcIngestHasMetadata) MarshalJSON() ([]byte, error) {
 func (v *HasMetadataSrcIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataSrcIngestHasMetadata, error) {
 	var retval __premarshalHasMetadataSrcIngestHasMetadata
 
-	retval.Id = v.allHasMetadata.Id
+	retval.Id = v.AllHasMetadata.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasMetadata.Subject
+		src := v.AllHasMetadata.Subject
 		var err error
-		*dst, err = __marshalallHasMetadataSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataSrcIngestHasMetadata.allHasMetadata.Subject: %w", err)
+				"unable to marshal HasMetadataSrcIngestHasMetadata.AllHasMetadata.Subject: %w", err)
 		}
 	}
-	retval.Key = v.allHasMetadata.Key
-	retval.Value = v.allHasMetadata.Value
-	retval.Timestamp = v.allHasMetadata.Timestamp
-	retval.Justification = v.allHasMetadata.Justification
-	retval.Origin = v.allHasMetadata.Origin
-	retval.Collector = v.allHasMetadata.Collector
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
 	return &retval, nil
 }
 
@@ -4826,36 +8820,36 @@ func (v *HasMetadataSrcResponse) GetIngestHasMetadata() HasMetadataSrcIngestHasM
 
 // HasSBOMArtifactIngestHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type HasSBOMArtifactIngestHasSBOM struct {
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetId returns HasSBOMArtifactIngestHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *HasSBOMArtifactIngestHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns HasSBOMArtifactIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *HasSBOMArtifactIngestHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns HasSBOMArtifactIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *HasSBOMArtifactIngestHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns HasSBOMArtifactIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *HasSBOMArtifactIngestHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns HasSBOMArtifactIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *HasSBOMArtifactIngestHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns HasSBOMArtifactIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
 func (v *HasSBOMArtifactIngestHasSBOM) GetDownloadLocation() string {
-	return v.allHasSBOMTree.DownloadLocation
+	return v.AllHasSBOMTree.DownloadLocation
 }
 
 // GetOrigin returns HasSBOMArtifactIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *HasSBOMArtifactIngestHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns HasSBOMArtifactIngestHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *HasSBOMArtifactIngestHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *HasSBOMArtifactIngestHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -4875,7 +8869,7 @@ func (v *HasSBOMArtifactIngestHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -4911,25 +8905,25 @@ func (v *HasSBOMArtifactIngestHasSBOM) MarshalJSON() ([]byte, error) {
 func (v *HasSBOMArtifactIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMArtifactIngestHasSBOM, error) {
 	var retval __premarshalHasSBOMArtifactIngestHasSBOM
 
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMArtifactIngestHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal HasSBOMArtifactIngestHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -4974,36 +8968,36 @@ func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
 // HasSBOMPkgIngestHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type HasSBOMPkgIngestHasSBOM struct {
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetId returns HasSBOMPkgIngestHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *HasSBOMPkgIngestHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns HasSBOMPkgIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *HasSBOMPkgIngestHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns HasSBOMPkgIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *HasSBOMPkgIngestHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns HasSBOMPkgIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *HasSBOMPkgIngestHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns HasSBOMPkgIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *HasSBOMPkgIngestHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns HasSBOMPkgIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
 func (v *HasSBOMPkgIngestHasSBOM) GetDownloadLocation() string {
-	return v.allHasSBOMTree.DownloadLocation
+	return v.AllHasSBOMTree.DownloadLocation
 }
 
 // GetOrigin returns HasSBOMPkgIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *HasSBOMPkgIngestHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns HasSBOMPkgIngestHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *HasSBOMPkgIngestHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *HasSBOMPkgIngestHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -5023,7 +9017,7 @@ func (v *HasSBOMPkgIngestHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -5059,25 +9053,25 @@ func (v *HasSBOMPkgIngestHasSBOM) MarshalJSON() ([]byte, error) {
 func (v *HasSBOMPkgIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMPkgIngestHasSBOM, error) {
 	var retval __premarshalHasSBOMPkgIngestHasSBOM
 
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMPkgIngestHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal HasSBOMPkgIngestHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -5095,35 +9089,35 @@ func (v *HasSBOMPkgResponse) GetIngestHasSBOM() HasSBOMPkgIngestHasSBOM { return
 //
 // HasSourceAt records that a package's repository is a given source.
 type HasSourceAtIngestHasSourceAt struct {
-	allHasSourceAt `json:"-"`
+	AllHasSourceAt `json:"-"`
 }
 
 // GetId returns HasSourceAtIngestHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetId() string { return v.allHasSourceAt.Id }
+func (v *HasSourceAtIngestHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
 
 // GetJustification returns HasSourceAtIngestHasSourceAt.Justification, and is useful for accessing the field via an interface.
 func (v *HasSourceAtIngestHasSourceAt) GetJustification() string {
-	return v.allHasSourceAt.Justification
+	return v.AllHasSourceAt.Justification
 }
 
 // GetKnownSince returns HasSourceAtIngestHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetKnownSince() time.Time { return v.allHasSourceAt.KnownSince }
+func (v *HasSourceAtIngestHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
 
 // GetPackage returns HasSourceAtIngestHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetPackage() allHasSourceAtPackage {
-	return v.allHasSourceAt.Package
+func (v *HasSourceAtIngestHasSourceAt) GetPackage() AllHasSourceAtPackage {
+	return v.AllHasSourceAt.Package
 }
 
 // GetSource returns HasSourceAtIngestHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetSource() allHasSourceAtSource {
-	return v.allHasSourceAt.Source
+func (v *HasSourceAtIngestHasSourceAt) GetSource() AllHasSourceAtSource {
+	return v.AllHasSourceAt.Source
 }
 
 // GetOrigin returns HasSourceAtIngestHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetOrigin() string { return v.allHasSourceAt.Origin }
+func (v *HasSourceAtIngestHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
 
 // GetCollector returns HasSourceAtIngestHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetCollector() string { return v.allHasSourceAt.Collector }
+func (v *HasSourceAtIngestHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
 
 func (v *HasSourceAtIngestHasSourceAt) UnmarshalJSON(b []byte) error {
 
@@ -5143,7 +9137,7 @@ func (v *HasSourceAtIngestHasSourceAt) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSourceAt)
+		b, &v.AllHasSourceAt)
 	if err != nil {
 		return err
 	}
@@ -5157,9 +9151,9 @@ type __premarshalHasSourceAtIngestHasSourceAt struct {
 
 	KnownSince time.Time `json:"knownSince"`
 
-	Package allHasSourceAtPackage `json:"package"`
+	Package AllHasSourceAtPackage `json:"package"`
 
-	Source allHasSourceAtSource `json:"source"`
+	Source AllHasSourceAtSource `json:"source"`
 
 	Origin string `json:"origin"`
 
@@ -5177,13 +9171,13 @@ func (v *HasSourceAtIngestHasSourceAt) MarshalJSON() ([]byte, error) {
 func (v *HasSourceAtIngestHasSourceAt) __premarshalJSON() (*__premarshalHasSourceAtIngestHasSourceAt, error) {
 	var retval __premarshalHasSourceAtIngestHasSourceAt
 
-	retval.Id = v.allHasSourceAt.Id
-	retval.Justification = v.allHasSourceAt.Justification
-	retval.KnownSince = v.allHasSourceAt.KnownSince
-	retval.Package = v.allHasSourceAt.Package
-	retval.Source = v.allHasSourceAt.Source
-	retval.Origin = v.allHasSourceAt.Origin
-	retval.Collector = v.allHasSourceAt.Collector
+	retval.Id = v.AllHasSourceAt.Id
+	retval.Justification = v.AllHasSourceAt.Justification
+	retval.KnownSince = v.AllHasSourceAt.KnownSince
+	retval.Package = v.AllHasSourceAt.Package
+	retval.Source = v.AllHasSourceAt.Source
+	retval.Origin = v.AllHasSourceAt.Origin
+	retval.Collector = v.AllHasSourceAt.Collector
 	return &retval, nil
 }
 
@@ -5223,25 +9217,25 @@ func (v *HasSourceAtResponse) GetIngestHasSourceAt() HasSourceAtIngestHasSourceA
 //
 // HashEqual is an attestation that a set of artifacts are identical.
 type HashEqualIngestHashEqual struct {
-	allHashEqualTree `json:"-"`
+	AllHashEqualTree `json:"-"`
 }
 
 // GetId returns HashEqualIngestHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetId() string { return v.allHashEqualTree.Id }
+func (v *HashEqualIngestHashEqual) GetId() string { return v.AllHashEqualTree.Id }
 
 // GetJustification returns HashEqualIngestHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetJustification() string { return v.allHashEqualTree.Justification }
+func (v *HashEqualIngestHashEqual) GetJustification() string { return v.AllHashEqualTree.Justification }
 
 // GetArtifacts returns HashEqualIngestHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetArtifacts() []allHashEqualTreeArtifactsArtifact {
-	return v.allHashEqualTree.Artifacts
+func (v *HashEqualIngestHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
+	return v.AllHashEqualTree.Artifacts
 }
 
 // GetOrigin returns HashEqualIngestHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetOrigin() string { return v.allHashEqualTree.Origin }
+func (v *HashEqualIngestHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
 
 // GetCollector returns HashEqualIngestHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetCollector() string { return v.allHashEqualTree.Collector }
+func (v *HashEqualIngestHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
 
 func (v *HashEqualIngestHashEqual) UnmarshalJSON(b []byte) error {
 
@@ -5261,7 +9255,7 @@ func (v *HashEqualIngestHashEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHashEqualTree)
+		b, &v.AllHashEqualTree)
 	if err != nil {
 		return err
 	}
@@ -5273,7 +9267,7 @@ type __premarshalHashEqualIngestHashEqual struct {
 
 	Justification string `json:"justification"`
 
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
 
 	Origin string `json:"origin"`
 
@@ -5291,11 +9285,11 @@ func (v *HashEqualIngestHashEqual) MarshalJSON() ([]byte, error) {
 func (v *HashEqualIngestHashEqual) __premarshalJSON() (*__premarshalHashEqualIngestHashEqual, error) {
 	var retval __premarshalHashEqualIngestHashEqual
 
-	retval.Id = v.allHashEqualTree.Id
-	retval.Justification = v.allHashEqualTree.Justification
-	retval.Artifacts = v.allHashEqualTree.Artifacts
-	retval.Origin = v.allHashEqualTree.Origin
-	retval.Collector = v.allHashEqualTree.Collector
+	retval.Id = v.AllHashEqualTree.Id
+	retval.Justification = v.AllHashEqualTree.Justification
+	retval.Artifacts = v.AllHashEqualTree.Artifacts
+	retval.Origin = v.AllHashEqualTree.Origin
+	retval.Collector = v.AllHashEqualTree.Collector
 	return &retval, nil
 }
 
@@ -6379,47 +10373,47 @@ func (v *IngestSourcesResponse) GetIngestSources() []IngestSourcesIngestSourcesS
 //
 // IsDependency is an attestation to record that a package depends on another.
 type IsDependenciesIngestDependenciesIsDependency struct {
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetId returns IsDependenciesIngestDependenciesIsDependency.Id, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetId() string {
-	return v.allIsDependencyTree.Id
+	return v.AllIsDependencyTree.Id
 }
 
 // GetJustification returns IsDependenciesIngestDependenciesIsDependency.Justification, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetJustification() string {
-	return v.allIsDependencyTree.Justification
+	return v.AllIsDependencyTree.Justification
 }
 
 // GetPackage returns IsDependenciesIngestDependenciesIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *IsDependenciesIngestDependenciesIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns IsDependenciesIngestDependenciesIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *IsDependenciesIngestDependenciesIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns IsDependenciesIngestDependenciesIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns IsDependenciesIngestDependenciesIsDependency.VersionRange, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetVersionRange() string {
-	return v.allIsDependencyTree.VersionRange
+	return v.AllIsDependencyTree.VersionRange
 }
 
 // GetOrigin returns IsDependenciesIngestDependenciesIsDependency.Origin, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetOrigin() string {
-	return v.allIsDependencyTree.Origin
+	return v.AllIsDependencyTree.Origin
 }
 
 // GetCollector returns IsDependenciesIngestDependenciesIsDependency.Collector, and is useful for accessing the field via an interface.
 func (v *IsDependenciesIngestDependenciesIsDependency) GetCollector() string {
-	return v.allIsDependencyTree.Collector
+	return v.AllIsDependencyTree.Collector
 }
 
 func (v *IsDependenciesIngestDependenciesIsDependency) UnmarshalJSON(b []byte) error {
@@ -6440,7 +10434,7 @@ func (v *IsDependenciesIngestDependenciesIsDependency) UnmarshalJSON(b []byte) e
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -6452,9 +10446,9 @@ type __premarshalIsDependenciesIngestDependenciesIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -6476,14 +10470,14 @@ func (v *IsDependenciesIngestDependenciesIsDependency) MarshalJSON() ([]byte, er
 func (v *IsDependenciesIngestDependenciesIsDependency) __premarshalJSON() (*__premarshalIsDependenciesIngestDependenciesIsDependency, error) {
 	var retval __premarshalIsDependenciesIngestDependenciesIsDependency
 
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -6503,45 +10497,45 @@ func (v *IsDependenciesResponse) GetIngestDependencies() []IsDependenciesIngestD
 //
 // IsDependency is an attestation to record that a package depends on another.
 type IsDependencyIngestDependencyIsDependency struct {
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetId returns IsDependencyIngestDependencyIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetId() string { return v.allIsDependencyTree.Id }
+func (v *IsDependencyIngestDependencyIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
 
 // GetJustification returns IsDependencyIngestDependencyIsDependency.Justification, and is useful for accessing the field via an interface.
 func (v *IsDependencyIngestDependencyIsDependency) GetJustification() string {
-	return v.allIsDependencyTree.Justification
+	return v.AllIsDependencyTree.Justification
 }
 
 // GetPackage returns IsDependencyIngestDependencyIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *IsDependencyIngestDependencyIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns IsDependencyIngestDependencyIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *IsDependencyIngestDependencyIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns IsDependencyIngestDependencyIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *IsDependencyIngestDependencyIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns IsDependencyIngestDependencyIsDependency.VersionRange, and is useful for accessing the field via an interface.
 func (v *IsDependencyIngestDependencyIsDependency) GetVersionRange() string {
-	return v.allIsDependencyTree.VersionRange
+	return v.AllIsDependencyTree.VersionRange
 }
 
 // GetOrigin returns IsDependencyIngestDependencyIsDependency.Origin, and is useful for accessing the field via an interface.
 func (v *IsDependencyIngestDependencyIsDependency) GetOrigin() string {
-	return v.allIsDependencyTree.Origin
+	return v.AllIsDependencyTree.Origin
 }
 
 // GetCollector returns IsDependencyIngestDependencyIsDependency.Collector, and is useful for accessing the field via an interface.
 func (v *IsDependencyIngestDependencyIsDependency) GetCollector() string {
-	return v.allIsDependencyTree.Collector
+	return v.AllIsDependencyTree.Collector
 }
 
 func (v *IsDependencyIngestDependencyIsDependency) UnmarshalJSON(b []byte) error {
@@ -6562,7 +10556,7 @@ func (v *IsDependencyIngestDependencyIsDependency) UnmarshalJSON(b []byte) error
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -6574,9 +10568,9 @@ type __premarshalIsDependencyIngestDependencyIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -6598,14 +10592,14 @@ func (v *IsDependencyIngestDependencyIsDependency) MarshalJSON() ([]byte, error)
 func (v *IsDependencyIngestDependencyIsDependency) __premarshalJSON() (*__premarshalIsDependencyIngestDependencyIsDependency, error) {
 	var retval __premarshalIsDependencyIngestDependencyIsDependency
 
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -7149,35 +11143,35 @@ func (v *IsOccurrencesSrcResponse) GetIngestOccurrences() []IsOccurrencesSrcInge
 //
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type IsVulnerabilityCVEIngestIsVulnerability struct {
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetId returns IsVulnerabilityCVEIngestIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityCVEIngestIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *IsVulnerabilityCVEIngestIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns IsVulnerabilityCVEIngestIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityCVEIngestIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
-	return v.allIsVulnerability.Osv
+func (v *IsVulnerabilityCVEIngestIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV {
+	return v.AllIsVulnerability.Osv
 }
 
 // GetVulnerability returns IsVulnerabilityCVEIngestIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityCVEIngestIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *IsVulnerabilityCVEIngestIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns IsVulnerabilityCVEIngestIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns IsVulnerabilityCVEIngestIsVulnerability.Origin, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestIsVulnerability) GetOrigin() string {
-	return v.allIsVulnerability.Origin
+	return v.AllIsVulnerability.Origin
 }
 
 // GetCollector returns IsVulnerabilityCVEIngestIsVulnerability.Collector, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityCVEIngestIsVulnerability) GetCollector() string {
-	return v.allIsVulnerability.Collector
+	return v.AllIsVulnerability.Collector
 }
 
 func (v *IsVulnerabilityCVEIngestIsVulnerability) UnmarshalJSON(b []byte) error {
@@ -7198,7 +11192,7 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) UnmarshalJSON(b []byte) error 
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -7208,7 +11202,7 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) UnmarshalJSON(b []byte) error 
 type __premarshalIsVulnerabilityCVEIngestIsVulnerability struct {
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -7230,23 +11224,23 @@ func (v *IsVulnerabilityCVEIngestIsVulnerability) MarshalJSON() ([]byte, error) 
 func (v *IsVulnerabilityCVEIngestIsVulnerability) __premarshalJSON() (*__premarshalIsVulnerabilityCVEIngestIsVulnerability, error) {
 	var retval __premarshalIsVulnerabilityCVEIngestIsVulnerability
 
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal IsVulnerabilityCVEIngestIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal IsVulnerabilityCVEIngestIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -7266,35 +11260,35 @@ func (v *IsVulnerabilityCVEResponse) GetIngestIsVulnerability() IsVulnerabilityC
 //
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type IsVulnerabilityGHSAIngestIsVulnerability struct {
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetId returns IsVulnerabilityGHSAIngestIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns IsVulnerabilityGHSAIngestIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
-	return v.allIsVulnerability.Osv
+func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV {
+	return v.AllIsVulnerability.Osv
 }
 
 // GetVulnerability returns IsVulnerabilityGHSAIngestIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns IsVulnerabilityGHSAIngestIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns IsVulnerabilityGHSAIngestIsVulnerability.Origin, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetOrigin() string {
-	return v.allIsVulnerability.Origin
+	return v.AllIsVulnerability.Origin
 }
 
 // GetCollector returns IsVulnerabilityGHSAIngestIsVulnerability.Collector, and is useful for accessing the field via an interface.
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) GetCollector() string {
-	return v.allIsVulnerability.Collector
+	return v.AllIsVulnerability.Collector
 }
 
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) UnmarshalJSON(b []byte) error {
@@ -7315,7 +11309,7 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) UnmarshalJSON(b []byte) error
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -7325,7 +11319,7 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) UnmarshalJSON(b []byte) error
 type __premarshalIsVulnerabilityGHSAIngestIsVulnerability struct {
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -7347,23 +11341,23 @@ func (v *IsVulnerabilityGHSAIngestIsVulnerability) MarshalJSON() ([]byte, error)
 func (v *IsVulnerabilityGHSAIngestIsVulnerability) __premarshalJSON() (*__premarshalIsVulnerabilityGHSAIngestIsVulnerability, error) {
 	var retval __premarshalIsVulnerabilityGHSAIngestIsVulnerability
 
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal IsVulnerabilityGHSAIngestIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal IsVulnerabilityGHSAIngestIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -7490,17 +11484,17 @@ func (v *NeighborsNeighborsArtifact) __premarshalJSON() (*__premarshalNeighborsN
 // Currently builders are identified by the uri field.
 type NeighborsNeighborsBuilder struct {
 	Typename       *string `json:"__typename"`
-	allBuilderTree `json:"-"`
+	AllBuilderTree `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsBuilder.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsBuilder) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsBuilder.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsBuilder) GetId() string { return v.allBuilderTree.Id }
+func (v *NeighborsNeighborsBuilder) GetId() string { return v.AllBuilderTree.Id }
 
 // GetUri returns NeighborsNeighborsBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsBuilder) GetUri() string { return v.allBuilderTree.Uri }
+func (v *NeighborsNeighborsBuilder) GetUri() string { return v.AllBuilderTree.Uri }
 
 func (v *NeighborsNeighborsBuilder) UnmarshalJSON(b []byte) error {
 
@@ -7520,7 +11514,7 @@ func (v *NeighborsNeighborsBuilder) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allBuilderTree)
+		b, &v.AllBuilderTree)
 	if err != nil {
 		return err
 	}
@@ -7547,8 +11541,8 @@ func (v *NeighborsNeighborsBuilder) __premarshalJSON() (*__premarshalNeighborsNe
 	var retval __premarshalNeighborsNeighborsBuilder
 
 	retval.Typename = v.Typename
-	retval.Id = v.allBuilderTree.Id
-	retval.Uri = v.allBuilderTree.Uri
+	retval.Id = v.AllBuilderTree.Id
+	retval.Uri = v.AllBuilderTree.Uri
 	return &retval, nil
 }
 
@@ -7762,30 +11756,30 @@ func (v *NeighborsNeighborsCertifyBad) __premarshalJSON() (*__premarshalNeighbor
 // SourceName.
 type NeighborsNeighborsCertifyGood struct {
 	Typename       *string `json:"__typename"`
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyGood) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *NeighborsNeighborsCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns NeighborsNeighborsCertifyGood.Justification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyGood) GetJustification() string {
-	return v.allCertifyGood.Justification
+	return v.AllCertifyGood.Justification
 }
 
 // GetSubject returns NeighborsNeighborsCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *NeighborsNeighborsCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns NeighborsNeighborsCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *NeighborsNeighborsCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns NeighborsNeighborsCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *NeighborsNeighborsCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *NeighborsNeighborsCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -7805,7 +11799,7 @@ func (v *NeighborsNeighborsCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -7838,22 +11832,22 @@ func (v *NeighborsNeighborsCertifyGood) __premarshalJSON() (*__premarshalNeighbo
 	var retval __premarshalNeighborsNeighborsCertifyGood
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NeighborsNeighborsCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal NeighborsNeighborsCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -7943,58 +11937,58 @@ func (v *NeighborsNeighborsCertifyScorecard) __premarshalJSON() (*__premarshalNe
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type NeighborsNeighborsCertifyVEXStatement struct {
 	Typename               *string `json:"__typename"`
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsCertifyVEXStatement.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyVEXStatement) GetId() string { return v.allCertifyVEXStatement.Id }
+func (v *NeighborsNeighborsCertifyVEXStatement) GetId() string { return v.AllCertifyVEXStatement.Id }
 
 // GetSubject returns NeighborsNeighborsCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *NeighborsNeighborsCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns NeighborsNeighborsCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *NeighborsNeighborsCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns NeighborsNeighborsCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns NeighborsNeighborsCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns NeighborsNeighborsCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns NeighborsNeighborsCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns NeighborsNeighborsCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns NeighborsNeighborsCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns NeighborsNeighborsCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *NeighborsNeighborsCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -8015,7 +12009,7 @@ func (v *NeighborsNeighborsCertifyVEXStatement) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -8058,38 +12052,38 @@ func (v *NeighborsNeighborsCertifyVEXStatement) __premarshalJSON() (*__premarsha
 	var retval __premarshalNeighborsNeighborsCertifyVEXStatement
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NeighborsNeighborsCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal NeighborsNeighborsCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NeighborsNeighborsCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal NeighborsNeighborsCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -8292,39 +12286,39 @@ func (v *NeighborsNeighborsHasMetadata) GetTypename() *string { return v.Typenam
 // NeighborsNeighborsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NeighborsNeighborsHasSBOM struct {
 	Typename       *string `json:"__typename"`
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsHasSBOM.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSBOM) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *NeighborsNeighborsHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns NeighborsNeighborsHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *NeighborsNeighborsHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns NeighborsNeighborsHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *NeighborsNeighborsHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns NeighborsNeighborsHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *NeighborsNeighborsHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns NeighborsNeighborsHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *NeighborsNeighborsHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns NeighborsNeighborsHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSBOM) GetDownloadLocation() string {
-	return v.allHasSBOMTree.DownloadLocation
+	return v.AllHasSBOMTree.DownloadLocation
 }
 
 // GetOrigin returns NeighborsNeighborsHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *NeighborsNeighborsHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns NeighborsNeighborsHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *NeighborsNeighborsHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *NeighborsNeighborsHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -8344,7 +12338,7 @@ func (v *NeighborsNeighborsHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -8383,25 +12377,25 @@ func (v *NeighborsNeighborsHasSBOM) __premarshalJSON() (*__premarshalNeighborsNe
 	var retval __premarshalNeighborsNeighborsHasSBOM
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NeighborsNeighborsHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal NeighborsNeighborsHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -8411,22 +12405,22 @@ func (v *NeighborsNeighborsHasSBOM) __premarshalJSON() (*__premarshalNeighborsNe
 // HasSLSA records that a subject node has a SLSA attestation.
 type NeighborsNeighborsHasSLSA struct {
 	Typename    *string `json:"__typename"`
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsHasSLSA.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSLSA) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *NeighborsNeighborsHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns NeighborsNeighborsHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSLSA) GetSubject() allSLSATreeSubjectArtifact {
-	return v.allSLSATree.Subject
+func (v *NeighborsNeighborsHasSLSA) GetSubject() AllSLSATreeSubjectArtifact {
+	return v.AllSLSATree.Subject
 }
 
 // GetSlsa returns NeighborsNeighborsHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *NeighborsNeighborsHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *NeighborsNeighborsHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -8446,7 +12440,7 @@ func (v *NeighborsNeighborsHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -8458,9 +12452,9 @@ type __premarshalNeighborsNeighborsHasSLSA struct {
 
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *NeighborsNeighborsHasSLSA) MarshalJSON() ([]byte, error) {
@@ -8475,9 +12469,9 @@ func (v *NeighborsNeighborsHasSLSA) __premarshalJSON() (*__premarshalNeighborsNe
 	var retval __premarshalNeighborsNeighborsHasSLSA
 
 	retval.Typename = v.Typename
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -8487,38 +12481,38 @@ func (v *NeighborsNeighborsHasSLSA) __premarshalJSON() (*__premarshalNeighborsNe
 // HasSourceAt records that a package's repository is a given source.
 type NeighborsNeighborsHasSourceAt struct {
 	Typename       *string `json:"__typename"`
-	allHasSourceAt `json:"-"`
+	AllHasSourceAt `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsHasSourceAt.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSourceAt) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetId() string { return v.allHasSourceAt.Id }
+func (v *NeighborsNeighborsHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
 
 // GetJustification returns NeighborsNeighborsHasSourceAt.Justification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasSourceAt) GetJustification() string {
-	return v.allHasSourceAt.Justification
+	return v.AllHasSourceAt.Justification
 }
 
 // GetKnownSince returns NeighborsNeighborsHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetKnownSince() time.Time { return v.allHasSourceAt.KnownSince }
+func (v *NeighborsNeighborsHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
 
 // GetPackage returns NeighborsNeighborsHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetPackage() allHasSourceAtPackage {
-	return v.allHasSourceAt.Package
+func (v *NeighborsNeighborsHasSourceAt) GetPackage() AllHasSourceAtPackage {
+	return v.AllHasSourceAt.Package
 }
 
 // GetSource returns NeighborsNeighborsHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetSource() allHasSourceAtSource {
-	return v.allHasSourceAt.Source
+func (v *NeighborsNeighborsHasSourceAt) GetSource() AllHasSourceAtSource {
+	return v.AllHasSourceAt.Source
 }
 
 // GetOrigin returns NeighborsNeighborsHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetOrigin() string { return v.allHasSourceAt.Origin }
+func (v *NeighborsNeighborsHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
 
 // GetCollector returns NeighborsNeighborsHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHasSourceAt) GetCollector() string { return v.allHasSourceAt.Collector }
+func (v *NeighborsNeighborsHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
 
 func (v *NeighborsNeighborsHasSourceAt) UnmarshalJSON(b []byte) error {
 
@@ -8538,7 +12532,7 @@ func (v *NeighborsNeighborsHasSourceAt) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSourceAt)
+		b, &v.AllHasSourceAt)
 	if err != nil {
 		return err
 	}
@@ -8554,9 +12548,9 @@ type __premarshalNeighborsNeighborsHasSourceAt struct {
 
 	KnownSince time.Time `json:"knownSince"`
 
-	Package allHasSourceAtPackage `json:"package"`
+	Package AllHasSourceAtPackage `json:"package"`
 
-	Source allHasSourceAtSource `json:"source"`
+	Source AllHasSourceAtSource `json:"source"`
 
 	Origin string `json:"origin"`
 
@@ -8575,13 +12569,13 @@ func (v *NeighborsNeighborsHasSourceAt) __premarshalJSON() (*__premarshalNeighbo
 	var retval __premarshalNeighborsNeighborsHasSourceAt
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSourceAt.Id
-	retval.Justification = v.allHasSourceAt.Justification
-	retval.KnownSince = v.allHasSourceAt.KnownSince
-	retval.Package = v.allHasSourceAt.Package
-	retval.Source = v.allHasSourceAt.Source
-	retval.Origin = v.allHasSourceAt.Origin
-	retval.Collector = v.allHasSourceAt.Collector
+	retval.Id = v.AllHasSourceAt.Id
+	retval.Justification = v.AllHasSourceAt.Justification
+	retval.KnownSince = v.AllHasSourceAt.KnownSince
+	retval.Package = v.AllHasSourceAt.Package
+	retval.Source = v.AllHasSourceAt.Source
+	retval.Origin = v.AllHasSourceAt.Origin
+	retval.Collector = v.AllHasSourceAt.Collector
 	return &retval, nil
 }
 
@@ -8591,30 +12585,30 @@ func (v *NeighborsNeighborsHasSourceAt) __premarshalJSON() (*__premarshalNeighbo
 // HashEqual is an attestation that a set of artifacts are identical.
 type NeighborsNeighborsHashEqual struct {
 	Typename         *string `json:"__typename"`
-	allHashEqualTree `json:"-"`
+	AllHashEqualTree `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsHashEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHashEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHashEqual) GetId() string { return v.allHashEqualTree.Id }
+func (v *NeighborsNeighborsHashEqual) GetId() string { return v.AllHashEqualTree.Id }
 
 // GetJustification returns NeighborsNeighborsHashEqual.Justification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHashEqual) GetJustification() string {
-	return v.allHashEqualTree.Justification
+	return v.AllHashEqualTree.Justification
 }
 
 // GetArtifacts returns NeighborsNeighborsHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHashEqual) GetArtifacts() []allHashEqualTreeArtifactsArtifact {
-	return v.allHashEqualTree.Artifacts
+func (v *NeighborsNeighborsHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
+	return v.AllHashEqualTree.Artifacts
 }
 
 // GetOrigin returns NeighborsNeighborsHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHashEqual) GetOrigin() string { return v.allHashEqualTree.Origin }
+func (v *NeighborsNeighborsHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
 
 // GetCollector returns NeighborsNeighborsHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsHashEqual) GetCollector() string { return v.allHashEqualTree.Collector }
+func (v *NeighborsNeighborsHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
 
 func (v *NeighborsNeighborsHashEqual) UnmarshalJSON(b []byte) error {
 
@@ -8634,7 +12628,7 @@ func (v *NeighborsNeighborsHashEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHashEqualTree)
+		b, &v.AllHashEqualTree)
 	if err != nil {
 		return err
 	}
@@ -8648,7 +12642,7 @@ type __premarshalNeighborsNeighborsHashEqual struct {
 
 	Justification string `json:"justification"`
 
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
 
 	Origin string `json:"origin"`
 
@@ -8667,11 +12661,11 @@ func (v *NeighborsNeighborsHashEqual) __premarshalJSON() (*__premarshalNeighbors
 	var retval __premarshalNeighborsNeighborsHashEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHashEqualTree.Id
-	retval.Justification = v.allHashEqualTree.Justification
-	retval.Artifacts = v.allHashEqualTree.Artifacts
-	retval.Origin = v.allHashEqualTree.Origin
-	retval.Collector = v.allHashEqualTree.Collector
+	retval.Id = v.AllHashEqualTree.Id
+	retval.Justification = v.AllHashEqualTree.Justification
+	retval.Artifacts = v.AllHashEqualTree.Artifacts
+	retval.Origin = v.AllHashEqualTree.Origin
+	retval.Collector = v.AllHashEqualTree.Collector
 	return &retval, nil
 }
 
@@ -8681,46 +12675,46 @@ func (v *NeighborsNeighborsHashEqual) __premarshalJSON() (*__premarshalNeighbors
 // IsDependency is an attestation to record that a package depends on another.
 type NeighborsNeighborsIsDependency struct {
 	Typename            *string `json:"__typename"`
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsIsDependency.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsDependency) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsDependency) GetId() string { return v.allIsDependencyTree.Id }
+func (v *NeighborsNeighborsIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
 
 // GetJustification returns NeighborsNeighborsIsDependency.Justification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsDependency) GetJustification() string {
-	return v.allIsDependencyTree.Justification
+	return v.AllIsDependencyTree.Justification
 }
 
 // GetPackage returns NeighborsNeighborsIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *NeighborsNeighborsIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns NeighborsNeighborsIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *NeighborsNeighborsIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns NeighborsNeighborsIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns NeighborsNeighborsIsDependency.VersionRange, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsDependency) GetVersionRange() string {
-	return v.allIsDependencyTree.VersionRange
+	return v.AllIsDependencyTree.VersionRange
 }
 
 // GetOrigin returns NeighborsNeighborsIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsDependency) GetOrigin() string { return v.allIsDependencyTree.Origin }
+func (v *NeighborsNeighborsIsDependency) GetOrigin() string { return v.AllIsDependencyTree.Origin }
 
 // GetCollector returns NeighborsNeighborsIsDependency.Collector, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsDependency) GetCollector() string {
-	return v.allIsDependencyTree.Collector
+	return v.AllIsDependencyTree.Collector
 }
 
 func (v *NeighborsNeighborsIsDependency) UnmarshalJSON(b []byte) error {
@@ -8741,7 +12735,7 @@ func (v *NeighborsNeighborsIsDependency) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -8755,9 +12749,9 @@ type __premarshalNeighborsNeighborsIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -8780,14 +12774,14 @@ func (v *NeighborsNeighborsIsDependency) __premarshalJSON() (*__premarshalNeighb
 	var retval __premarshalNeighborsNeighborsIsDependency
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -8910,36 +12904,36 @@ func (v *NeighborsNeighborsIsOccurrence) __premarshalJSON() (*__premarshalNeighb
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type NeighborsNeighborsIsVulnerability struct {
 	Typename           *string `json:"__typename"`
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsIsVulnerability.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsVulnerability) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *NeighborsNeighborsIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns NeighborsNeighborsIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
-	return v.allIsVulnerability.Osv
+func (v *NeighborsNeighborsIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV {
+	return v.AllIsVulnerability.Osv
 }
 
 // GetVulnerability returns NeighborsNeighborsIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *NeighborsNeighborsIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns NeighborsNeighborsIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns NeighborsNeighborsIsVulnerability.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsIsVulnerability) GetOrigin() string { return v.allIsVulnerability.Origin }
+func (v *NeighborsNeighborsIsVulnerability) GetOrigin() string { return v.AllIsVulnerability.Origin }
 
 // GetCollector returns NeighborsNeighborsIsVulnerability.Collector, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsIsVulnerability) GetCollector() string {
-	return v.allIsVulnerability.Collector
+	return v.AllIsVulnerability.Collector
 }
 
 func (v *NeighborsNeighborsIsVulnerability) UnmarshalJSON(b []byte) error {
@@ -8960,7 +12954,7 @@ func (v *NeighborsNeighborsIsVulnerability) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -8972,7 +12966,7 @@ type __premarshalNeighborsNeighborsIsVulnerability struct {
 
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -8995,23 +12989,23 @@ func (v *NeighborsNeighborsIsVulnerability) __premarshalJSON() (*__premarshalNei
 	var retval __premarshalNeighborsNeighborsIsVulnerability
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NeighborsNeighborsIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal NeighborsNeighborsIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -9634,28 +13628,28 @@ func (v *NeighborsNeighborsPackage) __premarshalJSON() (*__premarshalNeighborsNe
 // PkgEqual is an attestation that a set of packages are similar.
 type NeighborsNeighborsPkgEqual struct {
 	Typename    *string `json:"__typename"`
-	allPkgEqual `json:"-"`
+	AllPkgEqual `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsPkgEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsPkgEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NeighborsNeighborsPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsPkgEqual) GetId() string { return v.allPkgEqual.Id }
+func (v *NeighborsNeighborsPkgEqual) GetId() string { return v.AllPkgEqual.Id }
 
 // GetJustification returns NeighborsNeighborsPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsPkgEqual) GetJustification() string { return v.allPkgEqual.Justification }
+func (v *NeighborsNeighborsPkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
 
 // GetPackages returns NeighborsNeighborsPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsPkgEqual) GetPackages() []allPkgEqualPackagesPackage {
-	return v.allPkgEqual.Packages
+func (v *NeighborsNeighborsPkgEqual) GetPackages() []AllPkgEqualPackagesPackage {
+	return v.AllPkgEqual.Packages
 }
 
 // GetOrigin returns NeighborsNeighborsPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsPkgEqual) GetOrigin() string { return v.allPkgEqual.Origin }
+func (v *NeighborsNeighborsPkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
 
 // GetCollector returns NeighborsNeighborsPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NeighborsNeighborsPkgEqual) GetCollector() string { return v.allPkgEqual.Collector }
+func (v *NeighborsNeighborsPkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
 
 func (v *NeighborsNeighborsPkgEqual) UnmarshalJSON(b []byte) error {
 
@@ -9675,7 +13669,7 @@ func (v *NeighborsNeighborsPkgEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPkgEqual)
+		b, &v.AllPkgEqual)
 	if err != nil {
 		return err
 	}
@@ -9689,7 +13683,7 @@ type __premarshalNeighborsNeighborsPkgEqual struct {
 
 	Justification string `json:"justification"`
 
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
 
 	Origin string `json:"origin"`
 
@@ -9708,11 +13702,11 @@ func (v *NeighborsNeighborsPkgEqual) __premarshalJSON() (*__premarshalNeighborsN
 	var retval __premarshalNeighborsNeighborsPkgEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allPkgEqual.Id
-	retval.Justification = v.allPkgEqual.Justification
-	retval.Packages = v.allPkgEqual.Packages
-	retval.Origin = v.allPkgEqual.Origin
-	retval.Collector = v.allPkgEqual.Collector
+	retval.Id = v.AllPkgEqual.Id
+	retval.Justification = v.AllPkgEqual.Justification
+	retval.Packages = v.AllPkgEqual.Packages
+	retval.Origin = v.AllPkgEqual.Origin
+	retval.Collector = v.AllPkgEqual.Collector
 	return &retval, nil
 }
 
@@ -10441,17 +14435,17 @@ func (v *NodeNodeArtifact) __premarshalJSON() (*__premarshalNodeNodeArtifact, er
 // Currently builders are identified by the uri field.
 type NodeNodeBuilder struct {
 	Typename       *string `json:"__typename"`
-	allBuilderTree `json:"-"`
+	AllBuilderTree `json:"-"`
 }
 
 // GetTypename returns NodeNodeBuilder.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeBuilder) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeBuilder.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeBuilder) GetId() string { return v.allBuilderTree.Id }
+func (v *NodeNodeBuilder) GetId() string { return v.AllBuilderTree.Id }
 
 // GetUri returns NodeNodeBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *NodeNodeBuilder) GetUri() string { return v.allBuilderTree.Uri }
+func (v *NodeNodeBuilder) GetUri() string { return v.AllBuilderTree.Uri }
 
 func (v *NodeNodeBuilder) UnmarshalJSON(b []byte) error {
 
@@ -10471,7 +14465,7 @@ func (v *NodeNodeBuilder) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allBuilderTree)
+		b, &v.AllBuilderTree)
 	if err != nil {
 		return err
 	}
@@ -10498,8 +14492,8 @@ func (v *NodeNodeBuilder) __premarshalJSON() (*__premarshalNodeNodeBuilder, erro
 	var retval __premarshalNodeNodeBuilder
 
 	retval.Typename = v.Typename
-	retval.Id = v.allBuilderTree.Id
-	retval.Uri = v.allBuilderTree.Uri
+	retval.Id = v.AllBuilderTree.Id
+	retval.Uri = v.AllBuilderTree.Uri
 	return &retval, nil
 }
 
@@ -10711,28 +14705,28 @@ func (v *NodeNodeCertifyBad) __premarshalJSON() (*__premarshalNodeNodeCertifyBad
 // SourceName.
 type NodeNodeCertifyGood struct {
 	Typename       *string `json:"__typename"`
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetTypename returns NodeNodeCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyGood) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *NodeNodeCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns NodeNodeCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyGood) GetJustification() string { return v.allCertifyGood.Justification }
+func (v *NodeNodeCertifyGood) GetJustification() string { return v.AllCertifyGood.Justification }
 
 // GetSubject returns NodeNodeCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *NodeNodeCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns NodeNodeCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *NodeNodeCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns NodeNodeCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *NodeNodeCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *NodeNodeCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -10752,7 +14746,7 @@ func (v *NodeNodeCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -10785,22 +14779,22 @@ func (v *NodeNodeCertifyGood) __premarshalJSON() (*__premarshalNodeNodeCertifyGo
 	var retval __premarshalNodeNodeCertifyGood
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodeNodeCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal NodeNodeCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -10890,54 +14884,54 @@ func (v *NodeNodeCertifyScorecard) __premarshalJSON() (*__premarshalNodeNodeCert
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type NodeNodeCertifyVEXStatement struct {
 	Typename               *string `json:"__typename"`
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetTypename returns NodeNodeCertifyVEXStatement.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyVEXStatement) GetId() string { return v.allCertifyVEXStatement.Id }
+func (v *NodeNodeCertifyVEXStatement) GetId() string { return v.AllCertifyVEXStatement.Id }
 
 // GetSubject returns NodeNodeCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *NodeNodeCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns NodeNodeCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *NodeNodeCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns NodeNodeCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyVEXStatement) GetStatus() VexStatus { return v.allCertifyVEXStatement.Status }
+func (v *NodeNodeCertifyVEXStatement) GetStatus() VexStatus { return v.AllCertifyVEXStatement.Status }
 
 // GetVexJustification returns NodeNodeCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns NodeNodeCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns NodeNodeCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns NodeNodeCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns NodeNodeCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeCertifyVEXStatement) GetOrigin() string { return v.allCertifyVEXStatement.Origin }
+func (v *NodeNodeCertifyVEXStatement) GetOrigin() string { return v.AllCertifyVEXStatement.Origin }
 
 // GetCollector returns NodeNodeCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *NodeNodeCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *NodeNodeCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -10958,7 +14952,7 @@ func (v *NodeNodeCertifyVEXStatement) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -11001,38 +14995,38 @@ func (v *NodeNodeCertifyVEXStatement) __premarshalJSON() (*__premarshalNodeNodeC
 	var retval __premarshalNodeNodeCertifyVEXStatement
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodeNodeCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal NodeNodeCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodeNodeCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal NodeNodeCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -11233,37 +15227,37 @@ func (v *NodeNodeHasMetadata) GetTypename() *string { return v.Typename }
 // NodeNodeHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NodeNodeHasSBOM struct {
 	Typename       *string `json:"__typename"`
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetTypename returns NodeNodeHasSBOM.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasSBOM) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *NodeNodeHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns NodeNodeHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *NodeNodeHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns NodeNodeHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *NodeNodeHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns NodeNodeHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *NodeNodeHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns NodeNodeHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *NodeNodeHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns NodeNodeHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
+func (v *NodeNodeHasSBOM) GetDownloadLocation() string { return v.AllHasSBOMTree.DownloadLocation }
 
 // GetOrigin returns NodeNodeHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *NodeNodeHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns NodeNodeHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *NodeNodeHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *NodeNodeHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -11283,7 +15277,7 @@ func (v *NodeNodeHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -11322,25 +15316,25 @@ func (v *NodeNodeHasSBOM) __premarshalJSON() (*__premarshalNodeNodeHasSBOM, erro
 	var retval __premarshalNodeNodeHasSBOM
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodeNodeHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal NodeNodeHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -11350,20 +15344,20 @@ func (v *NodeNodeHasSBOM) __premarshalJSON() (*__premarshalNodeNodeHasSBOM, erro
 // HasSLSA records that a subject node has a SLSA attestation.
 type NodeNodeHasSLSA struct {
 	Typename    *string `json:"__typename"`
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetTypename returns NodeNodeHasSLSA.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasSLSA) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *NodeNodeHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns NodeNodeHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSLSA) GetSubject() allSLSATreeSubjectArtifact { return v.allSLSATree.Subject }
+func (v *NodeNodeHasSLSA) GetSubject() AllSLSATreeSubjectArtifact { return v.AllSLSATree.Subject }
 
 // GetSlsa returns NodeNodeHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *NodeNodeHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *NodeNodeHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -11383,7 +15377,7 @@ func (v *NodeNodeHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -11395,9 +15389,9 @@ type __premarshalNodeNodeHasSLSA struct {
 
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *NodeNodeHasSLSA) MarshalJSON() ([]byte, error) {
@@ -11412,9 +15406,9 @@ func (v *NodeNodeHasSLSA) __premarshalJSON() (*__premarshalNodeNodeHasSLSA, erro
 	var retval __premarshalNodeNodeHasSLSA
 
 	retval.Typename = v.Typename
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -11424,32 +15418,32 @@ func (v *NodeNodeHasSLSA) __premarshalJSON() (*__premarshalNodeNodeHasSLSA, erro
 // HasSourceAt records that a package's repository is a given source.
 type NodeNodeHasSourceAt struct {
 	Typename       *string `json:"__typename"`
-	allHasSourceAt `json:"-"`
+	AllHasSourceAt `json:"-"`
 }
 
 // GetTypename returns NodeNodeHasSourceAt.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasSourceAt) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetId() string { return v.allHasSourceAt.Id }
+func (v *NodeNodeHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
 
 // GetJustification returns NodeNodeHasSourceAt.Justification, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetJustification() string { return v.allHasSourceAt.Justification }
+func (v *NodeNodeHasSourceAt) GetJustification() string { return v.AllHasSourceAt.Justification }
 
 // GetKnownSince returns NodeNodeHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetKnownSince() time.Time { return v.allHasSourceAt.KnownSince }
+func (v *NodeNodeHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
 
 // GetPackage returns NodeNodeHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetPackage() allHasSourceAtPackage { return v.allHasSourceAt.Package }
+func (v *NodeNodeHasSourceAt) GetPackage() AllHasSourceAtPackage { return v.AllHasSourceAt.Package }
 
 // GetSource returns NodeNodeHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetSource() allHasSourceAtSource { return v.allHasSourceAt.Source }
+func (v *NodeNodeHasSourceAt) GetSource() AllHasSourceAtSource { return v.AllHasSourceAt.Source }
 
 // GetOrigin returns NodeNodeHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetOrigin() string { return v.allHasSourceAt.Origin }
+func (v *NodeNodeHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
 
 // GetCollector returns NodeNodeHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeHasSourceAt) GetCollector() string { return v.allHasSourceAt.Collector }
+func (v *NodeNodeHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
 
 func (v *NodeNodeHasSourceAt) UnmarshalJSON(b []byte) error {
 
@@ -11469,7 +15463,7 @@ func (v *NodeNodeHasSourceAt) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSourceAt)
+		b, &v.AllHasSourceAt)
 	if err != nil {
 		return err
 	}
@@ -11485,9 +15479,9 @@ type __premarshalNodeNodeHasSourceAt struct {
 
 	KnownSince time.Time `json:"knownSince"`
 
-	Package allHasSourceAtPackage `json:"package"`
+	Package AllHasSourceAtPackage `json:"package"`
 
-	Source allHasSourceAtSource `json:"source"`
+	Source AllHasSourceAtSource `json:"source"`
 
 	Origin string `json:"origin"`
 
@@ -11506,13 +15500,13 @@ func (v *NodeNodeHasSourceAt) __premarshalJSON() (*__premarshalNodeNodeHasSource
 	var retval __premarshalNodeNodeHasSourceAt
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSourceAt.Id
-	retval.Justification = v.allHasSourceAt.Justification
-	retval.KnownSince = v.allHasSourceAt.KnownSince
-	retval.Package = v.allHasSourceAt.Package
-	retval.Source = v.allHasSourceAt.Source
-	retval.Origin = v.allHasSourceAt.Origin
-	retval.Collector = v.allHasSourceAt.Collector
+	retval.Id = v.AllHasSourceAt.Id
+	retval.Justification = v.AllHasSourceAt.Justification
+	retval.KnownSince = v.AllHasSourceAt.KnownSince
+	retval.Package = v.AllHasSourceAt.Package
+	retval.Source = v.AllHasSourceAt.Source
+	retval.Origin = v.AllHasSourceAt.Origin
+	retval.Collector = v.AllHasSourceAt.Collector
 	return &retval, nil
 }
 
@@ -11522,28 +15516,28 @@ func (v *NodeNodeHasSourceAt) __premarshalJSON() (*__premarshalNodeNodeHasSource
 // HashEqual is an attestation that a set of artifacts are identical.
 type NodeNodeHashEqual struct {
 	Typename         *string `json:"__typename"`
-	allHashEqualTree `json:"-"`
+	AllHashEqualTree `json:"-"`
 }
 
 // GetTypename returns NodeNodeHashEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeHashEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeHashEqual) GetId() string { return v.allHashEqualTree.Id }
+func (v *NodeNodeHashEqual) GetId() string { return v.AllHashEqualTree.Id }
 
 // GetJustification returns NodeNodeHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *NodeNodeHashEqual) GetJustification() string { return v.allHashEqualTree.Justification }
+func (v *NodeNodeHashEqual) GetJustification() string { return v.AllHashEqualTree.Justification }
 
 // GetArtifacts returns NodeNodeHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *NodeNodeHashEqual) GetArtifacts() []allHashEqualTreeArtifactsArtifact {
-	return v.allHashEqualTree.Artifacts
+func (v *NodeNodeHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
+	return v.AllHashEqualTree.Artifacts
 }
 
 // GetOrigin returns NodeNodeHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeHashEqual) GetOrigin() string { return v.allHashEqualTree.Origin }
+func (v *NodeNodeHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
 
 // GetCollector returns NodeNodeHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeHashEqual) GetCollector() string { return v.allHashEqualTree.Collector }
+func (v *NodeNodeHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
 
 func (v *NodeNodeHashEqual) UnmarshalJSON(b []byte) error {
 
@@ -11563,7 +15557,7 @@ func (v *NodeNodeHashEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHashEqualTree)
+		b, &v.AllHashEqualTree)
 	if err != nil {
 		return err
 	}
@@ -11577,7 +15571,7 @@ type __premarshalNodeNodeHashEqual struct {
 
 	Justification string `json:"justification"`
 
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
 
 	Origin string `json:"origin"`
 
@@ -11596,11 +15590,11 @@ func (v *NodeNodeHashEqual) __premarshalJSON() (*__premarshalNodeNodeHashEqual, 
 	var retval __premarshalNodeNodeHashEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHashEqualTree.Id
-	retval.Justification = v.allHashEqualTree.Justification
-	retval.Artifacts = v.allHashEqualTree.Artifacts
-	retval.Origin = v.allHashEqualTree.Origin
-	retval.Collector = v.allHashEqualTree.Collector
+	retval.Id = v.AllHashEqualTree.Id
+	retval.Justification = v.AllHashEqualTree.Justification
+	retval.Artifacts = v.AllHashEqualTree.Artifacts
+	retval.Origin = v.AllHashEqualTree.Origin
+	retval.Collector = v.AllHashEqualTree.Collector
 	return &retval, nil
 }
 
@@ -11610,41 +15604,41 @@ func (v *NodeNodeHashEqual) __premarshalJSON() (*__premarshalNodeNodeHashEqual, 
 // IsDependency is an attestation to record that a package depends on another.
 type NodeNodeIsDependency struct {
 	Typename            *string `json:"__typename"`
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetTypename returns NodeNodeIsDependency.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeIsDependency) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetId() string { return v.allIsDependencyTree.Id }
+func (v *NodeNodeIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
 
 // GetJustification returns NodeNodeIsDependency.Justification, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetJustification() string { return v.allIsDependencyTree.Justification }
+func (v *NodeNodeIsDependency) GetJustification() string { return v.AllIsDependencyTree.Justification }
 
 // GetPackage returns NodeNodeIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *NodeNodeIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns NodeNodeIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *NodeNodeIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns NodeNodeIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *NodeNodeIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns NodeNodeIsDependency.VersionRange, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetVersionRange() string { return v.allIsDependencyTree.VersionRange }
+func (v *NodeNodeIsDependency) GetVersionRange() string { return v.AllIsDependencyTree.VersionRange }
 
 // GetOrigin returns NodeNodeIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetOrigin() string { return v.allIsDependencyTree.Origin }
+func (v *NodeNodeIsDependency) GetOrigin() string { return v.AllIsDependencyTree.Origin }
 
 // GetCollector returns NodeNodeIsDependency.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsDependency) GetCollector() string { return v.allIsDependencyTree.Collector }
+func (v *NodeNodeIsDependency) GetCollector() string { return v.AllIsDependencyTree.Collector }
 
 func (v *NodeNodeIsDependency) UnmarshalJSON(b []byte) error {
 
@@ -11664,7 +15658,7 @@ func (v *NodeNodeIsDependency) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -11678,9 +15672,9 @@ type __premarshalNodeNodeIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -11703,14 +15697,14 @@ func (v *NodeNodeIsDependency) __premarshalJSON() (*__premarshalNodeNodeIsDepend
 	var retval __premarshalNodeNodeIsDependency
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -11829,33 +15823,33 @@ func (v *NodeNodeIsOccurrence) __premarshalJSON() (*__premarshalNodeNodeIsOccurr
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type NodeNodeIsVulnerability struct {
 	Typename           *string `json:"__typename"`
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetTypename returns NodeNodeIsVulnerability.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeIsVulnerability) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodeIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *NodeNodeIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns NodeNodeIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV { return v.allIsVulnerability.Osv }
+func (v *NodeNodeIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV { return v.AllIsVulnerability.Osv }
 
 // GetVulnerability returns NodeNodeIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *NodeNodeIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns NodeNodeIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *NodeNodeIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns NodeNodeIsVulnerability.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsVulnerability) GetOrigin() string { return v.allIsVulnerability.Origin }
+func (v *NodeNodeIsVulnerability) GetOrigin() string { return v.AllIsVulnerability.Origin }
 
 // GetCollector returns NodeNodeIsVulnerability.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodeIsVulnerability) GetCollector() string { return v.allIsVulnerability.Collector }
+func (v *NodeNodeIsVulnerability) GetCollector() string { return v.AllIsVulnerability.Collector }
 
 func (v *NodeNodeIsVulnerability) UnmarshalJSON(b []byte) error {
 
@@ -11875,7 +15869,7 @@ func (v *NodeNodeIsVulnerability) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -11887,7 +15881,7 @@ type __premarshalNodeNodeIsVulnerability struct {
 
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -11910,23 +15904,23 @@ func (v *NodeNodeIsVulnerability) __premarshalJSON() (*__premarshalNodeNodeIsVul
 	var retval __premarshalNodeNodeIsVulnerability
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodeNodeIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal NodeNodeIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -12118,26 +16112,26 @@ func (v *NodeNodePackage) __premarshalJSON() (*__premarshalNodeNodePackage, erro
 // PkgEqual is an attestation that a set of packages are similar.
 type NodeNodePkgEqual struct {
 	Typename    *string `json:"__typename"`
-	allPkgEqual `json:"-"`
+	AllPkgEqual `json:"-"`
 }
 
 // GetTypename returns NodeNodePkgEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodePkgEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NodeNodePkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *NodeNodePkgEqual) GetId() string { return v.allPkgEqual.Id }
+func (v *NodeNodePkgEqual) GetId() string { return v.AllPkgEqual.Id }
 
 // GetJustification returns NodeNodePkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *NodeNodePkgEqual) GetJustification() string { return v.allPkgEqual.Justification }
+func (v *NodeNodePkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
 
 // GetPackages returns NodeNodePkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *NodeNodePkgEqual) GetPackages() []allPkgEqualPackagesPackage { return v.allPkgEqual.Packages }
+func (v *NodeNodePkgEqual) GetPackages() []AllPkgEqualPackagesPackage { return v.AllPkgEqual.Packages }
 
 // GetOrigin returns NodeNodePkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NodeNodePkgEqual) GetOrigin() string { return v.allPkgEqual.Origin }
+func (v *NodeNodePkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
 
 // GetCollector returns NodeNodePkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NodeNodePkgEqual) GetCollector() string { return v.allPkgEqual.Collector }
+func (v *NodeNodePkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
 
 func (v *NodeNodePkgEqual) UnmarshalJSON(b []byte) error {
 
@@ -12157,7 +16151,7 @@ func (v *NodeNodePkgEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPkgEqual)
+		b, &v.AllPkgEqual)
 	if err != nil {
 		return err
 	}
@@ -12171,7 +16165,7 @@ type __premarshalNodeNodePkgEqual struct {
 
 	Justification string `json:"justification"`
 
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
 
 	Origin string `json:"origin"`
 
@@ -12190,11 +16184,11 @@ func (v *NodeNodePkgEqual) __premarshalJSON() (*__premarshalNodeNodePkgEqual, er
 	var retval __premarshalNodeNodePkgEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allPkgEqual.Id
-	retval.Justification = v.allPkgEqual.Justification
-	retval.Packages = v.allPkgEqual.Packages
-	retval.Origin = v.allPkgEqual.Origin
-	retval.Collector = v.allPkgEqual.Collector
+	retval.Id = v.AllPkgEqual.Id
+	retval.Justification = v.AllPkgEqual.Justification
+	retval.Packages = v.AllPkgEqual.Packages
+	retval.Origin = v.AllPkgEqual.Origin
+	retval.Collector = v.AllPkgEqual.Collector
 	return &retval, nil
 }
 
@@ -12477,17 +16471,17 @@ func (v *NodesNodesArtifact) __premarshalJSON() (*__premarshalNodesNodesArtifact
 // Currently builders are identified by the uri field.
 type NodesNodesBuilder struct {
 	Typename       *string `json:"__typename"`
-	allBuilderTree `json:"-"`
+	AllBuilderTree `json:"-"`
 }
 
 // GetTypename returns NodesNodesBuilder.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesBuilder) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesBuilder.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesBuilder) GetId() string { return v.allBuilderTree.Id }
+func (v *NodesNodesBuilder) GetId() string { return v.AllBuilderTree.Id }
 
 // GetUri returns NodesNodesBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *NodesNodesBuilder) GetUri() string { return v.allBuilderTree.Uri }
+func (v *NodesNodesBuilder) GetUri() string { return v.AllBuilderTree.Uri }
 
 func (v *NodesNodesBuilder) UnmarshalJSON(b []byte) error {
 
@@ -12507,7 +16501,7 @@ func (v *NodesNodesBuilder) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allBuilderTree)
+		b, &v.AllBuilderTree)
 	if err != nil {
 		return err
 	}
@@ -12534,8 +16528,8 @@ func (v *NodesNodesBuilder) __premarshalJSON() (*__premarshalNodesNodesBuilder, 
 	var retval __premarshalNodesNodesBuilder
 
 	retval.Typename = v.Typename
-	retval.Id = v.allBuilderTree.Id
-	retval.Uri = v.allBuilderTree.Uri
+	retval.Id = v.AllBuilderTree.Id
+	retval.Uri = v.AllBuilderTree.Uri
 	return &retval, nil
 }
 
@@ -12747,28 +16741,28 @@ func (v *NodesNodesCertifyBad) __premarshalJSON() (*__premarshalNodesNodesCertif
 // SourceName.
 type NodesNodesCertifyGood struct {
 	Typename       *string `json:"__typename"`
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetTypename returns NodesNodesCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyGood) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *NodesNodesCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns NodesNodesCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyGood) GetJustification() string { return v.allCertifyGood.Justification }
+func (v *NodesNodesCertifyGood) GetJustification() string { return v.AllCertifyGood.Justification }
 
 // GetSubject returns NodesNodesCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *NodesNodesCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns NodesNodesCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *NodesNodesCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns NodesNodesCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *NodesNodesCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *NodesNodesCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -12788,7 +16782,7 @@ func (v *NodesNodesCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -12821,22 +16815,22 @@ func (v *NodesNodesCertifyGood) __premarshalJSON() (*__premarshalNodesNodesCerti
 	var retval __premarshalNodesNodesCertifyGood
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodesNodesCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal NodesNodesCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -12926,54 +16920,54 @@ func (v *NodesNodesCertifyScorecard) __premarshalJSON() (*__premarshalNodesNodes
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type NodesNodesCertifyVEXStatement struct {
 	Typename               *string `json:"__typename"`
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetTypename returns NodesNodesCertifyVEXStatement.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyVEXStatement) GetId() string { return v.allCertifyVEXStatement.Id }
+func (v *NodesNodesCertifyVEXStatement) GetId() string { return v.AllCertifyVEXStatement.Id }
 
 // GetSubject returns NodesNodesCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *NodesNodesCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns NodesNodesCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *NodesNodesCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns NodesNodesCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyVEXStatement) GetStatus() VexStatus { return v.allCertifyVEXStatement.Status }
+func (v *NodesNodesCertifyVEXStatement) GetStatus() VexStatus { return v.AllCertifyVEXStatement.Status }
 
 // GetVexJustification returns NodesNodesCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns NodesNodesCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns NodesNodesCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns NodesNodesCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns NodesNodesCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesCertifyVEXStatement) GetOrigin() string { return v.allCertifyVEXStatement.Origin }
+func (v *NodesNodesCertifyVEXStatement) GetOrigin() string { return v.AllCertifyVEXStatement.Origin }
 
 // GetCollector returns NodesNodesCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *NodesNodesCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *NodesNodesCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -12994,7 +16988,7 @@ func (v *NodesNodesCertifyVEXStatement) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -13037,38 +17031,38 @@ func (v *NodesNodesCertifyVEXStatement) __premarshalJSON() (*__premarshalNodesNo
 	var retval __premarshalNodesNodesCertifyVEXStatement
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodesNodesCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal NodesNodesCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodesNodesCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal NodesNodesCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -13269,37 +17263,37 @@ func (v *NodesNodesHasMetadata) GetTypename() *string { return v.Typename }
 // NodesNodesHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NodesNodesHasSBOM struct {
 	Typename       *string `json:"__typename"`
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetTypename returns NodesNodesHasSBOM.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesHasSBOM) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *NodesNodesHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns NodesNodesHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *NodesNodesHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns NodesNodesHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *NodesNodesHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns NodesNodesHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *NodesNodesHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns NodesNodesHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *NodesNodesHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns NodesNodesHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
+func (v *NodesNodesHasSBOM) GetDownloadLocation() string { return v.AllHasSBOMTree.DownloadLocation }
 
 // GetOrigin returns NodesNodesHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *NodesNodesHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns NodesNodesHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *NodesNodesHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *NodesNodesHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -13319,7 +17313,7 @@ func (v *NodesNodesHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -13358,25 +17352,25 @@ func (v *NodesNodesHasSBOM) __premarshalJSON() (*__premarshalNodesNodesHasSBOM, 
 	var retval __premarshalNodesNodesHasSBOM
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodesNodesHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal NodesNodesHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -13386,20 +17380,20 @@ func (v *NodesNodesHasSBOM) __premarshalJSON() (*__premarshalNodesNodesHasSBOM, 
 // HasSLSA records that a subject node has a SLSA attestation.
 type NodesNodesHasSLSA struct {
 	Typename    *string `json:"__typename"`
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetTypename returns NodesNodesHasSLSA.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesHasSLSA) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *NodesNodesHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns NodesNodesHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSLSA) GetSubject() allSLSATreeSubjectArtifact { return v.allSLSATree.Subject }
+func (v *NodesNodesHasSLSA) GetSubject() AllSLSATreeSubjectArtifact { return v.AllSLSATree.Subject }
 
 // GetSlsa returns NodesNodesHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *NodesNodesHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *NodesNodesHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -13419,7 +17413,7 @@ func (v *NodesNodesHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -13431,9 +17425,9 @@ type __premarshalNodesNodesHasSLSA struct {
 
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *NodesNodesHasSLSA) MarshalJSON() ([]byte, error) {
@@ -13448,9 +17442,9 @@ func (v *NodesNodesHasSLSA) __premarshalJSON() (*__premarshalNodesNodesHasSLSA, 
 	var retval __premarshalNodesNodesHasSLSA
 
 	retval.Typename = v.Typename
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -13460,32 +17454,32 @@ func (v *NodesNodesHasSLSA) __premarshalJSON() (*__premarshalNodesNodesHasSLSA, 
 // HasSourceAt records that a package's repository is a given source.
 type NodesNodesHasSourceAt struct {
 	Typename       *string `json:"__typename"`
-	allHasSourceAt `json:"-"`
+	AllHasSourceAt `json:"-"`
 }
 
 // GetTypename returns NodesNodesHasSourceAt.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesHasSourceAt) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetId() string { return v.allHasSourceAt.Id }
+func (v *NodesNodesHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
 
 // GetJustification returns NodesNodesHasSourceAt.Justification, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetJustification() string { return v.allHasSourceAt.Justification }
+func (v *NodesNodesHasSourceAt) GetJustification() string { return v.AllHasSourceAt.Justification }
 
 // GetKnownSince returns NodesNodesHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetKnownSince() time.Time { return v.allHasSourceAt.KnownSince }
+func (v *NodesNodesHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
 
 // GetPackage returns NodesNodesHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetPackage() allHasSourceAtPackage { return v.allHasSourceAt.Package }
+func (v *NodesNodesHasSourceAt) GetPackage() AllHasSourceAtPackage { return v.AllHasSourceAt.Package }
 
 // GetSource returns NodesNodesHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetSource() allHasSourceAtSource { return v.allHasSourceAt.Source }
+func (v *NodesNodesHasSourceAt) GetSource() AllHasSourceAtSource { return v.AllHasSourceAt.Source }
 
 // GetOrigin returns NodesNodesHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetOrigin() string { return v.allHasSourceAt.Origin }
+func (v *NodesNodesHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
 
 // GetCollector returns NodesNodesHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesHasSourceAt) GetCollector() string { return v.allHasSourceAt.Collector }
+func (v *NodesNodesHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
 
 func (v *NodesNodesHasSourceAt) UnmarshalJSON(b []byte) error {
 
@@ -13505,7 +17499,7 @@ func (v *NodesNodesHasSourceAt) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSourceAt)
+		b, &v.AllHasSourceAt)
 	if err != nil {
 		return err
 	}
@@ -13521,9 +17515,9 @@ type __premarshalNodesNodesHasSourceAt struct {
 
 	KnownSince time.Time `json:"knownSince"`
 
-	Package allHasSourceAtPackage `json:"package"`
+	Package AllHasSourceAtPackage `json:"package"`
 
-	Source allHasSourceAtSource `json:"source"`
+	Source AllHasSourceAtSource `json:"source"`
 
 	Origin string `json:"origin"`
 
@@ -13542,13 +17536,13 @@ func (v *NodesNodesHasSourceAt) __premarshalJSON() (*__premarshalNodesNodesHasSo
 	var retval __premarshalNodesNodesHasSourceAt
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSourceAt.Id
-	retval.Justification = v.allHasSourceAt.Justification
-	retval.KnownSince = v.allHasSourceAt.KnownSince
-	retval.Package = v.allHasSourceAt.Package
-	retval.Source = v.allHasSourceAt.Source
-	retval.Origin = v.allHasSourceAt.Origin
-	retval.Collector = v.allHasSourceAt.Collector
+	retval.Id = v.AllHasSourceAt.Id
+	retval.Justification = v.AllHasSourceAt.Justification
+	retval.KnownSince = v.AllHasSourceAt.KnownSince
+	retval.Package = v.AllHasSourceAt.Package
+	retval.Source = v.AllHasSourceAt.Source
+	retval.Origin = v.AllHasSourceAt.Origin
+	retval.Collector = v.AllHasSourceAt.Collector
 	return &retval, nil
 }
 
@@ -13558,28 +17552,28 @@ func (v *NodesNodesHasSourceAt) __premarshalJSON() (*__premarshalNodesNodesHasSo
 // HashEqual is an attestation that a set of artifacts are identical.
 type NodesNodesHashEqual struct {
 	Typename         *string `json:"__typename"`
-	allHashEqualTree `json:"-"`
+	AllHashEqualTree `json:"-"`
 }
 
 // GetTypename returns NodesNodesHashEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesHashEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesHashEqual) GetId() string { return v.allHashEqualTree.Id }
+func (v *NodesNodesHashEqual) GetId() string { return v.AllHashEqualTree.Id }
 
 // GetJustification returns NodesNodesHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *NodesNodesHashEqual) GetJustification() string { return v.allHashEqualTree.Justification }
+func (v *NodesNodesHashEqual) GetJustification() string { return v.AllHashEqualTree.Justification }
 
 // GetArtifacts returns NodesNodesHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *NodesNodesHashEqual) GetArtifacts() []allHashEqualTreeArtifactsArtifact {
-	return v.allHashEqualTree.Artifacts
+func (v *NodesNodesHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
+	return v.AllHashEqualTree.Artifacts
 }
 
 // GetOrigin returns NodesNodesHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesHashEqual) GetOrigin() string { return v.allHashEqualTree.Origin }
+func (v *NodesNodesHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
 
 // GetCollector returns NodesNodesHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesHashEqual) GetCollector() string { return v.allHashEqualTree.Collector }
+func (v *NodesNodesHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
 
 func (v *NodesNodesHashEqual) UnmarshalJSON(b []byte) error {
 
@@ -13599,7 +17593,7 @@ func (v *NodesNodesHashEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHashEqualTree)
+		b, &v.AllHashEqualTree)
 	if err != nil {
 		return err
 	}
@@ -13613,7 +17607,7 @@ type __premarshalNodesNodesHashEqual struct {
 
 	Justification string `json:"justification"`
 
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
 
 	Origin string `json:"origin"`
 
@@ -13632,11 +17626,11 @@ func (v *NodesNodesHashEqual) __premarshalJSON() (*__premarshalNodesNodesHashEqu
 	var retval __premarshalNodesNodesHashEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHashEqualTree.Id
-	retval.Justification = v.allHashEqualTree.Justification
-	retval.Artifacts = v.allHashEqualTree.Artifacts
-	retval.Origin = v.allHashEqualTree.Origin
-	retval.Collector = v.allHashEqualTree.Collector
+	retval.Id = v.AllHashEqualTree.Id
+	retval.Justification = v.AllHashEqualTree.Justification
+	retval.Artifacts = v.AllHashEqualTree.Artifacts
+	retval.Origin = v.AllHashEqualTree.Origin
+	retval.Collector = v.AllHashEqualTree.Collector
 	return &retval, nil
 }
 
@@ -13646,43 +17640,43 @@ func (v *NodesNodesHashEqual) __premarshalJSON() (*__premarshalNodesNodesHashEqu
 // IsDependency is an attestation to record that a package depends on another.
 type NodesNodesIsDependency struct {
 	Typename            *string `json:"__typename"`
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetTypename returns NodesNodesIsDependency.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesIsDependency) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetId() string { return v.allIsDependencyTree.Id }
+func (v *NodesNodesIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
 
 // GetJustification returns NodesNodesIsDependency.Justification, and is useful for accessing the field via an interface.
 func (v *NodesNodesIsDependency) GetJustification() string {
-	return v.allIsDependencyTree.Justification
+	return v.AllIsDependencyTree.Justification
 }
 
 // GetPackage returns NodesNodesIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *NodesNodesIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns NodesNodesIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *NodesNodesIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns NodesNodesIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *NodesNodesIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns NodesNodesIsDependency.VersionRange, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetVersionRange() string { return v.allIsDependencyTree.VersionRange }
+func (v *NodesNodesIsDependency) GetVersionRange() string { return v.AllIsDependencyTree.VersionRange }
 
 // GetOrigin returns NodesNodesIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetOrigin() string { return v.allIsDependencyTree.Origin }
+func (v *NodesNodesIsDependency) GetOrigin() string { return v.AllIsDependencyTree.Origin }
 
 // GetCollector returns NodesNodesIsDependency.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsDependency) GetCollector() string { return v.allIsDependencyTree.Collector }
+func (v *NodesNodesIsDependency) GetCollector() string { return v.AllIsDependencyTree.Collector }
 
 func (v *NodesNodesIsDependency) UnmarshalJSON(b []byte) error {
 
@@ -13702,7 +17696,7 @@ func (v *NodesNodesIsDependency) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -13716,9 +17710,9 @@ type __premarshalNodesNodesIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -13741,14 +17735,14 @@ func (v *NodesNodesIsDependency) __premarshalJSON() (*__premarshalNodesNodesIsDe
 	var retval __premarshalNodesNodesIsDependency
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -13869,35 +17863,35 @@ func (v *NodesNodesIsOccurrence) __premarshalJSON() (*__premarshalNodesNodesIsOc
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type NodesNodesIsVulnerability struct {
 	Typename           *string `json:"__typename"`
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetTypename returns NodesNodesIsVulnerability.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesIsVulnerability) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *NodesNodesIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns NodesNodesIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV {
-	return v.allIsVulnerability.Osv
+func (v *NodesNodesIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV {
+	return v.AllIsVulnerability.Osv
 }
 
 // GetVulnerability returns NodesNodesIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *NodesNodesIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns NodesNodesIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *NodesNodesIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns NodesNodesIsVulnerability.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsVulnerability) GetOrigin() string { return v.allIsVulnerability.Origin }
+func (v *NodesNodesIsVulnerability) GetOrigin() string { return v.AllIsVulnerability.Origin }
 
 // GetCollector returns NodesNodesIsVulnerability.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesIsVulnerability) GetCollector() string { return v.allIsVulnerability.Collector }
+func (v *NodesNodesIsVulnerability) GetCollector() string { return v.AllIsVulnerability.Collector }
 
 func (v *NodesNodesIsVulnerability) UnmarshalJSON(b []byte) error {
 
@@ -13917,7 +17911,7 @@ func (v *NodesNodesIsVulnerability) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -13929,7 +17923,7 @@ type __premarshalNodesNodesIsVulnerability struct {
 
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -13952,23 +17946,23 @@ func (v *NodesNodesIsVulnerability) __premarshalJSON() (*__premarshalNodesNodesI
 	var retval __premarshalNodesNodesIsVulnerability
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal NodesNodesIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal NodesNodesIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -14591,28 +18585,28 @@ func (v *NodesNodesPackage) __premarshalJSON() (*__premarshalNodesNodesPackage, 
 // PkgEqual is an attestation that a set of packages are similar.
 type NodesNodesPkgEqual struct {
 	Typename    *string `json:"__typename"`
-	allPkgEqual `json:"-"`
+	AllPkgEqual `json:"-"`
 }
 
 // GetTypename returns NodesNodesPkgEqual.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesPkgEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns NodesNodesPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *NodesNodesPkgEqual) GetId() string { return v.allPkgEqual.Id }
+func (v *NodesNodesPkgEqual) GetId() string { return v.AllPkgEqual.Id }
 
 // GetJustification returns NodesNodesPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *NodesNodesPkgEqual) GetJustification() string { return v.allPkgEqual.Justification }
+func (v *NodesNodesPkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
 
 // GetPackages returns NodesNodesPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *NodesNodesPkgEqual) GetPackages() []allPkgEqualPackagesPackage {
-	return v.allPkgEqual.Packages
+func (v *NodesNodesPkgEqual) GetPackages() []AllPkgEqualPackagesPackage {
+	return v.AllPkgEqual.Packages
 }
 
 // GetOrigin returns NodesNodesPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *NodesNodesPkgEqual) GetOrigin() string { return v.allPkgEqual.Origin }
+func (v *NodesNodesPkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
 
 // GetCollector returns NodesNodesPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *NodesNodesPkgEqual) GetCollector() string { return v.allPkgEqual.Collector }
+func (v *NodesNodesPkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
 
 func (v *NodesNodesPkgEqual) UnmarshalJSON(b []byte) error {
 
@@ -14632,7 +18626,7 @@ func (v *NodesNodesPkgEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPkgEqual)
+		b, &v.AllPkgEqual)
 	if err != nil {
 		return err
 	}
@@ -14646,7 +18640,7 @@ type __premarshalNodesNodesPkgEqual struct {
 
 	Justification string `json:"justification"`
 
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
 
 	Origin string `json:"origin"`
 
@@ -14665,11 +18659,11 @@ func (v *NodesNodesPkgEqual) __premarshalJSON() (*__premarshalNodesNodesPkgEqual
 	var retval __premarshalNodesNodesPkgEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allPkgEqual.Id
-	retval.Justification = v.allPkgEqual.Justification
-	retval.Packages = v.allPkgEqual.Packages
-	retval.Origin = v.allPkgEqual.Origin
-	retval.Collector = v.allPkgEqual.Collector
+	retval.Id = v.AllPkgEqual.Id
+	retval.Justification = v.AllPkgEqual.Justification
+	retval.Packages = v.AllPkgEqual.Packages
+	retval.Origin = v.AllPkgEqual.Origin
+	retval.Collector = v.AllPkgEqual.Collector
 	return &retval, nil
 }
 
@@ -15201,17 +19195,17 @@ func (v *PathPathArtifact) __premarshalJSON() (*__premarshalPathPathArtifact, er
 // Currently builders are identified by the uri field.
 type PathPathBuilder struct {
 	Typename       *string `json:"__typename"`
-	allBuilderTree `json:"-"`
+	AllBuilderTree `json:"-"`
 }
 
 // GetTypename returns PathPathBuilder.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathBuilder) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathBuilder.Id, and is useful for accessing the field via an interface.
-func (v *PathPathBuilder) GetId() string { return v.allBuilderTree.Id }
+func (v *PathPathBuilder) GetId() string { return v.AllBuilderTree.Id }
 
 // GetUri returns PathPathBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *PathPathBuilder) GetUri() string { return v.allBuilderTree.Uri }
+func (v *PathPathBuilder) GetUri() string { return v.AllBuilderTree.Uri }
 
 func (v *PathPathBuilder) UnmarshalJSON(b []byte) error {
 
@@ -15231,7 +19225,7 @@ func (v *PathPathBuilder) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allBuilderTree)
+		b, &v.AllBuilderTree)
 	if err != nil {
 		return err
 	}
@@ -15258,8 +19252,8 @@ func (v *PathPathBuilder) __premarshalJSON() (*__premarshalPathPathBuilder, erro
 	var retval __premarshalPathPathBuilder
 
 	retval.Typename = v.Typename
-	retval.Id = v.allBuilderTree.Id
-	retval.Uri = v.allBuilderTree.Uri
+	retval.Id = v.AllBuilderTree.Id
+	retval.Uri = v.AllBuilderTree.Uri
 	return &retval, nil
 }
 
@@ -15471,28 +19465,28 @@ func (v *PathPathCertifyBad) __premarshalJSON() (*__premarshalPathPathCertifyBad
 // SourceName.
 type PathPathCertifyGood struct {
 	Typename       *string `json:"__typename"`
-	allCertifyGood `json:"-"`
+	AllCertifyGood `json:"-"`
 }
 
 // GetTypename returns PathPathCertifyGood.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyGood) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyGood) GetId() string { return v.allCertifyGood.Id }
+func (v *PathPathCertifyGood) GetId() string { return v.AllCertifyGood.Id }
 
 // GetJustification returns PathPathCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyGood) GetJustification() string { return v.allCertifyGood.Justification }
+func (v *PathPathCertifyGood) GetJustification() string { return v.AllCertifyGood.Justification }
 
 // GetSubject returns PathPathCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.allCertifyGood.Subject
+func (v *PathPathCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
+	return v.AllCertifyGood.Subject
 }
 
 // GetOrigin returns PathPathCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyGood) GetOrigin() string { return v.allCertifyGood.Origin }
+func (v *PathPathCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
 
 // GetCollector returns PathPathCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyGood) GetCollector() string { return v.allCertifyGood.Collector }
+func (v *PathPathCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
 
 func (v *PathPathCertifyGood) UnmarshalJSON(b []byte) error {
 
@@ -15512,7 +19506,7 @@ func (v *PathPathCertifyGood) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyGood)
+		b, &v.AllCertifyGood)
 	if err != nil {
 		return err
 	}
@@ -15545,22 +19539,22 @@ func (v *PathPathCertifyGood) __premarshalJSON() (*__premarshalPathPathCertifyGo
 	var retval __premarshalPathPathCertifyGood
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyGood.Id
-	retval.Justification = v.allCertifyGood.Justification
+	retval.Id = v.AllCertifyGood.Id
+	retval.Justification = v.AllCertifyGood.Justification
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyGood.Subject
+		src := v.AllCertifyGood.Subject
 		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PathPathCertifyGood.allCertifyGood.Subject: %w", err)
+				"unable to marshal PathPathCertifyGood.AllCertifyGood.Subject: %w", err)
 		}
 	}
-	retval.Origin = v.allCertifyGood.Origin
-	retval.Collector = v.allCertifyGood.Collector
+	retval.Origin = v.AllCertifyGood.Origin
+	retval.Collector = v.AllCertifyGood.Collector
 	return &retval, nil
 }
 
@@ -15650,54 +19644,54 @@ func (v *PathPathCertifyScorecard) __premarshalJSON() (*__premarshalPathPathCert
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type PathPathCertifyVEXStatement struct {
 	Typename               *string `json:"__typename"`
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetTypename returns PathPathCertifyVEXStatement.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyVEXStatement) GetId() string { return v.allCertifyVEXStatement.Id }
+func (v *PathPathCertifyVEXStatement) GetId() string { return v.AllCertifyVEXStatement.Id }
 
 // GetSubject returns PathPathCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *PathPathCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns PathPathCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *PathPathCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns PathPathCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyVEXStatement) GetStatus() VexStatus { return v.allCertifyVEXStatement.Status }
+func (v *PathPathCertifyVEXStatement) GetStatus() VexStatus { return v.AllCertifyVEXStatement.Status }
 
 // GetVexJustification returns PathPathCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns PathPathCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns PathPathCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns PathPathCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns PathPathCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathCertifyVEXStatement) GetOrigin() string { return v.allCertifyVEXStatement.Origin }
+func (v *PathPathCertifyVEXStatement) GetOrigin() string { return v.AllCertifyVEXStatement.Origin }
 
 // GetCollector returns PathPathCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *PathPathCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *PathPathCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -15718,7 +19712,7 @@ func (v *PathPathCertifyVEXStatement) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -15761,38 +19755,38 @@ func (v *PathPathCertifyVEXStatement) __premarshalJSON() (*__premarshalPathPathC
 	var retval __premarshalPathPathCertifyVEXStatement
 
 	retval.Typename = v.Typename
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PathPathCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal PathPathCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PathPathCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal PathPathCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -15993,37 +19987,37 @@ func (v *PathPathHasMetadata) GetTypename() *string { return v.Typename }
 // PathPathHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type PathPathHasSBOM struct {
 	Typename       *string `json:"__typename"`
-	allHasSBOMTree `json:"-"`
+	AllHasSBOMTree `json:"-"`
 }
 
 // GetTypename returns PathPathHasSBOM.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathHasSBOM) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetId() string { return v.allHasSBOMTree.Id }
+func (v *PathPathHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
 
 // GetSubject returns PathPathHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact {
-	return v.allHasSBOMTree.Subject
+func (v *PathPathHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
 }
 
 // GetUri returns PathPathHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetUri() string { return v.allHasSBOMTree.Uri }
+func (v *PathPathHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
 
 // GetAlgorithm returns PathPathHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetAlgorithm() string { return v.allHasSBOMTree.Algorithm }
+func (v *PathPathHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
 
 // GetDigest returns PathPathHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetDigest() string { return v.allHasSBOMTree.Digest }
+func (v *PathPathHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
 
 // GetDownloadLocation returns PathPathHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetDownloadLocation() string { return v.allHasSBOMTree.DownloadLocation }
+func (v *PathPathHasSBOM) GetDownloadLocation() string { return v.AllHasSBOMTree.DownloadLocation }
 
 // GetOrigin returns PathPathHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetOrigin() string { return v.allHasSBOMTree.Origin }
+func (v *PathPathHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
 
 // GetCollector returns PathPathHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathHasSBOM) GetCollector() string { return v.allHasSBOMTree.Collector }
+func (v *PathPathHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
 
 func (v *PathPathHasSBOM) UnmarshalJSON(b []byte) error {
 
@@ -16043,7 +20037,7 @@ func (v *PathPathHasSBOM) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSBOMTree)
+		b, &v.AllHasSBOMTree)
 	if err != nil {
 		return err
 	}
@@ -16082,25 +20076,25 @@ func (v *PathPathHasSBOM) __premarshalJSON() (*__premarshalPathPathHasSBOM, erro
 	var retval __premarshalPathPathHasSBOM
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSBOMTree.Id
+	retval.Id = v.AllHasSBOMTree.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allHasSBOMTree.Subject
+		src := v.AllHasSBOMTree.Subject
 		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PathPathHasSBOM.allHasSBOMTree.Subject: %w", err)
+				"unable to marshal PathPathHasSBOM.AllHasSBOMTree.Subject: %w", err)
 		}
 	}
-	retval.Uri = v.allHasSBOMTree.Uri
-	retval.Algorithm = v.allHasSBOMTree.Algorithm
-	retval.Digest = v.allHasSBOMTree.Digest
-	retval.DownloadLocation = v.allHasSBOMTree.DownloadLocation
-	retval.Origin = v.allHasSBOMTree.Origin
-	retval.Collector = v.allHasSBOMTree.Collector
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
 	return &retval, nil
 }
 
@@ -16110,20 +20104,20 @@ func (v *PathPathHasSBOM) __premarshalJSON() (*__premarshalPathPathHasSBOM, erro
 // HasSLSA records that a subject node has a SLSA attestation.
 type PathPathHasSLSA struct {
 	Typename    *string `json:"__typename"`
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetTypename returns PathPathHasSLSA.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathHasSLSA) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *PathPathHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *PathPathHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns PathPathHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *PathPathHasSLSA) GetSubject() allSLSATreeSubjectArtifact { return v.allSLSATree.Subject }
+func (v *PathPathHasSLSA) GetSubject() AllSLSATreeSubjectArtifact { return v.AllSLSATree.Subject }
 
 // GetSlsa returns PathPathHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *PathPathHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *PathPathHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *PathPathHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -16143,7 +20137,7 @@ func (v *PathPathHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -16155,9 +20149,9 @@ type __premarshalPathPathHasSLSA struct {
 
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *PathPathHasSLSA) MarshalJSON() ([]byte, error) {
@@ -16172,9 +20166,9 @@ func (v *PathPathHasSLSA) __premarshalJSON() (*__premarshalPathPathHasSLSA, erro
 	var retval __premarshalPathPathHasSLSA
 
 	retval.Typename = v.Typename
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -16184,32 +20178,32 @@ func (v *PathPathHasSLSA) __premarshalJSON() (*__premarshalPathPathHasSLSA, erro
 // HasSourceAt records that a package's repository is a given source.
 type PathPathHasSourceAt struct {
 	Typename       *string `json:"__typename"`
-	allHasSourceAt `json:"-"`
+	AllHasSourceAt `json:"-"`
 }
 
 // GetTypename returns PathPathHasSourceAt.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathHasSourceAt) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetId() string { return v.allHasSourceAt.Id }
+func (v *PathPathHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
 
 // GetJustification returns PathPathHasSourceAt.Justification, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetJustification() string { return v.allHasSourceAt.Justification }
+func (v *PathPathHasSourceAt) GetJustification() string { return v.AllHasSourceAt.Justification }
 
 // GetKnownSince returns PathPathHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetKnownSince() time.Time { return v.allHasSourceAt.KnownSince }
+func (v *PathPathHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
 
 // GetPackage returns PathPathHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetPackage() allHasSourceAtPackage { return v.allHasSourceAt.Package }
+func (v *PathPathHasSourceAt) GetPackage() AllHasSourceAtPackage { return v.AllHasSourceAt.Package }
 
 // GetSource returns PathPathHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetSource() allHasSourceAtSource { return v.allHasSourceAt.Source }
+func (v *PathPathHasSourceAt) GetSource() AllHasSourceAtSource { return v.AllHasSourceAt.Source }
 
 // GetOrigin returns PathPathHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetOrigin() string { return v.allHasSourceAt.Origin }
+func (v *PathPathHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
 
 // GetCollector returns PathPathHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathHasSourceAt) GetCollector() string { return v.allHasSourceAt.Collector }
+func (v *PathPathHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
 
 func (v *PathPathHasSourceAt) UnmarshalJSON(b []byte) error {
 
@@ -16229,7 +20223,7 @@ func (v *PathPathHasSourceAt) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHasSourceAt)
+		b, &v.AllHasSourceAt)
 	if err != nil {
 		return err
 	}
@@ -16245,9 +20239,9 @@ type __premarshalPathPathHasSourceAt struct {
 
 	KnownSince time.Time `json:"knownSince"`
 
-	Package allHasSourceAtPackage `json:"package"`
+	Package AllHasSourceAtPackage `json:"package"`
 
-	Source allHasSourceAtSource `json:"source"`
+	Source AllHasSourceAtSource `json:"source"`
 
 	Origin string `json:"origin"`
 
@@ -16266,13 +20260,13 @@ func (v *PathPathHasSourceAt) __premarshalJSON() (*__premarshalPathPathHasSource
 	var retval __premarshalPathPathHasSourceAt
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHasSourceAt.Id
-	retval.Justification = v.allHasSourceAt.Justification
-	retval.KnownSince = v.allHasSourceAt.KnownSince
-	retval.Package = v.allHasSourceAt.Package
-	retval.Source = v.allHasSourceAt.Source
-	retval.Origin = v.allHasSourceAt.Origin
-	retval.Collector = v.allHasSourceAt.Collector
+	retval.Id = v.AllHasSourceAt.Id
+	retval.Justification = v.AllHasSourceAt.Justification
+	retval.KnownSince = v.AllHasSourceAt.KnownSince
+	retval.Package = v.AllHasSourceAt.Package
+	retval.Source = v.AllHasSourceAt.Source
+	retval.Origin = v.AllHasSourceAt.Origin
+	retval.Collector = v.AllHasSourceAt.Collector
 	return &retval, nil
 }
 
@@ -16282,28 +20276,28 @@ func (v *PathPathHasSourceAt) __premarshalJSON() (*__premarshalPathPathHasSource
 // HashEqual is an attestation that a set of artifacts are identical.
 type PathPathHashEqual struct {
 	Typename         *string `json:"__typename"`
-	allHashEqualTree `json:"-"`
+	AllHashEqualTree `json:"-"`
 }
 
 // GetTypename returns PathPathHashEqual.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathHashEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *PathPathHashEqual) GetId() string { return v.allHashEqualTree.Id }
+func (v *PathPathHashEqual) GetId() string { return v.AllHashEqualTree.Id }
 
 // GetJustification returns PathPathHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *PathPathHashEqual) GetJustification() string { return v.allHashEqualTree.Justification }
+func (v *PathPathHashEqual) GetJustification() string { return v.AllHashEqualTree.Justification }
 
 // GetArtifacts returns PathPathHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *PathPathHashEqual) GetArtifacts() []allHashEqualTreeArtifactsArtifact {
-	return v.allHashEqualTree.Artifacts
+func (v *PathPathHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
+	return v.AllHashEqualTree.Artifacts
 }
 
 // GetOrigin returns PathPathHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathHashEqual) GetOrigin() string { return v.allHashEqualTree.Origin }
+func (v *PathPathHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
 
 // GetCollector returns PathPathHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathHashEqual) GetCollector() string { return v.allHashEqualTree.Collector }
+func (v *PathPathHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
 
 func (v *PathPathHashEqual) UnmarshalJSON(b []byte) error {
 
@@ -16323,7 +20317,7 @@ func (v *PathPathHashEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allHashEqualTree)
+		b, &v.AllHashEqualTree)
 	if err != nil {
 		return err
 	}
@@ -16337,7 +20331,7 @@ type __premarshalPathPathHashEqual struct {
 
 	Justification string `json:"justification"`
 
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
+	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
 
 	Origin string `json:"origin"`
 
@@ -16356,11 +20350,11 @@ func (v *PathPathHashEqual) __premarshalJSON() (*__premarshalPathPathHashEqual, 
 	var retval __premarshalPathPathHashEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allHashEqualTree.Id
-	retval.Justification = v.allHashEqualTree.Justification
-	retval.Artifacts = v.allHashEqualTree.Artifacts
-	retval.Origin = v.allHashEqualTree.Origin
-	retval.Collector = v.allHashEqualTree.Collector
+	retval.Id = v.AllHashEqualTree.Id
+	retval.Justification = v.AllHashEqualTree.Justification
+	retval.Artifacts = v.AllHashEqualTree.Artifacts
+	retval.Origin = v.AllHashEqualTree.Origin
+	retval.Collector = v.AllHashEqualTree.Collector
 	return &retval, nil
 }
 
@@ -16370,41 +20364,41 @@ func (v *PathPathHashEqual) __premarshalJSON() (*__premarshalPathPathHashEqual, 
 // IsDependency is an attestation to record that a package depends on another.
 type PathPathIsDependency struct {
 	Typename            *string `json:"__typename"`
-	allIsDependencyTree `json:"-"`
+	AllIsDependencyTree `json:"-"`
 }
 
 // GetTypename returns PathPathIsDependency.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathIsDependency) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetId() string { return v.allIsDependencyTree.Id }
+func (v *PathPathIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
 
 // GetJustification returns PathPathIsDependency.Justification, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetJustification() string { return v.allIsDependencyTree.Justification }
+func (v *PathPathIsDependency) GetJustification() string { return v.AllIsDependencyTree.Justification }
 
 // GetPackage returns PathPathIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetPackage() allIsDependencyTreePackage {
-	return v.allIsDependencyTree.Package
+func (v *PathPathIsDependency) GetPackage() AllIsDependencyTreePackage {
+	return v.AllIsDependencyTree.Package
 }
 
 // GetDependentPackage returns PathPathIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.allIsDependencyTree.DependentPackage
+func (v *PathPathIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
+	return v.AllIsDependencyTree.DependentPackage
 }
 
 // GetDependencyType returns PathPathIsDependency.DependencyType, and is useful for accessing the field via an interface.
 func (v *PathPathIsDependency) GetDependencyType() DependencyType {
-	return v.allIsDependencyTree.DependencyType
+	return v.AllIsDependencyTree.DependencyType
 }
 
 // GetVersionRange returns PathPathIsDependency.VersionRange, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetVersionRange() string { return v.allIsDependencyTree.VersionRange }
+func (v *PathPathIsDependency) GetVersionRange() string { return v.AllIsDependencyTree.VersionRange }
 
 // GetOrigin returns PathPathIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetOrigin() string { return v.allIsDependencyTree.Origin }
+func (v *PathPathIsDependency) GetOrigin() string { return v.AllIsDependencyTree.Origin }
 
 // GetCollector returns PathPathIsDependency.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathIsDependency) GetCollector() string { return v.allIsDependencyTree.Collector }
+func (v *PathPathIsDependency) GetCollector() string { return v.AllIsDependencyTree.Collector }
 
 func (v *PathPathIsDependency) UnmarshalJSON(b []byte) error {
 
@@ -16424,7 +20418,7 @@ func (v *PathPathIsDependency) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsDependencyTree)
+		b, &v.AllIsDependencyTree)
 	if err != nil {
 		return err
 	}
@@ -16438,9 +20432,9 @@ type __premarshalPathPathIsDependency struct {
 
 	Justification string `json:"justification"`
 
-	Package allIsDependencyTreePackage `json:"package"`
+	Package AllIsDependencyTreePackage `json:"package"`
 
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
+	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
 
 	DependencyType DependencyType `json:"dependencyType"`
 
@@ -16463,14 +20457,14 @@ func (v *PathPathIsDependency) __premarshalJSON() (*__premarshalPathPathIsDepend
 	var retval __premarshalPathPathIsDependency
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsDependencyTree.Id
-	retval.Justification = v.allIsDependencyTree.Justification
-	retval.Package = v.allIsDependencyTree.Package
-	retval.DependentPackage = v.allIsDependencyTree.DependentPackage
-	retval.DependencyType = v.allIsDependencyTree.DependencyType
-	retval.VersionRange = v.allIsDependencyTree.VersionRange
-	retval.Origin = v.allIsDependencyTree.Origin
-	retval.Collector = v.allIsDependencyTree.Collector
+	retval.Id = v.AllIsDependencyTree.Id
+	retval.Justification = v.AllIsDependencyTree.Justification
+	retval.Package = v.AllIsDependencyTree.Package
+	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
+	retval.DependencyType = v.AllIsDependencyTree.DependencyType
+	retval.VersionRange = v.AllIsDependencyTree.VersionRange
+	retval.Origin = v.AllIsDependencyTree.Origin
+	retval.Collector = v.AllIsDependencyTree.Collector
 	return &retval, nil
 }
 
@@ -16589,33 +20583,33 @@ func (v *PathPathIsOccurrence) __premarshalJSON() (*__premarshalPathPathIsOccurr
 // IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
 type PathPathIsVulnerability struct {
 	Typename           *string `json:"__typename"`
-	allIsVulnerability `json:"-"`
+	AllIsVulnerability `json:"-"`
 }
 
 // GetTypename returns PathPathIsVulnerability.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathIsVulnerability) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *PathPathIsVulnerability) GetId() string { return v.allIsVulnerability.Id }
+func (v *PathPathIsVulnerability) GetId() string { return v.AllIsVulnerability.Id }
 
 // GetOsv returns PathPathIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *PathPathIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV { return v.allIsVulnerability.Osv }
+func (v *PathPathIsVulnerability) GetOsv() AllIsVulnerabilityOsvOSV { return v.AllIsVulnerability.Osv }
 
 // GetVulnerability returns PathPathIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *PathPathIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.allIsVulnerability.Vulnerability
+func (v *PathPathIsVulnerability) GetVulnerability() AllIsVulnerabilityVulnerabilityCveOrGhsa {
+	return v.AllIsVulnerability.Vulnerability
 }
 
 // GetJustification returns PathPathIsVulnerability.Justification, and is useful for accessing the field via an interface.
 func (v *PathPathIsVulnerability) GetJustification() string {
-	return v.allIsVulnerability.Justification
+	return v.AllIsVulnerability.Justification
 }
 
 // GetOrigin returns PathPathIsVulnerability.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathIsVulnerability) GetOrigin() string { return v.allIsVulnerability.Origin }
+func (v *PathPathIsVulnerability) GetOrigin() string { return v.AllIsVulnerability.Origin }
 
 // GetCollector returns PathPathIsVulnerability.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathIsVulnerability) GetCollector() string { return v.allIsVulnerability.Collector }
+func (v *PathPathIsVulnerability) GetCollector() string { return v.AllIsVulnerability.Collector }
 
 func (v *PathPathIsVulnerability) UnmarshalJSON(b []byte) error {
 
@@ -16635,7 +20629,7 @@ func (v *PathPathIsVulnerability) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allIsVulnerability)
+		b, &v.AllIsVulnerability)
 	if err != nil {
 		return err
 	}
@@ -16647,7 +20641,7 @@ type __premarshalPathPathIsVulnerability struct {
 
 	Id string `json:"id"`
 
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
+	Osv AllIsVulnerabilityOsvOSV `json:"osv"`
 
 	Vulnerability json.RawMessage `json:"vulnerability"`
 
@@ -16670,23 +20664,23 @@ func (v *PathPathIsVulnerability) __premarshalJSON() (*__premarshalPathPathIsVul
 	var retval __premarshalPathPathIsVulnerability
 
 	retval.Typename = v.Typename
-	retval.Id = v.allIsVulnerability.Id
-	retval.Osv = v.allIsVulnerability.Osv
+	retval.Id = v.AllIsVulnerability.Id
+	retval.Osv = v.AllIsVulnerability.Osv
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allIsVulnerability.Vulnerability
+		src := v.AllIsVulnerability.Vulnerability
 		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
+		*dst, err = __marshalAllIsVulnerabilityVulnerabilityCveOrGhsa(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PathPathIsVulnerability.allIsVulnerability.Vulnerability: %w", err)
+				"unable to marshal PathPathIsVulnerability.AllIsVulnerability.Vulnerability: %w", err)
 		}
 	}
-	retval.Justification = v.allIsVulnerability.Justification
-	retval.Origin = v.allIsVulnerability.Origin
-	retval.Collector = v.allIsVulnerability.Collector
+	retval.Justification = v.AllIsVulnerability.Justification
+	retval.Origin = v.AllIsVulnerability.Origin
+	retval.Collector = v.AllIsVulnerability.Collector
 	return &retval, nil
 }
 
@@ -17309,26 +21303,26 @@ func (v *PathPathPackage) __premarshalJSON() (*__premarshalPathPathPackage, erro
 // PkgEqual is an attestation that a set of packages are similar.
 type PathPathPkgEqual struct {
 	Typename    *string `json:"__typename"`
-	allPkgEqual `json:"-"`
+	AllPkgEqual `json:"-"`
 }
 
 // GetTypename returns PathPathPkgEqual.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathPkgEqual) GetTypename() *string { return v.Typename }
 
 // GetId returns PathPathPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *PathPathPkgEqual) GetId() string { return v.allPkgEqual.Id }
+func (v *PathPathPkgEqual) GetId() string { return v.AllPkgEqual.Id }
 
 // GetJustification returns PathPathPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *PathPathPkgEqual) GetJustification() string { return v.allPkgEqual.Justification }
+func (v *PathPathPkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
 
 // GetPackages returns PathPathPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *PathPathPkgEqual) GetPackages() []allPkgEqualPackagesPackage { return v.allPkgEqual.Packages }
+func (v *PathPathPkgEqual) GetPackages() []AllPkgEqualPackagesPackage { return v.AllPkgEqual.Packages }
 
 // GetOrigin returns PathPathPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *PathPathPkgEqual) GetOrigin() string { return v.allPkgEqual.Origin }
+func (v *PathPathPkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
 
 // GetCollector returns PathPathPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *PathPathPkgEqual) GetCollector() string { return v.allPkgEqual.Collector }
+func (v *PathPathPkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
 
 func (v *PathPathPkgEqual) UnmarshalJSON(b []byte) error {
 
@@ -17348,7 +21342,7 @@ func (v *PathPathPkgEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPkgEqual)
+		b, &v.AllPkgEqual)
 	if err != nil {
 		return err
 	}
@@ -17362,7 +21356,7 @@ type __premarshalPathPathPkgEqual struct {
 
 	Justification string `json:"justification"`
 
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
 
 	Origin string `json:"origin"`
 
@@ -17381,11 +21375,11 @@ func (v *PathPathPkgEqual) __premarshalJSON() (*__premarshalPathPathPkgEqual, er
 	var retval __premarshalPathPathPkgEqual
 
 	retval.Typename = v.Typename
-	retval.Id = v.allPkgEqual.Id
-	retval.Justification = v.allPkgEqual.Justification
-	retval.Packages = v.allPkgEqual.Packages
-	retval.Origin = v.allPkgEqual.Origin
-	retval.Collector = v.allPkgEqual.Collector
+	retval.Id = v.AllPkgEqual.Id
+	retval.Justification = v.AllPkgEqual.Justification
+	retval.Packages = v.AllPkgEqual.Packages
+	retval.Origin = v.AllPkgEqual.Origin
+	retval.Collector = v.AllPkgEqual.Collector
 	return &retval, nil
 }
 
@@ -17601,25 +21595,25 @@ func (v *PathResponse) __premarshalJSON() (*__premarshalPathResponse, error) {
 //
 // PkgEqual is an attestation that a set of packages are similar.
 type PkgEqualIngestPkgEqual struct {
-	allPkgEqual `json:"-"`
+	AllPkgEqual `json:"-"`
 }
 
 // GetId returns PkgEqualIngestPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetId() string { return v.allPkgEqual.Id }
+func (v *PkgEqualIngestPkgEqual) GetId() string { return v.AllPkgEqual.Id }
 
 // GetJustification returns PkgEqualIngestPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetJustification() string { return v.allPkgEqual.Justification }
+func (v *PkgEqualIngestPkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
 
 // GetPackages returns PkgEqualIngestPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetPackages() []allPkgEqualPackagesPackage {
-	return v.allPkgEqual.Packages
+func (v *PkgEqualIngestPkgEqual) GetPackages() []AllPkgEqualPackagesPackage {
+	return v.AllPkgEqual.Packages
 }
 
 // GetOrigin returns PkgEqualIngestPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetOrigin() string { return v.allPkgEqual.Origin }
+func (v *PkgEqualIngestPkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
 
 // GetCollector returns PkgEqualIngestPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetCollector() string { return v.allPkgEqual.Collector }
+func (v *PkgEqualIngestPkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
 
 func (v *PkgEqualIngestPkgEqual) UnmarshalJSON(b []byte) error {
 
@@ -17639,7 +21633,7 @@ func (v *PkgEqualIngestPkgEqual) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPkgEqual)
+		b, &v.AllPkgEqual)
 	if err != nil {
 		return err
 	}
@@ -17651,7 +21645,7 @@ type __premarshalPkgEqualIngestPkgEqual struct {
 
 	Justification string `json:"justification"`
 
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
+	Packages []AllPkgEqualPackagesPackage `json:"packages"`
 
 	Origin string `json:"origin"`
 
@@ -17669,11 +21663,11 @@ func (v *PkgEqualIngestPkgEqual) MarshalJSON() ([]byte, error) {
 func (v *PkgEqualIngestPkgEqual) __premarshalJSON() (*__premarshalPkgEqualIngestPkgEqual, error) {
 	var retval __premarshalPkgEqualIngestPkgEqual
 
-	retval.Id = v.allPkgEqual.Id
-	retval.Justification = v.allPkgEqual.Justification
-	retval.Packages = v.allPkgEqual.Packages
-	retval.Origin = v.allPkgEqual.Origin
-	retval.Collector = v.allPkgEqual.Collector
+	retval.Id = v.AllPkgEqual.Id
+	retval.Justification = v.AllPkgEqual.Justification
+	retval.Packages = v.AllPkgEqual.Packages
+	retval.Origin = v.AllPkgEqual.Origin
+	retval.Collector = v.AllPkgEqual.Collector
 	return &retval, nil
 }
 
@@ -17988,45 +21982,45 @@ func (v *PkgSpec) GetSubpath() *string { return v.Subpath }
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type PointOfContactArtifactIngestPointOfContact struct {
-	allPointOfContact `json:"-"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetId returns PointOfContactArtifactIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetId() string { return v.allPointOfContact.Id }
+func (v *PointOfContactArtifactIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
 
 // GetSubject returns PointOfContactArtifactIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetSubject() allPointOfContactSubjectPackageSourceOrArtifact {
-	return v.allPointOfContact.Subject
+func (v *PointOfContactArtifactIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
 }
 
 // GetEmail returns PointOfContactArtifactIngestPointOfContact.Email, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetEmail() string {
-	return v.allPointOfContact.Email
+	return v.AllPointOfContact.Email
 }
 
 // GetInfo returns PointOfContactArtifactIngestPointOfContact.Info, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetInfo() string {
-	return v.allPointOfContact.Info
+	return v.AllPointOfContact.Info
 }
 
 // GetSince returns PointOfContactArtifactIngestPointOfContact.Since, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetSince() time.Time {
-	return v.allPointOfContact.Since
+	return v.AllPointOfContact.Since
 }
 
 // GetJustification returns PointOfContactArtifactIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetJustification() string {
-	return v.allPointOfContact.Justification
+	return v.AllPointOfContact.Justification
 }
 
 // GetOrigin returns PointOfContactArtifactIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetOrigin() string {
-	return v.allPointOfContact.Origin
+	return v.AllPointOfContact.Origin
 }
 
 // GetCollector returns PointOfContactArtifactIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
 func (v *PointOfContactArtifactIngestPointOfContact) GetCollector() string {
-	return v.allPointOfContact.Collector
+	return v.AllPointOfContact.Collector
 }
 
 func (v *PointOfContactArtifactIngestPointOfContact) UnmarshalJSON(b []byte) error {
@@ -18047,7 +22041,7 @@ func (v *PointOfContactArtifactIngestPointOfContact) UnmarshalJSON(b []byte) err
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPointOfContact)
+		b, &v.AllPointOfContact)
 	if err != nil {
 		return err
 	}
@@ -18083,25 +22077,25 @@ func (v *PointOfContactArtifactIngestPointOfContact) MarshalJSON() ([]byte, erro
 func (v *PointOfContactArtifactIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactArtifactIngestPointOfContact, error) {
 	var retval __premarshalPointOfContactArtifactIngestPointOfContact
 
-	retval.Id = v.allPointOfContact.Id
+	retval.Id = v.AllPointOfContact.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allPointOfContact.Subject
+		src := v.AllPointOfContact.Subject
 		var err error
-		*dst, err = __marshalallPointOfContactSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactArtifactIngestPointOfContact.allPointOfContact.Subject: %w", err)
+				"unable to marshal PointOfContactArtifactIngestPointOfContact.AllPointOfContact.Subject: %w", err)
 		}
 	}
-	retval.Email = v.allPointOfContact.Email
-	retval.Info = v.allPointOfContact.Info
-	retval.Since = v.allPointOfContact.Since
-	retval.Justification = v.allPointOfContact.Justification
-	retval.Origin = v.allPointOfContact.Origin
-	retval.Collector = v.allPointOfContact.Collector
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
 	return &retval, nil
 }
 
@@ -18169,39 +22163,39 @@ func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type PointOfContactPkgIngestPointOfContact struct {
-	allPointOfContact `json:"-"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetId returns PointOfContactPkgIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetId() string { return v.allPointOfContact.Id }
+func (v *PointOfContactPkgIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
 
 // GetSubject returns PointOfContactPkgIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetSubject() allPointOfContactSubjectPackageSourceOrArtifact {
-	return v.allPointOfContact.Subject
+func (v *PointOfContactPkgIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
 }
 
 // GetEmail returns PointOfContactPkgIngestPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetEmail() string { return v.allPointOfContact.Email }
+func (v *PointOfContactPkgIngestPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
 
 // GetInfo returns PointOfContactPkgIngestPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetInfo() string { return v.allPointOfContact.Info }
+func (v *PointOfContactPkgIngestPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
 
 // GetSince returns PointOfContactPkgIngestPointOfContact.Since, and is useful for accessing the field via an interface.
 func (v *PointOfContactPkgIngestPointOfContact) GetSince() time.Time {
-	return v.allPointOfContact.Since
+	return v.AllPointOfContact.Since
 }
 
 // GetJustification returns PointOfContactPkgIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
 func (v *PointOfContactPkgIngestPointOfContact) GetJustification() string {
-	return v.allPointOfContact.Justification
+	return v.AllPointOfContact.Justification
 }
 
 // GetOrigin returns PointOfContactPkgIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetOrigin() string { return v.allPointOfContact.Origin }
+func (v *PointOfContactPkgIngestPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
 
 // GetCollector returns PointOfContactPkgIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
 func (v *PointOfContactPkgIngestPointOfContact) GetCollector() string {
-	return v.allPointOfContact.Collector
+	return v.AllPointOfContact.Collector
 }
 
 func (v *PointOfContactPkgIngestPointOfContact) UnmarshalJSON(b []byte) error {
@@ -18222,7 +22216,7 @@ func (v *PointOfContactPkgIngestPointOfContact) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPointOfContact)
+		b, &v.AllPointOfContact)
 	if err != nil {
 		return err
 	}
@@ -18258,25 +22252,25 @@ func (v *PointOfContactPkgIngestPointOfContact) MarshalJSON() ([]byte, error) {
 func (v *PointOfContactPkgIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactPkgIngestPointOfContact, error) {
 	var retval __premarshalPointOfContactPkgIngestPointOfContact
 
-	retval.Id = v.allPointOfContact.Id
+	retval.Id = v.AllPointOfContact.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allPointOfContact.Subject
+		src := v.AllPointOfContact.Subject
 		var err error
-		*dst, err = __marshalallPointOfContactSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactPkgIngestPointOfContact.allPointOfContact.Subject: %w", err)
+				"unable to marshal PointOfContactPkgIngestPointOfContact.AllPointOfContact.Subject: %w", err)
 		}
 	}
-	retval.Email = v.allPointOfContact.Email
-	retval.Info = v.allPointOfContact.Info
-	retval.Since = v.allPointOfContact.Since
-	retval.Justification = v.allPointOfContact.Justification
-	retval.Origin = v.allPointOfContact.Origin
-	retval.Collector = v.allPointOfContact.Collector
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
 	return &retval, nil
 }
 
@@ -18316,39 +22310,39 @@ func (v *PointOfContactPkgResponse) GetIngestPointOfContact() PointOfContactPkgI
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type PointOfContactSrcIngestPointOfContact struct {
-	allPointOfContact `json:"-"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetId returns PointOfContactSrcIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetId() string { return v.allPointOfContact.Id }
+func (v *PointOfContactSrcIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
 
 // GetSubject returns PointOfContactSrcIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetSubject() allPointOfContactSubjectPackageSourceOrArtifact {
-	return v.allPointOfContact.Subject
+func (v *PointOfContactSrcIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
 }
 
 // GetEmail returns PointOfContactSrcIngestPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetEmail() string { return v.allPointOfContact.Email }
+func (v *PointOfContactSrcIngestPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
 
 // GetInfo returns PointOfContactSrcIngestPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetInfo() string { return v.allPointOfContact.Info }
+func (v *PointOfContactSrcIngestPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
 
 // GetSince returns PointOfContactSrcIngestPointOfContact.Since, and is useful for accessing the field via an interface.
 func (v *PointOfContactSrcIngestPointOfContact) GetSince() time.Time {
-	return v.allPointOfContact.Since
+	return v.AllPointOfContact.Since
 }
 
 // GetJustification returns PointOfContactSrcIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
 func (v *PointOfContactSrcIngestPointOfContact) GetJustification() string {
-	return v.allPointOfContact.Justification
+	return v.AllPointOfContact.Justification
 }
 
 // GetOrigin returns PointOfContactSrcIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetOrigin() string { return v.allPointOfContact.Origin }
+func (v *PointOfContactSrcIngestPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
 
 // GetCollector returns PointOfContactSrcIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
 func (v *PointOfContactSrcIngestPointOfContact) GetCollector() string {
-	return v.allPointOfContact.Collector
+	return v.AllPointOfContact.Collector
 }
 
 func (v *PointOfContactSrcIngestPointOfContact) UnmarshalJSON(b []byte) error {
@@ -18369,7 +22363,7 @@ func (v *PointOfContactSrcIngestPointOfContact) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allPointOfContact)
+		b, &v.AllPointOfContact)
 	if err != nil {
 		return err
 	}
@@ -18405,25 +22399,25 @@ func (v *PointOfContactSrcIngestPointOfContact) MarshalJSON() ([]byte, error) {
 func (v *PointOfContactSrcIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactSrcIngestPointOfContact, error) {
 	var retval __premarshalPointOfContactSrcIngestPointOfContact
 
-	retval.Id = v.allPointOfContact.Id
+	retval.Id = v.AllPointOfContact.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allPointOfContact.Subject
+		src := v.AllPointOfContact.Subject
 		var err error
-		*dst, err = __marshalallPointOfContactSubjectPackageSourceOrArtifact(
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactSrcIngestPointOfContact.allPointOfContact.Subject: %w", err)
+				"unable to marshal PointOfContactSrcIngestPointOfContact.AllPointOfContact.Subject: %w", err)
 		}
 	}
-	retval.Email = v.allPointOfContact.Email
-	retval.Info = v.allPointOfContact.Info
-	retval.Since = v.allPointOfContact.Since
-	retval.Justification = v.allPointOfContact.Justification
-	retval.Origin = v.allPointOfContact.Origin
-	retval.Collector = v.allPointOfContact.Collector
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
 	return &retval, nil
 }
 
@@ -18443,19 +22437,19 @@ func (v *PointOfContactSrcResponse) GetIngestPointOfContact() PointOfContactSrcI
 //
 // HasSLSA records that a subject node has a SLSA attestation.
 type SLSAForArtifactIngestSLSAHasSLSA struct {
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetId returns SLSAForArtifactIngestSLSAHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *SLSAForArtifactIngestSLSAHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns SLSAForArtifactIngestSLSAHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSubject() allSLSATreeSubjectArtifact {
-	return v.allSLSATree.Subject
+func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSubject() AllSLSATreeSubjectArtifact {
+	return v.AllSLSATree.Subject
 }
 
 // GetSlsa returns SLSAForArtifactIngestSLSAHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *SLSAForArtifactIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -18475,7 +22469,7 @@ func (v *SLSAForArtifactIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -18485,9 +22479,9 @@ func (v *SLSAForArtifactIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
 type __premarshalSLSAForArtifactIngestSLSAHasSLSA struct {
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *SLSAForArtifactIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
@@ -18501,9 +22495,9 @@ func (v *SLSAForArtifactIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
 func (v *SLSAForArtifactIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAForArtifactIngestSLSAHasSLSA, error) {
 	var retval __premarshalSLSAForArtifactIngestSLSAHasSLSA
 
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -18846,57 +22840,57 @@ func (v *SourcesSourcesSource) __premarshalJSON() (*__premarshalSourcesSourcesSo
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -18917,7 +22911,7 @@ func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -18957,38 +22951,38 @@ func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) MarshalJSON() (
 func (v *VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VEXPackageAndGhsaIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -19009,57 +23003,57 @@ func (v *VEXPackageAndGhsaResponse) GetIngestVEXStatement() VEXPackageAndGhsaIng
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VexArtifactAndCveIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -19080,7 +23074,7 @@ func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -19120,38 +23114,38 @@ func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) MarshalJSON() (
 func (v *VexArtifactAndCveIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVexArtifactAndCveIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVexArtifactAndCveIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VexArtifactAndCveIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -19172,57 +23166,57 @@ func (v *VexArtifactAndCveResponse) GetIngestVEXStatement() VexArtifactAndCveIng
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -19243,7 +23237,7 @@ func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -19283,38 +23277,38 @@ func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) MarshalJSON() 
 func (v *VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VexArtifactAndGhsaIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -19335,57 +23329,57 @@ func (v *VexArtifactAndGhsaResponse) GetIngestVEXStatement() VexArtifactAndGhsaI
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -19406,7 +23400,7 @@ func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -19446,38 +23440,38 @@ func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) MarshalJSON() (
 func (v *VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVexArtifactAndOsvIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVexArtifactAndOsvIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VexArtifactAndOsvIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -19510,57 +23504,57 @@ const (
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VexPackageAndCveIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VexPackageAndCveIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -19581,7 +23575,7 @@ func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b 
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -19621,38 +23615,38 @@ func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) MarshalJSON() ([
 func (v *VexPackageAndCveIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVexPackageAndCveIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVexPackageAndCveIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexPackageAndCveIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VexPackageAndCveIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexPackageAndCveIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VexPackageAndCveIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -19673,57 +23667,57 @@ func (v *VexPackageAndCveResponse) GetIngestVEXStatement() VexPackageAndCveInges
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
 // artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
 type VexPackageAndOsvIngestVEXStatementCertifyVEXStatement struct {
-	allCertifyVEXStatement `json:"-"`
+	AllCertifyVEXStatement `json:"-"`
 }
 
 // GetId returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.allCertifyVEXStatement.Id
+	return v.AllCertifyVEXStatement.Id
 }
 
 // GetSubject returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.allCertifyVEXStatement.Subject
+func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
+	return v.AllCertifyVEXStatement.Subject
 }
 
 // GetVulnerability returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.allCertifyVEXStatement.Vulnerability
+func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
+	return v.AllCertifyVEXStatement.Vulnerability
 }
 
 // GetStatus returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.allCertifyVEXStatement.Status
+	return v.AllCertifyVEXStatement.Status
 }
 
 // GetVexJustification returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.allCertifyVEXStatement.VexJustification
+	return v.AllCertifyVEXStatement.VexJustification
 }
 
 // GetStatement returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.allCertifyVEXStatement.Statement
+	return v.AllCertifyVEXStatement.Statement
 }
 
 // GetStatusNotes returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.allCertifyVEXStatement.StatusNotes
+	return v.AllCertifyVEXStatement.StatusNotes
 }
 
 // GetKnownSince returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.allCertifyVEXStatement.KnownSince
+	return v.AllCertifyVEXStatement.KnownSince
 }
 
 // GetOrigin returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.allCertifyVEXStatement.Origin
+	return v.AllCertifyVEXStatement.Origin
 }
 
 // GetCollector returns VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.allCertifyVEXStatement.Collector
+	return v.AllCertifyVEXStatement.Collector
 }
 
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
@@ -19744,7 +23738,7 @@ func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b 
 	}
 
 	err = json.Unmarshal(
-		b, &v.allCertifyVEXStatement)
+		b, &v.AllCertifyVEXStatement)
 	if err != nil {
 		return err
 	}
@@ -19784,38 +23778,38 @@ func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) MarshalJSON() ([
 func (v *VexPackageAndOsvIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalVexPackageAndOsvIngestVEXStatementCertifyVEXStatement, error) {
 	var retval __premarshalVexPackageAndOsvIngestVEXStatementCertifyVEXStatement
 
-	retval.Id = v.allCertifyVEXStatement.Id
+	retval.Id = v.AllCertifyVEXStatement.Id
 	{
 
 		dst := &retval.Subject
-		src := v.allCertifyVEXStatement.Subject
+		src := v.AllCertifyVEXStatement.Subject
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
+		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Subject: %w", err)
+				"unable to marshal VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
 		}
 	}
 	{
 
 		dst := &retval.Vulnerability
-		src := v.allCertifyVEXStatement.Vulnerability
+		src := v.AllCertifyVEXStatement.Vulnerability
 		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
+		*dst, err = __marshalAllCertifyVEXStatementVulnerability(
 			&src)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"unable to marshal VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.allCertifyVEXStatement.Vulnerability: %w", err)
+				"unable to marshal VexPackageAndOsvIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Vulnerability: %w", err)
 		}
 	}
-	retval.Status = v.allCertifyVEXStatement.Status
-	retval.VexJustification = v.allCertifyVEXStatement.VexJustification
-	retval.Statement = v.allCertifyVEXStatement.Statement
-	retval.StatusNotes = v.allCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.allCertifyVEXStatement.KnownSince
-	retval.Origin = v.allCertifyVEXStatement.Origin
-	retval.Collector = v.allCertifyVEXStatement.Collector
+	retval.Status = v.AllCertifyVEXStatement.Status
+	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
+	retval.Statement = v.AllCertifyVEXStatement.Statement
+	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
+	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
+	retval.Origin = v.AllCertifyVEXStatement.Origin
+	retval.Collector = v.AllCertifyVEXStatement.Collector
 	return &retval, nil
 }
 
@@ -20723,4000 +24717,6 @@ func (v *__VexPackageAndOsvInput) GetOsv() OSVInputSpec { return v.Osv }
 // GetVexStatement returns __VexPackageAndOsvInput.VexStatement, and is useful for accessing the field via an interface.
 func (v *__VexPackageAndOsvInput) GetVexStatement() VexStatementInputSpec { return v.VexStatement }
 
-// allBuilderTree includes the GraphQL fields of Builder requested by the fragment allBuilderTree.
-// The GraphQL type's documentation follows.
-//
-// Builder represents the builder (e.g., FRSCA or GitHub Actions).
-//
-// Currently builders are identified by the uri field.
-type allBuilderTree struct {
-	Id  string `json:"id"`
-	Uri string `json:"uri"`
-}
-
-// GetId returns allBuilderTree.Id, and is useful for accessing the field via an interface.
-func (v *allBuilderTree) GetId() string { return v.Id }
-
-// GetUri returns allBuilderTree.Uri, and is useful for accessing the field via an interface.
-func (v *allBuilderTree) GetUri() string { return v.Uri }
-
-// allCertifyGood includes the GraphQL fields of CertifyGood requested by the fragment allCertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type allCertifyGood struct {
-	Id            string                                       `json:"id"`
-	Justification string                                       `json:"justification"`
-	Subject       allCertifyGoodSubjectPackageSourceOrArtifact `json:"-"`
-	Origin        string                                       `json:"origin"`
-	Collector     string                                       `json:"collector"`
-}
-
-// GetId returns allCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyGood) GetId() string { return v.Id }
-
-// GetJustification returns allCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *allCertifyGood) GetJustification() string { return v.Justification }
-
-// GetSubject returns allCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *allCertifyGood) GetSubject() allCertifyGoodSubjectPackageSourceOrArtifact { return v.Subject }
-
-// GetOrigin returns allCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *allCertifyGood) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *allCertifyGood) GetCollector() string { return v.Collector }
-
-func (v *allCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyGood
-		Subject json.RawMessage `json:"subject"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallCertifyGoodSubjectPackageSourceOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allCertifyGood.Subject: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyGood) __premarshalJSON() (*__premarshalallCertifyGood, error) {
-	var retval __premarshalallCertifyGood
-
-	retval.Id = v.Id
-	retval.Justification = v.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalallCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allCertifyGoodSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allCertifyGoodSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns allCertifyGoodSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyGoodSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allCertifyGoodSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allCertifyGoodSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allCertifyGoodSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyGoodSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyGoodSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyGoodSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allCertifyGoodSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyGoodSubjectArtifact) __premarshalJSON() (*__premarshalallCertifyGoodSubjectArtifact, error) {
-	var retval __premarshalallCertifyGoodSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allCertifyGoodSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allCertifyGoodSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns allCertifyGoodSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyGoodSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allCertifyGoodSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allCertifyGoodSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allCertifyGoodSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyGoodSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyGoodSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyGoodSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allCertifyGoodSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyGoodSubjectPackage) __premarshalJSON() (*__premarshalallCertifyGoodSubjectPackage, error) {
-	var retval __premarshalallCertifyGoodSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allCertifyGoodSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
-//
-// allCertifyGoodSubjectPackageSourceOrArtifact is implemented by the following types:
-// allCertifyGoodSubjectArtifact
-// allCertifyGoodSubjectPackage
-// allCertifyGoodSubjectSource
-// The GraphQL type's documentation follows.
-//
-// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
-type allCertifyGoodSubjectPackageSourceOrArtifact interface {
-	implementsGraphQLInterfaceallCertifyGoodSubjectPackageSourceOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allCertifyGoodSubjectArtifact) implementsGraphQLInterfaceallCertifyGoodSubjectPackageSourceOrArtifact() {
-}
-func (v *allCertifyGoodSubjectPackage) implementsGraphQLInterfaceallCertifyGoodSubjectPackageSourceOrArtifact() {
-}
-func (v *allCertifyGoodSubjectSource) implementsGraphQLInterfaceallCertifyGoodSubjectPackageSourceOrArtifact() {
-}
-
-func __unmarshalallCertifyGoodSubjectPackageSourceOrArtifact(b []byte, v *allCertifyGoodSubjectPackageSourceOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(allCertifyGoodSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(allCertifyGoodSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "Source":
-		*v = new(allCertifyGoodSubjectSource)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageSourceOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allCertifyGoodSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallCertifyGoodSubjectPackageSourceOrArtifact(v *allCertifyGoodSubjectPackageSourceOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allCertifyGoodSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyGoodSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allCertifyGoodSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyGoodSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allCertifyGoodSubjectSource:
-		typename = "Source"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyGoodSubjectSource
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allCertifyGoodSubjectPackageSourceOrArtifact: "%T"`, v)
-	}
-}
-
-// allCertifyGoodSubjectSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type allCertifyGoodSubjectSource struct {
-	Typename      *string `json:"__typename"`
-	AllSourceTree `json:"-"`
-}
-
-// GetTypename returns allCertifyGoodSubjectSource.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectSource) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyGoodSubjectSource.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns allCertifyGoodSubjectSource.Type, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns allCertifyGoodSubjectSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allCertifyGoodSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *allCertifyGoodSubjectSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyGoodSubjectSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyGoodSubjectSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyGoodSubjectSource struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *allCertifyGoodSubjectSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyGoodSubjectSource) __premarshalJSON() (*__premarshalallCertifyGoodSubjectSource, error) {
-	var retval __premarshalallCertifyGoodSubjectSource
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
-
-// allCertifyVEXStatement includes the GraphQL fields of CertifyVEXStatement requested by the fragment allCertifyVEXStatement.
-// The GraphQL type's documentation follows.
-//
-// CertifyVEXStatement is an attestation to attach VEX statements to a package or
-// artifact to clarify the impact of a specific vulnerability (CVE, GHSA or OSV).
-type allCertifyVEXStatement struct {
-	Id string `json:"id"`
-	// Subject of attestation
-	Subject allCertifyVEXStatementSubjectPackageOrArtifact `json:"-"`
-	// Attested vulnerability
-	Vulnerability allCertifyVEXStatementVulnerability `json:"-"`
-	// Status of the vulnerabilities with respect to the subject
-	Status VexStatus `json:"status"`
-	// Justification from VEX statement
-	VexJustification VexJustification `json:"vexJustification"`
-	// VEX statement: impact_statement or action_statement depending on status
-	Statement string `json:"statement"`
-	// statusNotes may convey information about how status was determined
-	StatusNotes string `json:"statusNotes"`
-	// Timestamp (exact time in RFC 3339 format) for the VEX statement
-	KnownSince time.Time `json:"knownSince"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetId() string { return v.Id }
-
-// GetSubject returns allCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetSubject() allCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.Subject
-}
-
-// GetVulnerability returns allCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetVulnerability() allCertifyVEXStatementVulnerability {
-	return v.Vulnerability
-}
-
-// GetStatus returns allCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetStatus() VexStatus { return v.Status }
-
-// GetVexJustification returns allCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetVexJustification() VexJustification { return v.VexJustification }
-
-// GetStatement returns allCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetStatement() string { return v.Statement }
-
-// GetStatusNotes returns allCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetStatusNotes() string { return v.StatusNotes }
-
-// GetKnownSince returns allCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetKnownSince() time.Time { return v.KnownSince }
-
-// GetOrigin returns allCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatement) GetCollector() string { return v.Collector }
-
-func (v *allCertifyVEXStatement) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatement
-		Subject       json.RawMessage `json:"subject"`
-		Vulnerability json.RawMessage `json:"vulnerability"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatement = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallCertifyVEXStatementSubjectPackageOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allCertifyVEXStatement.Subject: %w", err)
-			}
-		}
-	}
-
-	{
-		dst := &v.Vulnerability
-		src := firstPass.Vulnerability
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallCertifyVEXStatementVulnerability(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allCertifyVEXStatement.Vulnerability: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatement struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Vulnerability json.RawMessage `json:"vulnerability"`
-
-	Status VexStatus `json:"status"`
-
-	VexJustification VexJustification `json:"vexJustification"`
-
-	Statement string `json:"statement"`
-
-	StatusNotes string `json:"statusNotes"`
-
-	KnownSince time.Time `json:"knownSince"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allCertifyVEXStatement) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatement) __premarshalJSON() (*__premarshalallCertifyVEXStatement, error) {
-	var retval __premarshalallCertifyVEXStatement
-
-	retval.Id = v.Id
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalallCertifyVEXStatementSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allCertifyVEXStatement.Subject: %w", err)
-		}
-	}
-	{
-
-		dst := &retval.Vulnerability
-		src := v.Vulnerability
-		var err error
-		*dst, err = __marshalallCertifyVEXStatementVulnerability(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allCertifyVEXStatement.Vulnerability: %w", err)
-		}
-	}
-	retval.Status = v.Status
-	retval.VexJustification = v.VexJustification
-	retval.Statement = v.Statement
-	retval.StatusNotes = v.StatusNotes
-	retval.KnownSince = v.KnownSince
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allCertifyVEXStatementSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allCertifyVEXStatementSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns allCertifyVEXStatementSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyVEXStatementSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allCertifyVEXStatementSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectArtifact) GetAlgorithm() string {
-	return v.AllArtifactTree.Algorithm
-}
-
-// GetDigest returns allCertifyVEXStatementSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allCertifyVEXStatementSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatementSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatementSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatementSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allCertifyVEXStatementSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatementSubjectArtifact) __premarshalJSON() (*__premarshalallCertifyVEXStatementSubjectArtifact, error) {
-	var retval __premarshalallCertifyVEXStatementSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allCertifyVEXStatementSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allCertifyVEXStatementSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns allCertifyVEXStatementSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyVEXStatementSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allCertifyVEXStatementSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allCertifyVEXStatementSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allCertifyVEXStatementSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatementSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatementSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatementSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allCertifyVEXStatementSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatementSubjectPackage) __premarshalJSON() (*__premarshalallCertifyVEXStatementSubjectPackage, error) {
-	var retval __premarshalallCertifyVEXStatementSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allCertifyVEXStatementSubjectPackageOrArtifact includes the requested fields of the GraphQL interface PackageOrArtifact.
-//
-// allCertifyVEXStatementSubjectPackageOrArtifact is implemented by the following types:
-// allCertifyVEXStatementSubjectArtifact
-// allCertifyVEXStatementSubjectPackage
-// The GraphQL type's documentation follows.
-//
-// PackageOrArtifact is a union of Package and Artifact.
-type allCertifyVEXStatementSubjectPackageOrArtifact interface {
-	implementsGraphQLInterfaceallCertifyVEXStatementSubjectPackageOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allCertifyVEXStatementSubjectArtifact) implementsGraphQLInterfaceallCertifyVEXStatementSubjectPackageOrArtifact() {
-}
-func (v *allCertifyVEXStatementSubjectPackage) implementsGraphQLInterfaceallCertifyVEXStatementSubjectPackageOrArtifact() {
-}
-
-func __unmarshalallCertifyVEXStatementSubjectPackageOrArtifact(b []byte, v *allCertifyVEXStatementSubjectPackageOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(allCertifyVEXStatementSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(allCertifyVEXStatementSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allCertifyVEXStatementSubjectPackageOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallCertifyVEXStatementSubjectPackageOrArtifact(v *allCertifyVEXStatementSubjectPackageOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allCertifyVEXStatementSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyVEXStatementSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allCertifyVEXStatementSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyVEXStatementSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allCertifyVEXStatementSubjectPackageOrArtifact: "%T"`, v)
-	}
-}
-
-// allCertifyVEXStatementVulnerability includes the requested fields of the GraphQL interface Vulnerability.
-//
-// allCertifyVEXStatementVulnerability is implemented by the following types:
-// allCertifyVEXStatementVulnerabilityCVE
-// allCertifyVEXStatementVulnerabilityGHSA
-// allCertifyVEXStatementVulnerabilityNoVuln
-// allCertifyVEXStatementVulnerabilityOSV
-// The GraphQL type's documentation follows.
-//
-// Vulnerability is a union of OSV, CVE, GHSA or the NoVuln node.
-type allCertifyVEXStatementVulnerability interface {
-	implementsGraphQLInterfaceallCertifyVEXStatementVulnerability()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allCertifyVEXStatementVulnerabilityCVE) implementsGraphQLInterfaceallCertifyVEXStatementVulnerability() {
-}
-func (v *allCertifyVEXStatementVulnerabilityGHSA) implementsGraphQLInterfaceallCertifyVEXStatementVulnerability() {
-}
-func (v *allCertifyVEXStatementVulnerabilityNoVuln) implementsGraphQLInterfaceallCertifyVEXStatementVulnerability() {
-}
-func (v *allCertifyVEXStatementVulnerabilityOSV) implementsGraphQLInterfaceallCertifyVEXStatementVulnerability() {
-}
-
-func __unmarshalallCertifyVEXStatementVulnerability(b []byte, v *allCertifyVEXStatementVulnerability) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "CVE":
-		*v = new(allCertifyVEXStatementVulnerabilityCVE)
-		return json.Unmarshal(b, *v)
-	case "GHSA":
-		*v = new(allCertifyVEXStatementVulnerabilityGHSA)
-		return json.Unmarshal(b, *v)
-	case "NoVuln":
-		*v = new(allCertifyVEXStatementVulnerabilityNoVuln)
-		return json.Unmarshal(b, *v)
-	case "OSV":
-		*v = new(allCertifyVEXStatementVulnerabilityOSV)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing Vulnerability.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allCertifyVEXStatementVulnerability: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallCertifyVEXStatementVulnerability(v *allCertifyVEXStatementVulnerability) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allCertifyVEXStatementVulnerabilityCVE:
-		typename = "CVE"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyVEXStatementVulnerabilityCVE
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allCertifyVEXStatementVulnerabilityGHSA:
-		typename = "GHSA"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyVEXStatementVulnerabilityGHSA
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allCertifyVEXStatementVulnerabilityNoVuln:
-		typename = "NoVuln"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*allCertifyVEXStatementVulnerabilityNoVuln
-		}{typename, v}
-		return json.Marshal(result)
-	case *allCertifyVEXStatementVulnerabilityOSV:
-		typename = "OSV"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallCertifyVEXStatementVulnerabilityOSV
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allCertifyVEXStatementVulnerability: "%T"`, v)
-	}
-}
-
-// allCertifyVEXStatementVulnerabilityCVE includes the requested fields of the GraphQL type CVE.
-// The GraphQL type's documentation follows.
-//
-// CVE represents a vulnerability in the Common Vulnerabilities and Exposures
-// schema.
-//
-// The vulnerability identifier contains a year field, so we are extracting that
-// to allow matching for vulnerabilities found in a given year.
-//
-// The vulnerability identifier field is mandatory and canonicalized to be
-// lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allCertifyVEXStatementVulnerabilityCVE struct {
-	Typename   *string `json:"__typename"`
-	AllCveTree `json:"-"`
-}
-
-// GetTypename returns allCertifyVEXStatementVulnerabilityCVE.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityCVE) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyVEXStatementVulnerabilityCVE.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityCVE) GetId() string { return v.AllCveTree.Id }
-
-// GetYear returns allCertifyVEXStatementVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityCVE) GetYear() int { return v.AllCveTree.Year }
-
-// GetCveId returns allCertifyVEXStatementVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityCVE) GetCveId() string { return v.AllCveTree.CveId }
-
-func (v *allCertifyVEXStatementVulnerabilityCVE) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatementVulnerabilityCVE
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatementVulnerabilityCVE = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCveTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatementVulnerabilityCVE struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Year int `json:"year"`
-
-	CveId string `json:"cveId"`
-}
-
-func (v *allCertifyVEXStatementVulnerabilityCVE) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatementVulnerabilityCVE) __premarshalJSON() (*__premarshalallCertifyVEXStatementVulnerabilityCVE, error) {
-	var retval __premarshalallCertifyVEXStatementVulnerabilityCVE
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllCveTree.Id
-	retval.Year = v.AllCveTree.Year
-	retval.CveId = v.AllCveTree.CveId
-	return &retval, nil
-}
-
-// allCertifyVEXStatementVulnerabilityGHSA includes the requested fields of the GraphQL type GHSA.
-// The GraphQL type's documentation follows.
-//
-// GHSA represents GitHub security advisories.
-//
-// The advisory id field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allCertifyVEXStatementVulnerabilityGHSA struct {
-	Typename    *string `json:"__typename"`
-	AllGHSATree `json:"-"`
-}
-
-// GetTypename returns allCertifyVEXStatementVulnerabilityGHSA.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityGHSA) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyVEXStatementVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityGHSA) GetId() string { return v.AllGHSATree.Id }
-
-// GetGhsaId returns allCertifyVEXStatementVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityGHSA) GetGhsaId() string { return v.AllGHSATree.GhsaId }
-
-func (v *allCertifyVEXStatementVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatementVulnerabilityGHSA
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatementVulnerabilityGHSA = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllGHSATree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatementVulnerabilityGHSA struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	GhsaId string `json:"ghsaId"`
-}
-
-func (v *allCertifyVEXStatementVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatementVulnerabilityGHSA) __premarshalJSON() (*__premarshalallCertifyVEXStatementVulnerabilityGHSA, error) {
-	var retval __premarshalallCertifyVEXStatementVulnerabilityGHSA
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllGHSATree.Id
-	retval.GhsaId = v.AllGHSATree.GhsaId
-	return &retval, nil
-}
-
-// allCertifyVEXStatementVulnerabilityNoVuln includes the requested fields of the GraphQL type NoVuln.
-// The GraphQL type's documentation follows.
-//
-// NoVuln is a special vulnerability node to attest that no vulnerability has been
-// found during a vulnerability scan.
-//
-// Backends guarantee that this is a singleton node.
-type allCertifyVEXStatementVulnerabilityNoVuln struct {
-	Typename *string `json:"__typename"`
-}
-
-// GetTypename returns allCertifyVEXStatementVulnerabilityNoVuln.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityNoVuln) GetTypename() *string { return v.Typename }
-
-// allCertifyVEXStatementVulnerabilityOSV includes the requested fields of the GraphQL type OSV.
-// The GraphQL type's documentation follows.
-//
-// OSV represents an Open Source Vulnerability.
-//
-// The osvId field is mandatory and canonicalized to be lowercase.
-//
-// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
-// CVE ID).
-//
-// This node can be referred to by other parts of GUAC.
-type allCertifyVEXStatementVulnerabilityOSV struct {
-	Typename   *string `json:"__typename"`
-	AllOSVTree `json:"-"`
-}
-
-// GetTypename returns allCertifyVEXStatementVulnerabilityOSV.Typename, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityOSV) GetTypename() *string { return v.Typename }
-
-// GetId returns allCertifyVEXStatementVulnerabilityOSV.Id, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityOSV) GetId() string { return v.AllOSVTree.Id }
-
-// GetOsvId returns allCertifyVEXStatementVulnerabilityOSV.OsvId, and is useful for accessing the field via an interface.
-func (v *allCertifyVEXStatementVulnerabilityOSV) GetOsvId() string { return v.AllOSVTree.OsvId }
-
-func (v *allCertifyVEXStatementVulnerabilityOSV) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allCertifyVEXStatementVulnerabilityOSV
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allCertifyVEXStatementVulnerabilityOSV = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllOSVTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallCertifyVEXStatementVulnerabilityOSV struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	OsvId string `json:"osvId"`
-}
-
-func (v *allCertifyVEXStatementVulnerabilityOSV) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allCertifyVEXStatementVulnerabilityOSV) __premarshalJSON() (*__premarshalallCertifyVEXStatementVulnerabilityOSV, error) {
-	var retval __premarshalallCertifyVEXStatementVulnerabilityOSV
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllOSVTree.Id
-	retval.OsvId = v.AllOSVTree.OsvId
-	return &retval, nil
-}
-
-// allHasMetadata includes the GraphQL fields of HasMetadata requested by the fragment allHasMetadata.
-// The GraphQL type's documentation follows.
-//
-// HasMetadata is an attestation that a package, source, or artifact has a certain
-// attested property (key) with value (value). For example, a source may have
-// metadata "SourceRepo2FAEnabled=true".
-//
-// The intent of this evidence tree predicate is to allow extensibility of metadata
-// expressible within the GUAC ontology. Metadata that is commonly used will then
-// be promoted to a predicate on its own.
-//
-// Justification indicates how the metadata was determined.
-//
-// The metadata applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type allHasMetadata struct {
-	Id            string                                       `json:"id"`
-	Subject       allHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
-	Key           string                                       `json:"key"`
-	Value         string                                       `json:"value"`
-	Timestamp     time.Time                                    `json:"timestamp"`
-	Justification string                                       `json:"justification"`
-	Origin        string                                       `json:"origin"`
-	Collector     string                                       `json:"collector"`
-}
-
-// GetId returns allHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetId() string { return v.Id }
-
-// GetSubject returns allHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetSubject() allHasMetadataSubjectPackageSourceOrArtifact { return v.Subject }
-
-// GetKey returns allHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetKey() string { return v.Key }
-
-// GetValue returns allHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetValue() string { return v.Value }
-
-// GetTimestamp returns allHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetTimestamp() time.Time { return v.Timestamp }
-
-// GetJustification returns allHasMetadata.Justification, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetJustification() string { return v.Justification }
-
-// GetOrigin returns allHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *allHasMetadata) GetCollector() string { return v.Collector }
-
-func (v *allHasMetadata) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasMetadata
-		Subject json.RawMessage `json:"subject"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasMetadata = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallHasMetadataSubjectPackageSourceOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allHasMetadata.Subject: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallHasMetadata struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Key string `json:"key"`
-
-	Value string `json:"value"`
-
-	Timestamp time.Time `json:"timestamp"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allHasMetadata) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasMetadata) __premarshalJSON() (*__premarshalallHasMetadata, error) {
-	var retval __premarshalallHasMetadata
-
-	retval.Id = v.Id
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalallHasMetadataSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allHasMetadata.Subject: %w", err)
-		}
-	}
-	retval.Key = v.Key
-	retval.Value = v.Value
-	retval.Timestamp = v.Timestamp
-	retval.Justification = v.Justification
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allHasMetadataSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allHasMetadataSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns allHasMetadataSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns allHasMetadataSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allHasMetadataSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allHasMetadataSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allHasMetadataSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasMetadataSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasMetadataSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasMetadataSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allHasMetadataSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasMetadataSubjectArtifact) __premarshalJSON() (*__premarshalallHasMetadataSubjectArtifact, error) {
-	var retval __premarshalallHasMetadataSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allHasMetadataSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allHasMetadataSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns allHasMetadataSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns allHasMetadataSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allHasMetadataSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allHasMetadataSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allHasMetadataSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasMetadataSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasMetadataSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasMetadataSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allHasMetadataSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasMetadataSubjectPackage) __premarshalJSON() (*__premarshalallHasMetadataSubjectPackage, error) {
-	var retval __premarshalallHasMetadataSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allHasMetadataSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
-//
-// allHasMetadataSubjectPackageSourceOrArtifact is implemented by the following types:
-// allHasMetadataSubjectArtifact
-// allHasMetadataSubjectPackage
-// allHasMetadataSubjectSource
-// The GraphQL type's documentation follows.
-//
-// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
-type allHasMetadataSubjectPackageSourceOrArtifact interface {
-	implementsGraphQLInterfaceallHasMetadataSubjectPackageSourceOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allHasMetadataSubjectArtifact) implementsGraphQLInterfaceallHasMetadataSubjectPackageSourceOrArtifact() {
-}
-func (v *allHasMetadataSubjectPackage) implementsGraphQLInterfaceallHasMetadataSubjectPackageSourceOrArtifact() {
-}
-func (v *allHasMetadataSubjectSource) implementsGraphQLInterfaceallHasMetadataSubjectPackageSourceOrArtifact() {
-}
-
-func __unmarshalallHasMetadataSubjectPackageSourceOrArtifact(b []byte, v *allHasMetadataSubjectPackageSourceOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(allHasMetadataSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(allHasMetadataSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "Source":
-		*v = new(allHasMetadataSubjectSource)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageSourceOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allHasMetadataSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallHasMetadataSubjectPackageSourceOrArtifact(v *allHasMetadataSubjectPackageSourceOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allHasMetadataSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallHasMetadataSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allHasMetadataSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallHasMetadataSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allHasMetadataSubjectSource:
-		typename = "Source"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallHasMetadataSubjectSource
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allHasMetadataSubjectPackageSourceOrArtifact: "%T"`, v)
-	}
-}
-
-// allHasMetadataSubjectSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type allHasMetadataSubjectSource struct {
-	Typename      *string `json:"__typename"`
-	AllSourceTree `json:"-"`
-}
-
-// GetTypename returns allHasMetadataSubjectSource.Typename, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectSource) GetTypename() *string { return v.Typename }
-
-// GetId returns allHasMetadataSubjectSource.Id, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns allHasMetadataSubjectSource.Type, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns allHasMetadataSubjectSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allHasMetadataSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *allHasMetadataSubjectSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasMetadataSubjectSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasMetadataSubjectSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasMetadataSubjectSource struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *allHasMetadataSubjectSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasMetadataSubjectSource) __premarshalJSON() (*__premarshalallHasMetadataSubjectSource, error) {
-	var retval __premarshalallHasMetadataSubjectSource
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
-
-// allHasSBOMTree includes the GraphQL fields of HasSBOM requested by the fragment allHasSBOMTree.
-type allHasSBOMTree struct {
-	Id string `json:"id"`
-	// SBOM subject
-	Subject allHasSBOMTreeSubjectPackageOrArtifact `json:"-"`
-	// Identifier for the SBOM document
-	Uri string `json:"uri"`
-	// Algorithm by which SBOMs digest was computed
-	Algorithm string `json:"algorithm"`
-	// Digest of SBOM
-	Digest string `json:"digest"`
-	// Location from which the SBOM can be downloaded
-	DownloadLocation string `json:"downloadLocation"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allHasSBOMTree.Id, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetId() string { return v.Id }
-
-// GetSubject returns allHasSBOMTree.Subject, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetSubject() allHasSBOMTreeSubjectPackageOrArtifact { return v.Subject }
-
-// GetUri returns allHasSBOMTree.Uri, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetUri() string { return v.Uri }
-
-// GetAlgorithm returns allHasSBOMTree.Algorithm, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetAlgorithm() string { return v.Algorithm }
-
-// GetDigest returns allHasSBOMTree.Digest, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetDigest() string { return v.Digest }
-
-// GetDownloadLocation returns allHasSBOMTree.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetDownloadLocation() string { return v.DownloadLocation }
-
-// GetOrigin returns allHasSBOMTree.Origin, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allHasSBOMTree.Collector, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTree) GetCollector() string { return v.Collector }
-
-func (v *allHasSBOMTree) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasSBOMTree
-		Subject json.RawMessage `json:"subject"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasSBOMTree = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallHasSBOMTreeSubjectPackageOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allHasSBOMTree.Subject: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallHasSBOMTree struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Uri string `json:"uri"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-
-	DownloadLocation string `json:"downloadLocation"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allHasSBOMTree) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasSBOMTree) __premarshalJSON() (*__premarshalallHasSBOMTree, error) {
-	var retval __premarshalallHasSBOMTree
-
-	retval.Id = v.Id
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalallHasSBOMTreeSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allHasSBOMTree.Subject: %w", err)
-		}
-	}
-	retval.Uri = v.Uri
-	retval.Algorithm = v.Algorithm
-	retval.Digest = v.Digest
-	retval.DownloadLocation = v.DownloadLocation
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allHasSBOMTreeSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allHasSBOMTreeSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns allHasSBOMTreeSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns allHasSBOMTreeSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allHasSBOMTreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allHasSBOMTreeSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allHasSBOMTreeSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasSBOMTreeSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasSBOMTreeSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasSBOMTreeSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allHasSBOMTreeSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasSBOMTreeSubjectArtifact) __premarshalJSON() (*__premarshalallHasSBOMTreeSubjectArtifact, error) {
-	var retval __premarshalallHasSBOMTreeSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allHasSBOMTreeSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allHasSBOMTreeSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns allHasSBOMTreeSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns allHasSBOMTreeSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allHasSBOMTreeSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allHasSBOMTreeSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allHasSBOMTreeSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allHasSBOMTreeSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasSBOMTreeSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasSBOMTreeSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasSBOMTreeSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allHasSBOMTreeSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasSBOMTreeSubjectPackage) __premarshalJSON() (*__premarshalallHasSBOMTreeSubjectPackage, error) {
-	var retval __premarshalallHasSBOMTreeSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allHasSBOMTreeSubjectPackageOrArtifact includes the requested fields of the GraphQL interface PackageOrArtifact.
-//
-// allHasSBOMTreeSubjectPackageOrArtifact is implemented by the following types:
-// allHasSBOMTreeSubjectArtifact
-// allHasSBOMTreeSubjectPackage
-// The GraphQL type's documentation follows.
-//
-// PackageOrArtifact is a union of Package and Artifact.
-type allHasSBOMTreeSubjectPackageOrArtifact interface {
-	implementsGraphQLInterfaceallHasSBOMTreeSubjectPackageOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allHasSBOMTreeSubjectArtifact) implementsGraphQLInterfaceallHasSBOMTreeSubjectPackageOrArtifact() {
-}
-func (v *allHasSBOMTreeSubjectPackage) implementsGraphQLInterfaceallHasSBOMTreeSubjectPackageOrArtifact() {
-}
-
-func __unmarshalallHasSBOMTreeSubjectPackageOrArtifact(b []byte, v *allHasSBOMTreeSubjectPackageOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(allHasSBOMTreeSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(allHasSBOMTreeSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allHasSBOMTreeSubjectPackageOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallHasSBOMTreeSubjectPackageOrArtifact(v *allHasSBOMTreeSubjectPackageOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allHasSBOMTreeSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallHasSBOMTreeSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allHasSBOMTreeSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallHasSBOMTreeSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allHasSBOMTreeSubjectPackageOrArtifact: "%T"`, v)
-	}
-}
-
-// allHasSourceAt includes the GraphQL fields of HasSourceAt requested by the fragment allHasSourceAt.
-// The GraphQL type's documentation follows.
-//
-// HasSourceAt records that a package's repository is a given source.
-type allHasSourceAt struct {
-	Id string `json:"id"`
-	// Justification for the attested relationship
-	Justification string `json:"justification"`
-	// Timestamp since this link between package and source was certified
-	KnownSince time.Time `json:"knownSince"`
-	// The subject of the attestation: can be a PackageName or a PackageVersion
-	Package allHasSourceAtPackage `json:"package"`
-	// Source repository from which the package is built
-	Source allHasSourceAtSource `json:"source"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetId() string { return v.Id }
-
-// GetJustification returns allHasSourceAt.Justification, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetJustification() string { return v.Justification }
-
-// GetKnownSince returns allHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetKnownSince() time.Time { return v.KnownSince }
-
-// GetPackage returns allHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetPackage() allHasSourceAtPackage { return v.Package }
-
-// GetSource returns allHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetSource() allHasSourceAtSource { return v.Source }
-
-// GetOrigin returns allHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *allHasSourceAt) GetCollector() string { return v.Collector }
-
-// allHasSourceAtPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allHasSourceAtPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns allHasSourceAtPackage.Id, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allHasSourceAtPackage.Type, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allHasSourceAtPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allHasSourceAtPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasSourceAtPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasSourceAtPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasSourceAtPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allHasSourceAtPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasSourceAtPackage) __premarshalJSON() (*__premarshalallHasSourceAtPackage, error) {
-	var retval __premarshalallHasSourceAtPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allHasSourceAtSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type allHasSourceAtSource struct {
-	AllSourceTree `json:"-"`
-}
-
-// GetId returns allHasSourceAtSource.Id, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns allHasSourceAtSource.Type, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns allHasSourceAtSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allHasSourceAtSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *allHasSourceAtSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHasSourceAtSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHasSourceAtSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHasSourceAtSource struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *allHasSourceAtSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHasSourceAtSource) __premarshalJSON() (*__premarshalallHasSourceAtSource, error) {
-	var retval __premarshalallHasSourceAtSource
-
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
-
-// allHashEqualTree includes the GraphQL fields of HashEqual requested by the fragment allHashEqualTree.
-// The GraphQL type's documentation follows.
-//
-// HashEqual is an attestation that a set of artifacts are identical.
-type allHashEqualTree struct {
-	Id string `json:"id"`
-	// Justification for the claim that the artifacts are similar
-	Justification string `json:"justification"`
-	// Collection of artifacts that are similar
-	Artifacts []allHashEqualTreeArtifactsArtifact `json:"artifacts"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allHashEqualTree.Id, and is useful for accessing the field via an interface.
-func (v *allHashEqualTree) GetId() string { return v.Id }
-
-// GetJustification returns allHashEqualTree.Justification, and is useful for accessing the field via an interface.
-func (v *allHashEqualTree) GetJustification() string { return v.Justification }
-
-// GetArtifacts returns allHashEqualTree.Artifacts, and is useful for accessing the field via an interface.
-func (v *allHashEqualTree) GetArtifacts() []allHashEqualTreeArtifactsArtifact { return v.Artifacts }
-
-// GetOrigin returns allHashEqualTree.Origin, and is useful for accessing the field via an interface.
-func (v *allHashEqualTree) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allHashEqualTree.Collector, and is useful for accessing the field via an interface.
-func (v *allHashEqualTree) GetCollector() string { return v.Collector }
-
-// allHashEqualTreeArtifactsArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allHashEqualTreeArtifactsArtifact struct {
-	AllArtifactTree `json:"-"`
-}
-
-// GetId returns allHashEqualTreeArtifactsArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allHashEqualTreeArtifactsArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allHashEqualTreeArtifactsArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allHashEqualTreeArtifactsArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allHashEqualTreeArtifactsArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allHashEqualTreeArtifactsArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allHashEqualTreeArtifactsArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allHashEqualTreeArtifactsArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allHashEqualTreeArtifactsArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallHashEqualTreeArtifactsArtifact struct {
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allHashEqualTreeArtifactsArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allHashEqualTreeArtifactsArtifact) __premarshalJSON() (*__premarshalallHashEqualTreeArtifactsArtifact, error) {
-	var retval __premarshalallHashEqualTreeArtifactsArtifact
-
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allIsDependencyTree includes the GraphQL fields of IsDependency requested by the fragment allIsDependencyTree.
-// The GraphQL type's documentation follows.
-//
-// IsDependency is an attestation to record that a package depends on another.
-type allIsDependencyTree struct {
-	Id string `json:"id"`
-	// Justification for the attested relationship
-	Justification string `json:"justification"`
-	// Package that has the dependency
-	Package allIsDependencyTreePackage `json:"package"`
-	// Package for the dependency; MUST BE PackageName, not PackageVersion
-	DependentPackage allIsDependencyTreeDependentPackage `json:"dependentPackage"`
-	// Type of dependency
-	DependencyType DependencyType `json:"dependencyType"`
-	// Version range for the dependency link
-	VersionRange string `json:"versionRange"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allIsDependencyTree.Id, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetId() string { return v.Id }
-
-// GetJustification returns allIsDependencyTree.Justification, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetJustification() string { return v.Justification }
-
-// GetPackage returns allIsDependencyTree.Package, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetPackage() allIsDependencyTreePackage { return v.Package }
-
-// GetDependentPackage returns allIsDependencyTree.DependentPackage, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetDependentPackage() allIsDependencyTreeDependentPackage {
-	return v.DependentPackage
-}
-
-// GetDependencyType returns allIsDependencyTree.DependencyType, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetDependencyType() DependencyType { return v.DependencyType }
-
-// GetVersionRange returns allIsDependencyTree.VersionRange, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetVersionRange() string { return v.VersionRange }
-
-// GetOrigin returns allIsDependencyTree.Origin, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allIsDependencyTree.Collector, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTree) GetCollector() string { return v.Collector }
-
-// allIsDependencyTreeDependentPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allIsDependencyTreeDependentPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns allIsDependencyTreeDependentPackage.Id, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreeDependentPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allIsDependencyTreeDependentPackage.Type, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreeDependentPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allIsDependencyTreeDependentPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreeDependentPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allIsDependencyTreeDependentPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsDependencyTreeDependentPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsDependencyTreeDependentPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallIsDependencyTreeDependentPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allIsDependencyTreeDependentPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsDependencyTreeDependentPackage) __premarshalJSON() (*__premarshalallIsDependencyTreeDependentPackage, error) {
-	var retval __premarshalallIsDependencyTreeDependentPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allIsDependencyTreePackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allIsDependencyTreePackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns allIsDependencyTreePackage.Id, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreePackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allIsDependencyTreePackage.Type, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreePackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allIsDependencyTreePackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allIsDependencyTreePackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allIsDependencyTreePackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsDependencyTreePackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsDependencyTreePackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallIsDependencyTreePackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allIsDependencyTreePackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsDependencyTreePackage) __premarshalJSON() (*__premarshalallIsDependencyTreePackage, error) {
-	var retval __premarshalallIsDependencyTreePackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allIsVulnerability includes the GraphQL fields of IsVulnerability requested by the fragment allIsVulnerability.
-// The GraphQL type's documentation follows.
-//
-// IsVulnerability is an attestation to link CVE/GHSA with data in OSV.
-type allIsVulnerability struct {
-	Id string `json:"id"`
-	// The OSV that encapsulates the vulnerability
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
-	// The upstream vulnerability information
-	Vulnerability allIsVulnerabilityVulnerabilityCveOrGhsa `json:"-"`
-	// Justification for the attested relationship
-	Justification string `json:"justification"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allIsVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetId() string { return v.Id }
-
-// GetOsv returns allIsVulnerability.Osv, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetOsv() allIsVulnerabilityOsvOSV { return v.Osv }
-
-// GetVulnerability returns allIsVulnerability.Vulnerability, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetVulnerability() allIsVulnerabilityVulnerabilityCveOrGhsa {
-	return v.Vulnerability
-}
-
-// GetJustification returns allIsVulnerability.Justification, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetJustification() string { return v.Justification }
-
-// GetOrigin returns allIsVulnerability.Origin, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allIsVulnerability.Collector, and is useful for accessing the field via an interface.
-func (v *allIsVulnerability) GetCollector() string { return v.Collector }
-
-func (v *allIsVulnerability) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsVulnerability
-		Vulnerability json.RawMessage `json:"vulnerability"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsVulnerability = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Vulnerability
-		src := firstPass.Vulnerability
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallIsVulnerabilityVulnerabilityCveOrGhsa(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allIsVulnerability.Vulnerability: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallIsVulnerability struct {
-	Id string `json:"id"`
-
-	Osv allIsVulnerabilityOsvOSV `json:"osv"`
-
-	Vulnerability json.RawMessage `json:"vulnerability"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allIsVulnerability) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsVulnerability) __premarshalJSON() (*__premarshalallIsVulnerability, error) {
-	var retval __premarshalallIsVulnerability
-
-	retval.Id = v.Id
-	retval.Osv = v.Osv
-	{
-
-		dst := &retval.Vulnerability
-		src := v.Vulnerability
-		var err error
-		*dst, err = __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allIsVulnerability.Vulnerability: %w", err)
-		}
-	}
-	retval.Justification = v.Justification
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allIsVulnerabilityOsvOSV includes the requested fields of the GraphQL type OSV.
-// The GraphQL type's documentation follows.
-//
-// OSV represents an Open Source Vulnerability.
-//
-// The osvId field is mandatory and canonicalized to be lowercase.
-//
-// This maps to a vulnerability ID specific to the environment (e.g., GHSA ID or
-// CVE ID).
-//
-// This node can be referred to by other parts of GUAC.
-type allIsVulnerabilityOsvOSV struct {
-	AllOSVTree `json:"-"`
-}
-
-// GetId returns allIsVulnerabilityOsvOSV.Id, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityOsvOSV) GetId() string { return v.AllOSVTree.Id }
-
-// GetOsvId returns allIsVulnerabilityOsvOSV.OsvId, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityOsvOSV) GetOsvId() string { return v.AllOSVTree.OsvId }
-
-func (v *allIsVulnerabilityOsvOSV) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsVulnerabilityOsvOSV
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsVulnerabilityOsvOSV = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllOSVTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallIsVulnerabilityOsvOSV struct {
-	Id string `json:"id"`
-
-	OsvId string `json:"osvId"`
-}
-
-func (v *allIsVulnerabilityOsvOSV) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsVulnerabilityOsvOSV) __premarshalJSON() (*__premarshalallIsVulnerabilityOsvOSV, error) {
-	var retval __premarshalallIsVulnerabilityOsvOSV
-
-	retval.Id = v.AllOSVTree.Id
-	retval.OsvId = v.AllOSVTree.OsvId
-	return &retval, nil
-}
-
-// allIsVulnerabilityVulnerabilityCVE includes the requested fields of the GraphQL type CVE.
-// The GraphQL type's documentation follows.
-//
-// CVE represents a vulnerability in the Common Vulnerabilities and Exposures
-// schema.
-//
-// The vulnerability identifier contains a year field, so we are extracting that
-// to allow matching for vulnerabilities found in a given year.
-//
-// The vulnerability identifier field is mandatory and canonicalized to be
-// lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allIsVulnerabilityVulnerabilityCVE struct {
-	Typename   *string `json:"__typename"`
-	AllCveTree `json:"-"`
-}
-
-// GetTypename returns allIsVulnerabilityVulnerabilityCVE.Typename, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityCVE) GetTypename() *string { return v.Typename }
-
-// GetId returns allIsVulnerabilityVulnerabilityCVE.Id, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityCVE) GetId() string { return v.AllCveTree.Id }
-
-// GetYear returns allIsVulnerabilityVulnerabilityCVE.Year, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityCVE) GetYear() int { return v.AllCveTree.Year }
-
-// GetCveId returns allIsVulnerabilityVulnerabilityCVE.CveId, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityCVE) GetCveId() string { return v.AllCveTree.CveId }
-
-func (v *allIsVulnerabilityVulnerabilityCVE) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsVulnerabilityVulnerabilityCVE
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsVulnerabilityVulnerabilityCVE = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCveTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallIsVulnerabilityVulnerabilityCVE struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Year int `json:"year"`
-
-	CveId string `json:"cveId"`
-}
-
-func (v *allIsVulnerabilityVulnerabilityCVE) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsVulnerabilityVulnerabilityCVE) __premarshalJSON() (*__premarshalallIsVulnerabilityVulnerabilityCVE, error) {
-	var retval __premarshalallIsVulnerabilityVulnerabilityCVE
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllCveTree.Id
-	retval.Year = v.AllCveTree.Year
-	retval.CveId = v.AllCveTree.CveId
-	return &retval, nil
-}
-
-// allIsVulnerabilityVulnerabilityCveOrGhsa includes the requested fields of the GraphQL interface CveOrGhsa.
-//
-// allIsVulnerabilityVulnerabilityCveOrGhsa is implemented by the following types:
-// allIsVulnerabilityVulnerabilityCVE
-// allIsVulnerabilityVulnerabilityGHSA
-// The GraphQL type's documentation follows.
-//
-// CveOrGhsa is a union of CVE and GHSA.
-type allIsVulnerabilityVulnerabilityCveOrGhsa interface {
-	implementsGraphQLInterfaceallIsVulnerabilityVulnerabilityCveOrGhsa()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allIsVulnerabilityVulnerabilityCVE) implementsGraphQLInterfaceallIsVulnerabilityVulnerabilityCveOrGhsa() {
-}
-func (v *allIsVulnerabilityVulnerabilityGHSA) implementsGraphQLInterfaceallIsVulnerabilityVulnerabilityCveOrGhsa() {
-}
-
-func __unmarshalallIsVulnerabilityVulnerabilityCveOrGhsa(b []byte, v *allIsVulnerabilityVulnerabilityCveOrGhsa) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "CVE":
-		*v = new(allIsVulnerabilityVulnerabilityCVE)
-		return json.Unmarshal(b, *v)
-	case "GHSA":
-		*v = new(allIsVulnerabilityVulnerabilityGHSA)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing CveOrGhsa.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allIsVulnerabilityVulnerabilityCveOrGhsa: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallIsVulnerabilityVulnerabilityCveOrGhsa(v *allIsVulnerabilityVulnerabilityCveOrGhsa) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allIsVulnerabilityVulnerabilityCVE:
-		typename = "CVE"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallIsVulnerabilityVulnerabilityCVE
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allIsVulnerabilityVulnerabilityGHSA:
-		typename = "GHSA"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallIsVulnerabilityVulnerabilityGHSA
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allIsVulnerabilityVulnerabilityCveOrGhsa: "%T"`, v)
-	}
-}
-
-// allIsVulnerabilityVulnerabilityGHSA includes the requested fields of the GraphQL type GHSA.
-// The GraphQL type's documentation follows.
-//
-// GHSA represents GitHub security advisories.
-//
-// The advisory id field is mandatory and canonicalized to be lowercase.
-//
-// This node can be referred to by other parts of GUAC.
-type allIsVulnerabilityVulnerabilityGHSA struct {
-	Typename    *string `json:"__typename"`
-	AllGHSATree `json:"-"`
-}
-
-// GetTypename returns allIsVulnerabilityVulnerabilityGHSA.Typename, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityGHSA) GetTypename() *string { return v.Typename }
-
-// GetId returns allIsVulnerabilityVulnerabilityGHSA.Id, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityGHSA) GetId() string { return v.AllGHSATree.Id }
-
-// GetGhsaId returns allIsVulnerabilityVulnerabilityGHSA.GhsaId, and is useful for accessing the field via an interface.
-func (v *allIsVulnerabilityVulnerabilityGHSA) GetGhsaId() string { return v.AllGHSATree.GhsaId }
-
-func (v *allIsVulnerabilityVulnerabilityGHSA) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allIsVulnerabilityVulnerabilityGHSA
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allIsVulnerabilityVulnerabilityGHSA = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllGHSATree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallIsVulnerabilityVulnerabilityGHSA struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	GhsaId string `json:"ghsaId"`
-}
-
-func (v *allIsVulnerabilityVulnerabilityGHSA) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allIsVulnerabilityVulnerabilityGHSA) __premarshalJSON() (*__premarshalallIsVulnerabilityVulnerabilityGHSA, error) {
-	var retval __premarshalallIsVulnerabilityVulnerabilityGHSA
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllGHSATree.Id
-	retval.GhsaId = v.AllGHSATree.GhsaId
-	return &retval, nil
-}
-
-// allPkgEqual includes the GraphQL fields of PkgEqual requested by the fragment allPkgEqual.
-// The GraphQL type's documentation follows.
-//
-// PkgEqual is an attestation that a set of packages are similar.
-type allPkgEqual struct {
-	Id string `json:"id"`
-	// Justification for the claim that the packages are similar
-	Justification string `json:"justification"`
-	// Collection of packages that are similar
-	Packages []allPkgEqualPackagesPackage `json:"packages"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetId returns allPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *allPkgEqual) GetId() string { return v.Id }
-
-// GetJustification returns allPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *allPkgEqual) GetJustification() string { return v.Justification }
-
-// GetPackages returns allPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *allPkgEqual) GetPackages() []allPkgEqualPackagesPackage { return v.Packages }
-
-// GetOrigin returns allPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *allPkgEqual) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *allPkgEqual) GetCollector() string { return v.Collector }
-
-// allPkgEqualPackagesPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allPkgEqualPackagesPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns allPkgEqualPackagesPackage.Id, and is useful for accessing the field via an interface.
-func (v *allPkgEqualPackagesPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allPkgEqualPackagesPackage.Type, and is useful for accessing the field via an interface.
-func (v *allPkgEqualPackagesPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allPkgEqualPackagesPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allPkgEqualPackagesPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allPkgEqualPackagesPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allPkgEqualPackagesPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allPkgEqualPackagesPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallPkgEqualPackagesPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allPkgEqualPackagesPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allPkgEqualPackagesPackage) __premarshalJSON() (*__premarshalallPkgEqualPackagesPackage, error) {
-	var retval __premarshalallPkgEqualPackagesPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allPointOfContact includes the GraphQL fields of PointOfContact requested by the fragment allPointOfContact.
-// The GraphQL type's documentation follows.
-//
-// PointOfContact is an attestation of how to get in touch with the person(s) responsible
-// for a package, source, or artifact.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The attestation applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-//
-// email is the email address (singular) of the point of contact.
-//
-// info is additional contact information other than email address. This is free
-// form.
-//
-// NOTE: the identifiers for point of contact should be part of software trees.
-// This will benefit from identifier look up and traversal as well as organization
-// hierarchy. However, until the use case arises, PointOfContact will be a flat
-// reference to the contact details.
-type allPointOfContact struct {
-	Id            string                                          `json:"id"`
-	Subject       allPointOfContactSubjectPackageSourceOrArtifact `json:"-"`
-	Email         string                                          `json:"email"`
-	Info          string                                          `json:"info"`
-	Since         time.Time                                       `json:"since"`
-	Justification string                                          `json:"justification"`
-	Origin        string                                          `json:"origin"`
-	Collector     string                                          `json:"collector"`
-}
-
-// GetId returns allPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetId() string { return v.Id }
-
-// GetSubject returns allPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetSubject() allPointOfContactSubjectPackageSourceOrArtifact {
-	return v.Subject
-}
-
-// GetEmail returns allPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetEmail() string { return v.Email }
-
-// GetInfo returns allPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetInfo() string { return v.Info }
-
-// GetSince returns allPointOfContact.Since, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetSince() time.Time { return v.Since }
-
-// GetJustification returns allPointOfContact.Justification, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetJustification() string { return v.Justification }
-
-// GetOrigin returns allPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allPointOfContact.Collector, and is useful for accessing the field via an interface.
-func (v *allPointOfContact) GetCollector() string { return v.Collector }
-
-func (v *allPointOfContact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allPointOfContact
-		Subject json.RawMessage `json:"subject"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allPointOfContact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalallPointOfContactSubjectPackageSourceOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal allPointOfContact.Subject: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalallPointOfContact struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Email string `json:"email"`
-
-	Info string `json:"info"`
-
-	Since time.Time `json:"since"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *allPointOfContact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allPointOfContact) __premarshalJSON() (*__premarshalallPointOfContact, error) {
-	var retval __premarshalallPointOfContact
-
-	retval.Id = v.Id
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalallPointOfContactSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal allPointOfContact.Subject: %w", err)
-		}
-	}
-	retval.Email = v.Email
-	retval.Info = v.Info
-	retval.Since = v.Since
-	retval.Justification = v.Justification
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// allPointOfContactSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allPointOfContactSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns allPointOfContactSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns allPointOfContactSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allPointOfContactSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allPointOfContactSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allPointOfContactSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allPointOfContactSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allPointOfContactSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallPointOfContactSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allPointOfContactSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allPointOfContactSubjectArtifact) __premarshalJSON() (*__premarshalallPointOfContactSubjectArtifact, error) {
-	var retval __premarshalallPointOfContactSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allPointOfContactSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type allPointOfContactSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns allPointOfContactSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns allPointOfContactSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns allPointOfContactSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns allPointOfContactSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *allPointOfContactSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allPointOfContactSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allPointOfContactSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallPointOfContactSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *allPointOfContactSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allPointOfContactSubjectPackage) __premarshalJSON() (*__premarshalallPointOfContactSubjectPackage, error) {
-	var retval __premarshalallPointOfContactSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// allPointOfContactSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
-//
-// allPointOfContactSubjectPackageSourceOrArtifact is implemented by the following types:
-// allPointOfContactSubjectArtifact
-// allPointOfContactSubjectPackage
-// allPointOfContactSubjectSource
-// The GraphQL type's documentation follows.
-//
-// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
-type allPointOfContactSubjectPackageSourceOrArtifact interface {
-	implementsGraphQLInterfaceallPointOfContactSubjectPackageSourceOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *allPointOfContactSubjectArtifact) implementsGraphQLInterfaceallPointOfContactSubjectPackageSourceOrArtifact() {
-}
-func (v *allPointOfContactSubjectPackage) implementsGraphQLInterfaceallPointOfContactSubjectPackageSourceOrArtifact() {
-}
-func (v *allPointOfContactSubjectSource) implementsGraphQLInterfaceallPointOfContactSubjectPackageSourceOrArtifact() {
-}
-
-func __unmarshalallPointOfContactSubjectPackageSourceOrArtifact(b []byte, v *allPointOfContactSubjectPackageSourceOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(allPointOfContactSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(allPointOfContactSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "Source":
-		*v = new(allPointOfContactSubjectSource)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageSourceOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for allPointOfContactSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalallPointOfContactSubjectPackageSourceOrArtifact(v *allPointOfContactSubjectPackageSourceOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *allPointOfContactSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallPointOfContactSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allPointOfContactSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallPointOfContactSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *allPointOfContactSubjectSource:
-		typename = "Source"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalallPointOfContactSubjectSource
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for allPointOfContactSubjectPackageSourceOrArtifact: "%T"`, v)
-	}
-}
-
-// allPointOfContactSubjectSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type allPointOfContactSubjectSource struct {
-	Typename      *string `json:"__typename"`
-	AllSourceTree `json:"-"`
-}
-
-// GetTypename returns allPointOfContactSubjectSource.Typename, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectSource) GetTypename() *string { return v.Typename }
-
-// GetId returns allPointOfContactSubjectSource.Id, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns allPointOfContactSubjectSource.Type, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns allPointOfContactSubjectSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *allPointOfContactSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *allPointOfContactSubjectSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allPointOfContactSubjectSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allPointOfContactSubjectSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallPointOfContactSubjectSource struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *allPointOfContactSubjectSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allPointOfContactSubjectSource) __premarshalJSON() (*__premarshalallPointOfContactSubjectSource, error) {
-	var retval __premarshalallPointOfContactSubjectSource
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
-
-// allSLSATree includes the GraphQL fields of HasSLSA requested by the fragment allSLSATree.
-// The GraphQL type's documentation follows.
-//
-// HasSLSA records that a subject node has a SLSA attestation.
-type allSLSATree struct {
-	Id string `json:"id"`
-	// The subject of SLSA attestation
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
-	// The SLSA attestation
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
-}
-
-// GetId returns allSLSATree.Id, and is useful for accessing the field via an interface.
-func (v *allSLSATree) GetId() string { return v.Id }
-
-// GetSubject returns allSLSATree.Subject, and is useful for accessing the field via an interface.
-func (v *allSLSATree) GetSubject() allSLSATreeSubjectArtifact { return v.Subject }
-
-// GetSlsa returns allSLSATree.Slsa, and is useful for accessing the field via an interface.
-func (v *allSLSATree) GetSlsa() allSLSATreeSlsaSLSA { return v.Slsa }
-
-// allSLSATreeSlsaSLSA includes the requested fields of the GraphQL type SLSA.
-// The GraphQL type's documentation follows.
-//
-// SLSA contains all of the fields present in a SLSA attestation.
-//
-// The materials and builders are objects of the HasSLSA predicate, everything
-// else are properties extracted from the attestation.
-//
-// We also include fields to specify under what conditions the check was performed
-// (time of scan, version of scanners, etc.) as well as how this information got
-// included into GUAC (origin document and the collector for that document).
-type allSLSATreeSlsaSLSA struct {
-	// Materials of the build resulting in subject
-	BuiltFrom []allSLSATreeSlsaSLSABuiltFromArtifact `json:"builtFrom"`
-	// Builder performing the build
-	BuiltBy allSLSATreeSlsaSLSABuiltByBuilder `json:"builtBy"`
-	// Type of the builder
-	BuildType string `json:"buildType"`
-	// Individual predicates found in the attestation
-	SlsaPredicate []allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate `json:"slsaPredicate"`
-	// Version of the SLSA predicate
-	SlsaVersion string `json:"slsaVersion"`
-	// Timestamp (RFC3339Nano format) of build start time
-	StartedOn *time.Time `json:"startedOn"`
-	// Timestamp (RFC3339Nano format) of build end time
-	FinishedOn *time.Time `json:"finishedOn"`
-	// Document from which this attestation is generated from
-	Origin string `json:"origin"`
-	// GUAC collector for the document
-	Collector string `json:"collector"`
-}
-
-// GetBuiltFrom returns allSLSATreeSlsaSLSA.BuiltFrom, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetBuiltFrom() []allSLSATreeSlsaSLSABuiltFromArtifact {
-	return v.BuiltFrom
-}
-
-// GetBuiltBy returns allSLSATreeSlsaSLSA.BuiltBy, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetBuiltBy() allSLSATreeSlsaSLSABuiltByBuilder { return v.BuiltBy }
-
-// GetBuildType returns allSLSATreeSlsaSLSA.BuildType, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetBuildType() string { return v.BuildType }
-
-// GetSlsaPredicate returns allSLSATreeSlsaSLSA.SlsaPredicate, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetSlsaPredicate() []allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate {
-	return v.SlsaPredicate
-}
-
-// GetSlsaVersion returns allSLSATreeSlsaSLSA.SlsaVersion, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetSlsaVersion() string { return v.SlsaVersion }
-
-// GetStartedOn returns allSLSATreeSlsaSLSA.StartedOn, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetStartedOn() *time.Time { return v.StartedOn }
-
-// GetFinishedOn returns allSLSATreeSlsaSLSA.FinishedOn, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetFinishedOn() *time.Time { return v.FinishedOn }
-
-// GetOrigin returns allSLSATreeSlsaSLSA.Origin, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetOrigin() string { return v.Origin }
-
-// GetCollector returns allSLSATreeSlsaSLSA.Collector, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSA) GetCollector() string { return v.Collector }
-
-// allSLSATreeSlsaSLSABuiltByBuilder includes the requested fields of the GraphQL type Builder.
-// The GraphQL type's documentation follows.
-//
-// Builder represents the builder (e.g., FRSCA or GitHub Actions).
-//
-// Currently builders are identified by the uri field.
-type allSLSATreeSlsaSLSABuiltByBuilder struct {
-	Id  string `json:"id"`
-	Uri string `json:"uri"`
-}
-
-// GetId returns allSLSATreeSlsaSLSABuiltByBuilder.Id, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSABuiltByBuilder) GetId() string { return v.Id }
-
-// GetUri returns allSLSATreeSlsaSLSABuiltByBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSABuiltByBuilder) GetUri() string { return v.Uri }
-
-// allSLSATreeSlsaSLSABuiltFromArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allSLSATreeSlsaSLSABuiltFromArtifact struct {
-	AllArtifactTree `json:"-"`
-}
-
-// GetId returns allSLSATreeSlsaSLSABuiltFromArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allSLSATreeSlsaSLSABuiltFromArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetAlgorithm() string {
-	return v.AllArtifactTree.Algorithm
-}
-
-// GetDigest returns allSLSATreeSlsaSLSABuiltFromArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allSLSATreeSlsaSLSABuiltFromArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allSLSATreeSlsaSLSABuiltFromArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallSLSATreeSlsaSLSABuiltFromArtifact struct {
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allSLSATreeSlsaSLSABuiltFromArtifact) __premarshalJSON() (*__premarshalallSLSATreeSlsaSLSABuiltFromArtifact, error) {
-	var retval __premarshalallSLSATreeSlsaSLSABuiltFromArtifact
-
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate includes the requested fields of the GraphQL type SLSAPredicate.
-// The GraphQL type's documentation follows.
-//
-// SLSAPredicate are the values from the SLSA predicate in key-value pair form.
-//
-// # For example, given the following predicate
-//
-// ```
-// "predicate": {
-// "buildDefinition": {
-// "externalParameters": {
-// "repository": "https://github.com/octocat/hello-world",
-// ...
-// },
-// ...
-// },
-// ...
-// }
-// ```
-//
-// we have
-//
-// ```
-// key   = "buildDefinition.externalParameters.repository"
-// value = "https://github.com/octocat/hello-world"
-// ```
-//
-// This node cannot be directly referred by other parts of GUAC.
-type allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-// GetKey returns allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Key, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetKey() string { return v.Key }
-
-// GetValue returns allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate.Value, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSlsaSLSASlsaPredicateSLSAPredicate) GetValue() string { return v.Value }
-
-// allSLSATreeSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type allSLSATreeSubjectArtifact struct {
-	AllArtifactTree `json:"-"`
-}
-
-// GetId returns allSLSATreeSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns allSLSATreeSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns allSLSATreeSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *allSLSATreeSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *allSLSATreeSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*allSLSATreeSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.allSLSATreeSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalallSLSATreeSubjectArtifact struct {
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *allSLSATreeSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *allSLSATreeSubjectArtifact) __premarshalJSON() (*__premarshalallSLSATreeSubjectArtifact, error) {
-	var retval __premarshalallSLSATreeSubjectArtifact
-
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
 // The query or mutation executed by Artifacts.
 const Artifacts_Operation = `
 query Artifacts ($filter: ArtifactSpec) {
@@ -25387,10 +25387,10 @@ func CertifyGHSA(
 const CertifyGoodArtifact_Operation = `
 mutation CertifyGoodArtifact ($artifact: ArtifactInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
 	ingestCertifyGood(subject: {artifact:$artifact}, certifyGood: $certifyGood) {
-		... allCertifyGood
+		... AllCertifyGood
 	}
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -25482,10 +25482,10 @@ func CertifyGoodArtifact(
 const CertifyGoodPkg_Operation = `
 mutation CertifyGoodPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $certifyGood: CertifyGoodInputSpec!) {
 	ingestCertifyGood(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood) {
-		... allCertifyGood
+		... AllCertifyGood
 	}
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -25579,10 +25579,10 @@ func CertifyGoodPkg(
 const CertifyGoodSrc_Operation = `
 mutation CertifyGoodSrc ($source: SourceInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
 	ingestCertifyGood(subject: {source:$source}, certifyGood: $certifyGood) {
-		... allCertifyGood
+		... AllCertifyGood
 	}
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -26139,10 +26139,10 @@ func GHSAs(
 const HasMetadataArtifact_Operation = `
 mutation HasMetadataArtifact ($artifact: ArtifactInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
 	ingestHasMetadata(subject: {artifact:$artifact}, hasMetadata: $hasMetadata) {
-		... allHasMetadata
+		... AllHasMetadata
 	}
 }
-fragment allHasMetadata on HasMetadata {
+fragment AllHasMetadata on HasMetadata {
 	id
 	subject {
 		__typename
@@ -26237,10 +26237,10 @@ func HasMetadataArtifact(
 const HasMetadataPkg_Operation = `
 mutation HasMetadataPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $hasMetadata: HasMetadataInputSpec!) {
 	ingestHasMetadata(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata) {
-		... allHasMetadata
+		... AllHasMetadata
 	}
 }
-fragment allHasMetadata on HasMetadata {
+fragment AllHasMetadata on HasMetadata {
 	id
 	subject {
 		__typename
@@ -26337,10 +26337,10 @@ func HasMetadataPkg(
 const HasMetadataSrc_Operation = `
 mutation HasMetadataSrc ($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
 	ingestHasMetadata(subject: {source:$source}, hasMetadata: $hasMetadata) {
-		... allHasMetadata
+		... AllHasMetadata
 	}
 }
-fragment allHasMetadata on HasMetadata {
+fragment AllHasMetadata on HasMetadata {
 	id
 	subject {
 		__typename
@@ -26435,10 +26435,10 @@ func HasMetadataSrc(
 const HasSBOMArtifact_Operation = `
 mutation HasSBOMArtifact ($artifact: ArtifactInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
 	ingestHasSBOM(subject: {artifact:$artifact}, hasSBOM: $hasSBOM) {
-		... allHasSBOMTree
+		... AllHasSBOMTree
 	}
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -26516,10 +26516,10 @@ func HasSBOMArtifact(
 const HasSBOMPkg_Operation = `
 mutation HasSBOMPkg ($pkg: PkgInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
 	ingestHasSBOM(subject: {package:$pkg}, hasSBOM: $hasSBOM) {
-		... allHasSBOMTree
+		... AllHasSBOMTree
 	}
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -26597,10 +26597,10 @@ func HasSBOMPkg(
 const HasSourceAt_Operation = `
 mutation HasSourceAt ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
 	ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt) {
-		... allHasSourceAt
+		... AllHasSourceAt
 	}
 }
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
 	id
 	justification
 	knownSince
@@ -26686,10 +26686,10 @@ func HasSourceAt(
 const HashEqual_Operation = `
 mutation HashEqual ($artifact: ArtifactInputSpec!, $otherArtifact: ArtifactInputSpec!, $hashEqual: HashEqualInputSpec!) {
 	ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual) {
-		... allHashEqualTree
+		... AllHashEqualTree
 	}
 }
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
 	id
 	justification
 	artifacts {
@@ -27335,10 +27335,10 @@ func IngestSources(
 const IsDependencies_Operation = `
 mutation IsDependencies ($pkgs: [PkgInputSpec!]!, $depPkgs: [PkgInputSpec!]!, $dependencies: [IsDependencyInputSpec!]!) {
 	ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, dependencies: $dependencies) {
-		... allIsDependencyTree
+		... AllIsDependencyTree
 	}
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -27409,10 +27409,10 @@ func IsDependencies(
 const IsDependency_Operation = `
 mutation IsDependency ($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: IsDependencyInputSpec!) {
 	ingestDependency(pkg: $pkg, depPkg: $depPkg, dependency: $dependency) {
-		... allIsDependencyTree
+		... AllIsDependencyTree
 	}
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -27871,10 +27871,10 @@ func IsOccurrencesSrc(
 const IsVulnerabilityCVE_Operation = `
 mutation IsVulnerabilityCVE ($osv: OSVInputSpec!, $cve: CVEInputSpec!, $isVulnerability: IsVulnerabilityInputSpec!) {
 	ingestIsVulnerability(osv: $osv, vulnerability: {cve:$cve}, isVulnerability: $isVulnerability) {
-		... allIsVulnerability
+		... AllIsVulnerability
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -27941,10 +27941,10 @@ func IsVulnerabilityCVE(
 const IsVulnerabilityGHSA_Operation = `
 mutation IsVulnerabilityGHSA ($osv: OSVInputSpec!, $ghsa: GHSAInputSpec!, $isVulnerability: IsVulnerabilityInputSpec!) {
 	ingestIsVulnerability(osv: $osv, vulnerability: {ghsa:$ghsa}, isVulnerability: $isVulnerability) {
-		... allIsVulnerability
+		... AllIsVulnerability
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -28022,7 +28022,7 @@ query Neighbors ($node: ID!, $usingOnly: [Edge!]!) {
 			... AllArtifactTree
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 		... on OSV {
 			... AllOSVTree
@@ -28040,43 +28040,43 @@ query Neighbors ($node: ID!, $usingOnly: [Edge!]!) {
 			... AllCertifyScorecard
 		}
 		... on PkgEqual {
-			... allPkgEqual
+			... AllPkgEqual
 		}
 		... on IsOccurrence {
 			... AllIsOccurrencesTree
 		}
 		... on IsDependency {
-			... allIsDependencyTree
+			... AllIsDependencyTree
 		}
 		... on HasSLSA {
-			... allSLSATree
+			... AllSLSATree
 		}
 		... on CertifyBad {
 			... AllCertifyBad
 		}
 		... on CertifyGood {
-			... allCertifyGood
+			... AllCertifyGood
 		}
 		... on HashEqual {
-			... allHashEqualTree
+			... AllHashEqualTree
 		}
 		... on HasSBOM {
-			... allHasSBOMTree
+			... AllHasSBOMTree
 		}
 		... on HasSourceAt {
-			... allHasSourceAt
+			... AllHasSourceAt
 		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
 		... on IsVulnerability {
-			... allIsVulnerability
+			... AllIsVulnerability
 		}
 		... on CertifyVEXStatement {
-			... allCertifyVEXStatement
+			... AllCertifyVEXStatement
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 	}
 }
@@ -28120,7 +28120,7 @@ fragment AllArtifactTree on Artifact {
 	algorithm
 	digest
 }
-fragment allBuilderTree on Builder {
+fragment AllBuilderTree on Builder {
 	id
 	uri
 }
@@ -28155,7 +28155,7 @@ fragment AllCertifyScorecard on CertifyScorecard {
 		collector
 	}
 }
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
 	id
 	justification
 	packages {
@@ -28182,7 +28182,7 @@ fragment AllIsOccurrencesTree on IsOccurrence {
 	origin
 	collector
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -28196,7 +28196,7 @@ fragment allIsDependencyTree on IsDependency {
 	origin
 	collector
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree
@@ -28239,7 +28239,7 @@ fragment AllCertifyBad on CertifyBad {
 	origin
 	collector
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -28257,7 +28257,7 @@ fragment allCertifyGood on CertifyGood {
 	origin
 	collector
 }
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
 	id
 	justification
 	artifacts {
@@ -28266,7 +28266,7 @@ fragment allHashEqualTree on HashEqual {
 	origin
 	collector
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -28284,7 +28284,7 @@ fragment allHasSBOMTree on HasSBOM {
 	origin
 	collector
 }
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
 	id
 	justification
 	knownSince
@@ -28327,7 +28327,7 @@ fragment AllCertifyVuln on CertifyVuln {
 		collector
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -28345,7 +28345,7 @@ fragment allIsVulnerability on IsVulnerability {
 	origin
 	collector
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -28421,7 +28421,7 @@ query Node ($node: ID!) {
 			... AllArtifactTree
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 		... on OSV {
 			... AllOSVTree
@@ -28439,43 +28439,43 @@ query Node ($node: ID!) {
 			... AllCertifyScorecard
 		}
 		... on PkgEqual {
-			... allPkgEqual
+			... AllPkgEqual
 		}
 		... on IsOccurrence {
 			... AllIsOccurrencesTree
 		}
 		... on IsDependency {
-			... allIsDependencyTree
+			... AllIsDependencyTree
 		}
 		... on HasSLSA {
-			... allSLSATree
+			... AllSLSATree
 		}
 		... on CertifyBad {
 			... AllCertifyBad
 		}
 		... on CertifyGood {
-			... allCertifyGood
+			... AllCertifyGood
 		}
 		... on HashEqual {
-			... allHashEqualTree
+			... AllHashEqualTree
 		}
 		... on HasSBOM {
-			... allHasSBOMTree
+			... AllHasSBOMTree
 		}
 		... on HasSourceAt {
-			... allHasSourceAt
+			... AllHasSourceAt
 		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
 		... on IsVulnerability {
-			... allIsVulnerability
+			... AllIsVulnerability
 		}
 		... on CertifyVEXStatement {
-			... allCertifyVEXStatement
+			... AllCertifyVEXStatement
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 	}
 }
@@ -28519,7 +28519,7 @@ fragment AllArtifactTree on Artifact {
 	algorithm
 	digest
 }
-fragment allBuilderTree on Builder {
+fragment AllBuilderTree on Builder {
 	id
 	uri
 }
@@ -28554,7 +28554,7 @@ fragment AllCertifyScorecard on CertifyScorecard {
 		collector
 	}
 }
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
 	id
 	justification
 	packages {
@@ -28581,7 +28581,7 @@ fragment AllIsOccurrencesTree on IsOccurrence {
 	origin
 	collector
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -28595,7 +28595,7 @@ fragment allIsDependencyTree on IsDependency {
 	origin
 	collector
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree
@@ -28638,7 +28638,7 @@ fragment AllCertifyBad on CertifyBad {
 	origin
 	collector
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -28656,7 +28656,7 @@ fragment allCertifyGood on CertifyGood {
 	origin
 	collector
 }
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
 	id
 	justification
 	artifacts {
@@ -28665,7 +28665,7 @@ fragment allHashEqualTree on HashEqual {
 	origin
 	collector
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -28683,7 +28683,7 @@ fragment allHasSBOMTree on HasSBOM {
 	origin
 	collector
 }
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
 	id
 	justification
 	knownSince
@@ -28726,7 +28726,7 @@ fragment AllCertifyVuln on CertifyVuln {
 		collector
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -28744,7 +28744,7 @@ fragment allIsVulnerability on IsVulnerability {
 	origin
 	collector
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -28818,7 +28818,7 @@ query Nodes ($nodes: [ID!]!) {
 			... AllArtifactTree
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 		... on OSV {
 			... AllOSVTree
@@ -28836,43 +28836,43 @@ query Nodes ($nodes: [ID!]!) {
 			... AllCertifyScorecard
 		}
 		... on PkgEqual {
-			... allPkgEqual
+			... AllPkgEqual
 		}
 		... on IsOccurrence {
 			... AllIsOccurrencesTree
 		}
 		... on IsDependency {
-			... allIsDependencyTree
+			... AllIsDependencyTree
 		}
 		... on HasSLSA {
-			... allSLSATree
+			... AllSLSATree
 		}
 		... on CertifyBad {
 			... AllCertifyBad
 		}
 		... on CertifyGood {
-			... allCertifyGood
+			... AllCertifyGood
 		}
 		... on HashEqual {
-			... allHashEqualTree
+			... AllHashEqualTree
 		}
 		... on HasSBOM {
-			... allHasSBOMTree
+			... AllHasSBOMTree
 		}
 		... on HasSourceAt {
-			... allHasSourceAt
+			... AllHasSourceAt
 		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
 		... on IsVulnerability {
-			... allIsVulnerability
+			... AllIsVulnerability
 		}
 		... on CertifyVEXStatement {
-			... allCertifyVEXStatement
+			... AllCertifyVEXStatement
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 	}
 }
@@ -28916,7 +28916,7 @@ fragment AllArtifactTree on Artifact {
 	algorithm
 	digest
 }
-fragment allBuilderTree on Builder {
+fragment AllBuilderTree on Builder {
 	id
 	uri
 }
@@ -28951,7 +28951,7 @@ fragment AllCertifyScorecard on CertifyScorecard {
 		collector
 	}
 }
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
 	id
 	justification
 	packages {
@@ -28978,7 +28978,7 @@ fragment AllIsOccurrencesTree on IsOccurrence {
 	origin
 	collector
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -28992,7 +28992,7 @@ fragment allIsDependencyTree on IsDependency {
 	origin
 	collector
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree
@@ -29035,7 +29035,7 @@ fragment AllCertifyBad on CertifyBad {
 	origin
 	collector
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -29053,7 +29053,7 @@ fragment allCertifyGood on CertifyGood {
 	origin
 	collector
 }
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
 	id
 	justification
 	artifacts {
@@ -29062,7 +29062,7 @@ fragment allHashEqualTree on HashEqual {
 	origin
 	collector
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -29080,7 +29080,7 @@ fragment allHasSBOMTree on HasSBOM {
 	origin
 	collector
 }
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
 	id
 	justification
 	knownSince
@@ -29123,7 +29123,7 @@ fragment AllCertifyVuln on CertifyVuln {
 		collector
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -29141,7 +29141,7 @@ fragment allIsVulnerability on IsVulnerability {
 	origin
 	collector
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -29310,7 +29310,7 @@ query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge
 			... AllArtifactTree
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 		... on OSV {
 			... AllOSVTree
@@ -29328,43 +29328,43 @@ query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge
 			... AllCertifyScorecard
 		}
 		... on PkgEqual {
-			... allPkgEqual
+			... AllPkgEqual
 		}
 		... on IsOccurrence {
 			... AllIsOccurrencesTree
 		}
 		... on IsDependency {
-			... allIsDependencyTree
+			... AllIsDependencyTree
 		}
 		... on HasSLSA {
-			... allSLSATree
+			... AllSLSATree
 		}
 		... on CertifyBad {
 			... AllCertifyBad
 		}
 		... on CertifyGood {
-			... allCertifyGood
+			... AllCertifyGood
 		}
 		... on HashEqual {
-			... allHashEqualTree
+			... AllHashEqualTree
 		}
 		... on HasSBOM {
-			... allHasSBOMTree
+			... AllHasSBOMTree
 		}
 		... on HasSourceAt {
-			... allHasSourceAt
+			... AllHasSourceAt
 		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
 		... on IsVulnerability {
-			... allIsVulnerability
+			... AllIsVulnerability
 		}
 		... on CertifyVEXStatement {
-			... allCertifyVEXStatement
+			... AllCertifyVEXStatement
 		}
 		... on Builder {
-			... allBuilderTree
+			... AllBuilderTree
 		}
 	}
 }
@@ -29408,7 +29408,7 @@ fragment AllArtifactTree on Artifact {
 	algorithm
 	digest
 }
-fragment allBuilderTree on Builder {
+fragment AllBuilderTree on Builder {
 	id
 	uri
 }
@@ -29443,7 +29443,7 @@ fragment AllCertifyScorecard on CertifyScorecard {
 		collector
 	}
 }
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
 	id
 	justification
 	packages {
@@ -29470,7 +29470,7 @@ fragment AllIsOccurrencesTree on IsOccurrence {
 	origin
 	collector
 }
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
 	id
 	justification
 	package {
@@ -29484,7 +29484,7 @@ fragment allIsDependencyTree on IsDependency {
 	origin
 	collector
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree
@@ -29527,7 +29527,7 @@ fragment AllCertifyBad on CertifyBad {
 	origin
 	collector
 }
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
 	id
 	justification
 	subject {
@@ -29545,7 +29545,7 @@ fragment allCertifyGood on CertifyGood {
 	origin
 	collector
 }
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
 	id
 	justification
 	artifacts {
@@ -29554,7 +29554,7 @@ fragment allHashEqualTree on HashEqual {
 	origin
 	collector
 }
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
 	id
 	subject {
 		__typename
@@ -29572,7 +29572,7 @@ fragment allHasSBOMTree on HasSBOM {
 	origin
 	collector
 }
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
 	id
 	justification
 	knownSince
@@ -29615,7 +29615,7 @@ fragment AllCertifyVuln on CertifyVuln {
 		collector
 	}
 }
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
 	id
 	osv {
 		... AllOSVTree
@@ -29633,7 +29633,7 @@ fragment allIsVulnerability on IsVulnerability {
 	origin
 	collector
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -29708,7 +29708,7 @@ mutation PkgEqual ($pkg: PkgInputSpec!, $otherPackage: PkgInputSpec!, $pkgEqual:
 		... AllPkgTree
 	}
 	ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual) {
-		... allPkgEqual
+		... AllPkgEqual
 	}
 }
 fragment AllPkgTree on Package {
@@ -29732,7 +29732,7 @@ fragment AllPkgTree on Package {
 		}
 	}
 }
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
 	id
 	justification
 	packages {
@@ -29777,10 +29777,10 @@ func PkgEqual(
 const PointOfContactArtifact_Operation = `
 mutation PointOfContactArtifact ($artifact: ArtifactInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
 	ingestPointOfContact(subject: {artifact:$artifact}, pointOfContact: $pointOfContact) {
-		... allPointOfContact
+		... AllPointOfContact
 	}
 }
-fragment allPointOfContact on PointOfContact {
+fragment AllPointOfContact on PointOfContact {
 	id
 	subject {
 		__typename
@@ -29875,10 +29875,10 @@ func PointOfContactArtifact(
 const PointOfContactPkg_Operation = `
 mutation PointOfContactPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $pointOfContact: PointOfContactInputSpec!) {
 	ingestPointOfContact(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact) {
-		... allPointOfContact
+		... AllPointOfContact
 	}
 }
-fragment allPointOfContact on PointOfContact {
+fragment AllPointOfContact on PointOfContact {
 	id
 	subject {
 		__typename
@@ -29975,10 +29975,10 @@ func PointOfContactPkg(
 const PointOfContactSrc_Operation = `
 mutation PointOfContactSrc ($source: SourceInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
 	ingestPointOfContact(subject: {source:$source}, pointOfContact: $pointOfContact) {
-		... allPointOfContact
+		... AllPointOfContact
 	}
 }
-fragment allPointOfContact on PointOfContact {
+fragment AllPointOfContact on PointOfContact {
 	id
 	subject {
 		__typename
@@ -30073,10 +30073,10 @@ func PointOfContactSrc(
 const SLSAForArtifact_Operation = `
 mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $materials: [ArtifactInputSpec!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
 	ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
-		... allSLSATree
+		... AllSLSATree
 	}
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree
@@ -30264,10 +30264,10 @@ func Sources(
 const VEXPackageAndGhsa_Operation = `
 mutation VEXPackageAndGhsa ($pkg: PkgInputSpec!, $ghsa: GHSAInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {package:$pkg}, vulnerability: {ghsa:$ghsa}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -30373,10 +30373,10 @@ func VEXPackageAndGhsa(
 const VexArtifactAndCve_Operation = `
 mutation VexArtifactAndCve ($artifact: ArtifactInputSpec!, $cve: CVEInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {artifact:$artifact}, vulnerability: {cve:$cve}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -30482,10 +30482,10 @@ func VexArtifactAndCve(
 const VexArtifactAndGhsa_Operation = `
 mutation VexArtifactAndGhsa ($artifact: ArtifactInputSpec!, $ghsa: GHSAInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {artifact:$artifact}, vulnerability: {ghsa:$ghsa}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -30591,10 +30591,10 @@ func VexArtifactAndGhsa(
 const VexArtifactAndOsv_Operation = `
 mutation VexArtifactAndOsv ($artifact: ArtifactInputSpec!, $osv: OSVInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {artifact:$artifact}, vulnerability: {osv:$osv}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -30700,10 +30700,10 @@ func VexArtifactAndOsv(
 const VexPackageAndCve_Operation = `
 mutation VexPackageAndCve ($pkg: PkgInputSpec!, $cve: CVEInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {package:$pkg}, vulnerability: {cve:$cve}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename
@@ -30809,10 +30809,10 @@ func VexPackageAndCve(
 const VexPackageAndOsv_Operation = `
 mutation VexPackageAndOsv ($pkg: PkgInputSpec!, $osv: OSVInputSpec!, $vexStatement: VexStatementInputSpec!) {
 	ingestVEXStatement(subject: {package:$pkg}, vulnerability: {osv:$osv}, vexStatement: $vexStatement) {
-		... allCertifyVEXStatement
+		... AllCertifyVEXStatement
 	}
 }
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
 	id
 	subject {
 		__typename

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -22517,19 +22517,19 @@ func (v *SLSAForArtifactResponse) GetIngestSLSA() SLSAForArtifactIngestSLSAHasSL
 //
 // HasSLSA records that a subject node has a SLSA attestation.
 type SLSAForArtifactsIngestSLSAsHasSLSA struct {
-	allSLSATree `json:"-"`
+	AllSLSATree `json:"-"`
 }
 
 // GetId returns SLSAForArtifactsIngestSLSAsHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetId() string { return v.allSLSATree.Id }
+func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetId() string { return v.AllSLSATree.Id }
 
 // GetSubject returns SLSAForArtifactsIngestSLSAsHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSubject() allSLSATreeSubjectArtifact {
-	return v.allSLSATree.Subject
+func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSubject() AllSLSATreeSubjectArtifact {
+	return v.AllSLSATree.Subject
 }
 
 // GetSlsa returns SLSAForArtifactsIngestSLSAsHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSlsa() allSLSATreeSlsaSLSA { return v.allSLSATree.Slsa }
+func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
 
 func (v *SLSAForArtifactsIngestSLSAsHasSLSA) UnmarshalJSON(b []byte) error {
 
@@ -22549,7 +22549,7 @@ func (v *SLSAForArtifactsIngestSLSAsHasSLSA) UnmarshalJSON(b []byte) error {
 	}
 
 	err = json.Unmarshal(
-		b, &v.allSLSATree)
+		b, &v.AllSLSATree)
 	if err != nil {
 		return err
 	}
@@ -22559,9 +22559,9 @@ func (v *SLSAForArtifactsIngestSLSAsHasSLSA) UnmarshalJSON(b []byte) error {
 type __premarshalSLSAForArtifactsIngestSLSAsHasSLSA struct {
 	Id string `json:"id"`
 
-	Subject allSLSATreeSubjectArtifact `json:"subject"`
+	Subject AllSLSATreeSubjectArtifact `json:"subject"`
 
-	Slsa allSLSATreeSlsaSLSA `json:"slsa"`
+	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
 }
 
 func (v *SLSAForArtifactsIngestSLSAsHasSLSA) MarshalJSON() ([]byte, error) {
@@ -22575,9 +22575,9 @@ func (v *SLSAForArtifactsIngestSLSAsHasSLSA) MarshalJSON() ([]byte, error) {
 func (v *SLSAForArtifactsIngestSLSAsHasSLSA) __premarshalJSON() (*__premarshalSLSAForArtifactsIngestSLSAsHasSLSA, error) {
 	var retval __premarshalSLSAForArtifactsIngestSLSAsHasSLSA
 
-	retval.Id = v.allSLSATree.Id
-	retval.Subject = v.allSLSATree.Subject
-	retval.Slsa = v.allSLSATree.Slsa
+	retval.Id = v.AllSLSATree.Id
+	retval.Subject = v.AllSLSATree.Subject
+	retval.Slsa = v.AllSLSATree.Slsa
 	return &retval, nil
 }
 
@@ -30144,10 +30144,10 @@ func SLSAForArtifact(
 const SLSAForArtifacts_Operation = `
 mutation SLSAForArtifacts ($artifacts: [ArtifactInputSpec!]!, $materialsList: [[ArtifactInputSpec!]!]!, $builders: [BuilderInputSpec!]!, $slsaList: [SLSAInputSpec!]!) {
 	ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList) {
-		... allSLSATree
+		... AllSLSATree
 	}
 }
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
 	id
 	subject {
 		... AllArtifactTree

--- a/pkg/assembler/clients/operations/certifyGood.graphql
+++ b/pkg/assembler/clients/operations/certifyGood.graphql
@@ -19,18 +19,18 @@
 
 mutation CertifyGoodPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $certifyGood: CertifyGoodInputSpec!) {
   ingestCertifyGood(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood) {
-    ...allCertifyGood
+    ...AllCertifyGood
   }
 }
 
 mutation CertifyGoodSrc($source: SourceInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
   ingestCertifyGood(subject: {source: $source}, certifyGood: $certifyGood) {
-    ...allCertifyGood
+    ...AllCertifyGood
   }
 }
 
 mutation CertifyGoodArtifact($artifact: ArtifactInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
   ingestCertifyGood(subject: {artifact: $artifact}, certifyGood: $certifyGood) {
-    ...allCertifyGood
+    ...AllCertifyGood
   }
 }

--- a/pkg/assembler/clients/operations/certifyVEXStatement.graphql
+++ b/pkg/assembler/clients/operations/certifyVEXStatement.graphql
@@ -19,36 +19,36 @@
 
 mutation VexPackageAndCve($pkg: PkgInputSpec!, $cve: CVEInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {package: $pkg}, vulnerability: {cve: $cve}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }
 
 mutation VEXPackageAndGhsa($pkg: PkgInputSpec!, $ghsa: GHSAInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {package: $pkg}, vulnerability: {ghsa: $ghsa}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }
 
 mutation VexPackageAndOsv($pkg: PkgInputSpec!, $osv: OSVInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {package: $pkg}, vulnerability: {osv: $osv}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }
 
 mutation VexArtifactAndCve($artifact: ArtifactInputSpec!, $cve: CVEInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: {cve: $cve}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }
 
 mutation VexArtifactAndGhsa($artifact: ArtifactInputSpec!, $ghsa: GHSAInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: {ghsa: $ghsa}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }
 
 mutation VexArtifactAndOsv($artifact: ArtifactInputSpec!, $osv: OSVInputSpec!, $vexStatement: VexStatementInputSpec!) {
   ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: {osv: $osv}, vexStatement: $vexStatement) {
-    ...allCertifyVEXStatement
+    ...AllCertifyVEXStatement
   }
 }

--- a/pkg/assembler/clients/operations/contact.graphql
+++ b/pkg/assembler/clients/operations/contact.graphql
@@ -19,18 +19,18 @@
 
 mutation PointOfContactPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $pointOfContact: PointOfContactInputSpec!) {
   ingestPointOfContact(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact) {
-    ...allPointOfContact
+    ...AllPointOfContact
   }
 }
 
 mutation PointOfContactSrc($source: SourceInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
   ingestPointOfContact(subject: {source: $source}, pointOfContact: $pointOfContact) {
-    ...allPointOfContact
+    ...AllPointOfContact
   }
 }
 
 mutation PointOfContactArtifact($artifact: ArtifactInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
   ingestPointOfContact(subject: {artifact: $artifact}, pointOfContact: $pointOfContact) {
-    ...allPointOfContact
+    ...AllPointOfContact
   }
 }

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -19,12 +19,12 @@
 
 mutation HasSBOMPkg($pkg: PkgInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
   ingestHasSBOM(subject: {package: $pkg}, hasSBOM: $hasSBOM) {
-    ...allHasSBOMTree
+    ...AllHasSBOMTree
   }
 }
 
 mutation HasSBOMArtifact($artifact: ArtifactInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
   ingestHasSBOM(subject: {artifact: $artifact}, hasSBOM: $hasSBOM) {
-    ...allHasSBOMTree
+    ...AllHasSBOMTree
   }
 }

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -27,6 +27,6 @@ mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $materials: [ArtifactInp
 
 mutation SLSAForArtifacts($artifacts: [ArtifactInputSpec!]!, $materialsList: [[ArtifactInputSpec!]!]!, $builders: [BuilderInputSpec!]!, $slsaList: [SLSAInputSpec!]!) {
   ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList) {
-    ...allSLSATree
+    ...AllSLSATree
   }
 }

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -19,7 +19,7 @@
 
 mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $materials: [ArtifactInputSpec!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
   ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
-    ...allSLSATree
+    ...AllSLSATree
   }
 }
 

--- a/pkg/assembler/clients/operations/hasSourceAt.graphql
+++ b/pkg/assembler/clients/operations/hasSourceAt.graphql
@@ -19,6 +19,6 @@
 
 mutation HasSourceAt($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
   ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt) {
-    ...allHasSourceAt
+    ...AllHasSourceAt
   }
 }

--- a/pkg/assembler/clients/operations/hashEqual.graphql
+++ b/pkg/assembler/clients/operations/hashEqual.graphql
@@ -19,6 +19,6 @@
 
 mutation HashEqual($artifact: ArtifactInputSpec!, $otherArtifact: ArtifactInputSpec!, $hashEqual: HashEqualInputSpec!) {
   ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual) {
-    ...allHashEqualTree
+    ...AllHashEqualTree
   }
 }

--- a/pkg/assembler/clients/operations/isDependency.graphql
+++ b/pkg/assembler/clients/operations/isDependency.graphql
@@ -19,7 +19,7 @@
 
 mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: IsDependencyInputSpec!) {
   ingestDependency(pkg: $pkg, depPkg: $depPkg, dependency: $dependency) {
-    ...allIsDependencyTree
+    ...AllIsDependencyTree
   }
 }
 
@@ -27,6 +27,6 @@ mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $dependency: 
 
 mutation IsDependencies($pkgs: [PkgInputSpec!]!, $depPkgs: [PkgInputSpec!]!, $dependencies: [IsDependencyInputSpec!]!) {
   ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, dependencies: $dependencies) {
-    ...allIsDependencyTree
+    ...AllIsDependencyTree
   }
 }

--- a/pkg/assembler/clients/operations/isVulnerability.graphql
+++ b/pkg/assembler/clients/operations/isVulnerability.graphql
@@ -19,12 +19,12 @@
 
 mutation IsVulnerabilityCVE($osv: OSVInputSpec!, $cve: CVEInputSpec!, $isVulnerability: IsVulnerabilityInputSpec!) {
   ingestIsVulnerability(osv: $osv, vulnerability: {cve: $cve}, isVulnerability: $isVulnerability) {
-    ...allIsVulnerability
+    ...AllIsVulnerability
   }
 }
 
 mutation IsVulnerabilityGHSA($osv: OSVInputSpec!, $ghsa: GHSAInputSpec!, $isVulnerability: IsVulnerabilityInputSpec!) {
   ingestIsVulnerability(osv: $osv, vulnerability: {ghsa: $ghsa}, isVulnerability: $isVulnerability) {
-    ...allIsVulnerability
+    ...AllIsVulnerability
   }
 }

--- a/pkg/assembler/clients/operations/metadata.graphql
+++ b/pkg/assembler/clients/operations/metadata.graphql
@@ -19,18 +19,18 @@
 
 mutation HasMetadataPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags, $hasMetadata: HasMetadataInputSpec!) {
   ingestHasMetadata(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata) {
-    ...allHasMetadata
+    ...AllHasMetadata
   }
 }
 
 mutation HasMetadataSrc($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
   ingestHasMetadata(subject: {source: $source}, hasMetadata: $hasMetadata) {
-    ...allHasMetadata
+    ...AllHasMetadata
   }
 }
 
 mutation HasMetadataArtifact($artifact: ArtifactInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
   ingestHasMetadata(subject: {artifact: $artifact}, hasMetadata: $hasMetadata) {
-    ...allHasMetadata
+    ...AllHasMetadata
   }
 }

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -30,7 +30,7 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!
       ...AllArtifactTree
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
     ... on OSV {
       ...AllOSVTree
@@ -48,43 +48,43 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!
       ...AllCertifyScorecard
     }
     ... on PkgEqual {
-      ...allPkgEqual
+      ...AllPkgEqual
     }
     ... on IsOccurrence {
       ...AllIsOccurrencesTree
     }
     ... on IsDependency {
-      ...allIsDependencyTree
+      ...AllIsDependencyTree
     }
     ... on HasSLSA {
-      ...allSLSATree
+      ...AllSLSATree
     }
     ... on CertifyBad {
       ...AllCertifyBad
     }
     ... on CertifyGood {
-      ...allCertifyGood
+      ...AllCertifyGood
     }
     ... on HashEqual {
-      ...allHashEqualTree
+      ...AllHashEqualTree
     }
     ... on HasSBOM {
-      ...allHasSBOMTree
+      ...AllHasSBOMTree
     }
     ... on HasSourceAt {
-      ...allHasSourceAt
+      ...AllHasSourceAt
     }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
     ... on IsVulnerability {
-      ...allIsVulnerability
+      ...AllIsVulnerability
     }
     ... on CertifyVEXStatement {
-      ...allCertifyVEXStatement
+      ...AllCertifyVEXStatement
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
   }
 }
@@ -102,7 +102,7 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
       ...AllArtifactTree
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
     ... on OSV {
       ...AllOSVTree
@@ -120,43 +120,43 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
       ...AllCertifyScorecard
     }
     ... on PkgEqual {
-      ...allPkgEqual
+      ...AllPkgEqual
     }
     ... on IsOccurrence {
       ...AllIsOccurrencesTree
     }
     ... on IsDependency {
-      ...allIsDependencyTree
+      ...AllIsDependencyTree
     }
     ... on HasSLSA {
-      ...allSLSATree
+      ...AllSLSATree
     }
     ... on CertifyBad {
       ...AllCertifyBad
     }
     ... on CertifyGood {
-      ...allCertifyGood
+      ...AllCertifyGood
     }
     ... on HashEqual {
-      ...allHashEqualTree
+      ...AllHashEqualTree
     }
     ... on HasSBOM {
-      ...allHasSBOMTree
+      ...AllHasSBOMTree
     }
     ... on HasSourceAt {
-      ...allHasSourceAt
+      ...AllHasSourceAt
     }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
     ... on IsVulnerability {
-      ...allIsVulnerability
+      ...AllIsVulnerability
     }
     ... on CertifyVEXStatement {
-      ...allCertifyVEXStatement
+      ...AllCertifyVEXStatement
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
   }
 }
@@ -174,7 +174,7 @@ query Node($node: ID!) {
       ...AllArtifactTree
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
     ... on OSV {
       ...AllOSVTree
@@ -192,43 +192,43 @@ query Node($node: ID!) {
       ...AllCertifyScorecard
     }
     ... on PkgEqual {
-      ...allPkgEqual
+      ...AllPkgEqual
     }
     ... on IsOccurrence {
       ...AllIsOccurrencesTree
     }
     ... on IsDependency {
-      ...allIsDependencyTree
+      ...AllIsDependencyTree
     }
     ... on HasSLSA {
-      ...allSLSATree
+      ...AllSLSATree
     }
     ... on CertifyBad {
       ...AllCertifyBad
     }
     ... on CertifyGood {
-      ...allCertifyGood
+      ...AllCertifyGood
     }
     ... on HashEqual {
-      ...allHashEqualTree
+      ...AllHashEqualTree
     }
     ... on HasSBOM {
-      ...allHasSBOMTree
+      ...AllHasSBOMTree
     }
     ... on HasSourceAt {
-      ...allHasSourceAt
+      ...AllHasSourceAt
     }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
     ... on IsVulnerability {
-      ...allIsVulnerability
+      ...AllIsVulnerability
     }
     ... on CertifyVEXStatement {
-      ...allCertifyVEXStatement
+      ...AllCertifyVEXStatement
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
   }
 }
@@ -246,7 +246,7 @@ query Nodes($nodes: [ID!]!) {
       ...AllArtifactTree
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
     ... on OSV {
       ...AllOSVTree
@@ -264,43 +264,43 @@ query Nodes($nodes: [ID!]!) {
       ...AllCertifyScorecard
     }
     ... on PkgEqual {
-      ...allPkgEqual
+      ...AllPkgEqual
     }
     ... on IsOccurrence {
       ...AllIsOccurrencesTree
     }
     ... on IsDependency {
-      ...allIsDependencyTree
+      ...AllIsDependencyTree
     }
     ... on HasSLSA {
-      ...allSLSATree
+      ...AllSLSATree
     }
     ... on CertifyBad {
       ...AllCertifyBad
     }
     ... on CertifyGood {
-      ...allCertifyGood
+      ...AllCertifyGood
     }
     ... on HashEqual {
-      ...allHashEqualTree
+      ...AllHashEqualTree
     }
     ... on HasSBOM {
-      ...allHasSBOMTree
+      ...AllHasSBOMTree
     }
     ... on HasSourceAt {
-      ...allHasSourceAt
+      ...AllHasSourceAt
     }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
     ... on IsVulnerability {
-      ...allIsVulnerability
+      ...AllIsVulnerability
     }
     ... on CertifyVEXStatement {
-      ...allCertifyVEXStatement
+      ...AllCertifyVEXStatement
     }
     ... on Builder {
-      ...allBuilderTree
+      ...AllBuilderTree
     }
   }
 }

--- a/pkg/assembler/clients/operations/pkgEqual.graphql
+++ b/pkg/assembler/clients/operations/pkgEqual.graphql
@@ -25,6 +25,6 @@ mutation PkgEqual($pkg: PkgInputSpec!, $otherPackage: PkgInputSpec!, $pkgEqual: 
     ...AllPkgTree
   }
   ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual) {
-    ...allPkgEqual
+    ...AllPkgEqual
   }
 }

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -17,7 +17,7 @@
 
 # Defines GraphQL fragments used in the operations
 
-# TODO(mihaimaruseac): Clean this up: do we want all of these to be returned?
+# TODO(mihaimaruseac): Clean this up: do we want All of these to be returned?
 
 fragment AllPkgTree on Package {
   id
@@ -62,7 +62,7 @@ fragment AllArtifactTree on Artifact {
   digest
 }
 
-fragment allBuilderTree on Builder {
+fragment AllBuilderTree on Builder {
   id
   uri
 }
@@ -121,7 +121,7 @@ fragment AllIsOccurrencesTree on IsOccurrence {
   collector
 }
 
-fragment allIsDependencyTree on IsDependency {
+fragment AllIsDependencyTree on IsDependency {
   id
   justification
   package {
@@ -136,7 +136,7 @@ fragment allIsDependencyTree on IsDependency {
   collector
 }
 
-fragment allSLSATree on HasSLSA {
+fragment AllSLSATree on HasSLSA {
   id
   subject {
     ...AllArtifactTree
@@ -181,7 +181,7 @@ fragment AllCertifyBad on CertifyBad {
   collector
 }
 
-fragment allCertifyGood on CertifyGood {
+fragment AllCertifyGood on CertifyGood {
   id
   justification
   subject {
@@ -200,7 +200,7 @@ fragment allCertifyGood on CertifyGood {
   collector
 }
 
-fragment allHashEqualTree on HashEqual {
+fragment AllHashEqualTree on HashEqual {
   id
   justification
   artifacts {
@@ -210,7 +210,7 @@ fragment allHashEqualTree on HashEqual {
   collector
 }
 
-fragment allHasSBOMTree on HasSBOM {
+fragment AllHasSBOMTree on HasSBOM {
   id
   subject {
     __typename
@@ -229,7 +229,7 @@ fragment allHasSBOMTree on HasSBOM {
   collector
 }
 
-fragment allHasSourceAt on HasSourceAt {
+fragment AllHasSourceAt on HasSourceAt {
   id
   justification
   knownSince
@@ -274,7 +274,7 @@ fragment AllCertifyVuln on CertifyVuln {
   }
 }
 
-fragment allPkgEqual on PkgEqual {
+fragment AllPkgEqual on PkgEqual {
   id
   justification
   packages {
@@ -284,7 +284,7 @@ fragment allPkgEqual on PkgEqual {
   collector
 }
 
-fragment allIsVulnerability on IsVulnerability {
+fragment AllIsVulnerability on IsVulnerability {
   id
   osv {
     ...AllOSVTree
@@ -303,7 +303,7 @@ fragment allIsVulnerability on IsVulnerability {
   collector
 }
 
-fragment allCertifyVEXStatement on CertifyVEXStatement {
+fragment AllCertifyVEXStatement on CertifyVEXStatement {
   id
   subject {
     __typename
@@ -335,7 +335,7 @@ fragment allCertifyVEXStatement on CertifyVEXStatement {
   collector
 }
 
-fragment allHasMetadata on HasMetadata {
+fragment AllHasMetadata on HasMetadata {
     id
     subject {
       __typename
@@ -358,7 +358,7 @@ fragment allHasMetadata on HasMetadata {
     collector
 }
 
-fragment allPointOfContact on PointOfContact {
+fragment AllPointOfContact on PointOfContact {
     id
     subject {
       __typename


### PR DESCRIPTION
# Description of the PR

Currently not all fragments in client GQL operations start with a capital letter (e.g. AllCertifyBad vs allCertifyGood). The result of this is that based on the codegen, some struct values are not exposed and some are (due to golang's handling of capital vs noncapital letter structs). 

This PR updates all client fragments to capital letters to expose them through the generated code.
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
