### PR TITLE
add vex info to VULN cli

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -176,13 +176,14 @@ var queryVulnCmd = &cobra.Command{
 			var path []string
 			var tableRows []table.Row
 			if pkgResponse.Packages[0].Type != guacType {
-				vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, model.EdgePackageCertifyVuln)
+				vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, []model.Edge{model.EdgePackageCertifyVuln, model.EdgePackageCertifyVexStatement})
 				if err != nil {
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
 				path = append(path, vulnPath...)
 				tableRows = append(tableRows, pkgVulnTableRows...)
 			}
+
 			depVulnPath, depVulnTableRows, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
 			if err != nil {
 				logger.Fatalf("error searching dependency packages match: %v", err)
@@ -205,10 +206,10 @@ var queryVulnCmd = &cobra.Command{
 	},
 }
 
-func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeType model.Edge) ([]string, []table.Row, error) {
+func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client, pkgVersionID string, edgeTypes []model.Edge) ([]string, []table.Row, error) {
 	var path []string
 	var tableRows []table.Row
-	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgVersionID, []model.Edge{edgeType})
+	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgVersionID, edgeTypes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
 	}
@@ -217,30 +218,75 @@ func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client
 		if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
 			certifyVulnFound = true
 			if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityOSV); ok {
-				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.OsvId})
+				tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.OsvId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}...)
 			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityCVE); ok {
-				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.CveId})
+				tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.CveId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}...)
 			} else if vuln, ok := certifyVuln.Vulnerability.(*model.AllCertifyVulnVulnerabilityGHSA); ok {
-				tableRows = append(tableRows, table.Row{certifyVulnStr, vuln.Id, "vulnerability ID: " + vuln.GhsaId})
+				tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.GhsaId})
 				path = append(path, []string{vuln.Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}...)
 			}
 		}
+
+		if certifyVex, ok := neighbor.(*model.NeighborsNeighborsCertifyVEXStatement); ok {
+			if vuln, ok := certifyVex.Vulnerability.(*model.AllCertifyVEXStatementVulnerabilityOSV); ok {
+				tableRows = append(tableRows, table.Row{vexLinkStr, certifyVex.Id, "vulnerability ID: " + vuln.OsvId + ", Vex Status: " + string(certifyVex.Status) + ", Subject: " + vexSubjectString(certifyVex.Subject)})
+				path = append(path, certifyVex.Id, vuln.Id)
+			} else if vuln, ok := certifyVex.Vulnerability.(*model.AllCertifyVEXStatementVulnerabilityCVE); ok {
+				tableRows = append(tableRows, table.Row{vexLinkStr, certifyVex.Id, "vulnerability ID: " + vuln.CveId + ", Vex Status: " + string(certifyVex.Status) + ", Subject: " + vexSubjectString(certifyVex.Subject)})
+				path = append(path, certifyVex.Id, vuln.Id)
+			} else if vuln, ok := certifyVex.Vulnerability.(*model.AllCertifyVEXStatementVulnerabilityGHSA); ok {
+				tableRows = append(tableRows, table.Row{vexLinkStr, certifyVex.Id, "vulnerability ID: " + vuln.GhsaId + ", Vex Status: " + string(certifyVex.Status) + ", Subject: " + vexSubjectString(certifyVex.Subject)})
+				path = append(path, certifyVex.Id, vuln.Id)
+			}
+			path = append(path, vexSubjectIds(certifyVex.Subject)...)
+		}
+
 	}
 	if !certifyVulnFound {
 		return nil, nil, fmt.Errorf("error certify vulnerability node not found, incomplete data. Please ensure certifier has run")
 	}
 	return path, tableRows, nil
+}
+
+func vexSubjectString(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) string {
+	switch v := s.(type) {
+	case *model.AllCertifyVEXStatementSubjectArtifact:
+		return fmt.Sprintf("artifact (id:%v) %v:%v", v.Id, v.Algorithm, v.Digest)
+	case *model.AllCertifyVEXStatementSubjectPackage:
+		return fmt.Sprintf("package (id:%v) %v:%v/%v@%v",
+			v.Id,
+			v.Type,
+			v.Namespaces[0].Namespace,
+			v.Namespaces[0].Names[0].Name,
+			v.Namespaces[0].Names[0].Versions[0].Version)
+	default:
+		return "unknown subject"
+	}
+}
+func vexSubjectIds(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) []string {
+	switch v := s.(type) {
+	case *model.AllCertifyVEXStatementSubjectArtifact:
+		return []string{v.Id}
+	case *model.AllCertifyVEXStatementSubjectPackage:
+		return []string{
+			v.Id,
+			v.Namespaces[0].Id,
+			v.Namespaces[0].Names[0].Id,
+			v.Namespaces[0].Names[0].Versions[0].Id}
+	default:
+		return []string{}
+	}
 }
 
 func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, []table.Row, error) {
@@ -301,7 +347,7 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 
 				for matchingDepPkgVersion := range matchingDepPkgVersions {
 					matchingDepPkgVersionID := depPkgVersionsMap[matchingDepPkgVersion]
-					vulnPath, foundVulnTableRow, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, matchingDepPkgVersionID, model.EdgePackageCertifyVuln)
+					vulnPath, foundVulnTableRow, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, matchingDepPkgVersionID, []model.Edge{model.EdgePackageCertifyVuln, model.EdgePackageCertifyVexStatement})
 					if err != nil {
 						return nil, nil, fmt.Errorf("error querying neighbor: %w", err)
 					}


### PR DESCRIPTION
# Description of the PR

Add vex nodes and information to vuln cli for non specified vuln search
```
+-------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| NODE TYPE   | NODE ID # | ADDITIONAL INFORMATION                                                                                                                                                                                               |
+-------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| vexLink     | 74        | vulnerability ID: cve-2021-29923, Vex Status: NOT_AFFECTED, Subject: package (id:40) oci:SANITIZE |
| vexLink     | 75        | vulnerability ID: cve-2022-41724, Vex Status: AFFECTED, Subject: package (id:40) oci:SANITIZE     |
| certifyVuln | 72        | vulnerability ID: cve-2021-29923                                                                                                                                                                                     |
| certifyVuln | 73        | vulnerability ID: cve-2022-41724                                                                                                                                                                                     |
+-------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Visualizer url: http://localhost:3000/?path=43,42,41,40,74,49,75,50,70,15,14,3,2,72,73
```
![image](https://github.com/guacsec/guac/assets/3060102/a98efed6-400b-4d61-9609-bc523feaeac6)

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
