### PR TITLE
Add PointOfContact predicate to PatchPlanning

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -13433,10 +13433,14 @@ func __marshalNeighborsNeighborsNode(v *NeighborsNeighborsNode) ([]byte, error) 
 	case *NeighborsNeighborsPointOfContact:
 		typename = "PointOfContact"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NeighborsNeighborsPointOfContact
-		}{typename, v}
+			*__premarshalNeighborsNeighborsPointOfContact
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NeighborsNeighborsSource:
 		typename = "Source"
@@ -13735,11 +13739,121 @@ func (v *NeighborsNeighborsPkgEqual) __premarshalJSON() (*__premarshalNeighborsN
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type NeighborsNeighborsPointOfContact struct {
-	Typename *string `json:"__typename"`
+	Typename          *string `json:"__typename"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsPointOfContact.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsPointOfContact) GetTypename() *string { return v.Typename }
+
+// GetId returns NeighborsNeighborsPointOfContact.Id, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetId() string { return v.AllPointOfContact.Id }
+
+// GetSubject returns NeighborsNeighborsPointOfContact.Subject, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
+}
+
+// GetEmail returns NeighborsNeighborsPointOfContact.Email, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
+
+// GetInfo returns NeighborsNeighborsPointOfContact.Info, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
+
+// GetSince returns NeighborsNeighborsPointOfContact.Since, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetSince() time.Time { return v.AllPointOfContact.Since }
+
+// GetJustification returns NeighborsNeighborsPointOfContact.Justification, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetJustification() string {
+	return v.AllPointOfContact.Justification
+}
+
+// GetOrigin returns NeighborsNeighborsPointOfContact.Origin, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
+
+// GetCollector returns NeighborsNeighborsPointOfContact.Collector, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsPointOfContact) GetCollector() string {
+	return v.AllPointOfContact.Collector
+}
+
+func (v *NeighborsNeighborsPointOfContact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NeighborsNeighborsPointOfContact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NeighborsNeighborsPointOfContact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPointOfContact)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNeighborsNeighborsPointOfContact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Email string `json:"email"`
+
+	Info string `json:"info"`
+
+	Since time.Time `json:"since"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NeighborsNeighborsPointOfContact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NeighborsNeighborsPointOfContact) __premarshalJSON() (*__premarshalNeighborsNeighborsPointOfContact, error) {
+	var retval __premarshalNeighborsNeighborsPointOfContact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPointOfContact.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllPointOfContact.Subject
+		var err error
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NeighborsNeighborsPointOfContact.AllPointOfContact.Subject: %w", err)
+		}
+	}
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
+	return &retval, nil
+}
 
 // NeighborsNeighborsSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
@@ -14322,10 +14436,14 @@ func __marshalNodeNode(v *NodeNode) ([]byte, error) {
 	case *NodeNodePointOfContact:
 		typename = "PointOfContact"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NodeNodePointOfContact
-		}{typename, v}
+			*__premarshalNodeNodePointOfContact
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NodeNodeSource:
 		typename = "Source"
@@ -16217,11 +16335,117 @@ func (v *NodeNodePkgEqual) __premarshalJSON() (*__premarshalNodeNodePkgEqual, er
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type NodeNodePointOfContact struct {
-	Typename *string `json:"__typename"`
+	Typename          *string `json:"__typename"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetTypename returns NodeNodePointOfContact.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodePointOfContact) GetTypename() *string { return v.Typename }
+
+// GetId returns NodeNodePointOfContact.Id, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetId() string { return v.AllPointOfContact.Id }
+
+// GetSubject returns NodeNodePointOfContact.Subject, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
+}
+
+// GetEmail returns NodeNodePointOfContact.Email, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
+
+// GetInfo returns NodeNodePointOfContact.Info, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
+
+// GetSince returns NodeNodePointOfContact.Since, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetSince() time.Time { return v.AllPointOfContact.Since }
+
+// GetJustification returns NodeNodePointOfContact.Justification, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetJustification() string { return v.AllPointOfContact.Justification }
+
+// GetOrigin returns NodeNodePointOfContact.Origin, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
+
+// GetCollector returns NodeNodePointOfContact.Collector, and is useful for accessing the field via an interface.
+func (v *NodeNodePointOfContact) GetCollector() string { return v.AllPointOfContact.Collector }
+
+func (v *NodeNodePointOfContact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NodeNodePointOfContact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NodeNodePointOfContact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPointOfContact)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNodeNodePointOfContact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Email string `json:"email"`
+
+	Info string `json:"info"`
+
+	Since time.Time `json:"since"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NodeNodePointOfContact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NodeNodePointOfContact) __premarshalJSON() (*__premarshalNodeNodePointOfContact, error) {
+	var retval __premarshalNodeNodePointOfContact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPointOfContact.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllPointOfContact.Subject
+		var err error
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NodeNodePointOfContact.AllPointOfContact.Subject: %w", err)
+		}
+	}
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
+	return &retval, nil
+}
 
 // NodeNodeSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
@@ -18390,10 +18614,14 @@ func __marshalNodesNodesNode(v *NodesNodesNode) ([]byte, error) {
 	case *NodesNodesPointOfContact:
 		typename = "PointOfContact"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NodesNodesPointOfContact
-		}{typename, v}
+			*__premarshalNodesNodesPointOfContact
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NodesNodesSource:
 		typename = "Source"
@@ -18692,11 +18920,119 @@ func (v *NodesNodesPkgEqual) __premarshalJSON() (*__premarshalNodesNodesPkgEqual
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type NodesNodesPointOfContact struct {
-	Typename *string `json:"__typename"`
+	Typename          *string `json:"__typename"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetTypename returns NodesNodesPointOfContact.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesPointOfContact) GetTypename() *string { return v.Typename }
+
+// GetId returns NodesNodesPointOfContact.Id, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetId() string { return v.AllPointOfContact.Id }
+
+// GetSubject returns NodesNodesPointOfContact.Subject, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
+}
+
+// GetEmail returns NodesNodesPointOfContact.Email, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
+
+// GetInfo returns NodesNodesPointOfContact.Info, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
+
+// GetSince returns NodesNodesPointOfContact.Since, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetSince() time.Time { return v.AllPointOfContact.Since }
+
+// GetJustification returns NodesNodesPointOfContact.Justification, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetJustification() string {
+	return v.AllPointOfContact.Justification
+}
+
+// GetOrigin returns NodesNodesPointOfContact.Origin, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
+
+// GetCollector returns NodesNodesPointOfContact.Collector, and is useful for accessing the field via an interface.
+func (v *NodesNodesPointOfContact) GetCollector() string { return v.AllPointOfContact.Collector }
+
+func (v *NodesNodesPointOfContact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NodesNodesPointOfContact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NodesNodesPointOfContact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPointOfContact)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNodesNodesPointOfContact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Email string `json:"email"`
+
+	Info string `json:"info"`
+
+	Since time.Time `json:"since"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NodesNodesPointOfContact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NodesNodesPointOfContact) __premarshalJSON() (*__premarshalNodesNodesPointOfContact, error) {
+	var retval __premarshalNodesNodesPointOfContact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPointOfContact.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllPointOfContact.Subject
+		var err error
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NodesNodesPointOfContact.AllPointOfContact.Subject: %w", err)
+		}
+	}
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
+	return &retval, nil
+}
 
 // NodesNodesSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
@@ -21108,10 +21444,14 @@ func __marshalPathPathNode(v *PathPathNode) ([]byte, error) {
 	case *PathPathPointOfContact:
 		typename = "PointOfContact"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*PathPathPointOfContact
-		}{typename, v}
+			*__premarshalPathPathPointOfContact
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *PathPathSource:
 		typename = "Source"
@@ -21408,11 +21748,117 @@ func (v *PathPathPkgEqual) __premarshalJSON() (*__premarshalPathPathPkgEqual, er
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type PathPathPointOfContact struct {
-	Typename *string `json:"__typename"`
+	Typename          *string `json:"__typename"`
+	AllPointOfContact `json:"-"`
 }
 
 // GetTypename returns PathPathPointOfContact.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathPointOfContact) GetTypename() *string { return v.Typename }
+
+// GetId returns PathPathPointOfContact.Id, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetId() string { return v.AllPointOfContact.Id }
+
+// GetSubject returns PathPathPointOfContact.Subject, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
+	return v.AllPointOfContact.Subject
+}
+
+// GetEmail returns PathPathPointOfContact.Email, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
+
+// GetInfo returns PathPathPointOfContact.Info, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
+
+// GetSince returns PathPathPointOfContact.Since, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetSince() time.Time { return v.AllPointOfContact.Since }
+
+// GetJustification returns PathPathPointOfContact.Justification, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetJustification() string { return v.AllPointOfContact.Justification }
+
+// GetOrigin returns PathPathPointOfContact.Origin, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
+
+// GetCollector returns PathPathPointOfContact.Collector, and is useful for accessing the field via an interface.
+func (v *PathPathPointOfContact) GetCollector() string { return v.AllPointOfContact.Collector }
+
+func (v *PathPathPointOfContact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*PathPathPointOfContact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.PathPathPointOfContact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPointOfContact)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalPathPathPointOfContact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Email string `json:"email"`
+
+	Info string `json:"info"`
+
+	Since time.Time `json:"since"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *PathPathPointOfContact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *PathPathPointOfContact) __premarshalJSON() (*__premarshalPathPathPointOfContact, error) {
+	var retval __premarshalPathPathPointOfContact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPointOfContact.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllPointOfContact.Subject
+		var err error
+		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal PathPathPointOfContact.AllPointOfContact.Subject: %w", err)
+		}
+	}
+	retval.Email = v.AllPointOfContact.Email
+	retval.Info = v.AllPointOfContact.Info
+	retval.Since = v.AllPointOfContact.Since
+	retval.Justification = v.AllPointOfContact.Justification
+	retval.Origin = v.AllPointOfContact.Origin
+	retval.Collector = v.AllPointOfContact.Collector
+	return &retval, nil
+}
 
 // PathPathSource includes the requested fields of the GraphQL type Source.
 // The GraphQL type's documentation follows.
@@ -28066,6 +28512,9 @@ query Neighbors ($node: ID!, $usingOnly: [Edge!]!) {
 		... on HasSourceAt {
 			... AllHasSourceAt
 		}
+		... on PointOfContact {
+			... AllPointOfContact
+		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
@@ -28294,6 +28743,27 @@ fragment AllHasSourceAt on HasSourceAt {
 	source {
 		... AllSourceTree
 	}
+	origin
+	collector
+}
+fragment AllPointOfContact on PointOfContact {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	email
+	info
+	since
+	justification
 	origin
 	collector
 }
@@ -28465,6 +28935,9 @@ query Node ($node: ID!) {
 		... on HasSourceAt {
 			... AllHasSourceAt
 		}
+		... on PointOfContact {
+			... AllPointOfContact
+		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
@@ -28693,6 +29166,27 @@ fragment AllHasSourceAt on HasSourceAt {
 	source {
 		... AllSourceTree
 	}
+	origin
+	collector
+}
+fragment AllPointOfContact on PointOfContact {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	email
+	info
+	since
+	justification
 	origin
 	collector
 }
@@ -28862,6 +29356,9 @@ query Nodes ($nodes: [ID!]!) {
 		... on HasSourceAt {
 			... AllHasSourceAt
 		}
+		... on PointOfContact {
+			... AllPointOfContact
+		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
@@ -29090,6 +29587,27 @@ fragment AllHasSourceAt on HasSourceAt {
 	source {
 		... AllSourceTree
 	}
+	origin
+	collector
+}
+fragment AllPointOfContact on PointOfContact {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	email
+	info
+	since
+	justification
 	origin
 	collector
 }
@@ -29354,6 +29872,9 @@ query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge
 		... on HasSourceAt {
 			... AllHasSourceAt
 		}
+		... on PointOfContact {
+			... AllPointOfContact
+		}
 		... on CertifyVuln {
 			... AllCertifyVuln
 		}
@@ -29582,6 +30103,27 @@ fragment AllHasSourceAt on HasSourceAt {
 	source {
 		... AllSourceTree
 	}
+	origin
+	collector
+}
+fragment AllPointOfContact on PointOfContact {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	email
+	info
+	since
+	justification
 	origin
 	collector
 }

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -74,6 +74,9 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!
     ... on HasSourceAt {
       ...AllHasSourceAt
     }
+    ... on PointOfContact{
+      ...AllPointOfContact
+    }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
@@ -145,6 +148,9 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
     }
     ... on HasSourceAt {
       ...AllHasSourceAt
+    }
+    ... on PointOfContact {
+      ...AllPointOfContact
     }
     ... on CertifyVuln {
       ...AllCertifyVuln
@@ -218,6 +224,9 @@ query Node($node: ID!) {
     ... on HasSourceAt {
       ...AllHasSourceAt
     }
+    ... on PointOfContact {
+      ...AllPointOfContact
+    }
     ... on CertifyVuln {
       ...AllCertifyVuln
     }
@@ -289,6 +298,9 @@ query Nodes($nodes: [ID!]!) {
     }
     ... on HasSourceAt {
       ...AllHasSourceAt
+    }
+    ... on PointOfContact{
+      ...AllPointOfContact
     }
     ... on CertifyVuln {
       ...AllCertifyVuln

--- a/pkg/guacanalytics/patchPlanning.go
+++ b/pkg/guacanalytics/patchPlanning.go
@@ -39,7 +39,7 @@ type BfsNode struct {
 	Depth            int
 	Type             NodeType
 	nodeVersions     []string // for a packageName, what was the packageVersion associated with this version.  For a packageVersion, what is the version.
-	PointOfContact   model.PointOfContactInputSpec
+	PointOfContactId string
 	NotInBlastRadius bool // true if it is solely an informational node, not to be included in the blast radius subgraph
 }
 
@@ -276,16 +276,14 @@ func exploreHasSourceAtFromPackage(ctx context.Context, gqlClient graphql.Client
 
 // TODO: implement
 func explorePointOfContact(ctx context.Context, gqlClient graphql.Client, q *queueValues, pointOfContact model.NeighborsNeighborsPointOfContact) {
-	pocFilter := model.PointOfContactSpec{
-		Subject: now,
-	}
-
-	pointOfContact.AllPointOfContact
-
 	// Step 1: Add field to current node in nodeMap of this POC (may need to copy over old fields)
 	q.nodeMap[q.now] = BfsNode{
-		Parent: q.nowNode.Parent,
-		Depth:  q.nowNode.Depth,
+		Parent:           q.nowNode.Parent,
+		Depth:            q.nowNode.Depth,
+		Type:             q.nowNode.Type,
+		nodeVersions:     q.nowNode.nodeVersions,
+		PointOfContactId: pointOfContact.AllPointOfContact.Id,
+		NotInBlastRadius: q.nowNode.NotInBlastRadius,
 	}
 
 	// Step 2: If it is a packageName, add the POC to applicable versions (versions in the nodeVersions) but not the reverse

--- a/pkg/guacanalytics/patchPlanning.go
+++ b/pkg/guacanalytics/patchPlanning.go
@@ -277,14 +277,11 @@ func exploreHasSourceAtFromPackage(ctx context.Context, gqlClient graphql.Client
 // TODO: implement
 func explorePointOfContact(ctx context.Context, gqlClient graphql.Client, q *queueValues, pointOfContact model.NeighborsNeighborsPointOfContact) {
 	// Step 1: Add field to current node in nodeMap of this POC (may need to copy over old fields)
-	q.nodeMap[q.now] = {
-	Parent: q.nowNode.Parent
-	Depth: q.nowNode.Depth
-	Type: q.nowNode.Type
-	nodeVersions: q.nowNode.nodeVersions
-	PointOfContact   pointOfContact.
-	NotInBlastRadius q.nowNode.NotInBlastRadius
+	q.nodeMap[q.now] = BfsNode{
+		Parent: q.nowNode.Parent,
+		Depth:  q.nowNode.Depth,
 	}
+	pointOfContact.Subject
 	// Step 2: If it is a packageName, add the POC to applicable versions (versions in the nodeVersions) but not the reverse
 	// (i.e. for a version do not add POC to associated name as it may not be applicable)
 }

--- a/pkg/guacanalytics/patchPlanning.go
+++ b/pkg/guacanalytics/patchPlanning.go
@@ -276,12 +276,18 @@ func exploreHasSourceAtFromPackage(ctx context.Context, gqlClient graphql.Client
 
 // TODO: implement
 func explorePointOfContact(ctx context.Context, gqlClient graphql.Client, q *queueValues, pointOfContact model.NeighborsNeighborsPointOfContact) {
+	pocFilter := model.PointOfContactSpec{
+		Subject: now,
+	}
+
+	pointOfContact.AllPointOfContact
+
 	// Step 1: Add field to current node in nodeMap of this POC (may need to copy over old fields)
 	q.nodeMap[q.now] = BfsNode{
 		Parent: q.nowNode.Parent,
 		Depth:  q.nowNode.Depth,
 	}
-	pointOfContact.Subject
+
 	// Step 2: If it is a packageName, add the POC to applicable versions (versions in the nodeVersions) but not the reverse
 	// (i.e. for a version do not add POC to associated name as it may not be applicable)
 }

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -1208,7 +1208,6 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 		expectedPkgs      []string
 		expectedArtifacts []string
 		expectedSrcs      []string
-		expectedPOC       []string
 		expectedPOCLen    int
 		graphInputs       []assembler.IngestPredicates
 	}{
@@ -1448,7 +1447,6 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			expectedPkgs:      []string{"pkgTypeL", "pkgTypeM"},
 			expectedSrcs:      []string{"srcTypeK"},
 			expectedArtifacts: []string{"testArtifactAlgorithmK"},
-			expectedPOC:       []string{"testEmailK", "testEmailL", "testEmailM"},
 			expectedPOCLen:    5,
 			graphInputs:       []assembler.IngestPredicates{pointOfContactGraph},
 		},

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -1209,6 +1209,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 		expectedArtifacts []string
 		expectedSrcs      []string
 		expectedPOCLen    int
+		expectedPOCs      []string
 		graphInputs       []assembler.IngestPredicates
 	}{
 		{
@@ -1447,6 +1448,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			expectedPkgs:      []string{"pkgTypeL", "pkgTypeM"},
 			expectedSrcs:      []string{"srcTypeK"},
 			expectedArtifacts: []string{"testArtifactAlgorithmK"},
+			expectedPOCs:      []string{"testEmailK", "testEmailL", "testEmailM"},
 			expectedPOCLen:    5,
 			graphInputs:       []assembler.IngestPredicates{pointOfContactGraph},
 		},
@@ -1546,8 +1548,22 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 				expectedSrcIDs = append(expectedSrcIDs, srcID)
 			}
 
-			if len(getReturnedPOCs(ctx, gqlClient, gotMap)) != tt.expectedPOCLen {
+			returnedPOCs := getReturnedPOCs(ctx, gqlClient, gotMap)
+			if len(returnedPOCs) != tt.expectedPOCLen {
 				t.Errorf("Found %d POCs recorded but expected %d \n", len(getReturnedPOCs(ctx, gqlClient, gotMap)), tt.expectedPOCLen)
+			}
+
+			inExpectedPOCs := false
+			for _, gotPOC := range returnedPOCs {
+				for _, expectedPOC := range tt.expectedPOCs {
+					if gotPOC == expectedPOC {
+						inExpectedPOCs = true
+						break
+					}
+				}
+				if !inExpectedPOCs {
+					t.Errorf("this ID appears in the returned POCs but is not expected: %s \n", gotPOC)
+				}
 			}
 
 			for gotID, node := range gotMap {
@@ -1573,7 +1589,6 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 						break
 					}
 				}
-
 				inExpectedSrcs := false
 				for _, expectedID := range expectedSrcIDs {
 					if expectedID == gotID {

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -796,6 +796,138 @@ var (
 			},
 		},
 	}
+	pointOfContactGraph = assembler.IngestPredicates{
+		IsOccurrence: []assembler.IsOccurrenceIngest{
+			{
+				Pkg: &model.PkgInputSpec{
+					Type:      "pkgTypeL",
+					Namespace: ptrfrom.String("pkgNamespaceL"),
+					Name:      "pkgNameL",
+					Version:   ptrfrom.String("1.19.0"),
+				},
+				Artifact: &model.ArtifactInputSpec{
+					Algorithm: "testArtifactAlgorithmK",
+					Digest:    "testArtifactDigestK",
+				},
+				IsOccurrence: &model.IsOccurrenceInputSpec{
+					Justification: "connect pkgL and artifactK",
+				},
+			},
+		},
+		HasSourceAt: []assembler.HasSourceAtIngest{
+			{
+				Src: &model.SourceInputSpec{
+					Type:      "srcTypeK",
+					Namespace: "srcNamespaceK",
+					Name:      "srcNameK",
+				},
+				Pkg: &model.PkgInputSpec{
+					Type:      "pkgTypeL",
+					Namespace: ptrfrom.String("pkgNamespaceL"),
+					Name:      "pkgNameL",
+					Version:   ptrfrom.String("1.19.0"),
+				},
+				HasSourceAt: &model.HasSourceAtInputSpec{
+					Justification: "test justification",
+					KnownSince:    tm,
+				},
+				PkgMatchFlag: model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+			},
+		},
+		IsDependency: []assembler.IsDependencyIngest{
+			{
+				Pkg: &model.PkgInputSpec{
+					Type:      "pkgTypeL",
+					Namespace: ptrfrom.String("pkgNamespaceL"),
+					Name:      "pkgNameL",
+					Version:   ptrfrom.String("1.19.0"),
+				},
+				DepPkg: &model.PkgInputSpec{
+					Type:      "pkgTypeM",
+					Namespace: ptrfrom.String("pkgNamespaceM"),
+					Name:      "pkgNameM",
+					Version:   ptrfrom.String("3.0.3"),
+				},
+				IsDependency: &model.IsDependencyInputSpec{
+					VersionRange:   "=>1.0.0",
+					DependencyType: model.DependencyTypeDirect,
+					Justification:  "test justification one",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+			},
+		},
+		PointOfContact: []assembler.PointOfContactIngest{
+			{
+				Pkg: &model.PkgInputSpec{
+					Type:      "pkgTypeM",
+					Namespace: ptrfrom.String("pkgNamespaceM"),
+					Name:      "pkgNameM",
+					Version:   ptrfrom.String("1.19.0"),
+				},
+				PkgMatchFlag: model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+				PointOfContact: &model.PointOfContactInputSpec{
+					Email:         "testEmailM",
+					Info:          "testInfo",
+					Since:         tm,
+					Justification: "testJustification",
+					Origin:        "testOrigin",
+					Collector:     "testCollector",
+				},
+			},
+			{
+				Pkg: &model.PkgInputSpec{
+					Type:      "pkgTypeL",
+					Namespace: ptrfrom.String("pkgNamespaceL"),
+					Name:      "pkgNameL",
+				},
+				PkgMatchFlag: model.MatchFlags{
+					Pkg: model.PkgMatchTypeAllVersions,
+				},
+				PointOfContact: &model.PointOfContactInputSpec{
+					Email:         "testEmailL",
+					Info:          "testInfo",
+					Since:         tm,
+					Justification: "testJustification",
+					Origin:        "testOrigin",
+					Collector:     "testCollector",
+				},
+			},
+			{
+				Artifact: &model.ArtifactInputSpec{
+					Algorithm: "testArtifactAlgorithmK",
+					Digest:    "testArtifactDigestK",
+				},
+				PointOfContact: &model.PointOfContactInputSpec{
+					Email:         "testEmailK",
+					Info:          "testInfo",
+					Since:         tm,
+					Justification: "testJustification",
+					Origin:        "testOrigin",
+					Collector:     "testCollector",
+				},
+			},
+			{
+				Src: &model.SourceInputSpec{
+					Type:      "srcTypeK",
+					Namespace: "srcNamespaceK",
+					Name:      "srcNameK",
+				},
+				PointOfContact: &model.PointOfContactInputSpec{
+					Email:         "testEmailK",
+					Info:          "testInfo",
+					Since:         tm,
+					Justification: "testJustification",
+					Origin:        "testOrigin",
+					Collector:     "testCollector",
+				},
+			},
+		},
+	}
 )
 
 func ingestIsDependency(ctx context.Context, client graphql.Client, graph assembler.IngestPredicates) error {
@@ -828,7 +960,7 @@ func ingestHasSLSA(ctx context.Context, client graphql.Client, graph assembler.I
 			return fmt.Errorf("error in ingesting Builder for HasSlsa: %v\n", err)
 		}
 
-		_, err = model.IngestArtifacts(ctx, client, ingest.Materials)
+		_, err = model.IngestMaterials(ctx, client, ingest.Materials)
 
 		if err != nil {
 			return fmt.Errorf("error in ingesting Material for HasSlsa: %v\n", err)
@@ -963,6 +1095,38 @@ func ingestHashEqual(ctx context.Context, client graphql.Client, graph assembler
 	return nil
 }
 
+func ingestPointOfContact(ctx context.Context, client graphql.Client, graph assembler.IngestPredicates) error {
+	for _, ingest := range graph.PointOfContact {
+		var err error
+
+		if ingest.Src != nil {
+			_, err = model.IngestSource(ctx, client, *ingest.Src)
+		} else if ingest.Pkg != nil {
+			_, err = model.IngestPackage(ctx, client, *ingest.Pkg)
+
+		} else {
+			_, err = model.IngestArtifact(ctx, client, *ingest.Artifact)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error in ingesting pkg/src/artifact PointOfContact: %v\n", err)
+		}
+
+		if ingest.Src != nil {
+			_, err = model.PointOfContactSrc(ctx, client, *ingest.Src, *ingest.PointOfContact)
+		} else if ingest.Pkg != nil {
+			_, err = model.PointOfContactPkg(ctx, client, *ingest.Pkg, &ingest.PkgMatchFlag, *ingest.PointOfContact)
+		} else {
+			_, err = model.PointOfContactArtifact(ctx, client, *ingest.Artifact, *ingest.PointOfContact)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error in ingesting PointOfContact: %v\n", err)
+		}
+	}
+	return nil
+}
+
 func ingestTestData(ctx context.Context, client graphql.Client, graph assembler.IngestPredicates) error {
 	if len(graph.IsDependency) > 0 {
 		err := ingestIsDependency(ctx, client, graph)
@@ -1013,6 +1177,13 @@ func ingestTestData(ctx context.Context, client graphql.Client, graph assembler.
 		}
 	}
 
+	if len(graph.PointOfContact) > 0 {
+		err := ingestPointOfContact(ctx, client, graph)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -1044,6 +1215,8 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 		expectedPkgs      []string
 		expectedArtifacts []string
 		expectedSrcs      []string
+		expectedPOC       []string
+		expectedPOCLen    int
 		graphInputs       []assembler.IngestPredicates
 	}{
 		{
@@ -1255,8 +1428,8 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			startName:      "aName",
 			startVersion:   ptrfrom.String("1.19.0"),
 			maxDepth:       10,
-			expectedLen:    8,                                            // change to 8 once implemented
-			expectedPkgs:   []string{"aType", "bType", "cType", "dType"}, // add dType once implemented
+			expectedLen:    8,
+			expectedPkgs:   []string{"aType", "bType", "cType", "dType"},
 			graphInputs:    []assembler.IngestPredicates{pkgEqualGraph},
 		},
 		{
@@ -1266,10 +1439,23 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			startName:         "abcPkgName1",
 			startVersion:      ptrfrom.String("3.0.3"),
 			maxDepth:          10,
-			expectedLen:       7,                              // change to 8 once implemented
-			expectedPkgs:      []string{"abcPkg1", "abcPkg2"}, // add abcPkg2 once implemented and expectedArtifacts abcTestArtifactAlgorithm
+			expectedLen:       7,
+			expectedPkgs:      []string{"abcPkg1", "abcPkg2"},
 			expectedArtifacts: []string{"abcTestArtifactAlgorithm"},
 			graphInputs:       []assembler.IngestPredicates{hashEqualGraph},
+		},
+		{
+			name:              "20: test pointOfContact",
+			startType:         "pkgTypeM",
+			startNamespace:    "pkgNamespaceM",
+			startName:         "pkgNameM",
+			startVersion:      ptrfrom.String("3.0.3"),
+			maxDepth:          9,
+			expectedLen:       6,
+			expectedPkgs:      []string{"pkgTypeL", "pkgTypeM"},
+			expectedSrcs:      []string{"srcTypeK"}, // add expectedPOC K, L, M once implemented w/ len 5
+			expectedArtifacts: []string{"testArtifactAlgorithmK"},
+			graphInputs:       []assembler.IngestPredicates{pointOfContactGraph},
 		},
 	}
 
@@ -1404,6 +1590,8 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 					t.Errorf("this ID appears in the returned map but is not expected: %s \n", gotID)
 					return
 				}
+
+				// TODO: add check for POC
 			}
 
 		})


### PR DESCRIPTION
# Description of the PR

Add POC predicate to patch planning

- regenerate files to update POC fields
- rename DfsNode to BfsNode to reflect code functionality

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
