### PR TITLE
add query for IsOccurrence, isDependency and HasSBOM for Arango backend

### DIFF
--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -27,7 +27,8 @@ import (
 
 func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.ArtifactSpec) ([]*model.Artifact, error) {
 	values := map[string]any{}
-	arangoQueryBuilder := setArtifactMatchValues(artifactSpec, values)
+
+	arangoQueryBuilder := setArtifactMatchValues(nil, artifactSpec, values)
 	arangoQueryBuilder.query.WriteString("\n")
 	arangoQueryBuilder.query.WriteString(`RETURN {
 		"id": art._id,
@@ -45,8 +46,10 @@ func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifa
 	return getArtifacts(ctx, cursor)
 }
 
-func setArtifactMatchValues(artifactSpec *model.ArtifactSpec, queryValues map[string]any) *arangoQueryBuilder {
-	arangoQueryBuilder := newForQuery(artifactsStr, "art")
+func setArtifactMatchValues(arangoQueryBuilder *arangoQueryBuilder, artifactSpec *model.ArtifactSpec, queryValues map[string]any) *arangoQueryBuilder {
+	if arangoQueryBuilder == nil {
+		arangoQueryBuilder = newForQuery(artifactsStr, "art")
+	}
 	if artifactSpec != nil {
 		if artifactSpec.ID != nil {
 			arangoQueryBuilder.filter("art", "_id", "==", "@id")

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -700,16 +700,43 @@ func newForQuery(repositoryName string, counterName string) *arangoQueryBuilder 
 	return aqb
 }
 
-func (aqb *arangoQueryBuilder) ForOutBound(edgeCollectionName string, counterName string, outBoundValueName string) *arangoQueryBuilder {
+func (aqb *arangoQueryBuilder) forOutBound(edgeCollectionName string, counterVertexName string, outBoundStartVertexName string) *arangoQueryBuilder {
 	aqb.query.WriteString("\n")
-	aqb.query.WriteString(fmt.Sprintf("FOR %s IN OUTBOUND %s %s", counterName, outBoundValueName, edgeCollectionName))
+
+	aqb.query.WriteString(fmt.Sprintf("FOR %s IN OUTBOUND %s %s", counterVertexName, outBoundStartVertexName, edgeCollectionName))
+
 	return aqb
 }
 
-func (aqb *arangoQueryBuilder) ForInBound(edgeCollectionName string, counterName string, inBoundValueName string) *arangoQueryBuilder {
+func (aqb *arangoQueryBuilder) forOutBoundWithEdgeCounter(edgeCollectionName string, counterVertexName string, counterEdgeName string, outBoundStartVertexName string) *arangoQueryBuilder {
 	aqb.query.WriteString("\n")
-	aqb.query.WriteString(fmt.Sprintf("FOR %s IN INBOUND %s %s", counterName, inBoundValueName, edgeCollectionName))
+
+	aqb.query.WriteString(fmt.Sprintf("FOR %s, %s IN OUTBOUND %s %s", counterVertexName, counterEdgeName, outBoundStartVertexName, edgeCollectionName))
+
 	return aqb
+}
+
+func (aqb *arangoQueryBuilder) forInBound(edgeCollectionName string, counterVertexName string, inBoundStartVertexName string) *arangoQueryBuilder {
+	aqb.query.WriteString("\n")
+
+	aqb.query.WriteString(fmt.Sprintf("FOR %s IN INBOUND %s %s", counterVertexName, inBoundStartVertexName, edgeCollectionName))
+
+	return aqb
+}
+
+func (aqb *arangoQueryBuilder) forInBoundWithEdgeCounter(edgeCollectionName string, counterVertexName string, counterEdgeName string, inBoundStartVertexName string) *arangoQueryBuilder {
+	aqb.query.WriteString("\n")
+
+	aqb.query.WriteString(fmt.Sprintf("FOR %s, %s IN INBOUND %s %s", counterVertexName, counterEdgeName, inBoundStartVertexName, edgeCollectionName))
+
+	return aqb
+}
+
+func (aqb *arangoQueryBuilder) prune(counterName string, fieldName string, condition string, value string) *arangoQueryFilter {
+	aqb.query.WriteString(" ")
+	aqb.query.WriteString(fmt.Sprintf("PRUNE %s.%s %s %s", counterName, fieldName, condition, value))
+
+	return newArangoQueryFilter(aqb)
 }
 
 func (aqb *arangoQueryBuilder) filter(counterName string, fieldName string, condition string, value string) *arangoQueryFilter {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -904,7 +904,7 @@ func preIngestPkgTypes(ctx context.Context, db driver.Database, pkgRoot *pkgRoot
 		  )
 	
 		  LET pkgHasTypeCollection = (
-			INSERT { _key: CONCAT("pkgHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "pkgHasType" } INTO pkgHasType OPTIONS { overwriteMode: "ignore" }
+			INSERT { _key: CONCAT("pkgHasType", @rootKey, type._key), _from: @rootID, _to: type._id} INTO pkgHasType OPTIONS { overwriteMode: "ignore" }
 		  )
 	
 		RETURN {
@@ -995,7 +995,7 @@ func preIngestSrcTypes(ctx context.Context, db driver.Database, srcRoot *srcRoot
 		  )
 	
 		  LET pkgHasTypeCollection = (
-			INSERT { _key: CONCAT("srcHasType", @rootKey, type._key), _from: @rootID, _to: type._id, label : "srcHasType" } INTO srcHasType OPTIONS { overwriteMode: "ignore" }
+			INSERT { _key: CONCAT("srcHasType", @rootKey, type._key), _from: @rootID, _to: type._id } INTO srcHasType OPTIONS { overwriteMode: "ignore" }
 		  )
 	
 		RETURN {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -706,6 +706,12 @@ func (aqb *arangoQueryBuilder) ForOutBound(edgeCollectionName string, counterNam
 	return aqb
 }
 
+func (aqb *arangoQueryBuilder) ForInBound(edgeCollectionName string, counterName string, inBoundValueName string) *arangoQueryBuilder {
+	aqb.query.WriteString("\n")
+	aqb.query.WriteString(fmt.Sprintf("FOR %s IN INBOUND %s %s", counterName, inBoundValueName, edgeCollectionName))
+	return aqb
+}
+
 func (aqb *arangoQueryBuilder) filter(counterName string, fieldName string, condition string, value string) *arangoQueryFilter {
 	aqb.query.WriteString(" ")
 

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -708,14 +708,6 @@ func (aqb *arangoQueryBuilder) forOutBound(edgeCollectionName string, counterVer
 	return aqb
 }
 
-func (aqb *arangoQueryBuilder) forOutBoundWithEdgeCounter(edgeCollectionName string, counterVertexName string, counterEdgeName string, outBoundStartVertexName string) *arangoQueryBuilder {
-	aqb.query.WriteString("\n")
-
-	aqb.query.WriteString(fmt.Sprintf("FOR %s, %s IN OUTBOUND %s %s", counterVertexName, counterEdgeName, outBoundStartVertexName, edgeCollectionName))
-
-	return aqb
-}
-
 func (aqb *arangoQueryBuilder) forInBound(edgeCollectionName string, counterVertexName string, inBoundStartVertexName string) *arangoQueryBuilder {
 	aqb.query.WriteString("\n")
 

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -221,7 +221,7 @@ func (c *arangoClient) IngestScorecards(ctx context.Context, sources []*model.So
 	)
 	
 	LET edgeCollection = (
-	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id, label : "certifyScorecard" } INTO scorecardEdges OPTIONS { overwriteMode: "ignore" }
+	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id } INTO scorecardEdges OPTIONS { overwriteMode: "ignore" }
 	)
 	  
 	  RETURN {
@@ -294,7 +294,7 @@ func (c *arangoClient) IngestScorecard(ctx context.Context, source model.SourceI
 	)
 	
 	LET edgeCollection = (
-	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id, label : "certifyScorecard" } INTO scorecardEdges OPTIONS { overwriteMode: "ignore" }
+	  INSERT {  _key: CONCAT("scorecardEdges", firstSrc.nameDoc._key, scorecard._key), _from: firstSrc.name_id, _to: scorecard._id } INTO scorecardEdges OPTIONS { overwriteMode: "ignore" }
 	)
 	  
 	  RETURN {

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -61,7 +61,7 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 		  )
 		  
 		  LET edgeCollection = (
-			INSERT {  _key: CONCAT("hasSBOMEdges", artifact._key, hasSBOM._key), _from: artifact._id, _to: hasSBOM._id, label : "hasSBOM" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
+			INSERT {  _key: CONCAT("hasSBOMEdges", artifact._key, hasSBOM._key), _from: artifact._id, _to: hasSBOM._id } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
 		  )
 		  
 		  RETURN {
@@ -129,7 +129,7 @@ func (c *arangoClient) IngestHasSbom(ctx context.Context, subject model.PackageO
 		  )
 		  
 		  LET edgeCollection = (
-			INSERT {  _key: CONCAT("hasSBOMEdges", firstPkg.versionDoc._key, hasSBOM._key), _from: firstPkg.version_id, _to: hasSBOM._id, label : "hasSBOM" } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
+			INSERT {  _key: CONCAT("hasSBOMEdges", firstPkg.versionDoc._key, hasSBOM._key), _from: firstPkg.version_id, _to: hasSBOM._id } INTO hasSBOMEdges OPTIONS { overwriteMode: "ignore" }
 		  )
 		  
 		  RETURN {

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -37,8 +37,10 @@ const (
 )
 
 func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
+
+	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
 	values := map[string]any{}
-	arangoQueryBuilder := setArtifactMatchValues(hasSLSASpec.Subject, values)
+	arangoQueryBuilder := setArtifactMatchValues(nil, hasSLSASpec.Subject, values)
 	setHasSLSAMatchValues(arangoQueryBuilder, hasSLSASpec, values)
 
 	arangoQueryBuilder.query.WriteString("\n")
@@ -77,7 +79,7 @@ func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASp
 func setHasSLSAMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSLSASpec *model.HasSLSASpec, queryValues map[string]any) {
 
 	// currently not filtering on builtFrom (artifacts). Is that a real usecase?
-	arangoQueryBuilder.ForOutBound(hasSLSASubjectEdgesStr, "hasSLSA", "art")
+	arangoQueryBuilder.forOutBound(hasSLSASubjectEdgesStr, "hasSLSA", "art")
 	if hasSLSASpec.BuildType != nil {
 		arangoQueryBuilder.filter("hasSLSA", buildTypeStr, "==", "@"+buildTypeStr)
 		queryValues[buildTypeStr] = hasSLSASpec.BuildType
@@ -107,7 +109,7 @@ func setHasSLSAMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSLSASpec *
 		arangoQueryBuilder.filter("hasSLSA", collector, "==", "@"+collector)
 		queryValues[collector] = hasSLSASpec.Collector
 	}
-	arangoQueryBuilder.ForOutBound(hasSLSABuiltByEdgesStr, "build", "hasSLSA")
+	arangoQueryBuilder.forOutBound(hasSLSABuiltByEdgesStr, "build", "hasSLSA")
 	if hasSLSASpec.BuiltBy != nil {
 		arangoQueryBuilder.filter("build", "uri", "==", "@uri")
 		queryValues["uri"] = hasSLSASpec.BuiltBy.URI

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -372,6 +372,7 @@ func getHasSLSA(c *arangoClient, ctx context.Context, cursor driver.Cursor, buil
 
 	var hasSLSAList []*model.HasSlsa
 	for _, createdValue := range createdValues {
+
 		var builtFromArtifacts []*model.Artifact
 		if val, ok := builtFromMap[artifactKey(createdValue.Subject.Algorithm, createdValue.Subject.Digest)]; ok {
 			builtFromArtifacts = val

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -25,6 +25,9 @@ import (
 )
 
 func (c *arangoClient) HashEqual(ctx context.Context, hashEqualSpec *model.HashEqualSpec) ([]*model.HashEqual, error) {
+
+	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
+
 	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
 		return nil, fmt.Errorf("cannot specify more than 2 artifacts in HashEquals")
 	}

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -33,6 +33,8 @@ const (
 // Query IsDependency
 
 func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error) {
+
+	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
 	values := map[string]any{}
 	arangoQueryBuilder := setPkgMatchValues(isDependencySpec.Package, values)
 	setIsDependencyMatchValues(arangoQueryBuilder, isDependencySpec, values)
@@ -80,7 +82,7 @@ func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model
 
 func setIsDependencyMatchValues(arangoQueryBuilder *arangoQueryBuilder, isDependencySpec *model.IsDependencySpec, queryValues map[string]any) {
 
-	arangoQueryBuilder.ForOutBound(isDependencySubjectEdgesStr, "isDependency", "pVersion")
+	arangoQueryBuilder.forOutBound(isDependencySubjectEdgesStr, "isDependency", "pVersion")
 	if isDependencySpec.VersionRange != nil {
 		arangoQueryBuilder.filter("isDependency", versionRangeStr, "==", "@"+versionRangeStr)
 		queryValues[versionRangeStr] = isDependencySpec.VersionRange
@@ -98,25 +100,25 @@ func setIsDependencyMatchValues(arangoQueryBuilder *arangoQueryBuilder, isDepend
 		queryValues[collector] = isDependencySpec.Collector
 	}
 	if isDependencySpec.DependentPackage != nil {
-		arangoQueryBuilder.ForOutBound(isDependencyEdgesStr, "depName", "isDependency")
+		arangoQueryBuilder.forOutBound(isDependencyEdgesStr, "depName", "isDependency")
 		if isDependencySpec.DependentPackage.Name != nil {
 			arangoQueryBuilder.filter("depName", "name", "==", "@name")
 			queryValues["name"] = *isDependencySpec.DependentPackage.Name
 		}
-		arangoQueryBuilder.ForInBound(pkgHasNameStr, "depNamespace", "depName")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "depNamespace", "depName")
 		if isDependencySpec.DependentPackage.Namespace != nil {
 			arangoQueryBuilder.filter("depNamespace", "namespace", "==", "@namespace")
 			queryValues["namespace"] = *isDependencySpec.DependentPackage.Namespace
 		}
-		arangoQueryBuilder.ForInBound(pkgHasNamespaceStr, "depType", "depNamespace")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "depType", "depNamespace")
 		if isDependencySpec.DependentPackage.Namespace != nil {
 			arangoQueryBuilder.filter("depType", "type", "==", "@type")
 			queryValues["type"] = *isDependencySpec.DependentPackage.Type
 		}
 	} else {
-		arangoQueryBuilder.ForOutBound(isDependencyEdgesStr, "depName", "isDependency")
-		arangoQueryBuilder.ForInBound(pkgHasNameStr, "depNamespace", "depName")
-		arangoQueryBuilder.ForInBound(pkgHasNamespaceStr, "depType", "depNamespace")
+		arangoQueryBuilder.forOutBound(isDependencyEdgesStr, "depName", "isDependency")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "depNamespace", "depName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "depType", "depNamespace")
 	}
 }
 

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -145,14 +145,10 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.Pkg
 			UPDATE {} IN isDependencies
 			RETURN NEW
 		)
-		
-	LET edgeCollection = (FOR edgeData IN [
-		{fromKey: isDependency._key, toKey: secondPkg.nameDoc._key, from: isDependency._id, to: secondPkg.name_id, label: 'dependency'}, 
-		{fromKey: firstPkg.versionDoc._key, toKey: isDependency._key, from: firstPkg.version_id, to: isDependency._id, label: 'subject'}]
-	  
-		INSERT { _key: CONCAT('isDependencyEdges', edgeData.fromKey, edgeData.toKey), _from: edgeData.from, _to: edgeData.to, label : edgeData.label } INTO isDependencyEdges OPTIONS { overwriteMode: 'ignore' }
-		)
-		
+	
+	INSERT { _key: CONCAT("isDependencySubjectEdges", firstPkg.versionDoc._key, isDependency._key), _from: firstPkg.version_id, _to: isDependency._id} INTO isDependencySubjectEdges OPTIONS { overwriteMode: "ignore" }
+	INSERT { _key: CONCAT("isDependencyEdges", isDependency._key, secondPkg.nameDoc._key), _from: isDependency._id, _to: secondPkg.name_id} INTO isDependencyEdges OPTIONS { overwriteMode: "ignore" }
+
 	RETURN {
 		'pkgVersion': {
 			'type_id': firstPkg.typeID,

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -217,15 +217,15 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	)
   
 	LET pkgHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("pkgHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "pkgHasNamespace"} INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("pkgHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id } INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasNameCollection = (
-	  INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "pkgHasName"} INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
+ 	  INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id } INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET pkgHasVersionCollection = (
-	  INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "pkgHasVersion"} INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id } INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
 	)
 	  
   RETURN {
@@ -278,15 +278,15 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 	  )
 	
 	  LET pkgHasNamespaceCollection = (
-		INSERT { _key: CONCAT("pkgHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "pkgHasNamespace"} INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id} INTO pkgHasNamespace OPTIONS { overwriteMode: "ignore" }
 	  )
 	  
 	  LET pkgHasNameCollection = (
-		INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "pkgHasName"} INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasName", ns._key, name._key), _from: ns._id, _to: name._id} INTO pkgHasName OPTIONS { overwriteMode: "ignore" }
 	  )
 	  
 	  LET pkgHasVersionCollection = (
-		INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id, label : "pkgHasVersion"} INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("pkgHasVersion", name._key, pkgVersionObj._key), _from: name._id, _to: pkgVersionObj._id } INTO pkgHasVersion OPTIONS { overwriteMode: "ignore" }
 	  )
 		
 	RETURN {

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -324,22 +324,22 @@ func setPkgMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *aran
 		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
 		arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 		queryValues["pkg"] = "pkg"
-		arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
 		if pkgSpec.Type != nil {
 			arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 			queryValues["pkgType"] = *pkgSpec.Type
 		}
-		arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
+		arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
 		if pkgSpec.Namespace != nil {
 			arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 			queryValues["namespace"] = *pkgSpec.Namespace
 		}
-		arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
+		arangoQueryBuilder.forOutBound(pkgHasNameStr, "pName", "pNs")
 		if pkgSpec.Name != nil {
 			arangoQueryBuilder.filter("pName", "name", "==", "@name")
 			queryValues["name"] = *pkgSpec.Name
 		}
-		arangoQueryBuilder.ForOutBound(pkgHasVersionStr, "pVersion", "pName")
+		arangoQueryBuilder.forOutBound(pkgHasVersionStr, "pVersion", "pName")
 		if pkgSpec.ID != nil {
 			arangoQueryBuilder.filter("pVersion", "_id", "==", "@id")
 			queryValues["id"] = *pkgSpec.ID
@@ -368,10 +368,10 @@ func setPkgMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *aran
 
 	} else {
 		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
-		arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
-		arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
-		arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
-		arangoQueryBuilder.ForOutBound(pkgHasVersionStr, "pVersion", "pName")
+		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
+		arangoQueryBuilder.forOutBound(pkgHasNameStr, "pName", "pNs")
+		arangoQueryBuilder.forOutBound(pkgHasVersionStr, "pVersion", "pName")
 	}
 	return arangoQueryBuilder
 }
@@ -440,7 +440,7 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
@@ -488,12 +488,12 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
+	arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
@@ -556,17 +556,17 @@ func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec)
 	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
 	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
 	values["pkg"] = "pkg"
-	arangoQueryBuilder.ForOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound(pkgHasNamespaceStr, "pNs", "pType")
+	arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
 	if pkgSpec.Namespace != nil {
 		arangoQueryBuilder.filter("pNs", "namespace", "==", "@namespace")
 		values["namespace"] = *pkgSpec.Namespace
 	}
-	arangoQueryBuilder.ForOutBound(pkgHasNameStr, "pName", "pNs")
+	arangoQueryBuilder.forOutBound(pkgHasNameStr, "pName", "pNs")
 	if pkgSpec.Name != nil {
 		arangoQueryBuilder.filter("pName", "name", "==", "@name")
 		values["name"] = *pkgSpec.Name

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -164,11 +164,11 @@ func (c *arangoClient) IngestSources(ctx context.Context, sources []*model.Sourc
 	)
   
 	LET srcHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("srcHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id, label : "srcHasNamespace"} INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasNamespace", doc.typeKey, ns._key), _from: doc.typeID, _to: ns._id } INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET srcHasNameCollection = (
-	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "srcHasName"} INTO srcHasName OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id } INTO srcHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	  
     RETURN {
@@ -211,11 +211,11 @@ func (c *arangoClient) IngestSource(ctx context.Context, source model.SourceInpu
 	)
   
 	LET srcHasNamespaceCollection = (
-	  INSERT { _key: CONCAT("srcHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id, label : "srcHasNamespace"} INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasNamespace", @typeKey, ns._key), _from: @typeID, _to: ns._id } INTO srcHasNamespace OPTIONS { overwriteMode: "ignore" }
 	)
 	
 	LET srcHasNameCollection = (
-	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id, label : "srcHasName"} INTO srcHasName OPTIONS { overwriteMode: "ignore" }
+	  INSERT { _key: CONCAT("srcHasName", ns._key, name._key), _from: ns._id, _to: name._id } INTO srcHasName OPTIONS { overwriteMode: "ignore" }
 	)
 	  
     RETURN {

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -251,17 +251,17 @@ func setSrcMatchValues(srcSpec *model.SourceSpec, queryValues map[string]any) *a
 		arangoQueryBuilder = newForQuery(srcRootsStr, "sRoot")
 		arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 		queryValues["src"] = "src"
-		arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
+		arangoQueryBuilder.forOutBound(srcHasTypeStr, "sType", "sRoot")
 		if srcSpec.Type != nil {
 			arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 			queryValues["srcType"] = *srcSpec.Type
 		}
-		arangoQueryBuilder.ForOutBound(srcHasNamespaceStr, "sNs", "sType")
+		arangoQueryBuilder.forOutBound(srcHasNamespaceStr, "sNs", "sType")
 		if srcSpec.Namespace != nil {
 			arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 			queryValues["namespace"] = *srcSpec.Namespace
 		}
-		arangoQueryBuilder.ForOutBound(srcHasNameStr, "sName", "sNs")
+		arangoQueryBuilder.forOutBound(srcHasNameStr, "sName", "sNs")
 		if srcSpec.ID != nil {
 			arangoQueryBuilder.filter("sName", "_id", "==", "@id")
 			queryValues["id"] = *srcSpec.ID
@@ -280,9 +280,9 @@ func setSrcMatchValues(srcSpec *model.SourceSpec, queryValues map[string]any) *a
 		}
 	} else {
 		arangoQueryBuilder = newForQuery(srcRootsStr, "sRoot")
-		arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
-		arangoQueryBuilder.ForOutBound(srcHasNamespaceStr, "sNs", "sType")
-		arangoQueryBuilder.ForOutBound(srcHasNameStr, "sName", "sNs")
+		arangoQueryBuilder.forOutBound(srcHasTypeStr, "sType", "sRoot")
+		arangoQueryBuilder.forOutBound(srcHasNamespaceStr, "sNs", "sType")
+		arangoQueryBuilder.forOutBound(srcHasNameStr, "sName", "sNs")
 	}
 	return arangoQueryBuilder
 }
@@ -343,7 +343,7 @@ func (c *arangoClient) sourcesType(ctx context.Context, sourceSpec *model.Source
 	arangoQueryBuilder := newForQuery(srcRootsStr, "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
+	arangoQueryBuilder.forOutBound(srcHasTypeStr, "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
@@ -391,12 +391,12 @@ func (c *arangoClient) sourcesNamespace(ctx context.Context, sourceSpec *model.S
 	arangoQueryBuilder := newForQuery(srcRootsStr, "sRoot")
 	arangoQueryBuilder.filter("sRoot", "root", "==", "@src")
 	values["src"] = "src"
-	arangoQueryBuilder.ForOutBound(srcHasTypeStr, "sType", "sRoot")
+	arangoQueryBuilder.forOutBound(srcHasTypeStr, "sType", "sRoot")
 	if sourceSpec.Type != nil {
 		arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
 		values["srcType"] = *sourceSpec.Type
 	}
-	arangoQueryBuilder.ForOutBound(srcHasNamespaceStr, "sNs", "sType")
+	arangoQueryBuilder.forOutBound(srcHasNamespaceStr, "sNs", "sType")
 	if sourceSpec.Namespace != nil {
 		arangoQueryBuilder.filter("sNs", "namespace", "==", "@namespace")
 		values["namespace"] = *sourceSpec.Namespace


### PR DESCRIPTION
# Description of the PR

- add query for IsOccurrence, isDependency and HasSBOM
- update scorecard query to be more robust

The next PR will include:

- remove src and package type pre-ingest
- return all artifacts from builtFrom from the hasSLSA query and filter
  in go
- query HashEqual
- ingest HasSBOMs (batch)
- ingest hashEqual (batch)

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
