### PR TITLE
Parse SPDX: manage relations with top level package

### DIFF
--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -123,9 +123,8 @@ func (s *spdxParser) getPackages() error {
 
 		if slices.Contains(topLevelSpdxIds, string(pac.PackageSPDXIdentifier)) {
 			s.topLevelPackages[string(s.spdxDoc.SPDXIdentifier)] = append(s.topLevelPackages[string(s.spdxDoc.SPDXIdentifier)], pkg)
-		} else {
-			s.packagePackages[string(pac.PackageSPDXIdentifier)] = append(s.packagePackages[string(pac.PackageSPDXIdentifier)], pkg)
 		}
+		s.packagePackages[string(pac.PackageSPDXIdentifier)] = append(s.packagePackages[string(pac.PackageSPDXIdentifier)], pkg)
 
 		// if checksums exists create an artifact for each of them
 		for _, checksum := range pac.PackageChecksums {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -248,6 +248,85 @@ func Test_spdxParser(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "SPDX with documentDescribes field",
+			additionalOpts: []cmp.Option{
+				cmpopts.IgnoreFields(assembler.HasSBOMIngest{},
+					"HasSBOM")},
+			doc: &processor.Document{
+				Blob: []byte(`
+		{
+			"SPDXID":"SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.2",
+			"documentDescribes": [
+				"SPDXRef-6dcd47a4-bfcb-47d7-8ee4-60b6dc4861a8"
+			],
+			"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
+			"packages":[
+				{
+					"SPDXID": "SPDXRef-8c5bc68a-d747-48de-b737-bc9703c330e7",
+					"externalRefs": [
+						{
+							"referenceCategory": "PACKAGE_MANAGER",
+							"referenceLocator": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64",
+							"referenceType": "purl"
+						}
+					],
+					"packageFileName": "python3-libcomps-0.1.18-1.el9.x86_64.rpm",
+					"versionInfo": "python3-libcomps-0.1.18-1.el9.x86_64"
+				},
+				{
+					"SPDXID": "SPDXRef-6dcd47a4-bfcb-47d7-8ee4-60b6dc4861a8",
+					"externalRefs": [
+						{
+							"referenceCategory": "PACKAGE_MANAGER",
+							"referenceLocator": "pkg:oci/redhat/ubi9-container@sha256:4227a4b5013999a412196237c62e40d778d09cdc751720a66ff3701fbe5a4a9d?repository_url=registry.redhat.io/ubi9&tag=9.1.0-1750",
+							"referenceType": "purl"
+						}
+					],
+					"name": "ubi9-container",
+					"versionInfo": "ubi9-container-9.1.0-1750.noarch"
+				}
+			],
+			"relationships":[
+				{
+					"relatedSpdxElement": "SPDXRef-6dcd47a4-bfcb-47d7-8ee4-60b6dc4861a8",
+					"relationshipType": "CONTAINED_BY",
+					"spdxElementId": "SPDXRef-8c5bc68a-d747-48de-b737-bc9703c330e7"
+				},
+				{
+					"relatedSpdxElement": "SPDXRef-6dcd47a4-bfcb-47d7-8ee4-60b6dc4861a8",
+					"relationshipType": "DESCRIBES",
+					"spdxElementId": "SPDXRef-DOCUMENT"
+				}
+			]
+		}
+	`),
+				Format: processor.FormatJSON,
+				Type:   processor.DocumentSPDX,
+				SourceInformation: processor.SourceInformation{
+					Collector: "TestCollector",
+					Source:    "TestSource",
+				},
+			},
+			wantPredicates: &assembler.IngestPredicates{
+				IsDependency: []assembler.IsDependencyIngest{
+					{
+						Pkg:    pUrlToPkgDiscardError("pkg:oci/redhat/ubi9-container@sha256:4227a4b5013999a412196237c62e40d778d09cdc751720a66ff3701fbe5a4a9d?repository_url=registry.redhat.io/ubi9&tag=9.1.0-1750"),
+						DepPkg: pUrlToPkgDiscardError("pkg:rpm/redhat/python3-libcomps@0.1.18-1.el9?arch=x86_64"),
+						IsDependency: &generated.IsDependencyInputSpec{
+							DependencyType: generated.DependencyTypeUnknown,
+							VersionRange:   "0.1.18-1.el9",
+							Justification:  "Derived from SPDX CONTAINED_BY relationship",
+						},
+					},
+				},
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: pUrlToPkgDiscardError("pkg:oci/redhat/ubi9-container@sha256:4227a4b5013999a412196237c62e40d778d09cdc751720a66ff3701fbe5a4a9d?repository_url=registry.redhat.io/ubi9&tag=9.1.0-1750")},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the PR
It looks like the `GetPredicates` method isn't able to create the `IsDependencyIngest` object because the `foundPackNodes := s.getPackageElement(foundId)` is always `nil` due to `getPackageElement` only searches in `packagePackages` map but the package, with current code, is available only in the `topLevelPackages` map (and with the `DOCUMENT` key).

Removing the `else` and so always adding the top packages to the `packagePackages` lets `getPackageElement` to find the top package and hence created the expected `IsDependencyIngest` object.

Fixes #1102 

# PR Checklist

- [] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
