### PR TITLE
issue-1105 inmem HasSBOM: manage no `hasSBOMSpec` sent

### DIFF
--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -224,7 +224,7 @@ func (c *demoClient) HasSBOM(ctx context.Context, filter *model.HasSBOMSpec) ([]
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	if filter.ID != nil {
+	if filter != nil && filter.ID != nil {
 		id64, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: invalid ID %v", funcName, err)
@@ -294,32 +294,34 @@ func (c *demoClient) addHasSBOMIfMatch(out []*model.HasSbom,
 	filter *model.HasSBOMSpec, link *hasSBOMStruct) (
 	[]*model.HasSbom, error) {
 
-	if noMatch(filter.URI, link.uri) ||
-		noMatch(toLower(filter.Algorithm), link.algorithm) ||
-		noMatch(toLower(filter.Digest), link.digest) ||
-		noMatch(filter.DownloadLocation, link.downloadLocation) ||
-		noMatch(filter.Origin, link.origin) ||
-		noMatch(filter.Collector, link.collector) {
-		return out, nil
-	}
-	if filter.Subject != nil {
-		if filter.Subject.Package != nil {
-			if link.pkg == 0 {
-				return out, nil
-			}
-			p, err := c.buildPackageResponse(link.pkg, filter.Subject.Package)
-			if err != nil {
-				return nil, err
-			}
-			if p == nil {
-				return out, nil
-			}
-		} else if filter.Subject.Artifact != nil {
-			if link.artifact == 0 {
-				return out, nil
-			}
-			if !c.artifactMatch(link.artifact, filter.Subject.Artifact) {
-				return out, nil
+	if filter != nil {
+		if noMatch(filter.URI, link.uri) ||
+			noMatch(toLower(filter.Algorithm), link.algorithm) ||
+			noMatch(toLower(filter.Digest), link.digest) ||
+			noMatch(filter.DownloadLocation, link.downloadLocation) ||
+			noMatch(filter.Origin, link.origin) ||
+			noMatch(filter.Collector, link.collector) {
+			return out, nil
+		}
+		if filter.Subject != nil {
+			if filter.Subject.Package != nil {
+				if link.pkg == 0 {
+					return out, nil
+				}
+				p, err := c.buildPackageResponse(link.pkg, filter.Subject.Package)
+				if err != nil {
+					return nil, err
+				}
+				if p == nil {
+					return out, nil
+				}
+			} else if filter.Subject.Artifact != nil {
+				if link.artifact == 0 {
+					return out, nil
+				}
+				if !c.artifactMatch(link.artifact, filter.Subject.Artifact) {
+					return out, nil
+				}
 			}
 		}
 	}

--- a/pkg/assembler/backends/inmem/hasSBOM_test.go
+++ b/pkg/assembler/backends/inmem/hasSBOM_test.go
@@ -465,6 +465,27 @@ func TestHasSBOM(t *testing.T) {
 			},
 			ExpQueryErr: true,
 		},
+		{
+			Name:  "Query without hasSBOMSpec",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: p1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						DownloadLocation: "location one",
+					},
+				},
+			},
+			Query: nil,
+			ExpHS: []*model.HasSbom{
+				{
+					Subject:          p1out,
+					DownloadLocation: "location one",
+				},
+			},
+		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
 		return strings.Compare(".ID", p[len(p)-1].String()) == 0


### PR DESCRIPTION
# Description of the PR

- checks for nil filter before retrieving by ID
- checks for nil filter in `addHasSBOMIfMatch` method to have `c.convHasSBOM(link)` to be executed

1st commit has the test reproducer for the issue so it's expected to fail the CI tests
2nd commit the fix (and should run fine the tests :sweat_smile: )

Fixes #1105 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
