### PR TITLE
Workaround depversion handling.

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -342,7 +342,11 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 
 				matchingDepPkgVersions, err := depversion.WhichVersionMatches(depPkgVersions, isDependency.VersionRange)
 				if err != nil {
-					return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
+					// TODO(jeffmendoza): depversion is not handling all/new possible
+					// version ranges from deps.dev. Continue here to report possible
+					// vulns even if some paths cannot be followed.
+					matchingDepPkgVersions = nil
+					//return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
 				}
 
 				for matchingDepPkgVersion := range matchingDepPkgVersions {


### PR DESCRIPTION
Update "guacone query vuln" to continue when finding errors with the isDependency version range parsing. Update depversion package to avoid panics and properly error before indexing into arrays.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
