### PR TITLE
add `certifyBad` query,  `certifyGood` ingestion and query, update bulk assembler

### DIFF
--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -47,9 +47,8 @@ func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifa
 }
 
 func setArtifactMatchValues(artifactSpec *model.ArtifactSpec, queryValues map[string]any) *arangoQueryBuilder {
-	var arangoQueryBuilder *arangoQueryBuilder
+	arangoQueryBuilder := newForQuery(artifactsStr, "art")
 	if artifactSpec != nil {
-		arangoQueryBuilder = newForQuery(artifactsStr, "art")
 		if artifactSpec.ID != nil {
 			arangoQueryBuilder.filter("art", "_id", "==", "@id")
 			queryValues["id"] = *artifactSpec.ID

--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -28,7 +28,7 @@ import (
 func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.ArtifactSpec) ([]*model.Artifact, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := setArtifactMatchValues(nil, artifactSpec, values)
+	arangoQueryBuilder := setArtifactMatchValues(artifactSpec, values)
 	arangoQueryBuilder.query.WriteString("\n")
 	arangoQueryBuilder.query.WriteString(`RETURN {
 		"id": art._id,
@@ -46,11 +46,10 @@ func (c *arangoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifa
 	return getArtifacts(ctx, cursor)
 }
 
-func setArtifactMatchValues(arangoQueryBuilder *arangoQueryBuilder, artifactSpec *model.ArtifactSpec, queryValues map[string]any) *arangoQueryBuilder {
-	if arangoQueryBuilder == nil {
-		arangoQueryBuilder = newForQuery(artifactsStr, "art")
-	}
+func setArtifactMatchValues(artifactSpec *model.ArtifactSpec, queryValues map[string]any) *arangoQueryBuilder {
+	var arangoQueryBuilder *arangoQueryBuilder
 	if artifactSpec != nil {
+		arangoQueryBuilder = newForQuery(artifactsStr, "art")
 		if artifactSpec.ID != nil {
 			arangoQueryBuilder.filter("art", "_id", "==", "@id")
 			queryValues["id"] = *artifactSpec.ID

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -376,17 +376,17 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 
 		var certifyGoodPkgNameEdges driver.EdgeDefinition
 		certifyGoodPkgNameEdges.Collection = certifyGoodPkgNameEdgesStr
-		certifyGoodPkgNameEdges.From = []string{pkgNamesStr, pkgVersionsStr, artifactsStr, srcNamesStr}
+		certifyGoodPkgNameEdges.From = []string{pkgNamesStr}
 		certifyGoodPkgNameEdges.To = []string{certifyGoodsStr}
 
 		var certifyGoodArtEdges driver.EdgeDefinition
 		certifyGoodArtEdges.Collection = certifyGoodArtEdgesStr
-		certifyGoodArtEdges.From = []string{pkgNamesStr, pkgVersionsStr, artifactsStr, srcNamesStr}
+		certifyGoodArtEdges.From = []string{artifactsStr}
 		certifyGoodArtEdges.To = []string{certifyGoodsStr}
 
 		var certifyGoodSrcEdges driver.EdgeDefinition
 		certifyGoodSrcEdges.Collection = certifyGoodSrcEdgesStr
-		certifyGoodSrcEdges.From = []string{pkgNamesStr, pkgVersionsStr, artifactsStr, srcNamesStr}
+		certifyGoodSrcEdges.From = []string{srcNamesStr}
 		certifyGoodSrcEdges.To = []string{certifyGoodsStr}
 
 		// A graph can contain additional vertex collections, defined in the set of orphan collections
@@ -668,14 +668,6 @@ func (aqb *arangoQueryBuilder) forInBound(edgeCollectionName string, counterVert
 	aqb.query.WriteString("\n")
 
 	aqb.query.WriteString(fmt.Sprintf("FOR %s IN INBOUND %s %s", counterVertexName, inBoundStartVertexName, edgeCollectionName))
-
-	return aqb
-}
-
-func (aqb *arangoQueryBuilder) forInBoundWithEdgeCounter(edgeCollectionName string, counterVertexName string, counterEdgeName string, inBoundStartVertexName string) *arangoQueryBuilder {
-	aqb.query.WriteString("\n")
-
-	aqb.query.WriteString(fmt.Sprintf("FOR %s, %s IN INBOUND %s %s", counterVertexName, counterEdgeName, inBoundStartVertexName, edgeCollectionName))
 
 	return aqb
 }

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -42,8 +42,6 @@ const (
 	guacEmpty     string        = "guac-empty-@@"
 
 	// Package collections
-	pkgHasTypeStr      string = "pkgHasType"
-	pkgRootsStr        string = "pkgRoots"
 	pkgTypesStr        string = "pkgTypes"
 	pkgHasNamespaceStr string = "pkgHasNamespace"
 	pkgNamespacesStr   string = "pkgNamespaces"
@@ -53,8 +51,6 @@ const (
 	pkgVersionsStr     string = "pkgVersions"
 
 	// source collections
-	srcHasTypeStr      string = "srcHasType"
-	srcRootsStr        string = "srcRoots"
 	srcTypesStr        string = "srcTypes"
 	srcHasNamespaceStr string = "srcHasNamespace"
 	srcNamespacesStr   string = "srcNamespaces"
@@ -151,24 +147,10 @@ type arangoQueryBuilder struct {
 	query strings.Builder
 }
 
-type pkgRootData struct {
-	Key     string `json:"_key"`
-	Id      string `json:"_id"`
-	PkgRoot string `json:"root"`
-}
-
-type srcRootData struct {
-	Key     string `json:"_key"`
-	Id      string `json:"_id"`
-	SrcRoot string `json:"root"`
-}
-
 type arangoClient struct {
-	client  driver.Client
-	db      driver.Database
-	graph   driver.Graph
-	pkgRoot *pkgRootData
-	srcRoot *srcRootData
+	client driver.Client
+	db     driver.Database
+	graph  driver.Graph
 }
 
 func arangoDBConnect(address, user, password string) (driver.Client, error) {
@@ -234,11 +216,6 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 	} else {
 
 		// setup package collections
-		var pkgHasType driver.EdgeDefinition
-		pkgHasType.Collection = pkgHasTypeStr
-		pkgHasType.From = []string{pkgRootsStr}
-		pkgHasType.To = []string{pkgTypesStr}
-
 		var pkgHasNamespace driver.EdgeDefinition
 		pkgHasNamespace.Collection = pkgHasNamespaceStr
 		pkgHasNamespace.From = []string{pkgTypesStr}
@@ -255,11 +232,6 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		pkgHasVersion.To = []string{pkgVersionsStr}
 
 		// setup source collections
-		var srcHasType driver.EdgeDefinition
-		srcHasType.Collection = srcHasTypeStr
-		srcHasType.From = []string{srcRootsStr}
-		srcHasType.To = []string{srcTypesStr}
-
 		var srcHasNamespace driver.EdgeDefinition
 		srcHasNamespace.Collection = srcHasNamespaceStr
 		srcHasNamespace.From = []string{srcTypesStr}
@@ -391,8 +363,8 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 
 		// A graph can contain additional vertex collections, defined in the set of orphan collections
 		var options driver.CreateGraphOptions
-		options.EdgeDefinitions = []driver.EdgeDefinition{pkgHasType, pkgHasNamespace, pkgHasName,
-			pkgHasVersion, srcHasType, srcHasNamespace, srcHasName, isDependencyDepPkgEdges, isDependencySubjectPkgEdges,
+		options.EdgeDefinitions = []driver.EdgeDefinition{pkgHasNamespace, pkgHasName,
+			pkgHasVersion, srcHasNamespace, srcHasName, isDependencyDepPkgEdges, isDependencySubjectPkgEdges,
 			isOccurrenceArtEdges, isOccurrenceSubjectPkgEdges, isOccurrenceSubjectSrcEdges, hasSLSASubjectArtEdges,
 			hasSLSABuiltByEdges, hasSLSABuiltFromEdges, hashEqualArtEdges, hashEqualSubjectArtEdges, hasSBOMPkgEdges,
 			hasSBOMArtEdges, certifyVulnEdges, certifyScorecardSrcEdges, certifyBadPkgVersionEdges, certifyBadPkgNameEdges,
@@ -435,10 +407,6 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			return nil, fmt.Errorf("failed to generate index for hashEquals: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, pkgTypesStr, []string{"_parent", "type"}, true, "byPkgTypeParent"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
-		}
-
 		if err := createIndexPerCollection(ctx, db, pkgTypesStr, []string{"type"}, true, "byPkgType"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgTypes: %w", err)
 		}
@@ -461,10 +429,6 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 
 		if err := createIndexPerCollection(ctx, db, pkgVersionsStr, []string{"qualifier_list[*]"}, false, "byQualifierList"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for pkgVersions: %w", err)
-		}
-
-		if err := createIndexPerCollection(ctx, db, srcTypesStr, []string{"_parent", "type"}, true, "bySrcTypeParent"); err != nil {
-			return nil, fmt.Errorf("failed to generate index for srcTypes: %w", err)
 		}
 
 		if err := createIndexPerCollection(ctx, db, srcTypesStr, []string{"type"}, true, "bySrcType"); err != nil {
@@ -583,17 +547,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		}
 	}
 
-	collectedPkgRootData, err := preIngestPkgRoot(ctx, db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create package root: %w", err)
-	}
-
-	collectedSrcRootData, err := preIngestSrcRoot(ctx, db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create source root: %w", err)
-	}
-
-	arangoClient := &arangoClient{client: arangodbClient, db: db, graph: graph, pkgRoot: collectedPkgRootData, srcRoot: collectedSrcRootData}
+	arangoClient := &arangoClient{client: arangodbClient, db: db, graph: graph}
 
 	return arangoClient, nil
 }
@@ -805,78 +759,6 @@ func (c *arangoClient) Nodes(ctx context.Context, nodes []string) ([]model.Node,
 }
 func (c *arangoClient) Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error) {
 	panic(fmt.Errorf("not implemented: Path - Path"))
-}
-
-func preIngestPkgRoot(ctx context.Context, db driver.Database) (*pkgRootData, error) {
-	query := `
-		UPSERT { root: "pkg" }
-		INSERT { root: "pkg" }
-		UPDATE {}
-		IN pkgRoots
-		RETURN NEW`
-
-	cursor, err := executeQueryWithRetry(ctx, db, query, nil, "preIngestPkgRoot")
-	if err != nil {
-		return nil, fmt.Errorf("failed to ingest package root node: %w", err)
-	}
-
-	var createdValues []pkgRootData
-	for {
-		var doc pkgRootData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				cursor.Close()
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest pkg root: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	if len(createdValues) == 1 {
-		return &createdValues[0], nil
-	} else {
-		return nil, fmt.Errorf("number of pkg root ingested is greater than one")
-	}
-}
-
-func preIngestSrcRoot(ctx context.Context, db driver.Database) (*srcRootData, error) {
-	query := `
-		UPSERT { root: "src" }
-		INSERT { root: "src" }
-		UPDATE {}
-		IN srcRoots
-		RETURN NEW`
-
-	cursor, err := executeQueryWithRetry(ctx, db, query, nil, "preIngestSrcRoot")
-	if err != nil {
-		return nil, fmt.Errorf("failed to ingest source root node: %w", err)
-	}
-
-	var createdValues []srcRootData
-	for {
-		var doc srcRootData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				cursor.Close()
-				break
-			} else {
-				return nil, fmt.Errorf("failed to ingest src root: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	if len(createdValues) == 1 {
-		return &createdValues[0], nil
-	} else {
-		return nil, fmt.Errorf("number of src root ingested is greater than one")
-	}
 }
 
 func ptrfromArangoSearchNGramStreamType(s driver.ArangoSearchNGramStreamType) *driver.ArangoSearchNGramStreamType {

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -26,23 +26,240 @@ import (
 )
 
 func (c *arangoClient) CertifyBad(ctx context.Context, certifyBadSpec *model.CertifyBadSpec) ([]*model.CertifyBad, error) {
-	return []*model.CertifyBad{}, fmt.Errorf("not implemented - CertifyBad")
+	values := map[string]any{}
+	var arangoQueryBuilder *arangoQueryBuilder
+	if certifyBadSpec.Subject != nil {
+		if certifyBadSpec.Subject.Package != nil {
+
+			var combinedCertifyBad []*model.CertifyBad
+
+			// pkgVersion certifyBad
+			arangoQueryBuilder = setPkgVersionMatchValues(certifyBadSpec.Subject.Package, values)
+			arangoQueryBuilder.forOutBound(certifyBadPkgVersionEdgesStr, "certifyBad", "pVersion")
+			setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+
+			pkgVersionCertifyBads, err := getPkgVersionCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package version certifyBad with error: %w", err)
+			}
+
+			combinedCertifyBad = append(combinedCertifyBad, pkgVersionCertifyBads...)
+
+			// pkgName certifyBad
+			arangoQueryBuilder = setPkgNameMatchValues(certifyBadSpec.Subject.Package, values)
+			arangoQueryBuilder.forOutBound(certifyBadPkgNameEdgesStr, "certifyBad", "pName")
+			setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+
+			pkgNameCertifyBads, err := getPkgNameCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package name certifyBad with error: %w", err)
+			}
+
+			combinedCertifyBad = append(combinedCertifyBad, pkgNameCertifyBads...)
+
+			return combinedCertifyBad, nil
+		} else if certifyBadSpec.Subject.Source != nil {
+			arangoQueryBuilder = setSrcMatchValues(certifyBadSpec.Subject.Source, values)
+			arangoQueryBuilder.forOutBound(certifyBadSrcEdgesStr, "certifyBad", "sName")
+			setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+
+			return getSrcCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		} else if certifyBadSpec.Subject.Artifact != nil {
+			arangoQueryBuilder = setSrcMatchValues(certifyBadSpec.Subject.Source, values)
+			arangoQueryBuilder.forOutBound(certifyBadArtEdgesStr, "certifyBad", "sName")
+			setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+
+			return getArtCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		} else {
+			return nil, fmt.Errorf("subject package, source or artifact not specified")
+		}
+	} else {
+		var combinedCertifyBad []*model.CertifyBad
+
+		// pkgVersion certifyBad
+		arangoQueryBuilder = newForQuery(certifyBadsStr, "certifyBad")
+		setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+		arangoQueryBuilder.forInBound(certifyBadPkgVersionEdgesStr, "pVersion", "certifyBad")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgVersionCertifyBads, err := getPkgVersionCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package version certifyBad  with error: %w", err)
+		}
+		combinedCertifyBad = append(combinedCertifyBad, pkgVersionCertifyBads...)
+
+		// pkgName certifyBad
+		arangoQueryBuilder = newForQuery(certifyBadsStr, "certifyBad")
+		setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+		arangoQueryBuilder.forInBound(certifyBadPkgNameEdgesStr, "pName", "certifyBad")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgNameCertifyBads, err := getPkgNameCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package name certifyBad  with error: %w", err)
+		}
+		combinedCertifyBad = append(combinedCertifyBad, pkgNameCertifyBads...)
+
+		// get sources
+		arangoQueryBuilder = newForQuery(certifyBadsStr, "certifyBad")
+		setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+		arangoQueryBuilder.forInBound(certifyBadSrcEdgesStr, "sName", "certifyBad")
+		arangoQueryBuilder.forInBound(srcHasNameStr, "sNs", "sName")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+
+		srcCertifyBads, err := getSrcCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve source certifyBad with error: %w", err)
+		}
+		combinedCertifyBad = append(combinedCertifyBad, srcCertifyBads...)
+
+		// get artifacts
+		arangoQueryBuilder = newForQuery(certifyBadsStr, "certifyBad")
+		setCertifyBadMatchValues(arangoQueryBuilder, certifyBadSpec, values)
+		arangoQueryBuilder.forInBound(certifyBadArtEdgesStr, "art", "certifyBad")
+
+		artCertifyBads, err := getArtCertifyBadForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve artifact certifyBad with error: %w", err)
+		}
+		combinedCertifyBad = append(combinedCertifyBad, artCertifyBads...)
+
+		return combinedCertifyBad, nil
+	}
 }
 
-// func setCertifyBadMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBadSpec *model.CertifyBadSpec, queryValues map[string]any) {
-// 	if certifyBadSpec.Justification != nil {
-// 		arangoQueryBuilder.filter("bad", justification, "==", "@"+justification)
-// 		queryValues[justification] = certifyBadSpec.Justification
-// 	}
-// 	if certifyBadSpec.Origin != nil {
-// 		arangoQueryBuilder.filter("bad", origin, "==", "@"+origin)
-// 		queryValues[origin] = certifyBadSpec.Origin
-// 	}
-// 	if certifyBadSpec.Collector != nil {
-// 		arangoQueryBuilder.filter("bad", collector, "==", "@"+collector)
-// 		queryValues[collector] = certifyBadSpec.Collector
-// 	}
-// }
+func getSrcCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyBad, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'srcName': {
+			'type_id': sType._id,
+			'type': sType.type,
+			'namespace_id': sNs._id,
+			'namespace': sNs.namespace,
+			'name_id': sName._id,
+			'name': sName.name,
+			'commit': sName.commit,
+			'tag': sName.tag
+		},
+		'certifyBad_id': certifyBad._id,
+		'justification': certifyBad.justification,
+		'collector': certifyBad.collector,
+		'origin': certifyBad.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyBad")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for CertifyBad: %w", err)
+	}
+	defer cursor.Close()
+
+	return getSourceCertifyBad(ctx, cursor)
+}
+
+func getArtCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyBad, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'artifact': {
+			'id': artifact._id,
+			'algorithm': artifact.algorithm,
+			'digest': artifact.digest
+		},
+		'certifyBad_id': certifyBad._id,
+		'justification': certifyBad.justification,
+		'collector': certifyBad.collector,
+		'origin': certifyBad.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyBad")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for CertifyBad: %w", err)
+	}
+	defer cursor.Close()
+
+	return getArtifactCertifyBad(ctx, cursor)
+}
+
+func getPkgNameCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyBad, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'pkgName': {
+			'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': pName._id,
+			'name': pName.name
+		},
+		'certifyBad_id': certifyBad._id,
+		'justification': certifyBad.justification,
+		'collector': certifyBad.collector,
+		'origin': certifyBad.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyBad")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for CertifyBad: %w", err)
+	}
+	defer cursor.Close()
+
+	return getPkgNameCertifyBad(ctx, cursor)
+}
+
+func getPkgVersionCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyBad, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'pkgVersion': {
+			'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': pName._id,
+			'name': pName.name,
+			'version_id': pVersion._id,
+			'version': pVersion.version,
+			'subpath': pVersion.subpath,
+			'qualifier_list': pVersion.qualifier_list
+		},
+		'certifyBad_id': certifyBad._id,
+		'justification': certifyBad.justification,
+		'collector': certifyBad.collector,
+		'origin': certifyBad.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyBad")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for CertifyBad: %w", err)
+	}
+	defer cursor.Close()
+
+	return getPkgVersionCertifyBad(ctx, cursor)
+}
+
+func setCertifyBadMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBadSpec *model.CertifyBadSpec, queryValues map[string]any) {
+	if certifyBadSpec.Justification != nil {
+		arangoQueryBuilder.filter("certifyBad", justification, "==", "@"+justification)
+		queryValues[justification] = certifyBadSpec.Justification
+	}
+	if certifyBadSpec.Origin != nil {
+		arangoQueryBuilder.filter("certifyBad", origin, "==", "@"+origin)
+		queryValues[origin] = certifyBadSpec.Origin
+	}
+	if certifyBadSpec.Collector != nil {
+		arangoQueryBuilder.filter("certifyBad", collector, "==", "@"+collector)
+		queryValues[collector] = certifyBadSpec.Collector
+	}
+}
 
 func getCertifyBadQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.MatchFlags, artifact *model.ArtifactInputSpec, source *model.SourceInputSpec, certifyBad *model.CertifyBadInputSpec) map[string]any {
 	values := map[string]any{}

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -17,19 +17,1045 @@ package arangodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) CertifyGood(ctx context.Context, certifyGoodSpec *model.CertifyGoodSpec) ([]*model.CertifyGood, error) {
-	panic(fmt.Errorf("not implemented: CertifyGood - CertifyGood"))
+	var arangoQueryBuilder *arangoQueryBuilder
+	if certifyGoodSpec.Subject != nil {
+		var combinedCertifyGood []*model.CertifyGood
+		if certifyGoodSpec.Subject.Package != nil {
+			values := map[string]any{}
+			// pkgVersion certifyGood
+			arangoQueryBuilder = setPkgVersionMatchValues(certifyGoodSpec.Subject.Package, values)
+			arangoQueryBuilder.forOutBound(certifyGoodPkgVersionEdgesStr, "certifyGood", "pVersion")
+			setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+
+			pkgVersionCertifyGoods, err := getPkgVersionCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package version certifyGood with error: %w", err)
+			}
+
+			combinedCertifyGood = append(combinedCertifyGood, pkgVersionCertifyGoods...)
+
+			// pkgName certifyGood
+			arangoQueryBuilder = setPkgNameMatchValues(certifyGoodSpec.Subject.Package, values)
+			arangoQueryBuilder.forOutBound(certifyGoodPkgNameEdgesStr, "certifyGood", "pName")
+			setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+
+			pkgNameCertifyGoods, err := getPkgNameCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package name certifyGood with error: %w", err)
+			}
+
+			combinedCertifyGood = append(combinedCertifyGood, pkgNameCertifyGoods...)
+		}
+		if certifyGoodSpec.Subject.Source != nil {
+			values := map[string]any{}
+			arangoQueryBuilder = setSrcMatchValues(certifyGoodSpec.Subject.Source, values)
+			arangoQueryBuilder.forOutBound(certifyGoodSrcEdgesStr, "certifyGood", "sName")
+			setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+
+			srcCertifyGoods, err := getSrcCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve source certifyGood with error: %w", err)
+			}
+
+			combinedCertifyGood = append(combinedCertifyGood, srcCertifyGoods...)
+		}
+		if certifyGoodSpec.Subject.Artifact != nil {
+			values := map[string]any{}
+			arangoQueryBuilder = setArtifactMatchValues(certifyGoodSpec.Subject.Artifact, values)
+			arangoQueryBuilder.forOutBound(certifyGoodArtEdgesStr, "certifyGood", "art")
+			setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+
+			artCertifyGoods, err := getArtCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve artifact certifyGood with error: %w", err)
+			}
+
+			combinedCertifyGood = append(combinedCertifyGood, artCertifyGoods...)
+		}
+		return combinedCertifyGood, nil
+	} else {
+		values := map[string]any{}
+		var combinedCertifyGood []*model.CertifyGood
+
+		// pkgVersion certifyGood
+		arangoQueryBuilder = newForQuery(certifyGoodsStr, "certifyGood")
+		setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+		arangoQueryBuilder.forInBound(certifyGoodPkgVersionEdgesStr, "pVersion", "certifyGood")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgVersionCertifyGoods, err := getPkgVersionCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package version certifyGood  with error: %w", err)
+		}
+		combinedCertifyGood = append(combinedCertifyGood, pkgVersionCertifyGoods...)
+
+		// pkgName certifyGood
+		arangoQueryBuilder = newForQuery(certifyGoodsStr, "certifyGood")
+		setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+		arangoQueryBuilder.forInBound(certifyGoodPkgNameEdgesStr, "pName", "certifyGood")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgNameCertifyGoods, err := getPkgNameCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package name certifyGood  with error: %w", err)
+		}
+		combinedCertifyGood = append(combinedCertifyGood, pkgNameCertifyGoods...)
+
+		// get sources
+		arangoQueryBuilder = newForQuery(certifyGoodsStr, "certifyGood")
+		setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+		arangoQueryBuilder.forInBound(certifyGoodSrcEdgesStr, "sName", "certifyGood")
+		arangoQueryBuilder.forInBound(srcHasNameStr, "sNs", "sName")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+
+		srcCertifyGoods, err := getSrcCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve source certifyGood with error: %w", err)
+		}
+		combinedCertifyGood = append(combinedCertifyGood, srcCertifyGoods...)
+
+		// get artifacts
+		arangoQueryBuilder = newForQuery(certifyGoodsStr, "certifyGood")
+		setCertifyGoodMatchValues(arangoQueryBuilder, certifyGoodSpec, values)
+		arangoQueryBuilder.forInBound(certifyGoodArtEdgesStr, "art", "certifyGood")
+
+		artCertifyGoods, err := getArtCertifyGoodForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve artifact certifyGood with error: %w", err)
+		}
+		combinedCertifyGood = append(combinedCertifyGood, artCertifyGoods...)
+
+		return combinedCertifyGood, nil
+	}
+}
+
+func getSrcCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyGood, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'srcName': {
+			'type_id': sType._id,
+			'type': sType.type,
+			'namespace_id': sNs._id,
+			'namespace': sNs.namespace,
+			'name_id': sName._id,
+			'name': sName.name,
+			'commit': sName.commit,
+			'tag': sName.tag
+		},
+		'certifyGood_id': certifyGood._id,
+		'justification': certifyGood.justification,
+		'collector': certifyGood.collector,
+		'origin': certifyGood.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "certifyGood")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyGood: %w", err)
+	}
+	defer cursor.Close()
+
+	return getSourceCertifyGood(ctx, cursor)
+}
+
+func getArtCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyGood, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'artifact': {
+			'id': art._id,
+			'algorithm': art.algorithm,
+			'digest': art.digest
+		},
+		'certifyGood_id': certifyGood._id,
+		'justification': certifyGood.justification,
+		'collector': certifyGood.collector,
+		'origin': certifyGood.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "certifyGood")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyGood: %w", err)
+	}
+	defer cursor.Close()
+
+	return getArtifactCertifyGood(ctx, cursor)
+}
+
+func getPkgNameCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyGood, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'pkgName': {
+			'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': pName._id,
+			'name': pName.name
+		},
+		'certifyGood_id': certifyGood._id,
+		'justification': certifyGood.justification,
+		'collector': certifyGood.collector,
+		'origin': certifyGood.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "certifyGood")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyGood: %w", err)
+	}
+	defer cursor.Close()
+
+	return getPkgNameCertifyGood(ctx, cursor)
+}
+
+func getPkgVersionCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyGood, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'pkgVersion': {
+			'type_id': pType._id,
+			'type': pType.type,
+			'namespace_id': pNs._id,
+			'namespace': pNs.namespace,
+			'name_id': pName._id,
+			'name': pName.name,
+			'version_id': pVersion._id,
+			'version': pVersion.version,
+			'subpath': pVersion.subpath,
+			'qualifier_list': pVersion.qualifier_list
+		},
+		'certifyGood_id': certifyGood._id,
+		'justification': certifyGood.justification,
+		'collector': certifyGood.collector,
+		'origin': certifyGood.origin
+	  }`)
+
+	fmt.Println(arangoQueryBuilder.string())
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyGood")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for CertifyGood: %w", err)
+	}
+	defer cursor.Close()
+
+	return getPkgVersionCertifyGood(ctx, cursor)
+}
+
+func setCertifyGoodMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyGoodSpec *model.CertifyGoodSpec, queryValues map[string]any) {
+	if certifyGoodSpec.ID != nil {
+		arangoQueryBuilder.filter("certifyGood", "_id", "==", "@id")
+		queryValues["id"] = *certifyGoodSpec.ID
+	}
+	if certifyGoodSpec.Justification != nil {
+		arangoQueryBuilder.filter("certifyGood", justification, "==", "@"+justification)
+		queryValues[justification] = certifyGoodSpec.Justification
+	}
+	if certifyGoodSpec.Origin != nil {
+		arangoQueryBuilder.filter("certifyGood", origin, "==", "@"+origin)
+		queryValues[origin] = certifyGoodSpec.Origin
+	}
+	if certifyGoodSpec.Collector != nil {
+		arangoQueryBuilder.filter("certifyGood", collector, "==", "@"+collector)
+		queryValues[collector] = certifyGoodSpec.Collector
+	}
+}
+
+func getCertifyGoodQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.MatchFlags, artifact *model.ArtifactInputSpec, source *model.SourceInputSpec, certifyGood *model.CertifyGoodInputSpec) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	if pkg != nil {
+		pkgId := guacPkgId(*pkg)
+		if pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
+			values["pkgNameGuacKey"] = pkgId.NameId
+		} else {
+			values["pkgVersionGuacKey"] = pkgId.VersionId
+		}
+	} else if artifact != nil {
+		values["art_algorithm"] = strings.ToLower(artifact.Algorithm)
+		values["art_digest"] = strings.ToLower(artifact.Digest)
+	} else {
+		source := guacSrcId(*source)
+		values["srcNameGuacKey"] = source.NameId
+	}
+
+	values["justification"] = certifyGood.Justification
+	values["origin"] = certifyGood.Origin
+	values["collector"] = certifyGood.Collector
+
+	return values
 }
 
 func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error) {
-	panic(fmt.Errorf("not implemented: IngestCertifyGood - IngestCertifyGood"))
+	if subject.Package != nil {
+		if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+			query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == @pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		  LET certifyGood = FIRST(
+			  UPSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin }
+				  INSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin }
+				  UPDATE {} IN certifyGoods
+				  RETURN NEW
+		  )
+
+		  LET edgeCollection = (
+			INSERT {  _key: CONCAT("certifyGoodPkgVersionEdges", firstPkg.versionDoc._key, certifyGood._key), _from: firstPkg.version_id, _to: certifyGood._id } INTO certifyGoodPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'certifyGood_id': certifyGood._id,
+			'justification': certifyGood.justification,
+			'collector': certifyGood.collector,
+			'origin': certifyGood.origin
+		  }`
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyGoodQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyGood), "IngestCertifyGood - PkgVersion")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyGood: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyGoodList, err := getPkgVersionCertifyGood(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+			}
+
+			if len(certifyGoodList) == 1 {
+				return certifyGoodList[0], nil
+			} else {
+				return nil, fmt.Errorf("number of certifyGood ingested is greater than one")
+			}
+		} else {
+			query := `
+			LET firstPkg = FIRST(
+				FOR pName in pkgNames
+				  FILTER pName.guacKey == @pkgNameGuacKey
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'nameDoc': pName
+				}
+			)
+
+			  LET certifyGood = FIRST(
+				  UPSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin }
+					  INSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin }
+					  UPDATE {} IN certifyGoods
+					  RETURN NEW
+			  )
+
+			  LET edgeCollection = (
+				INSERT {  _key: CONCAT("certifyGoodPkgNameEdges", firstPkg.nameDoc._key, certifyGood._key), _from: firstPkg.name_id, _to: certifyGood._id } INTO certifyGoodPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+			  )
+
+			  RETURN {
+				'pkgName': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name
+				},
+				'certifyGood_id': certifyGood._id,
+				'justification': certifyGood.justification,
+				'collector': certifyGood.collector,
+				'origin': certifyGood.origin
+			  }`
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyGoodQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyGood), "IngestCertifyGood - PkgName")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyGood: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyGoodList, err := getPkgNameCertifyGood(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+			}
+
+			if len(certifyGoodList) == 1 {
+				return certifyGoodList[0], nil
+			} else {
+				return nil, fmt.Errorf("number of certifyGood ingested is greater than one")
+			}
+		}
+
+	} else if subject.Artifact != nil {
+		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
+
+		LET certifyGood = FIRST(
+			UPSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin }
+				INSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin }
+				UPDATE {} IN certifyGoods
+				RETURN NEW
+		)
+
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("certifyGoodArtEdges", artifact._key, certifyGood._key), _from: artifact._id, _to: certifyGood._id } INTO certifyGoodArtEdges OPTIONS { overwriteMode: "ignore" }
+		)
+
+		RETURN {
+		  'artifact': {
+			  'id': artifact._id,
+			  'algorithm': artifact.algorithm,
+			  'digest': artifact.digest
+		  },
+		  'certifyGood_id': certifyGood._id,
+		  'justification': certifyGood.justification,
+		  'collector': certifyGood.collector,
+		  'origin': certifyGood.origin
+		}`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyGoodQueryValues(nil, nil, subject.Artifact, nil, &certifyGood), "IngestCertifyGood - artifact")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest artifact certifyGood: %w", err)
+		}
+		defer cursor.Close()
+		certifyGoodList, err := getArtifactCertifyGood(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+		}
+
+		if len(certifyGoodList) == 1 {
+			return certifyGoodList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of certifyGood ingested is greater than one")
+		}
+
+	} else if subject.Source != nil {
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == @srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+
+		LET certifyGood = FIRST(
+			UPSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin }
+				INSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin }
+				UPDATE {} IN certifyGoods
+				RETURN NEW
+		)
+
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("certifyGoodSrcEdges", firstSrc.nameDoc._key, certifyGood._key), _from: firstSrc.name_id, _to: certifyGood._id } INTO certifyGoodSrcEdges OPTIONS { overwriteMode: "ignore" }
+		)
+
+		RETURN {
+		  'srcName': {
+			  'type_id': firstSrc.typeID,
+			  'type': firstSrc.type,
+			  'namespace_id': firstSrc.namespace_id,
+			  'namespace': firstSrc.namespace,
+			  'name_id': firstSrc.name_id,
+			  'name': firstSrc.name,
+			  'commit': firstSrc.commit,
+			  'tag': firstSrc.tag
+		  },
+		  'certifyGood_id': certifyGood._id,
+		  'justification': certifyGood.justification,
+		  'collector': certifyGood.collector,
+		  'origin': certifyGood.origin
+		}`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyGoodQueryValues(nil, nil, nil, subject.Source, &certifyGood), "IngestCertifyGood - source")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source certifyGood: %w", err)
+		}
+		defer cursor.Close()
+		certifyGoodList, err := getSourceCertifyGood(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+		}
+
+		if len(certifyGoodList) == 1 {
+			return certifyGoodList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of certifyGood ingested is greater than one")
+		}
+
+	} else {
+		return nil, fmt.Errorf("package, artifact, or source is specified for IngestCertifyGood")
+	}
 }
 
 func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]*model.CertifyGood, error) {
-	panic(fmt.Errorf("not implemented: IngestCertifyGood - IngestCertifyGood"))
+	if len(subjects.Packages) > 0 {
+		if len(subjects.Packages) != len(certifyGoods) {
+			return nil, fmt.Errorf("uneven packages and certifyGoods for ingestion")
+		}
+
+		var listOfValues []map[string]any
+
+		for i := range subjects.Packages {
+			listOfValues = append(listOfValues, getCertifyGoodQueryValues(subjects.Packages[i], pkgMatchType, nil, nil, certifyGoods[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+			query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+		  
+		  LET certifyGood = FIRST(
+			  UPSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN certifyGoods
+				  RETURN NEW
+		  )
+		  
+		  LET edgeCollection = (
+			INSERT {  _key: CONCAT("certifyGoodPkgVersionEdges", firstPkg.versionDoc._key, certifyGood._key), _from: firstPkg.version_id, _to: certifyGood._id } INTO certifyGoodPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'certifyGood_id': certifyGood._id,
+			'justification': certifyGood.justification,
+			'collector': certifyGood.collector,
+			'origin': certifyGood.origin  
+		  }`
+
+			sb.WriteString(query)
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestCertifyGoods - PkgVersion")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyGoods: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyGoodList, err := getPkgVersionCertifyGood(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+			}
+
+			return certifyGoodList, nil
+		} else {
+			query := `
+			LET firstPkg = FIRST(
+				FOR pName in pkgNames
+				  FILTER pName.guacKey == doc.pkgNameGuacKey
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+		
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'nameDoc': pName
+				}
+			)
+			  
+			  LET certifyGood = FIRST(
+				  UPSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  INSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  UPDATE {} IN certifyGoods
+					  RETURN NEW
+			  )
+			  
+			  LET edgeCollection = (
+				INSERT {  _key: CONCAT("certifyGoodPkgNameEdges", firstPkg.nameDoc._key, certifyGood._key), _from: firstPkg.name_id, _to: certifyGood._id } INTO certifyGoodPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+			  )
+			  
+			  RETURN {
+				'pkgName': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name
+				},
+				'certifyGood_id': certifyGood._id,
+				'justification': certifyGood.justification,
+				'collector': certifyGood.collector,
+				'origin': certifyGood.origin  
+			  }`
+
+			sb.WriteString(query)
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestCertifyGoods - PkgName")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyGoods: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyGoodList, err := getPkgNameCertifyGood(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+			}
+
+			return certifyGoodList, nil
+		}
+
+	} else if len(subjects.Artifacts) > 0 {
+
+		if len(subjects.Artifacts) != len(certifyGoods) {
+			return nil, fmt.Errorf("uneven artifacts and certifyGoods for ingestion")
+		}
+
+		var listOfValues []map[string]any
+
+		for i := range subjects.Artifacts {
+			listOfValues = append(listOfValues, getCertifyGoodQueryValues(nil, nil, subjects.Artifacts[i], nil, certifyGoods[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
+		  
+		LET certifyGood = FIRST(
+			UPSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				INSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				UPDATE {} IN certifyGoods
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("certifyGoodArtEdges", artifact._key, certifyGood._key), _from: artifact._id, _to: certifyGood._id } INTO certifyGoodArtEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'artifact': {
+			  'id': artifact._id,
+			  'algorithm': artifact.algorithm,
+			  'digest': artifact.digest
+		  },
+		  'certifyGood_id': certifyGood._id,
+		  'justification': certifyGood.justification,
+		  'collector': certifyGood.collector,
+		  'origin': certifyGood.origin
+		}`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestCertifyGoods - artifact")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest artifact certifyGoods %w", err)
+		}
+		defer cursor.Close()
+		certifyGoodList, err := getArtifactCertifyGood(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+		}
+
+		return certifyGoodList, nil
+
+	} else if len(subjects.Sources) > 0 {
+
+		if len(subjects.Sources) != len(certifyGoods) {
+			return nil, fmt.Errorf("uneven sources and certifyGoods for ingestion")
+		}
+
+		var listOfValues []map[string]any
+
+		for i := range subjects.Sources {
+			listOfValues = append(listOfValues, getCertifyGoodQueryValues(nil, nil, nil, subjects.Sources[i], certifyGoods[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == doc.srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		LET certifyGood = FIRST(
+			UPSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				INSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				UPDATE {} IN certifyGoods
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("certifyGoodSrcEdges", firstSrc.nameDoc._key, certifyGood._key), _from: firstSrc.name_id, _to: certifyGood._id } INTO certifyGoodSrcEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'srcName': {
+			  'type_id': firstSrc.typeID,
+			  'type': firstSrc.type,
+			  'namespace_id': firstSrc.namespace_id,
+			  'namespace': firstSrc.namespace,
+			  'name_id': firstSrc.name_id,
+			  'name': firstSrc.name,
+			  'commit': firstSrc.commit,
+			  'tag': firstSrc.tag
+		  },
+		  'certifyGood_id': certifyGood._id,
+		  'justification': certifyGood.justification,
+		  'collector': certifyGood.collector,
+		  'origin': certifyGood.origin
+		}`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestCertifyGoods - source")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source certifyGoods: %w", err)
+		}
+		defer cursor.Close()
+		certifyGoodList, err := getSourceCertifyGood(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
+		}
+
+		return certifyGoodList, nil
+
+	} else {
+		return nil, fmt.Errorf("packages, artifacts, or sources not specified for IngestCertifyGoods")
+	}
+}
+
+func getPkgNameCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
+	type collectedData struct {
+		PkgName       *dbPkgName `json:"pkgName"`
+		CertifyGoodID string     `json:"certifyGood_id"`
+		Justification string     `json:"justification"`
+		Collector     string     `json:"collector"`
+		Origin        string     `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to package name certifyGood from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyGoodList []*model.CertifyGood
+	for _, createdValue := range createdValues {
+		pkg := generateModelPackage(createdValue.PkgName.TypeID, createdValue.PkgName.PkgType, createdValue.PkgName.NamespaceID, createdValue.PkgName.Namespace, createdValue.PkgName.NameID,
+			createdValue.PkgName.Name, nil, nil, nil, nil)
+
+		certifyGood := &model.CertifyGood{
+			ID:            createdValue.CertifyGoodID,
+			Subject:       pkg,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+		certifyGoodList = append(certifyGoodList, certifyGood)
+	}
+	return certifyGoodList, nil
+}
+
+func getPkgVersionCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
+	type collectedData struct {
+		PkgVersion    *dbPkgVersion `json:"pkgVersion"`
+		CertifyGoodID string        `json:"certifyGood_id"`
+		Justification string        `json:"justification"`
+		Collector     string        `json:"collector"`
+		Origin        string        `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to package version certifyGood from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyGoodList []*model.CertifyGood
+	for _, createdValue := range createdValues {
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+
+		certifyGood := &model.CertifyGood{
+			ID:            createdValue.CertifyGoodID,
+			Subject:       pkg,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+		certifyGoodList = append(certifyGoodList, certifyGood)
+	}
+	return certifyGoodList, nil
+}
+
+func getArtifactCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
+	type collectedData struct {
+		Artifact      *model.Artifact `json:"artifact"`
+		CertifyGoodID string          `json:"certifyGood_id"`
+		Justification string          `json:"justification"`
+		Collector     string          `json:"collector"`
+		Origin        string          `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to artifact certifyGood from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyGoodList []*model.CertifyGood
+	for _, createdValue := range createdValues {
+		certifyGood := &model.CertifyGood{
+			ID:            createdValue.CertifyGoodID,
+			Subject:       createdValue.Artifact,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+		certifyGoodList = append(certifyGoodList, certifyGood)
+	}
+	return certifyGoodList, nil
+}
+
+func getSourceCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
+	type collectedData struct {
+		SrcName       *dbSrcName `json:"srcName"`
+		CertifyGoodID string     `json:"certifyGood_id"`
+		Justification string     `json:"justification"`
+		Collector     string     `json:"collector"`
+		Origin        string     `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to source certifyGood from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyGoodList []*model.CertifyGood
+	for _, createdValue := range createdValues {
+
+		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+			createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
+
+		certifyGood := &model.CertifyGood{
+			ID:            createdValue.CertifyGoodID,
+			Subject:       src,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+		certifyGoodList = append(certifyGoodList, certifyGood)
+	}
+	return certifyGoodList, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -85,6 +85,10 @@ func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *mod
 }
 
 func setCertifyScorecardMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyScorecardSpec *model.CertifyScorecardSpec, queryValues map[string]any) {
+	if certifyScorecardSpec.ID != nil {
+		arangoQueryBuilder.filter("scorecard", "_id", "==", "@id")
+		queryValues["id"] = *certifyScorecardSpec.ID
+	}
 	if certifyScorecardSpec.TimeScanned != nil {
 		arangoQueryBuilder.filter("scorecard", timeScannedStr, "==", "@"+timeScannedStr)
 		queryValues[timeScannedStr] = certifyScorecardSpec.TimeScanned.UTC()

--- a/pkg/assembler/backends/arangodb/cve.go
+++ b/pkg/assembler/backends/arangodb/cve.go
@@ -28,6 +28,10 @@ import (
 func (c *arangoClient) Cve(ctx context.Context, cveSpec *model.CVESpec) ([]*model.Cve, error) {
 	values := map[string]any{}
 	arangoQueryBuilder := newForQuery(cvesStr, "cve")
+	if cveSpec.ID != nil {
+		arangoQueryBuilder.filter("cve", "_id", "==", "@id")
+		values["id"] = *cveSpec.ID
+	}
 	if cveSpec.Year != nil {
 		arangoQueryBuilder.filter("cve", "year", "==", "@year")
 		values["year"] = *cveSpec.Year

--- a/pkg/assembler/backends/arangodb/ghsa.go
+++ b/pkg/assembler/backends/arangodb/ghsa.go
@@ -28,6 +28,10 @@ import (
 func (c *arangoClient) Ghsa(ctx context.Context, ghsaSpec *model.GHSASpec) ([]*model.Ghsa, error) {
 	values := map[string]any{}
 	arangoQueryBuilder := newForQuery(ghsasStr, "ghsa")
+	if ghsaSpec.ID != nil {
+		arangoQueryBuilder.filter("ghsa", "_id", "==", "@id")
+		values["id"] = *ghsaSpec.ID
+	}
 	if ghsaSpec.GhsaID != nil {
 		arangoQueryBuilder.filter("ghsa", "ghsaId", "==", "@ghsaId")
 		values["ghsaId"] = strings.ToLower(*ghsaSpec.GhsaID)

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -38,9 +38,9 @@ const (
 
 func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
 
-	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
+	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval (like from builtBy/builtFrom if specified)
 	values := map[string]any{}
-	arangoQueryBuilder := setArtifactMatchValues(nil, hasSLSASpec.Subject, values)
+	arangoQueryBuilder := setArtifactMatchValues(hasSLSASpec.Subject, values)
 	setHasSLSAMatchValues(arangoQueryBuilder, hasSLSASpec, values)
 
 	arangoQueryBuilder.query.WriteString("\n")
@@ -80,6 +80,10 @@ func setHasSLSAMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSLSASpec *
 
 	// currently not filtering on builtFrom (artifacts). Is that a real usecase?
 	arangoQueryBuilder.forOutBound(hasSLSASubjectArtEdgesStr, "hasSLSA", "art")
+	if hasSLSASpec.ID != nil {
+		arangoQueryBuilder.filter("hasSLSA", "_id", "==", "@id")
+		queryValues["id"] = *hasSLSASpec.ID
+	}
 	if hasSLSASpec.BuildType != nil {
 		arangoQueryBuilder.filter("hasSLSA", buildTypeStr, "==", "@"+buildTypeStr)
 		queryValues[buildTypeStr] = hasSLSASpec.BuildType

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -51,7 +51,7 @@ func matchHashEqualByInput(ctx context.Context, c *arangoClient, hashEqualSpec *
 
 	var combinedHashEqual []*model.HashEqual
 
-	arangoQueryBuilder := setArtifactMatchValues(nil, firstArtifact, values)
+	arangoQueryBuilder := setArtifactMatchValues(firstArtifact, values)
 	arangoQueryBuilder.forOutBound(hashEqualSubjectArtEdgesStr, "hashEqual", "art")
 	setHashEqualMatchValues(arangoQueryBuilder, hashEqualSpec, values)
 	arangoQueryBuilder.forOutBound(hashEqualArtEdgesStr, "equalArt", "hashEqual")
@@ -76,7 +76,7 @@ func matchHashEqualByInput(ctx context.Context, c *arangoClient, hashEqualSpec *
 	}
 	combinedHashEqual = append(combinedHashEqual, artSubjectHashEqual...)
 
-	arangoQueryBuilder = setArtifactMatchValues(nil, firstArtifact, values)
+	arangoQueryBuilder = setArtifactMatchValues(firstArtifact, values)
 	arangoQueryBuilder.forInBound(hashEqualArtEdgesStr, "hashEqual", "art")
 	setHashEqualMatchValues(arangoQueryBuilder, hashEqualSpec, values)
 	arangoQueryBuilder.forInBound(hashEqualSubjectArtEdgesStr, "equalArt", "hashEqual")
@@ -135,6 +135,10 @@ func getHashEqualForQuery(ctx context.Context, c *arangoClient, arangoQueryBuild
 }
 
 func setHashEqualMatchValues(arangoQueryBuilder *arangoQueryBuilder, hashEqualSpec *model.HashEqualSpec, queryValues map[string]any) {
+	if hashEqualSpec.ID != nil {
+		arangoQueryBuilder.filter("hashEqual", "_id", "==", "@id")
+		queryValues["id"] = *hashEqualSpec.ID
+	}
 	if hashEqualSpec.Justification != nil {
 		arangoQueryBuilder.filter("hashEqual", justification, "==", "@"+justification)
 		queryValues[justification] = hashEqualSpec.Justification

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -36,7 +36,7 @@ func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model
 
 	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
 	values := map[string]any{}
-	arangoQueryBuilder := setPkgMatchValues(isDependencySpec.Package, values)
+	arangoQueryBuilder := setPkgVersionMatchValues(isDependencySpec.Package, values)
 	setIsDependencyMatchValues(arangoQueryBuilder, isDependencySpec, values)
 
 	arangoQueryBuilder.query.WriteString("\n")

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -34,11 +34,31 @@ const (
 
 func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model.IsDependencySpec) ([]*model.IsDependency, error) {
 
-	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval
-	values := map[string]any{}
-	arangoQueryBuilder := setPkgVersionMatchValues(isDependencySpec.Package, values)
-	setIsDependencyMatchValues(arangoQueryBuilder, isDependencySpec, values)
+	// TODO (pxp928): Optimization of the query can be done by starting from the dependent package node (if specified)
+	var arangoQueryBuilder *arangoQueryBuilder
 
+	if isDependencySpec.Package != nil {
+		values := map[string]any{}
+		arangoQueryBuilder := setPkgVersionMatchValues(isDependencySpec.Package, values)
+		arangoQueryBuilder.forOutBound(isDependencySubjectPkgEdgesStr, "isDependency", "pVersion")
+		setIsDependencyMatchValues(arangoQueryBuilder, isDependencySpec, values)
+
+		return getDependencyForQuery(ctx, c, arangoQueryBuilder, values)
+	} else {
+		values := map[string]any{}
+		// get packages
+		arangoQueryBuilder = newForQuery(isDependenciesStr, "isDependency")
+		setIsDependencyMatchValues(arangoQueryBuilder, isDependencySpec, values)
+		arangoQueryBuilder.forInBound(isDependencySubjectPkgEdgesStr, "pVersion", "isDependency")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		return getDependencyForQuery(ctx, c, arangoQueryBuilder, values)
+	}
+}
+
+func getDependencyForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.IsDependency, error) {
 	arangoQueryBuilder.query.WriteString("\n")
 	arangoQueryBuilder.query.WriteString(`RETURN {
 		'pkgVersion': {
@@ -81,8 +101,10 @@ func (c *arangoClient) IsDependency(ctx context.Context, isDependencySpec *model
 }
 
 func setIsDependencyMatchValues(arangoQueryBuilder *arangoQueryBuilder, isDependencySpec *model.IsDependencySpec, queryValues map[string]any) {
-
-	arangoQueryBuilder.forOutBound(isDependencySubjectPkgEdgesStr, "isDependency", "pVersion")
+	if isDependencySpec.ID != nil {
+		arangoQueryBuilder.filter("isDependency", "_id", "==", "@id")
+		queryValues["id"] = *isDependencySpec.ID
+	}
 	if isDependencySpec.VersionRange != nil {
 		arangoQueryBuilder.filter("isDependency", versionRangeStr, "==", "@"+versionRangeStr)
 		queryValues[versionRangeStr] = isDependencySpec.VersionRange

--- a/pkg/assembler/backends/arangodb/osv.go
+++ b/pkg/assembler/backends/arangodb/osv.go
@@ -28,6 +28,10 @@ import (
 func (c *arangoClient) Osv(ctx context.Context, osvSpec *model.OSVSpec) ([]*model.Osv, error) {
 	values := map[string]any{}
 	arangoQueryBuilder := newForQuery(osvsStr, "osv")
+	if osvSpec.ID != nil {
+		arangoQueryBuilder.filter("osv", "_id", "==", "@id")
+		values["id"] = *osvSpec.ID
+	}
 	if osvSpec.OsvID != nil {
 		arangoQueryBuilder.filter("osv", "osvId", "==", "@osvId")
 		values["osvId"] = strings.ToLower(*osvSpec.OsvID)

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -121,10 +121,6 @@ func getPackageQueryValues(c *arangoClient, pkg *model.PkgInputSpec) map[string]
 	values := map[string]any{}
 
 	// add guac keys
-
-	values["rootID"] = c.pkgRoot.Id
-	values["rootKey"] = c.pkgRoot.Key
-
 	guacIds := guacPkgId(*pkg)
 	values["guacNsKey"] = guacIds.NamespaceId
 	values["guacNameKey"] = guacIds.NameId
@@ -194,10 +190,10 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 
 	query := `
 	LET type = FIRST(
-		UPSERT { type: doc.pkgType, _parent: doc.rootID }
-		INSERT { type: doc.pkgType, _parent: doc.rootID }
+		UPSERT { type: doc.pkgType}
+		INSERT { type: doc.pkgType}
 		UPDATE {}
-		IN pkgTypes OPTIONS { indexHint: "byPkgTypeParent" }
+		IN pkgTypes OPTIONS { indexHint: "byPkgType" }
 		RETURN NEW
 	)
 
@@ -223,10 +219,6 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 	  UPDATE {}
 	  IN pkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
 	  RETURN NEW
-	)
-
-	LET pkgHasTypeCollection = (
-	  INSERT { _key: CONCAT("pkgHasType", doc.rootKey, type._key), _from: doc.rootID, _to: type._id} INTO pkgHasType OPTIONS { overwriteMode: "ignore" }
 	)
   
 	LET pkgHasNamespaceCollection = (
@@ -267,10 +259,10 @@ func (c *arangoClient) IngestPackages(ctx context.Context, pkgs []*model.PkgInpu
 func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error) {
 	query := `
 	  LET type = FIRST(
-		UPSERT { type: @pkgType, _parent: @rootID }
-		INSERT { type: @pkgType, _parent: @rootID }
+		UPSERT { type: @pkgType }
+		INSERT { type: @pkgType }
 		UPDATE {}
-		IN pkgTypes OPTIONS { indexHint: "byPkgTypeParent" }
+		IN pkgTypes OPTIONS { indexHint: "byPkgType" }
 		RETURN NEW
 	  )
 
@@ -296,10 +288,6 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 		UPDATE {}
 		IN pkgVersions OPTIONS { indexHint: "byVersionGuacKey" }
 		RETURN NEW
-	  )
-
-	  LET pkgHasTypeCollection = (
-		INSERT { _key: CONCAT("pkgHasType", @rootKey, type._key), _from: @rootID, _to: type._id} INTO pkgHasType OPTIONS { overwriteMode: "ignore" }
 	  )
 	
 	  LET pkgHasNamespaceCollection = (
@@ -346,10 +334,7 @@ func (c *arangoClient) IngestPackage(ctx context.Context, pkg model.PkgInputSpec
 func setPkgNameMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *arangoQueryBuilder {
 	var arangoQueryBuilder *arangoQueryBuilder
 	if pkgSpec != nil {
-		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
-		arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
-		queryValues["pkg"] = "pkg"
-		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder = newForQuery(pkgTypesStr, "pType")
 		if pkgSpec.Type != nil {
 			arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 			queryValues["pkgType"] = *pkgSpec.Type
@@ -365,8 +350,7 @@ func setPkgNameMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *
 			queryValues["name"] = *pkgSpec.Name
 		}
 	} else {
-		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
-		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder = newForQuery(pkgTypesStr, "pType")
 		arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
 		arangoQueryBuilder.forOutBound(pkgHasNameStr, "pName", "pNs")
 	}
@@ -376,10 +360,7 @@ func setPkgNameMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *
 func setPkgVersionMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any) *arangoQueryBuilder {
 	var arangoQueryBuilder *arangoQueryBuilder
 	if pkgSpec != nil {
-		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
-		arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
-		queryValues["pkg"] = "pkg"
-		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder = newForQuery(pkgTypesStr, "pType")
 		if pkgSpec.Type != nil {
 			arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 			queryValues["pkgType"] = *pkgSpec.Type
@@ -422,8 +403,7 @@ func setPkgVersionMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any
 		}
 
 	} else {
-		arangoQueryBuilder = newForQuery(pkgRootsStr, "pRoot")
-		arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+		arangoQueryBuilder = newForQuery(pkgTypesStr, "pType")
 		arangoQueryBuilder.forOutBound(pkgHasNamespaceStr, "pNs", "pType")
 		arangoQueryBuilder.forOutBound(pkgHasNameStr, "pName", "pNs")
 		arangoQueryBuilder.forOutBound(pkgHasVersionStr, "pVersion", "pName")
@@ -492,10 +472,7 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
-	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
-	values["pkg"] = "pkg"
-	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgTypesStr, "pType")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
@@ -540,10 +517,7 @@ func (c *arangoClient) packagesType(ctx context.Context, pkgSpec *model.PkgSpec)
 func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
-	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
-	values["pkg"] = "pkg"
-	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgTypesStr, "pType")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type
@@ -608,10 +582,7 @@ func (c *arangoClient) packagesNamespace(ctx context.Context, pkgSpec *model.Pkg
 func (c *arangoClient) packagesName(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
 	values := map[string]any{}
 
-	arangoQueryBuilder := newForQuery(pkgRootsStr, "pRoot")
-	arangoQueryBuilder.filter("pRoot", "root", "==", "@pkg")
-	values["pkg"] = "pkg"
-	arangoQueryBuilder.forOutBound(pkgHasTypeStr, "pType", "pRoot")
+	arangoQueryBuilder := newForQuery(pkgTypesStr, "pType")
 	if pkgSpec.Type != nil {
 		arangoQueryBuilder.filter("pType", "type", "==", "@pkgType")
 		values["pkgType"] = *pkgSpec.Type


### PR DESCRIPTION
# Description of the PR

- remove root `src` and `pkg`
- add `certifyBad` query
- add `certifyGood` ingestion and query 
- update bulk assembler to use `certifyBad` and `certifyGood` bulk ingest
- Add ID matching to queries
- update `isDependency` query to be more robust
- Change query to search for multiple subjects 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
