### PR TITLE
Refactored and Included Tests for TopoSortFromBfsNodeMap

### DIFF
--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -92,7 +92,7 @@ var queryPatchCmd = &cobra.Command{
 			logger.Fatalf("error searching dependents-- %s\n", err)
 		}
 
-		frontiers, infoNodes, err := analysis.ToposortFromBfsNodeMap(ctx, gqlClient, bfsMap)
+		frontiers, infoNodes, err := analysis.TopoSortFromBfsNodeMap(ctx, gqlClient, bfsMap)
 
 		if err != nil {
 			fmt.Printf("WARNING: There was cycle detected in the toposort so the results are incomplete: %s\n", err)

--- a/pkg/guacanalytics/toposort.go
+++ b/pkg/guacanalytics/toposort.go
@@ -26,30 +26,31 @@ import (
 func TopoSortFromBfsNodeMap(ctx context.Context, gqlClient graphql.Client, nodeMap map[string]BfsNode) (map[int][]string, []string, error) {
 	sortedNodes := make(map[int][]string) // map of level -> list of nodeIDs at that level
 	parentsMap, childrensMap, infoNodes := copyParents(nodeMap)
-	// parentsMap: map of nodeID (child) -> list of parents in the form of a map
-	// childrensMap: map of nodeID (parent) -> list of children in the form of a list
+	// parentsMap: map of nodeID (child) -> the struct parent which contains a list of parents in the form of a map
+	// childrensMap: map of nodeID (parent) -> list of children in the form of an array
 	bfsLevel := 0
 	numNodes := 0
 	totalNodes := len(parentsMap)
 
 	for numNodes < totalNodes {
 		foundIDs := make(map[string]bool)
-		for id, pMap := range parentsMap {
-			if pMap.parents != nil && len(pMap.parents) == 0 { // if this node has no parents, it is a root node
+		for id, p := range parentsMap {
+			if p.parents != nil && len(p.parents) == 0 { // if this node has no parents, it is a root node
 				sortedNodes[bfsLevel] = append(sortedNodes[bfsLevel], id)
 				numNodes++
 				foundIDs[id] = true
-				delete(parentsMap, id)
 			}
 		}
 
 		for id := range foundIDs {
+			delete(parentsMap, id)                     // remove this node from the map of parents
 			for _, childID := range childrensMap[id] { // loop through all the children of this node
 				delete(parentsMap[childID].parents, id) // remove this node from the map of parents of the child
 			}
 		}
 
 		if len(foundIDs) == 0 {
+			// TODO: print out offending cycle
 			return sortedNodes, infoNodes, fmt.Errorf("error: cycle detected")
 		}
 

--- a/pkg/guacanalytics/toposort_test.go
+++ b/pkg/guacanalytics/toposort_test.go
@@ -1,0 +1,113 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guacanalytics
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/Khan/genqlient/graphql"
+)
+
+func TestTopoSortFromBfsNodeMap(t *testing.T) {
+	type args struct {
+		nodeMap map[string]BfsNode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[int][]string
+		want1   []string
+		wantErr bool
+	}{
+		{
+			name: "default",
+			args: args{
+				/*
+						1
+					   / \
+					  2   3
+					 / \   \
+					4   5   6
+				*/
+				nodeMap: map[string]BfsNode{
+					"1": {Parents: []string{}},
+					"2": {Parents: []string{"1"}},
+					"3": {Parents: []string{"1"}},
+					"4": {Parents: []string{"2"}},
+					"5": {Parents: []string{"2"}},
+					"6": {Parents: []string{"3"}},
+				},
+			},
+			want: map[int][]string{
+				0: {"1"},
+				1: {"2", "3"},
+				2: {"4", "5", "6"},
+			},
+			want1: *new([]string),
+		},
+		{
+			name: "cycle error",
+			args: args{
+				/*
+						1
+					   / \
+					  2 - 3
+				*/
+				nodeMap: map[string]BfsNode{
+					"1": {Parents: []string{"3"}},
+					"2": {Parents: []string{"1"}},
+					"3": {Parents: []string{"2"}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "infoNodes not empty",
+			args: args{
+				nodeMap: map[string]BfsNode{
+					"1": {NotInBlastRadius: true},
+				},
+			},
+			want:  map[int][]string{},
+			want1: []string{"1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			gqlClient := graphql.NewClient("test", nil)
+			got, got1, err := TopoSortFromBfsNodeMap(ctx, gqlClient, tt.args.nodeMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TopoSortFromBfsNodeMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for k := range got {
+				sort.Strings(got[k])
+				sort.Strings(tt.want[k])
+				if !reflect.DeepEqual(got[k], tt.want[k]) {
+					t.Errorf("TopoSortFromBfsNodeMap() got = %v, want %v", got, tt.want)
+				}
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("TopoSortFromBfsNodeMap() got1 = %v, want %v", got1, tt.want1)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
# Description of the PR

* Refactored the code for TopoSortFromBfsNodeMap for readability and time complexity purposes.
* Included tests for TopoSortFromBfsNodeMap

In regards of improving the time complexity here is what I did:

I changed `parentsMap` from a `map[string] []string` to a `map[string] parent`, with `parent` being: 

``` go
type parent struct {  
	parents map[string]bool // Consider the map[string]bool as a set, the value doesn't matter just the key  
}
```

So basically now `parentsMap = map[string] map[string] bool`. This so that we don't have to loop through every value in `parentsMap`. Doing this change will improve the time complexity by a lot, instead of looping through every value, we will only be doing an `O(1)` operation to remove each `id` from the maps.

I also added a `map[string] []string` called `childrensMap`, it is a map of parents to a list of children. This makes it so that we know which children have which parents. We can use this to only loop through the nodes that have a certain parent and not just loop through each and every node. 

This may be affected by: #1132 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
