### PR TITLE
[PatchPlanning] Rename dependencies to dependents in search

### DIFF
--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -86,10 +86,10 @@ var queryPatchCmd = &cobra.Command{
 
 		}
 
-		bfsMap, path, err := analysis.SearchDependenciesFromStartNode(ctx, gqlClient, startID, stopID, opts.depth)
+		bfsMap, path, err := analysis.SearchDependentsFromStartPackage(ctx, gqlClient, startID, stopID, opts.depth)
 
 		if err != nil {
-			logger.Fatalf("error searching dependencies-- %s\n", err)
+			logger.Fatalf("error searching dependents-- %s\n", err)
 		}
 
 		frontiers, infoNodes, err := analysis.ToposortFromBfsNodeMap(ctx, gqlClient, bfsMap)

--- a/pkg/guacanalytics/patchPlanning.go
+++ b/pkg/guacanalytics/patchPlanning.go
@@ -52,7 +52,7 @@ type queueValues struct {
 	queue   []string
 }
 
-func SearchDependenciesFromStartNode(ctx context.Context, gqlClient graphql.Client, startID string, stopID *string, maxDepth int) (map[string]BfsNode, []string, error) {
+func SearchDependentsFromStartPackage(ctx context.Context, gqlClient graphql.Client, startID string, stopID *string, maxDepth int) (map[string]BfsNode, []string, error) {
 	startNode, err := model.Node(ctx, gqlClient, startID)
 
 	if err != nil {
@@ -80,7 +80,7 @@ func SearchDependenciesFromStartNode(ctx context.Context, gqlClient graphql.Clie
 	}
 
 	if len(nodePkg.AllPkgTree.Namespaces[0].Names[0].Versions) == 0 {
-		// TODO: handle case where there are circular dependencies that introduce more versions to the version list on a node that requires revisiting
+		// TODO: handle case where there are circular dependents that introduce more versions to the version list on a node that requires revisiting
 		err := q.addNodesToQueueFromPackageName(ctx, gqlClient, nodePkg.AllPkgTree.Type, nodePkg.AllPkgTree.Namespaces[0].Namespace, nodePkg.AllPkgTree.Namespaces[0].Names[0].Name, startID)
 
 		if err != nil {

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -1258,7 +1258,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 		graphInputs       []assembler.IngestPredicates
 	}{
 		{
-			name:           "1: two levels of dependencies, no stopID and no limiting maxDepth",
+			name:           "1: two levels of dependents, no stopID and no limiting maxDepth",
 			startType:      "conan",
 			startNamespace: "openssl.org",
 			startName:      "openssl",
@@ -1269,7 +1269,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			graphInputs:    []assembler.IngestPredicates{simpleIsDependencyGraph},
 		},
 		{
-			name:           "2:  one level of dependencies, no stopID and no limiting maxDepth",
+			name:           "2:  one level of dependents, no stopID and no limiting maxDepth",
 			startType:      "deb",
 			startNamespace: "ubuntu",
 			startName:      "dpkg",
@@ -1280,7 +1280,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			graphInputs:    []assembler.IngestPredicates{simpleIsDependencyGraph},
 		},
 		{
-			name:           "3: two levels of dependencies, a stopID at the first level and no limiting maxDepth",
+			name:           "3: two levels of dependents, a stopID at the first level and no limiting maxDepth",
 			startType:      "conan",
 			startNamespace: "openssl.org",
 			startName:      "openssl",
@@ -1295,7 +1295,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 			graphInputs:    []assembler.IngestPredicates{simpleIsDependencyGraph},
 		},
 		{
-			name:           "4: two levels of dependencies, no stopID and a limiting maxDepth at the first level",
+			name:           "4: two levels of dependents, no stopID and a limiting maxDepth at the first level",
 			startType:      "conan",
 			startNamespace: "openssl.org",
 			startName:      "openssl",
@@ -1550,10 +1550,10 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 				stopID = getPackageIDsValues[0]
 			}
 
-			gotMap, _, err := SearchDependenciesFromStartNode(ctx, gqlClient, startID, stopID, tt.maxDepth)
+			gotMap, _, err := SearchDependentsFromStartPackage(ctx, gqlClient, startID, stopID, tt.maxDepth)
 
 			if err != nil {
-				t.Errorf("got err from SearchDependenciesFromStartNode: %s", err)
+				t.Errorf("got err from SearchDependentsFromStartPackage: %s", err)
 			}
 
 			if diff := cmp.Diff(tt.expectedLen, len(gotMap)); len(diff) > 0 {


### PR DESCRIPTION
# Description of the PR

Rename dependencies and SearchDependenciesFromStartNode to dependents and SearchDependentsFromStartPackage to reflect the behavior and functionality of the code.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
