### PR TITLE
Fixed a Potential Stack Overflow Error in findPurl

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -84,7 +84,11 @@ func (c *csafParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStri
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string, visited map[string]bool) *string {
+func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string) *string {
+	return findPurlSearch(ctx, tree, product_ref, make(map[string]bool))
+}
+
+func findPurlSearch(ctx context.Context, tree csaf.ProductBranch, product_ref string, visited map[string]bool) *string {
 	if visited[tree.Name] {
 		return nil
 	}
@@ -96,7 +100,7 @@ func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string, 
 	}
 
 	for _, b := range tree.Branches {
-		purl := findPurl(ctx, b, product_ref, visited)
+		purl := findPurlSearch(ctx, b, product_ref, visited)
 		if purl != nil {
 			return purl
 		}
@@ -151,7 +155,7 @@ func (c *csafParser) findPkgSpec(ctx context.Context, product_id string) (*gener
 		return nil, fmt.Errorf("unable to locate product reference for id %s", product_id)
 	}
 
-	purl := findPurl(ctx, c.csaf.ProductTree, *pref, make(map[string]bool))
+	purl := findPurl(ctx, c.csaf.ProductTree, *pref)
 	if purl == nil {
 		return nil, fmt.Errorf("unable to locate product url for reference %s", *pref)
 	}

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -131,7 +131,7 @@ func Test_findPurl(t *testing.T) {
 				test.args.tree.Branches[0].Branches = append(test.args.tree.Branches[0].Branches, test.args.tree)
 			}
 
-			if got := findPurl(test.args.ctx, test.args.tree, test.args.product_ref, make(map[string]bool)); !reflect.DeepEqual(got, test.want) {
+			if got := findPurl(test.args.ctx, test.args.tree, test.args.product_ref); !reflect.DeepEqual(got, test.want) {
 				t.Errorf("findPurl() = %v, want %v", got, test.want)
 			}
 		})

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -17,7 +17,10 @@ package csaf
 
 import (
 	"context"
+	"reflect"
 	"testing"
+
+	"github.com/openvex/go-vex/pkg/csaf"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/testdata"
@@ -65,6 +68,71 @@ func Test_csafParser(t *testing.T) {
 			preds := s.GetPredicates(ctx)
 			if d := cmp.Diff(tt.wantPredicates, preds, testdata.IngestPredicatesCmpOpts...); len(d) != 0 {
 				t.Errorf("csaf.GetPredicate mismatch values (+got, -expected): %s", d)
+			}
+		})
+	}
+}
+
+func Test_findPurl(t *testing.T) {
+	defaultTestTree := csaf.ProductBranch{
+		Name: "node1",
+		Branches: []csaf.ProductBranch{
+			{
+				Name: "node2",
+				Product: csaf.Product{
+					IdentificationHelper: map[string]string{
+						"purl": "test 2",
+					},
+				},
+			},
+		},
+	}
+
+	returnedPurl := defaultTestTree.Branches[0].Product.IdentificationHelper["purl"]
+	type args struct {
+		ctx         context.Context
+		tree        csaf.ProductBranch
+		product_ref string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		stackOverflow bool
+		want          *string
+	}{
+		{
+			name: "default",
+			args: args{
+				ctx:         context.Background(),
+				tree:        defaultTestTree,
+				product_ref: "node2",
+			},
+			want: &returnedPurl,
+		},
+		{
+			name: "can stack overflow",
+			args: args{
+				ctx: context.Background(),
+				tree: csaf.ProductBranch{
+					Name: "node1",
+				},
+				product_ref: "not equal to any tree nodes",
+			},
+			stackOverflow: true,
+			want:          nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.stackOverflow {
+				test.args.tree.Branches = append(test.args.tree.Branches, csaf.ProductBranch{
+					Name: "node2",
+				})
+				test.args.tree.Branches[0].Branches = append(test.args.tree.Branches[0].Branches, test.args.tree)
+			}
+
+			if got := findPurl(test.args.ctx, test.args.tree, test.args.product_ref, make(map[string]bool)); !reflect.DeepEqual(got, test.want) {
+				t.Errorf("findPurl() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -115,6 +115,11 @@ func Test_findPurl(t *testing.T) {
 				ctx: context.Background(),
 				tree: csaf.ProductBranch{
 					Name: "node1",
+					Branches: []csaf.ProductBranch{
+						{
+							Name: "node2",
+						},
+					},
 				},
 				product_ref: "not equal to any tree nodes",
 			},
@@ -125,9 +130,6 @@ func Test_findPurl(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.stackOverflow {
-				test.args.tree.Branches = append(test.args.tree.Branches, csaf.ProductBranch{
-					Name: "node2",
-				})
 				test.args.tree.Branches[0].Branches = append(test.args.tree.Branches[0].Branches, test.args.tree)
 			}
 


### PR DESCRIPTION
# Description of the PR

* Fixed the potential stack overflow error for the function `findPurl` in `pkg/ingestor/parser/csaf/parser_csaf.go`
* Included unit tests for `findPurl`
* Used a visted map to solve the stack overflow, and didn't use Dynamic Programing because there was no need to go over the nodes again.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
