### PR TITLE
Fixed a Potential Stack Overflow Error in findProductRef

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -17,9 +17,10 @@ package csaf
 
 import (
 	"context"
-	"github.com/openvex/go-vex/pkg/csaf"
 	"reflect"
 	"testing"
+
+	"github.com/openvex/go-vex/pkg/csaf"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/testdata"


### PR DESCRIPTION
* Fixed the potential stack overflow error for the function `findProductRef` in `pkg/ingestor/parser/csaf/parser_csaf.go`
* Included unit tests for `findProductRef`
* Used a visted map to solve the stack overflow, and didn't use Dynamic Programing because there was no need to go over the nodes again

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
