### PR TITLE
fix to add type filter for dependent package

### DIFF
--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -124,18 +124,18 @@ func setIsDependencyMatchValues(arangoQueryBuilder *arangoQueryBuilder, isDepend
 	if isDependencySpec.DependentPackage != nil {
 		arangoQueryBuilder.forOutBound(isDependencyDepPkgEdgesStr, "depName", "isDependency")
 		if isDependencySpec.DependentPackage.Name != nil {
-			arangoQueryBuilder.filter("depName", "name", "==", "@name")
-			queryValues["name"] = *isDependencySpec.DependentPackage.Name
+			arangoQueryBuilder.filter("depName", "name", "==", "@depName")
+			queryValues["depName"] = *isDependencySpec.DependentPackage.Name
 		}
 		arangoQueryBuilder.forInBound(pkgHasNameStr, "depNamespace", "depName")
 		if isDependencySpec.DependentPackage.Namespace != nil {
-			arangoQueryBuilder.filter("depNamespace", "namespace", "==", "@namespace")
-			queryValues["namespace"] = *isDependencySpec.DependentPackage.Namespace
+			arangoQueryBuilder.filter("depNamespace", "namespace", "==", "@depNamespace")
+			queryValues["depNamespace"] = *isDependencySpec.DependentPackage.Namespace
 		}
 		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "depType", "depNamespace")
-		if isDependencySpec.DependentPackage.Namespace != nil {
-			arangoQueryBuilder.filter("depType", "type", "==", "@type")
-			queryValues["type"] = *isDependencySpec.DependentPackage.Type
+		if isDependencySpec.DependentPackage.Type != nil {
+			arangoQueryBuilder.filter("depType", "type", "==", "@depType")
+			queryValues["depType"] = *isDependencySpec.DependentPackage.Type
 		}
 	} else {
 		arangoQueryBuilder.forOutBound(isDependencyDepPkgEdgesStr, "depName", "isDependency")


### PR DESCRIPTION
# Description of the PR

fix to add type filter for dependent package

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
