### PR TITLE
Fixed Part of SemVer Issue

### DIFF
--- a/pkg/misc/depversion/depversion.go
+++ b/pkg/misc/depversion/depversion.go
@@ -333,8 +333,18 @@ func getConstraint(s string) (string, error) {
 
 	// ignoring the tilde for the wildcard check
 	wildcardVersion := strings.TrimPrefix(s, "~")
+	// ignoring the ^ for the wildcard check, but using it during the parsing
+	wildcardVersion = strings.TrimPrefix(wildcardVersion, "^")
+
 	// check for 1.x minor and patch versions
 	if isSemVerWildcard(wildcardVersion) {
+		if strings.HasPrefix(s, "^") {
+			split := strings.Split(wildcardVersion, ".")
+			if len(split) == 3 {
+				wildcardVersion = fmt.Sprintf("%s.%s", split[0], split[2])
+			}
+		}
+
 		_, major, minor, _, _, _, err := parseWildcardSemver(wildcardVersion)
 		if err != nil {
 			return "", fmt.Errorf("unable to parse semver with wildcard: %v", err)

--- a/pkg/misc/depversion/depversion_test.go
+++ b/pkg/misc/depversion/depversion_test.go
@@ -243,6 +243,14 @@ func Test_VersionRangeParse(t *testing.T) {
 			},
 		},
 		{
+			input: "~0.10.x",
+			expect: VersionMatchObject{
+				VRSet: []VersionRange{
+					{">=,<0.11.0"},
+				},
+			},
+		},
+		{
 			// special case latest set to no constraint
 			input: "latest",
 			expect: VersionMatchObject{
@@ -262,7 +270,7 @@ func Test_VersionRangeParse(t *testing.T) {
 
 			got, err := ParseVersionRange(tt.input)
 			if err != nil {
-				t.Errorf("got unexpected err: %v", err)
+				t.Errorf("got unexpected err from ParseVersionRange: %v", err)
 				return
 			}
 

--- a/pkg/misc/depversion/depversion_test.go
+++ b/pkg/misc/depversion/depversion_test.go
@@ -246,7 +246,7 @@ func Test_VersionRangeParse(t *testing.T) {
 			input: "~0.10.x",
 			expect: VersionMatchObject{
 				VRSet: []VersionRange{
-					{">=,<0.11.0"},
+					{">=0.10.0,<0.11.0"},
 				},
 			},
 		},

--- a/pkg/misc/depversion/depversion_test.go
+++ b/pkg/misc/depversion/depversion_test.go
@@ -144,6 +144,30 @@ func Test_VersionRangeParse(t *testing.T) {
 			},
 		},
 		{
+			input: "^1.0.x",
+			expect: VersionMatchObject{
+				VRSet: []VersionRange{
+					{">=1.0.0,<2.0.0"},
+				},
+			},
+		},
+		{
+			input: "^1.x",
+			expect: VersionMatchObject{
+				VRSet: []VersionRange{
+					{">=1.0.0,<2.0.0"},
+				},
+			},
+		},
+		{
+			input: "^1.3.x",
+			expect: VersionMatchObject{
+				VRSet: []VersionRange{
+					{">=1.0.0,<2.0.0"},
+				},
+			},
+		},
+		{
 			input: "v0.0.0-20190603091049-60506f45cf65",
 			expect: VersionMatchObject{
 				VRSet: []VersionRange{


### PR DESCRIPTION
# Description of the PR

* Fixes the first part of https://github.com/guacsec/guac/issues/1087
* Fixed the error for `versionRange` having a tilde `"~"` and wildcard `"x"` (ie. `"versionRange": "~0.10.x"`).
* Also included a test for tilde and wildcard

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
