### PR TITLE
Feature/arango certify vuln implementation

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -47,6 +47,7 @@ func ingestData(port int) {
 	ingestDependency(ctx, gqlclient)
 	ingestOccurrence(ctx, gqlclient)
 	ingestVulnerability(ctx, gqlclient)
+	ingestVulnerabilities(ctx, gqlclient)
 	ingestPkgEqual(ctx, gqlclient)
 	ingestCertifyBad(ctx, gqlclient)
 	ingestCertifyBads(ctx, gqlclient)
@@ -650,6 +651,265 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 		}
 		if _, err := model.CertifyVulnPkg(ctx, client, *ingest.pkg, *ingest.vuln, ingest.vulnerability); err != nil {
 			logger.Errorf("Error in ingesting: %v\n", err)
+		}
+
+	}
+}
+
+func ingestVulnerabilities(ctx context.Context, client graphql.Client) {
+	logger := logging.FromContext(ctx)
+	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
+	opensslNs := "openssl.org"
+	opensslVersion := "3.0.3"
+	djangoNs := ""
+	ingestVulnerabilities := []struct {
+		name              string
+		pkgs              []model.PkgInputSpec
+		vulns             []model.VulnerabilityInputSpec
+		vulnerabilityList []model.ScanMetadataInput
+	}{
+		{
+			name: "bulk ingest",
+			pkgs: []model.PkgInputSpec{
+				{
+					Type:      "conan",
+					Namespace: &opensslNs,
+					Name:      "openssl",
+					Version:   &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{
+						{Key: "user", Value: "bincrafters"},
+						{Key: "channel", Value: "stable"},
+					},
+				},
+				{
+					Type:      "conan",
+					Namespace: &opensslNs,
+					Name:      "openssl",
+					Version:   &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{
+						{Key: "user", Value: "bincrafters"},
+						{Key: "channel", Value: "stable"},
+					},
+				},
+				{
+					Type:      "conan",
+					Namespace: &opensslNs,
+					Name:      "openssl",
+					Version:   &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{
+						{Key: "user", Value: "bincrafters"},
+						{Key: "channel", Value: "stable"},
+					},
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+				{
+					Type:      "conan",
+					Namespace: &opensslNs,
+					Name:      "openssl",
+					Version:   &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{
+						{Key: "user", Value: "bincrafters"},
+						{Key: "channel", Value: "stable"},
+					},
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+				{
+					Type:      "conan",
+					Namespace: &opensslNs,
+					Name:      "openssl",
+					Version:   &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{
+						{Key: "user", Value: "bincrafters"},
+						{Key: "channel", Value: "stable"},
+					},
+				},
+				{
+					Type:      "pypi",
+					Namespace: &djangoNs,
+					Name:      "django",
+				},
+			},
+			vulns: []model.VulnerabilityInputSpec{
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-h45f-rjvw-2rv2",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2018-12310",
+				},
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2018-12310",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-f45f-jj4w-2rv2",
+				},
+				{
+					Type:            "noVuln",
+					VulnerabilityID: "",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-f45f-jj4w-2rv2",
+				},
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "noVuln",
+					VulnerabilityID: "",
+				},
+			},
+			vulnerabilityList: []model.ScanMetadataInput{
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+				{
+					TimeScanned:    tm,
+					DbUri:          "MITRE",
+					DbVersion:      "v1.0.0",
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "Demo ingestion",
+					Collector:      "Demo ingestion",
+				},
+			},
+		},
+	}
+	for _, ingest := range ingestVulnerabilities {
+		if _, err := model.IngestPackages(ctx, client, ingest.pkgs); err != nil {
+			logger.Errorf("Error in ingesting packages: %v\n", err)
+		}
+		if _, err := model.IngestVulnerabilities(ctx, client, ingest.vulns); err != nil {
+			logger.Errorf("Error in ingesting vulnerabilities: %v\n", err)
+		}
+		if _, err := model.CertifyVulnPkgs(ctx, client, ingest.pkgs, ingest.vulns, ingest.vulnerabilityList); err != nil {
+			logger.Errorf("Error in ingesting CertifyVulnPkgs: %v\n", err)
 		}
 
 	}

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -716,9 +716,6 @@ func getPreloadString(prefix, name string) string {
 func (c *arangoClient) CertifyVEXStatement(ctx context.Context, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) ([]*model.CertifyVEXStatement, error) {
 	panic(fmt.Errorf("not implemented: CertifyVEXStatement - CertifyVEXStatement"))
 }
-func (c *arangoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
-	panic(fmt.Errorf("not implemented: CertifyVuln - CertifyVuln"))
-}
 
 func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
 	panic(fmt.Errorf("not implemented: HasSourceAt - HasSourceAt"))
@@ -744,9 +741,6 @@ func (c *arangoClient) IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpe
 }
 func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
 	panic(fmt.Errorf("not implemented: IngestVEXStatement - IngestVEXStatement"))
-}
-func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error) {
-	panic(fmt.Errorf("not implemented: IngestCertifyVuln"))
 }
 
 // Topological queries: queries where node connectivity matters more than node type

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -105,9 +105,9 @@ const (
 	hasSBOMsStr        string = "hasSBOMs"
 
 	// certifyVuln collection
-	// TODO (pxp928): update collections based on edge collections
-	certifyVulnEdgesStr string = "certifyVulnEdges"
-	certifyVulnsStr     string = "certifyVulns"
+	certifyVulnPkgEdgesStr string = "certifyVulnPkgEdges"
+	certifyVulnEdgesStr    string = "certifyVulnEdges"
+	certifyVulnsStr        string = "certifyVulns"
 
 	// certifyScorecard collection
 
@@ -309,10 +309,16 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		hasSBOMArtEdges.To = []string{hasSBOMsStr}
 
 		// setup certifyVuln collections
+		var certifyVulnPkgEdges driver.EdgeDefinition
+		certifyVulnPkgEdges.Collection = certifyVulnPkgEdgesStr
+		certifyVulnPkgEdges.From = []string{pkgVersionsStr}
+		certifyVulnPkgEdges.To = []string{certifyVulnsStr}
+
+		// setup certifyVuln collections
 		var certifyVulnEdges driver.EdgeDefinition
 		certifyVulnEdges.Collection = certifyVulnEdgesStr
-		certifyVulnEdges.From = []string{pkgVersionsStr, certifyVulnsStr}
-		certifyVulnEdges.To = []string{certifyVulnsStr, vulnerabilitiesStr}
+		certifyVulnEdges.From = []string{certifyVulnsStr}
+		certifyVulnEdges.To = []string{vulnerabilitiesStr}
 
 		// setup certifyScorecard collections
 		var certifyScorecardSrcEdges driver.EdgeDefinition
@@ -368,7 +374,7 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			pkgHasVersion, srcHasNamespace, srcHasName, vulnHasVulnerabilityID, isDependencyDepPkgEdges, isDependencySubjectPkgEdges,
 			isOccurrenceArtEdges, isOccurrenceSubjectPkgEdges, isOccurrenceSubjectSrcEdges, hasSLSASubjectArtEdges,
 			hasSLSABuiltByEdges, hasSLSABuiltFromEdges, hashEqualArtEdges, hashEqualSubjectArtEdges, hasSBOMPkgEdges,
-			hasSBOMArtEdges, certifyVulnEdges, certifyScorecardSrcEdges, certifyBadPkgVersionEdges, certifyBadPkgNameEdges,
+			hasSBOMArtEdges, certifyVulnPkgEdges, certifyVulnEdges, certifyScorecardSrcEdges, certifyBadPkgVersionEdges, certifyBadPkgNameEdges,
 			certifyBadArtEdges, certifyBadSrcEdges, certifyGoodPkgVersionEdges, certifyGoodPkgNameEdges, certifyGoodArtEdges, certifyGoodSrcEdges}
 
 		// create a graph

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -20,7 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -32,7 +34,108 @@ const (
 )
 
 func (c *arangoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
-	panic(fmt.Errorf("not implemented: CertifyVuln - CertifyVuln"))
+
+	// TODO (pxp928): Optimization of the query can be done by starting from the vulnerability node (if specified)
+	var arangoQueryBuilder *arangoQueryBuilder
+	if certifyVulnSpec.Package != nil {
+		var combinedCertifyVuln []*model.CertifyVuln
+		if certifyVulnSpec.Package != nil {
+			values := map[string]any{}
+
+			arangoQueryBuilder = setPkgVersionMatchValues(certifyVulnSpec.Package, values)
+			arangoQueryBuilder.forOutBound(certifyVulnPkgEdgesStr, "certVuln", "pVersion")
+			setIsOccurrenceMatchValues(arangoQueryBuilder, isOccurrenceSpec, values)
+
+			pkgVersionOccurrences, err := getPkgOccurrencesForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package version occurrences with error: %w", err)
+			}
+
+			combinedCertifyVuln = append(combinedCertifyVuln, pkgVersionOccurrences...)
+		}
+	} else {
+		var combinedOccurrence []*model.CertifyVuln
+		values := map[string]any{}
+		// get packages
+		arangoQueryBuilder = newForQuery(isOccurrencesStr, "isOccurrence")
+		setIsOccurrenceMatchValues(arangoQueryBuilder, isOccurrenceSpec, values)
+		arangoQueryBuilder.forInBound(isOccurrenceSubjectPkgEdgesStr, "pVersion", "isOccurrence")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgIsOccurrences, err := getPkgOccurrencesForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package occurrences with error: %w", err)
+		}
+		combinedOccurrence = append(combinedOccurrence, pkgIsOccurrences...)
+
+		// get sources
+		arangoQueryBuilder = newForQuery(isOccurrencesStr, "isOccurrence")
+		setIsOccurrenceMatchValues(arangoQueryBuilder, isOccurrenceSpec, values)
+		arangoQueryBuilder.forInBound(isOccurrenceSubjectSrcEdgesStr, "sName", "isOccurrence")
+		arangoQueryBuilder.forInBound(srcHasNameStr, "sNs", "sName")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+
+		srcIsOccurrences, err := getSrcOccurrencesForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve source occurrences with error: %w", err)
+		}
+		combinedOccurrence = append(combinedOccurrence, srcIsOccurrences...)
+
+		return combinedOccurrence, nil
+	}
+}
+
+func setCertifyVulnMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyVulnSpec *model.CertifyVulnSpec, queryValues map[string]any) {
+	if certifyVulnSpec.ID != nil {
+		arangoQueryBuilder.filter("certVuln", "_id", "==", "@id")
+		queryValues["id"] = *certifyVulnSpec.ID
+	}
+	if certifyVulnSpec.TimeScanned != nil {
+		arangoQueryBuilder.filter("certVuln", justification, "==", "@"+timeScannedStr)
+		queryValues[timeScannedStr] = certifyVulnSpec.TimeScanned
+	}
+	if certifyVulnSpec.DbURI != nil {
+		arangoQueryBuilder.filter("certVuln", justification, "==", "@"+dbUriStr)
+		queryValues[dbUriStr] = certifyVulnSpec.DbURI
+	}
+	if certifyVulnSpec.DbVersion != nil {
+		arangoQueryBuilder.filter("certVuln", justification, "==", "@"+dbVersionStr)
+		queryValues[dbVersionStr] = certifyVulnSpec.DbVersion
+	}
+	if certifyVulnSpec.ScannerURI != nil {
+		arangoQueryBuilder.filter("certVuln", justification, "==", "@"+scannerUriStr)
+		queryValues[scannerUriStr] = certifyVulnSpec.ScannerURI
+	}
+	if certifyVulnSpec.ScannerVersion != nil {
+		arangoQueryBuilder.filter("certVuln", justification, "==", "@"+scannerVersionStr)
+		queryValues[scannerVersionStr] = certifyVulnSpec.ScannerVersion
+	}
+	if certifyVulnSpec.Origin != nil {
+		arangoQueryBuilder.filter("certVuln", origin, "==", "@"+origin)
+		queryValues[origin] = certifyVulnSpec.Origin
+	}
+	if certifyVulnSpec.Collector != nil {
+		arangoQueryBuilder.filter("certVuln", collector, "==", "@"+collector)
+		queryValues[collector] = certifyVulnSpec.Collector
+	}
+	arangoQueryBuilder.forOutBound(certifyVulnEdgesStr, "vuln", "certVuln")
+	if certifyVulnSpec.Vulnerability != nil {
+		if certifyVulnSpec.Vulnerability.ID != nil {
+			arangoQueryBuilder.filter("art", "_id", "==", "@id")
+			queryValues["id"] = *isOccurrenceSpec.Artifact.ID
+		}
+		if certifyVulnSpec.Vulnerability.VulnerabilityID != nil {
+			arangoQueryBuilder.filter("art", "digest", "==", "@digest")
+			queryValues["digest"] = strings.ToLower(*isOccurrenceSpec.Artifact.Digest)
+		}
+		if certifyVulnSpec.Vulnerability.Type != nil {
+			arangoQueryBuilder.filter("art", "algorithm", "==", "@algorithm")
+			queryValues["algorithm"] = strings.ToLower(*isOccurrenceSpec.Artifact.Algorithm)
+		}
+	}
+
 }
 
 func getCertifyVulnQueryValues(pkg *model.PkgInputSpec, vulnerability *model.VulnerabilityInputSpec, certifyVuln *model.ScanMetadataInput) map[string]any {
@@ -122,32 +225,28 @@ func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.Pkg
 		)
 
 		LET firstVuln = FIRST(
-			FOR pVersion in pkgVersions
-			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
-			FOR pName in pkgNames
-			  FILTER pName._id == pVersion._parent
-			FOR pNs in pkgNamespaces
-			  FILTER pNs._id == pName._parent
-			FOR pType in pkgTypes
-			  FILTER pType._id == pNs._parent
+			FOR vVulnID in vulnerabilities
+			  FILTER vVulnID.guacKey == doc.guacVulnKey
+			FOR vType in vulnTypes
+			  FILTER vType._id == vVulnID._parent
 	
 			RETURN {
-			  "type_id": vType._id,
+			  "typeID": vType._id,
 			  "type": vType.type,
 			  "vuln_id": vVulnID._id,
 			  "vuln": vVulnID.vulnerabilityID
 			}
 		)
 		  
-		  LET isOccurrence = FIRST(
-			  UPSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				  INSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				  UPDATE {} IN isOccurrences
+		  LET certifyVuln = FIRST(
+			  UPSERT { packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln._id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin } 
+				  INSERT { packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln._id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN certifyVulns
 				  RETURN NEW
 		  )
 		  			
-		  INSERT { _key: CONCAT("isOccurrenceSubjectPkgEdges", firstPkg.versionDoc._key, isOccurrence._key), _from: firstPkg.versionDoc._id, _to: isOccurrence._id } INTO isOccurrenceSubjectPkgEdges OPTIONS { overwriteMode: "ignore" }
-		  INSERT { _key: CONCAT("isOccurrenceArtEdges", isOccurrence._key, artifact._key), _from: isOccurrence._id, _to: artifact._id } INTO isOccurrenceArtEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("certifyVulnPkgEdges", firstPkg.versionDoc._key, certifyVuln._key), _from: firstPkg.versionDoc._id, _to: certifyVuln._id } INTO certifyVulnPkgEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("certifyVulnEdges", certifyVuln._key, artifact._key), _from: certifyVuln._id, _to: firstVuln._id } INTO certifyVulnEdges OPTIONS { overwriteMode: "ignore" }
 		  
 		  RETURN {
 			'pkgVersion': {
@@ -162,33 +261,196 @@ func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.Pkg
 				'subpath': firstPkg.subpath,
 				'qualifier_list': firstPkg.qualifier_list
 			},
-			'artifact': {
-				'id': artifact._id,
-				'algorithm': artifact.algorithm,
-				'digest': artifact.digest
+			'vulnerability': {
+				'type_id': firstVuln.typeID,
+				'type': firstVuln.type,
+				'vuln_id': firstVuln.vuln_id,
+				'vuln': firstVuln.vuln,
 			},
-			'isOccurrence_id': isOccurrence._id,
-     		'justification': isOccurrence.justification,
-			'collector': isOccurrence.collector,
-			'origin': isOccurrence.origin
+			'certifyVuln_id': certifyVuln._id,
+     		'timeScanned': certifyVuln.timeScanned,
+			'dbUri': certifyVuln.dbUri,
+			'dbVersion': certifyVuln.dbVersion,
+			'scannerUri': certifyVuln.scannerUri,
+			'scannerVersion': certifyVuln.scannerVersion,
+			'collector': certifyVuln.collector,
+			'origin': certifyVuln.origin
 		  }`
 
 	sb.WriteString(query)
 
-	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestOccurrence")
+	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestCertifyVulns")
 	if err != nil {
-		return nil, fmt.Errorf("failed to ingest package occurrence: %w", err)
+		return nil, fmt.Errorf("failed to ingest certifyVulns %w", err)
 	}
 	defer cursor.Close()
 
-	isOccurrenceList, err := getPkgIsOccurrence(ctx, cursor)
+	certifyVulnList, err := geCertifyVuln(ctx, cursor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+		return nil, fmt.Errorf("failed to get certifyVulns from arango cursor: %w", err)
 	}
 
-	return isOccurrenceList, nil
+	return certifyVulnList, nil
 }
 
 func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error) {
-	return nil, fmt.Errorf("not implemented - IngestCertifyVuln")
+	query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == @pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		LET firstVuln = FIRST(
+			FOR vVulnID in vulnerabilities
+			  FILTER vVulnID.guacKey == @guacVulnKey
+			FOR vType in vulnTypes
+			  FILTER vType._id == vVulnID._parent
+	
+			RETURN {
+			  "typeID": vType._id,
+			  "type": vType.type,
+			  "vuln_id": vVulnID._id,
+			  "vuln": vVulnID.vulnerabilityID
+			}
+		)
+		  
+		  LET certifyVuln = FIRST(
+			  UPSERT { packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln._id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin } 
+				  INSERT { packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln._id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin } 
+				  UPDATE {} IN certifyVulns
+				  RETURN NEW
+		  )
+		  			
+		  INSERT { _key: CONCAT("certifyVulnPkgEdges", firstPkg.versionDoc._key, certifyVuln._key), _from: firstPkg.versionDoc._id, _to: certifyVuln._id } INTO certifyVulnPkgEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("certifyVulnEdges", certifyVuln._key, artifact._key), _from: certifyVuln._id, _to: firstVuln._id } INTO certifyVulnEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'vulnerability': {
+				'type_id': firstVuln.typeID,
+				'type': firstVuln.type,
+				'vuln_id': firstVuln.vuln_id,
+				'vuln': firstVuln.vuln,
+			},
+			'certifyVuln_id': certifyVuln._id,
+     		'timeScanned': certifyVuln.timeScanned,
+			'dbUri': certifyVuln.dbUri,
+			'dbVersion': certifyVuln.dbVersion,
+			'scannerUri': certifyVuln.scannerUri,
+			'scannerVersion': certifyVuln.scannerVersion,
+			'collector': certifyVuln.collector,
+			'origin': certifyVuln.origin
+		  }`
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyVulnQueryValues(&pkg, &vulnerability, &certifyVuln), "IngestCertifyVuln")
+	if err != nil {
+		return nil, fmt.Errorf("failed to ingest certifyVuln: %w", err)
+	}
+	defer cursor.Close()
+
+	certifyVulnList, err := geCertifyVuln(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get certifyVulns from arango cursor: %w", err)
+	}
+
+	if len(certifyVulnList) == 1 {
+		return certifyVulnList[0], nil
+	} else {
+		return nil, fmt.Errorf("number of certifyVulns ingested is greater than one")
+	}
+}
+
+func geCertifyVuln(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyVuln, error) {
+	type collectedData struct {
+		PkgVersion     *dbPkgVersion `json:"pkgVersion"`
+		Vulnerability  *dbVulnID     `json:"vulnerability"`
+		CertifyVulnID  string        `json:"certifyVuln_id"`
+		TimeScanned    time.Time     `json:"timeScanned"`
+		DbUri          string        `json:"dbUri"`
+		DbVersion      string        `json:"dbVersion"`
+		ScannerUri     string        `json:"scannerUri"`
+		ScannerVersion string        `json:"scannerVersion"`
+		Collector      string        `json:"collector"`
+		Origin         string        `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to package occurrence from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyVulnList []*model.CertifyVuln
+	for _, createdValue := range createdValues {
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+			createdValue.PkgVersion.Name, &createdValue.PkgVersion.VersionID, &createdValue.PkgVersion.Version, &createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+
+		vuln := &model.Vulnerability{
+			ID:   createdValue.Vulnerability.VulnID,
+			Type: createdValue.Vulnerability.VulnType,
+			VulnerabilityIDs: []*model.VulnerabilityID{
+				{
+					ID:              createdValue.Vulnerability.VulnID,
+					VulnerabilityID: createdValue.Vulnerability.Vuln,
+				},
+			},
+		}
+
+		certifyVuln := &model.CertifyVuln{
+			ID:            createdValue.CertifyVulnID,
+			Package:       pkg,
+			Vulnerability: vuln,
+			Metadata: &model.ScanMetadata{
+				TimeScanned:    createdValue.TimeScanned,
+				DbURI:          createdValue.DbUri,
+				DbVersion:      createdValue.DbVersion,
+				ScannerURI:     createdValue.ScannerUri,
+				ScannerVersion: createdValue.ScannerVersion,
+				Origin:         createdValue.Origin,
+				Collector:      createdValue.Collector,
+			},
+		}
+		certifyVulnList = append(certifyVulnList, certifyVuln)
+	}
+	return certifyVulnList, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -17,17 +17,176 @@ package arangodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+const (
+	dbUriStr          string = "dbUri"
+	dbVersionStr      string = "dbVersion"
+	scannerUriStr     string = "scannerUri"
+	scannerVersionStr string = "scannerVersion"
 )
 
 func (c *arangoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
 	panic(fmt.Errorf("not implemented: CertifyVuln - CertifyVuln"))
 }
 
+func getCertifyVulnQueryValues(pkg *model.PkgInputSpec, vulnerability *model.VulnerabilityInputSpec, certifyVuln *model.ScanMetadataInput) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	if pkg != nil {
+		pkgId := guacPkgId(*pkg)
+		values["pkgVersionGuacKey"] = pkgId.VersionId
+	}
+	if vulnerability != nil {
+		vuln := guacVulnId(*vulnerability)
+		values["guacVulnKey"] = vuln.VulnerabilityID
+	}
+
+	values[timeScannedStr] = certifyVuln.TimeScanned
+	values[dbUriStr] = certifyVuln.TimeScanned
+	values[dbVersionStr] = certifyVuln.TimeScanned
+	values[scannerUriStr] = certifyVuln.TimeScanned
+	values[scannerVersionStr] = certifyVuln.TimeScanned
+	values[origin] = certifyVuln.Origin
+	values[collector] = certifyVuln.Collector
+
+	return values
+}
+
 func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
-	return nil, fmt.Errorf("not implemented - IngestCertifyVulns")
+	// TODO (pxp928): move checks to resolver so all backends don't have to implement
+	if len(pkgs) != len(vulnerabilities) {
+		return nil, fmt.Errorf("uneven packages and vulnerabilities for ingestion")
+	}
+	if len(pkgs) != len(certifyVulns) {
+		return nil, fmt.Errorf("uneven packages and certifyVuln for ingestion")
+	}
+
+	var listOfValues []map[string]any
+
+	for i := range certifyVulns {
+		listOfValues = append(listOfValues, getCertifyVulnQueryValues(pkgs[i], vulnerabilities[i], certifyVulns[i]))
+	}
+
+	var documents []string
+	for _, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		documents = append(documents, string(bs))
+	}
+
+	queryValues := map[string]any{}
+	queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+	var sb strings.Builder
+
+	sb.WriteString("for doc in [")
+	for i, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		if i == len(listOfValues)-1 {
+			sb.WriteString(string(bs))
+		} else {
+			sb.WriteString(string(bs) + ",")
+		}
+	}
+	sb.WriteString("]")
+
+	query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		LET firstVuln = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  "type_id": vType._id,
+			  "type": vType.type,
+			  "vuln_id": vVulnID._id,
+			  "vuln": vVulnID.vulnerabilityID
+			}
+		)
+		  
+		  LET isOccurrence = FIRST(
+			  UPSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT { packageID:firstPkg.versionDoc._id, artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN isOccurrences
+				  RETURN NEW
+		  )
+		  			
+		  INSERT { _key: CONCAT("isOccurrenceSubjectPkgEdges", firstPkg.versionDoc._key, isOccurrence._key), _from: firstPkg.versionDoc._id, _to: isOccurrence._id } INTO isOccurrenceSubjectPkgEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("isOccurrenceArtEdges", isOccurrence._key, artifact._key), _from: isOccurrence._id, _to: artifact._id } INTO isOccurrenceArtEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'artifact': {
+				'id': artifact._id,
+				'algorithm': artifact.algorithm,
+				'digest': artifact.digest
+			},
+			'isOccurrence_id': isOccurrence._id,
+     		'justification': isOccurrence.justification,
+			'collector': isOccurrence.collector,
+			'origin': isOccurrence.origin
+		  }`
+
+	sb.WriteString(query)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestOccurrence")
+	if err != nil {
+		return nil, fmt.Errorf("failed to ingest package occurrence: %w", err)
+	}
+	defer cursor.Close()
+
+	isOccurrenceList, err := getPkgIsOccurrence(ctx, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get occurrences from arango cursor: %w", err)
+	}
+
+	return isOccurrenceList, nil
 }
 
 func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error) {

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+func (c *arangoClient) CertifyVuln(ctx context.Context, certifyVulnSpec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
+	panic(fmt.Errorf("not implemented: CertifyVuln - CertifyVuln"))
+}
+
+func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented - IngestCertifyVulns")
+}
+
+func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented - IngestCertifyVuln")
+}

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -83,6 +83,7 @@ type Backend interface {
 	IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
 	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error)
+	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error)
 	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error)
 	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (*model.PointOfContact, error)
 

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -17,6 +17,7 @@ package inmem
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
@@ -59,6 +60,10 @@ func (n *certifyVulnerabilityLink) BuildModelNode(c *demoClient) (model.Node, er
 }
 
 // Ingest CertifyVuln
+func (c *demoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented - IngestCertifyVulns")
+}
+
 func (c *demoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error) {
 	return c.ingestVulnerability(ctx, pkg, vulnerability, certifyVuln, true)
 }

--- a/pkg/assembler/backends/inmem/certifyVuln_test.go
+++ b/pkg/assembler/backends/inmem/certifyVuln_test.go
@@ -435,6 +435,487 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 	}
 }
 
+func TestIngestCertifyVulns(t *testing.T) {
+	type call struct {
+		Pkgs         []*model.PkgInputSpec
+		Vulns        []*model.VulnerabilityInputSpec
+		CertifyVulns []*model.ScanMetadataInput
+	}
+
+	tests := []struct {
+		InPkg        []*model.PkgInputSpec
+		Name         string
+		InVuln       []*model.VulnerabilityInputSpec
+		Calls        []call
+		ExpVuln      []*model.CertifyVuln
+		Query        *model.CertifyVulnSpec
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "HappyPath",
+			InVuln: []*model.VulnerabilityInputSpec{c1, c2},
+			InPkg:  []*model.PkgInputSpec{p1, p2},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p1},
+					Vulns: []*model.VulnerabilityInputSpec{c1, c2},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					ID:      "1",
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+					},
+					Metadata: vmd1,
+				},
+				{
+					ID:      "10",
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Certify NoVuln",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, noVulnInput},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p1},
+					Vulns: []*model.VulnerabilityInputSpec{noVulnInput, noVulnInput},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Certify OSV",
+			InVuln: []*model.VulnerabilityInputSpec{o1},
+			InPkg:  []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2},
+					Vulns: []*model.VulnerabilityInputSpec{o1},
+					CertifyVulns: []*model.ScanMetadataInput{
+						&model.ScanMetadataInput{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "osv",
+						VulnerabilityIDs: []*model.VulnerabilityID{o1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Certify GHSA",
+			InVuln: []*model.VulnerabilityInputSpec{g1},
+			InPkg:  []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2},
+					Vulns: []*model.VulnerabilityInputSpec{g1},
+					CertifyVulns: []*model.ScanMetadataInput{
+						&model.ScanMetadataInput{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query on GHSA",
+			InVuln: []*model.VulnerabilityInputSpec{g1, g2},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p1},
+					Vulns: []*model.VulnerabilityInputSpec{g1, g2},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					VulnerabilityID: &g1.VulnerabilityID,
+				},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query ID",
+			InVuln: []*model.VulnerabilityInputSpec{g1},
+			InPkg:  []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2},
+					Vulns: []*model.VulnerabilityInputSpec{g1},
+					CertifyVulns: []*model.ScanMetadataInput{
+						&model.ScanMetadataInput{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				ID: ptrfrom.String("7"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query on Package",
+			InVuln: []*model.VulnerabilityInputSpec{g1, g2},
+			InPkg:  []*model.PkgInputSpec{p2, p4},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p4},
+					Vulns: []*model.VulnerabilityInputSpec{g1, g2},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Package: &model.PkgSpec{
+					Name: ptrfrom.String(p2.Name),
+				},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query none",
+			InVuln: []*model.VulnerabilityInputSpec{g1, g2},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p1},
+					Vulns: []*model.VulnerabilityInputSpec{g1, g2},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					VulnerabilityID: ptrfrom.String("asdf"),
+				},
+			},
+			ExpVuln: nil,
+		},
+		{
+			Name:   "Query No Vuln",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, noVulnInput},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{p2, p1},
+					Vulns: []*model.VulnerabilityInputSpec{noVulnInput, noVulnInput},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type: ptrfrom.String("noVuln"),
+				},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:  "Ingest without vuln",
+			InPkg: []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Pkgs:         []*model.PkgInputSpec{p2},
+					Vulns:        []*model.VulnerabilityInputSpec{},
+					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
+				},
+			},
+			Query:        &model.CertifyVulnSpec{},
+			ExpIngestErr: true,
+		},
+		{
+			Name:  "Ingest missing pkg",
+			InPkg: []*model.PkgInputSpec{},
+			Calls: []call{
+				{
+					Pkgs:         []*model.PkgInputSpec{},
+					Vulns:        []*model.VulnerabilityInputSpec{},
+					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
+				},
+			},
+			Query:        &model.CertifyVulnSpec{},
+			ExpIngestErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := inmem.GetBackend(nil)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+
+			if _, err := b.IngestVulnerabilities(ctx, test.InVuln); err != nil {
+				t.Fatalf("Could not ingest vulnerabilities: %a", err)
+			}
+			if _, err := b.IngestPackages(ctx, test.InPkg); err != nil {
+				t.Fatalf("Could not ingest packages: %v", err)
+			}
+
+			for _, o := range test.Calls {
+				_, err := b.IngestCertifyVulns(ctx, o.Pkgs, o.Vulns, o.CertifyVulns)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+
+			}
+
+			got, err := b.CertifyVuln(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpVuln, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCertifyVulnNeighbors(t *testing.T) {
 	type call struct {
 		Pkg         *model.PkgInputSpec

--- a/pkg/assembler/backends/neo4j/certifyVuln.go
+++ b/pkg/assembler/backends/neo4j/certifyVuln.go
@@ -557,3 +557,7 @@ func (c *neo4jClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInputS
 	// }
 	return nil, fmt.Errorf("not implemented - IngestCertifyVuln")
 }
+
+func (c *neo4jClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented - IngestCertifyVulns")
+}

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -7372,6 +7372,100 @@ func (v *CertifyVulnPkgResponse) GetIngestCertifyVuln() CertifyVulnPkgIngestCert
 	return v.IngestCertifyVuln
 }
 
+// CertifyVulnPkgsIngestCertifyVulnsCertifyVuln includes the requested fields of the GraphQL type CertifyVuln.
+// The GraphQL type's documentation follows.
+//
+// CertifyVuln is an attestation to attach vulnerability information to a package.
+//
+// This information is obtained via a scanner. If there is no vulnerability
+// detected, we attach the a vulnerability with "NoVuln" type and an empty string
+// for the vulnerability ID.
+type CertifyVulnPkgsIngestCertifyVulnsCertifyVuln struct {
+	AllCertifyVuln `json:"-"`
+}
+
+// GetId returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Id, and is useful for accessing the field via an interface.
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetId() string { return v.AllCertifyVuln.Id }
+
+// GetPackage returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Package, and is useful for accessing the field via an interface.
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetPackage() AllCertifyVulnPackage {
+	return v.AllCertifyVuln.Package
+}
+
+// GetVulnerability returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Vulnerability, and is useful for accessing the field via an interface.
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetVulnerability() AllCertifyVulnVulnerability {
+	return v.AllCertifyVuln.Vulnerability
+}
+
+// GetMetadata returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Metadata, and is useful for accessing the field via an interface.
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetMetadata() AllCertifyVulnMetadataScanMetadata {
+	return v.AllCertifyVuln.Metadata
+}
+
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CertifyVulnPkgsIngestCertifyVulnsCertifyVuln
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CertifyVulnPkgsIngestCertifyVulnsCertifyVuln = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllCertifyVuln)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln struct {
+	Id string `json:"id"`
+
+	Package AllCertifyVulnPackage `json:"package"`
+
+	Vulnerability AllCertifyVulnVulnerability `json:"vulnerability"`
+
+	Metadata AllCertifyVulnMetadataScanMetadata `json:"metadata"`
+}
+
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) __premarshalJSON() (*__premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln, error) {
+	var retval __premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln
+
+	retval.Id = v.AllCertifyVuln.Id
+	retval.Package = v.AllCertifyVuln.Package
+	retval.Vulnerability = v.AllCertifyVuln.Vulnerability
+	retval.Metadata = v.AllCertifyVuln.Metadata
+	return &retval, nil
+}
+
+// CertifyVulnPkgsResponse is returned by CertifyVulnPkgs on success.
+type CertifyVulnPkgsResponse struct {
+	// Bulk add certifications that a package has been scanned for vulnerabilities.
+	IngestCertifyVulns []CertifyVulnPkgsIngestCertifyVulnsCertifyVuln `json:"ingestCertifyVulns"`
+}
+
+// GetIngestCertifyVulns returns CertifyVulnPkgsResponse.IngestCertifyVulns, and is useful for accessing the field via an interface.
+func (v *CertifyVulnPkgsResponse) GetIngestCertifyVulns() []CertifyVulnPkgsIngestCertifyVulnsCertifyVuln {
+	return v.IngestCertifyVulns
+}
+
 // DependencyType determines the type of the dependency.
 type DependencyType string
 
@@ -22785,6 +22879,24 @@ func (v *__CertifyVulnPkgInput) GetVulnerability() VulnerabilityInputSpec { retu
 // GetCertifyVuln returns __CertifyVulnPkgInput.CertifyVuln, and is useful for accessing the field via an interface.
 func (v *__CertifyVulnPkgInput) GetCertifyVuln() ScanMetadataInput { return v.CertifyVuln }
 
+// __CertifyVulnPkgsInput is used internally by genqlient
+type __CertifyVulnPkgsInput struct {
+	Pkgs            []PkgInputSpec           `json:"pkgs"`
+	Vulnerabilities []VulnerabilityInputSpec `json:"vulnerabilities"`
+	CertifyVulns    []ScanMetadataInput      `json:"certifyVulns"`
+}
+
+// GetPkgs returns __CertifyVulnPkgsInput.Pkgs, and is useful for accessing the field via an interface.
+func (v *__CertifyVulnPkgsInput) GetPkgs() []PkgInputSpec { return v.Pkgs }
+
+// GetVulnerabilities returns __CertifyVulnPkgsInput.Vulnerabilities, and is useful for accessing the field via an interface.
+func (v *__CertifyVulnPkgsInput) GetVulnerabilities() []VulnerabilityInputSpec {
+	return v.Vulnerabilities
+}
+
+// GetCertifyVulns returns __CertifyVulnPkgsInput.CertifyVulns, and is useful for accessing the field via an interface.
+func (v *__CertifyVulnPkgsInput) GetCertifyVulns() []ScanMetadataInput { return v.CertifyVulns }
+
 // __FindSoftwareInput is used internally by genqlient
 type __FindSoftwareInput struct {
 	SearchText string `json:"searchText"`
@@ -25017,6 +25129,92 @@ func CertifyVulnPkg(
 	var err error
 
 	var data CertifyVulnPkgResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by CertifyVulnPkgs.
+const CertifyVulnPkgs_Operation = `
+mutation CertifyVulnPkgs ($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $certifyVulns: [ScanMetadataInput!]!) {
+	ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns) {
+		... AllCertifyVuln
+	}
+}
+fragment AllCertifyVuln on CertifyVuln {
+	id
+	package {
+		... AllPkgTree
+	}
+	vulnerability {
+		... AllVulnerabilityTree
+	}
+	metadata {
+		dbUri
+		dbVersion
+		scannerUri
+		scannerVersion
+		timeScanned
+		origin
+		collector
+	}
+}
+fragment AllPkgTree on Package {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			versions {
+				id
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment AllVulnerabilityTree on Vulnerability {
+	id
+	type
+	vulnerabilityIDs {
+		id
+		vulnerabilityID
+	}
+}
+`
+
+func CertifyVulnPkgs(
+	ctx context.Context,
+	client graphql.Client,
+	pkgs []PkgInputSpec,
+	vulnerabilities []VulnerabilityInputSpec,
+	certifyVulns []ScanMetadataInput,
+) (*CertifyVulnPkgsResponse, error) {
+	req := &graphql.Request{
+		OpName: "CertifyVulnPkgs",
+		Query:  CertifyVulnPkgs_Operation,
+		Variables: &__CertifyVulnPkgsInput{
+			Pkgs:            pkgs,
+			Vulnerabilities: vulnerabilities,
+			CertifyVulns:    certifyVulns,
+		},
+	}
+	var err error
+
+	var data CertifyVulnPkgsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/operations/certifyVuln.graphql
+++ b/pkg/assembler/clients/operations/certifyVuln.graphql
@@ -22,3 +22,11 @@ mutation CertifyVulnPkg($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputS
     ...AllCertifyVuln
   }
 }
+
+# Defines the GraphQL operations to bulk ingest vulnerability certifications into GUAC
+
+mutation CertifyVulnPkgs($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $certifyVulns: [ScanMetadataInput!]!) {
+  ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns) {
+    ...AllCertifyVuln
+  }
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -31,6 +31,7 @@ type MutationResolver interface {
 	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
 	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error)
+	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error)
 	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (*model.PointOfContact, error)
 	IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (*model.HasSbom, error)
 	IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error)
@@ -307,6 +308,39 @@ func (ec *executionContext) field_Mutation_ingestCertifyVuln_args(ctx context.Co
 		}
 	}
 	args["certifyVuln"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestCertifyVulns_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.PkgInputSpec
+	if tmp, ok := rawArgs["pkgs"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgs"))
+		arg0, err = ec.unmarshalNPkgInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkgs"] = arg0
+	var arg1 []*model.VulnerabilityInputSpec
+	if tmp, ok := rawArgs["vulnerabilities"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilities"))
+		arg1, err = ec.unmarshalNVulnerabilityInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["vulnerabilities"] = arg1
+	var arg2 []*model.ScanMetadataInput
+	if tmp, ok := rawArgs["certifyVulns"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("certifyVulns"))
+		arg2, err = ec.unmarshalNScanMetadataInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScanMetadataInputᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["certifyVulns"] = arg2
 	return args, nil
 }
 
@@ -2329,6 +2363,71 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyVuln(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestCertifyVuln_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestCertifyVulns(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestCertifyVulns(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestCertifyVulns(rctx, fc.Args["pkgs"].([]*model.PkgInputSpec), fc.Args["vulnerabilities"].([]*model.VulnerabilityInputSpec), fc.Args["certifyVulns"].([]*model.ScanMetadataInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CertifyVuln)
+	fc.Result = res
+	return ec.marshalNCertifyVuln2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestCertifyVulns(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyVuln_id(ctx, field)
+			case "package":
+				return ec.fieldContext_CertifyVuln_package(ctx, field)
+			case "vulnerability":
+				return ec.fieldContext_CertifyVuln_vulnerability(ctx, field)
+			case "metadata":
+				return ec.fieldContext_CertifyVuln_metadata(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyVuln", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestCertifyVulns_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5751,6 +5850,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "ingestCertifyVuln":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestCertifyVuln(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ingestCertifyVulns":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestCertifyVulns(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -956,4 +956,26 @@ func (ec *executionContext) unmarshalNScanMetadataInput2githubᚗcomᚋguacsec�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNScanMetadataInput2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScanMetadataInputᚄ(ctx context.Context, v interface{}) ([]*model.ScanMetadataInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.ScanMetadataInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNScanMetadataInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScanMetadataInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNScanMetadataInput2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐScanMetadataInput(ctx context.Context, v interface{}) (*model.ScanMetadataInput, error) {
+	res, err := ec.unmarshalInputScanMetadataInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 // endregion ***************************** type.gotpl *****************************

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -168,6 +168,7 @@ type ComplexityRoot struct {
 		IngestCertifyGood     func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) int
 		IngestCertifyGoods    func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) int
 		IngestCertifyVuln     func(childComplexity int, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) int
+		IngestCertifyVulns    func(childComplexity int, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) int
 		IngestDependencies    func(childComplexity int, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, dependencies []*model.IsDependencyInputSpec) int
 		IngestDependency      func(childComplexity int, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, dependency model.IsDependencyInputSpec) int
 		IngestHasMetadata     func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) int
@@ -1013,6 +1014,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestCertifyVuln(childComplexity, args["pkg"].(model.PkgInputSpec), args["vulnerability"].(model.VulnerabilityInputSpec), args["certifyVuln"].(model.ScanMetadataInput)), true
+
+	case "Mutation.ingestCertifyVulns":
+		if e.complexity.Mutation.IngestCertifyVulns == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestCertifyVulns_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestCertifyVulns(childComplexity, args["pkgs"].([]*model.PkgInputSpec), args["vulnerabilities"].([]*model.VulnerabilityInputSpec), args["certifyVulns"].([]*model.ScanMetadataInput)), true
 
 	case "Mutation.ingestDependencies":
 		if e.complexity.Mutation.IngestDependencies == nil {
@@ -2997,6 +3010,8 @@ extend type Query {
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
   ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): CertifyVuln!
+  "Bulk add certifications that a package has been scanned for vulnerabilities."
+  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [CertifyVuln!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/contact.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -19,6 +19,20 @@ func (r *mutationResolver) IngestCertifyVuln(ctx context.Context, pkg model.PkgI
 		certifyVuln)
 }
 
+// IngestCertifyVulns is the resolver for the ingestCertifyVulns field.
+func (r *mutationResolver) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
+	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
+	var lowercaseVulnInputList []*model.VulnerabilityInputSpec
+	for _, v := range vulnerabilities {
+		lowercaseVulnInput := model.VulnerabilityInputSpec{
+			Type:            strings.ToLower(v.Type),
+			VulnerabilityID: strings.ToLower(v.VulnerabilityID),
+		}
+		lowercaseVulnInputList = append(lowercaseVulnInputList, &lowercaseVulnInput)
+	}
+	return r.Backend.IngestCertifyVulns(ctx, pkgs, lowercaseVulnInputList, certifyVulns)
+}
+
 // CertifyVuln is the resolver for the CertifyVuln field.
 func (r *queryResolver) CertifyVuln(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -101,4 +101,6 @@ extend type Query {
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
   ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): CertifyVuln!
+  "Bulk add certifications that a package has been scanned for vulnerabilities."
+  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [CertifyVuln!]!
 }


### PR DESCRIPTION
# Description of the PR

Add bulk ingestion for certifyVuln along with arango implementation

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
