### PR TITLE
Fix XML format validation

### DIFF
--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -18,6 +18,7 @@ package process
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 
 	uuid "github.com/gofrs/uuid"
@@ -175,6 +176,10 @@ func validateFormat(i *processor.Document) error {
 	case processor.FormatJSON:
 		if !json.Valid(i.Blob) {
 			return fmt.Errorf("invalid JSON document")
+		}
+	case processor.FormatXML:
+		if err := xml.Unmarshal(i.Blob, &struct{}{}); err != nil {
+			return fmt.Errorf("invalid XML document")
 		}
 	case processor.FormatUnknown:
 		return nil

--- a/pkg/handler/processor/process/process_test.go
+++ b/pkg/handler/processor/process/process_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	"github.com/guacsec/guac/internal/testing/simpledoc"
+	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/handler/processor/guesser"
 	"github.com/guacsec/guac/pkg/logging"
@@ -540,6 +541,61 @@ func Test_SimpleDocProcessTest(t *testing.T) {
 					}
 				}
 			*/
+		})
+	}
+}
+
+func Test_validateFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     processor.Document
+		wantErr bool
+	}{
+		{
+			name: "valid XML format document",
+			doc: processor.Document{
+				Blob:   []byte(testdata.CycloneDXExampleLaravelXML),
+				Type:   processor.DocumentCycloneDX,
+				Format: processor.FormatXML,
+				SourceInformation: processor.SourceInformation{
+					Collector: "a-collector",
+					Source:    "a-source",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid XML format document",
+			doc: processor.Document{
+				Blob:   []byte(testdata.CycloneDXInvalidExampleXML),
+				Type:   processor.DocumentCycloneDX,
+				Format: processor.FormatXML,
+				SourceInformation: processor.SourceInformation{
+					Collector: "a-collector",
+					Source:    "a-source",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid JSON document",
+			doc: processor.Document{
+				Blob:   []byte(testdata.SpdxExampleSmall),
+				Type:   processor.DocumentSPDX,
+				Format: processor.FormatJSON,
+				SourceInformation: processor.SourceInformation{
+					Collector: "a-collector",
+					Source:    "a-source",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateFormat(&tt.doc); (err != nil) != tt.wantErr {
+				t.Errorf("validateFormat() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
XML format was left off the validateFormat helper which causes any XML documents, e.g. CycloneDX XML documents to be seen as invalid, even though we do have functionality elsewhere to parse them correctly.

Fixes initial cause of #1162. #1162 will still fail but that's related to issue #976

```
{"level":"fatal","ts":1692227764.851379,"caller":"cmd/files.go:211","msg":"unable to ingest doc tree: guac currently does not support CycloneDX component field in metadata or the BOM ref being nil. See issue #976 for more details","stacktrace":"github.com/guacsec/guac/cmd/guacone/cmd.glob..func5\n\t/Users/mlieberman/Projects/guac/cmd/guacone/cmd/files.go:211\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/mlieberman/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/mlieberman/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/mlieberman/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992\ngithub.com/guacsec/guac/cmd/guacone/cmd.Execute\n\t/Users/mlieberman/Projects/guac/cmd/guacone/cmd/root.go:56\nmain.main\n\t/Users/mlieberman/Projects/guac/cmd/guacone/main.go:23\nruntime.main\n\t/nix/store/kiqbin2zi2d2m41papc3s12q04agsic0-go-1.19.11/share/go/src/runtime/proc.go:250"}
```