### PR TITLE
Feature/add novuln bool to vulnerability filter

### DIFF
--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -227,8 +227,14 @@ func (c *demoClient) CertifyVuln(ctx context.Context, filter *model.CertifyVulnS
 			search = append(search, exactVuln.certifyVulnLinks...)
 			foundOne = true
 		}
-	}
-	if !foundOne && filter != nil && filter.Vulnerability != nil {
+	} else if !foundOne && filter != nil && filter.Vulnerability != nil {
+
+		if filter.Vulnerability.NoVuln != nil && !*filter.Vulnerability.NoVuln {
+			if filter.Vulnerability.Type != nil && *filter.Vulnerability.Type == noVulnType {
+				return []*model.CertifyVuln{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
+			}
+		}
+
 		exactVuln, err := c.exactVulnerability(filter.Vulnerability)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)

--- a/pkg/assembler/backends/inmem/certifyVuln_test.go
+++ b/pkg/assembler/backends/inmem/certifyVuln_test.go
@@ -357,12 +357,25 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 		},
 		{
 			Name:   "Query No Vuln - with novuln boolen",
-			InVuln: []*model.VulnerabilityInputSpec{noVulnInput},
-			InPkg:  []*model.PkgInputSpec{p2},
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, c1},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
 			Calls: []call{
 				{
 					Pkg:  p2,
 					Vuln: noVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+				{
+					Pkg:  p1,
+					Vuln: c1,
 					CertifyVuln: &model.ScanMetadataInput{
 						Collector:      "test collector",
 						Origin:         "test origin",
@@ -437,6 +450,122 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 					Metadata: vmd1,
 				},
 			},
+		},
+		{
+			Name:   "Query all vulns - with novuln boolean omitted",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, c1, g1},
+			InPkg:  []*model.PkgInputSpec{p2, p1, p1},
+			Calls: []call{
+				{
+					Pkg:  p2,
+					Vuln: noVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+				{
+					Pkg:  p1,
+					Vuln: c1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+				{
+					Pkg:  p1,
+					Vuln: g1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query No Vuln - with novuln boolen false but type set to novuln",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, c1},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkg:  p2,
+					Vuln: noVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+				{
+					Pkg:  p1,
+					Vuln: c1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					NoVuln: ptrfrom.Bool(false),
+					Type:   ptrfrom.String("novuln"),
+				},
+			},
+			ExpVuln:     []*model.CertifyVuln{},
+			ExpQueryErr: true,
 		},
 		{
 			Name:  "Ingest without vuln",

--- a/pkg/assembler/backends/inmem/certifyVuln_test.go
+++ b/pkg/assembler/backends/inmem/certifyVuln_test.go
@@ -356,6 +356,89 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 			},
 		},
 		{
+			Name:   "Query No Vuln - with novuln boolen",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput},
+			InPkg:  []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Pkg:  p2,
+					Vuln: noVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					NoVuln: ptrfrom.Bool(true),
+				},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
+			Name:   "Query only cve (exclude novuln) - with novuln boolen",
+			InVuln: []*model.VulnerabilityInputSpec{noVulnInput, c1},
+			InPkg:  []*model.PkgInputSpec{p2, p1},
+			Calls: []call{
+				{
+					Pkg:  p2,
+					Vuln: noVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+				{
+					Pkg:  p1,
+					Vuln: c1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    t1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					NoVuln: ptrfrom.Bool(false),
+				},
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+					},
+					Metadata: vmd1,
+				},
+			},
+		},
+		{
 			Name:  "Ingest without vuln",
 			InPkg: []*model.PkgInputSpec{p2},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/vulnerability.go
+++ b/pkg/assembler/backends/inmem/vulnerability.go
@@ -184,6 +184,12 @@ func (c *demoClient) Vulnerabilities(ctx context.Context, filter *model.Vulnerab
 		return []*model.Vulnerability{v}, nil
 	}
 
+	if filter.NoVuln != nil && !*filter.NoVuln {
+		if filter.Type != nil && *filter.Type == noVulnType {
+			return []*model.Vulnerability{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
+		}
+	}
+
 	out := []*model.Vulnerability{}
 	// if novuln is specified, retrieve all "novuln" type nodes
 	if filter != nil && filter.NoVuln != nil && *filter.NoVuln {

--- a/pkg/assembler/backends/inmem/vulnerability.go
+++ b/pkg/assembler/backends/inmem/vulnerability.go
@@ -28,33 +28,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-// func registerAllCVE(client *demoClient) {
-// 	ctx := context.Background()
-
-// 	inputs := []model.CVEInputSpec{{
-// 		Year:  2019,
-// 		CveID: "CVE-2019-13110",
-// 	}, {
-// 		Year:  2014,
-// 		CveID: "CVE-2014-8139",
-// 	}, {
-// 		Year:  2014,
-// 		CveID: "CVE-2014-8140",
-// 	}, {
-// 		Year:  2022,
-// 		CveID: "CVE-2022-26499",
-// 	}, {
-// 		Year:  2014,
-// 		CveID: "CVE-2014-8140",
-// 	}}
-// 	for _, input := range inputs {
-// 		_, err := client.IngestCve(ctx, &input)
-// 		if err != nil {
-// 			log.Printf("Error in ingesting: %v\n", err)
-// 		}
-// 	}
-// }
-
 const noVulnType string = "novuln"
 
 // Internal data: Vulnerability
@@ -118,7 +91,7 @@ func (n *vulnIDNode) setVulnEqualLinks(id uint32) { n.vulnEqualLinks = append(n.
 // certifyVexStatement back edges
 func (n *vulnIDNode) setVexLinks(id uint32) { n.vexLinks = append(n.vexLinks, id) }
 
-// Ingest CVE
+// Ingest Vulnerabilities
 
 func (c *demoClient) IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]*model.Vulnerability, error) {
 	var modelVulnerabilities []*model.Vulnerability
@@ -191,7 +164,7 @@ func duplicateVulnID(vulnIDs vulnIDList, input model.VulnerabilityInputSpec) (bo
 	return false, nil
 }
 
-// Query CVE
+// Query Vulnerabilities
 func (c *demoClient) Vulnerabilities(ctx context.Context, filter *model.VulnerabilitySpec) ([]*model.Vulnerability, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
@@ -361,13 +334,4 @@ func getVulnerabilityIDFromInput(c *demoClient, input model.VulnerabilityInputSp
 		return 0, gqlerror.Errorf("No vulnerability matches input")
 	}
 	return vulnNodeID, nil
-}
-
-// Checks if the given filter satisfies the condition for NoVuln in the CertifyVulnSpec.
-// It returns true if any of the following conditions are met:
-// 1. The filter is nil.
-// 2. The filter.Vulnerability is nil.
-// 3. The value of filter.Vulnerability.NoVuln matches the expected value.
-func checkNoVulnFilter(filter *model.CertifyVulnSpec, expected bool) bool {
-	return filter == nil || filter.Vulnerability == nil || *filter.Vulnerability.NoVuln == expected
 }

--- a/pkg/assembler/backends/inmem/vulnerability.go
+++ b/pkg/assembler/backends/inmem/vulnerability.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -53,6 +54,8 @@ import (
 // 		}
 // 	}
 // }
+
+const noVulnType string = "novuln"
 
 // Internal data: Vulnerability
 type vulnTypeMap map[string]*vulnTypeStruct
@@ -209,6 +212,12 @@ func (c *demoClient) Vulnerabilities(ctx context.Context, filter *model.Vulnerab
 	}
 
 	out := []*model.Vulnerability{}
+	// if novuln is specified, retrieve all "novuln" type nodes
+	if filter != nil && filter.NoVuln != nil && *filter.NoVuln {
+		filter.Type = ptrfrom.String(noVulnType)
+		filter.VulnerabilityID = ptrfrom.String("")
+	}
+
 	if filter != nil && filter.Type != nil {
 		typeStruct, ok := c.vulnerabilities[strings.ToLower(*filter.Type)]
 		if ok {
@@ -352,4 +361,13 @@ func getVulnerabilityIDFromInput(c *demoClient, input model.VulnerabilityInputSp
 		return 0, gqlerror.Errorf("No vulnerability matches input")
 	}
 	return vulnNodeID, nil
+}
+
+// Checks if the given filter satisfies the condition for NoVuln in the CertifyVulnSpec.
+// It returns true if any of the following conditions are met:
+// 1. The filter is nil.
+// 2. The filter.Vulnerability is nil.
+// 3. The value of filter.Vulnerability.NoVuln matches the expected value.
+func checkNoVulnFilter(filter *model.CertifyVulnSpec, expected bool) bool {
+	return filter == nil || filter.Vulnerability == nil || *filter.Vulnerability.NoVuln == expected
 }

--- a/pkg/assembler/backends/inmem/vulnerability_test.go
+++ b/pkg/assembler/backends/inmem/vulnerability_test.go
@@ -206,6 +206,19 @@ func TestVulnerability(t *testing.T) {
 			},
 		},
 		{
+			Name:    "Query by type - noVuln with boolean",
+			Ingests: []*model.VulnerabilityInputSpec{noVulnInput},
+			Query: &model.VulnerabilitySpec{
+				NoVuln: ptrfrom.Bool(true),
+			},
+			Exp: []*model.Vulnerability{
+				&model.Vulnerability{
+					Type:             "novuln",
+					VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
+				},
+			},
+		},
+		{
 			Name:    "Query by vulnID",
 			Ingests: []*model.VulnerabilityInputSpec{c1, c2, c3},
 			Query: &model.VulnerabilitySpec{

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -22616,10 +22616,17 @@ func (v *VulnerabilityInputSpec) GetVulnerabilityID() string { return v.Vulnerab
 // Use null to match on all values at that level.
 // For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 // where every field is null.
+//
+// Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
+// Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
+// and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
+// with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
+// vulnerabilities for the corresponding type and vulnerabilityID.
 type VulnerabilitySpec struct {
 	Id              *string `json:"id"`
 	Type            *string `json:"type"`
 	VulnerabilityID *string `json:"vulnerabilityID"`
+	NoVuln          *bool   `json:"noVuln"`
 }
 
 // GetId returns VulnerabilitySpec.Id, and is useful for accessing the field via an interface.
@@ -22630,6 +22637,9 @@ func (v *VulnerabilitySpec) GetType() *string { return v.Type }
 
 // GetVulnerabilityID returns VulnerabilitySpec.VulnerabilityID, and is useful for accessing the field via an interface.
 func (v *VulnerabilitySpec) GetVulnerabilityID() *string { return v.VulnerabilityID }
+
+// GetNoVuln returns VulnerabilitySpec.NoVuln, and is useful for accessing the field via an interface.
+func (v *VulnerabilitySpec) GetNoVuln() *bool { return v.NoVuln }
 
 // __ArtifactsInput is used internally by genqlient
 type __ArtifactsInput struct {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -22619,9 +22619,9 @@ func (v *VulnerabilityInputSpec) GetVulnerabilityID() string { return v.Vulnerab
 //
 // Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
 // Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
-// and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
-// with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
-// vulnerabilities for the corresponding type and vulnerabilityID.
+// and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
+// Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding
+// type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
 type VulnerabilitySpec struct {
 	Id              *string `json:"id"`
 	Type            *string `json:"type"`

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -83,3 +83,13 @@ query CertifyVulnQ7 {
     ...allCertifyVulnTree
   }
 }
+
+# Setting noVuln to true return all packages that have no vulnerabilities
+# Setting noVuln to false return all packages with vulnerabilities
+query CertifyNoVuln {
+  CertifyVuln(certifyVulnSpec: {
+    vulnerability: {noVuln: true}
+  }) {
+    ...allCertifyVulnTree
+  }
+}

--- a/pkg/assembler/graphql/examples/vulnerability.gql
+++ b/pkg/assembler/graphql/examples/vulnerability.gql
@@ -90,3 +90,11 @@ mutation OSVM2 {
     ...allVulnerabilityTree
   }
 }
+
+# Setting noVuln to true return the noVuln node
+# Setting noVuln to false return all vulnerabilities nodes
+query noVuln {
+  vulnerabilities(vulnSpec: {noVuln: true}) {
+    ...allVulnerabilityTree
+  }
+}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -4468,9 +4468,9 @@ where every field is null.
 
 Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
 Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
-and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
-with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
-vulnerabilities for the corresponding type and vulnerabilityID.
+and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
+Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding 
+type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
 
 """
 input VulnerabilitySpec {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -4466,11 +4466,18 @@ Use null to match on all values at that level.
 For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 where every field is null.
 
+Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
+Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
+and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
+with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
+vulnerabilities for the corresponding type and vulnerabilityID.
+
 """
 input VulnerabilitySpec {
   id: ID
   type: String
   vulnerabilityID: String
+  noVuln: Boolean
 }
 
 """

--- a/pkg/assembler/graphql/generated/vulnerability.generated.go
+++ b/pkg/assembler/graphql/generated/vulnerability.generated.go
@@ -304,7 +304,7 @@ func (ec *executionContext) unmarshalInputVulnerabilitySpec(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "type", "vulnerabilityID"}
+	fieldsInOrder := [...]string{"id", "type", "vulnerabilityID", "noVuln"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -338,6 +338,15 @@ func (ec *executionContext) unmarshalInputVulnerabilitySpec(ctx context.Context,
 				return it, err
 			}
 			it.VulnerabilityID = data
+		case "noVuln":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("noVuln"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NoVuln = data
 		}
 	}
 

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1286,10 +1286,17 @@ type VulnerabilityInputSpec struct {
 // Use null to match on all values at that level.
 // For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 // where every field is null.
+//
+// Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
+// Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
+// and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
+// with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
+// vulnerabilities for the corresponding type and vulnerabilityID.
 type VulnerabilitySpec struct {
 	ID              *string `json:"id,omitempty"`
 	Type            *string `json:"type,omitempty"`
 	VulnerabilityID *string `json:"vulnerabilityID,omitempty"`
+	NoVuln          *bool   `json:"noVuln,omitempty"`
 }
 
 // DependencyType determines the type of the dependency.

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1289,9 +1289,9 @@ type VulnerabilityInputSpec struct {
 //
 // Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
 // Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
-// and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
-// with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
-// vulnerabilities for the corresponding type and vulnerabilityID.
+// and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
+// Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding
+// type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
 type VulnerabilitySpec struct {
 	ID              *string `json:"id,omitempty"`
 	Type            *string `json:"type,omitempty"`

--- a/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
@@ -24,8 +24,10 @@ func (r *queryResolver) CertifyVEXStatement(ctx context.Context, certifyVEXState
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 	if certifyVEXStatementSpec.Vulnerability != nil {
 		lowercaseVulnFilter := model.VulnerabilitySpec{
+			ID:              certifyVEXStatementSpec.Vulnerability.ID,
 			Type:            toLower(certifyVEXStatementSpec.Vulnerability.Type),
 			VulnerabilityID: toLower(certifyVEXStatementSpec.Vulnerability.VulnerabilityID),
+			NoVuln:          certifyVEXStatementSpec.Vulnerability.NoVuln,
 		}
 
 		lowercaseCertifyVexFilter := model.CertifyVEXStatementSpec{

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -38,13 +38,14 @@ func (r *mutationResolver) IngestCertifyVulns(ctx context.Context, pkgs []*model
 func (r *queryResolver) CertifyVuln(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 
-	if certifyVulnSpec.Vulnerability.NoVuln != nil && !*certifyVulnSpec.Vulnerability.NoVuln {
-		if certifyVulnSpec.Vulnerability.Type != nil && *certifyVulnSpec.Vulnerability.Type == noVulnType {
-			return []*model.CertifyVuln{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
-		}
-	}
-
 	if certifyVulnSpec.Vulnerability != nil {
+
+		if certifyVulnSpec.Vulnerability.NoVuln != nil && !*certifyVulnSpec.Vulnerability.NoVuln {
+			if certifyVulnSpec.Vulnerability.Type != nil && *certifyVulnSpec.Vulnerability.Type == "novuln" {
+				return []*model.CertifyVuln{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
+			}
+		}
+
 		lowercaseVulnFilter := model.VulnerabilitySpec{
 			ID:              certifyVulnSpec.Vulnerability.ID,
 			Type:            toLower(certifyVulnSpec.Vulnerability.Type),

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -38,8 +38,10 @@ func (r *queryResolver) CertifyVuln(ctx context.Context, certifyVulnSpec model.C
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 	if certifyVulnSpec.Vulnerability != nil {
 		lowercaseVulnFilter := model.VulnerabilitySpec{
+			ID:              certifyVulnSpec.Vulnerability.ID,
 			Type:            toLower(certifyVulnSpec.Vulnerability.Type),
 			VulnerabilityID: toLower(certifyVulnSpec.Vulnerability.VulnerabilityID),
+			NoVuln:          certifyVulnSpec.Vulnerability.NoVuln,
 		}
 
 		lowercaseCertifyVulnFilter := model.CertifyVulnSpec{

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestCertifyVuln is the resolver for the ingestCertifyVuln field.
@@ -36,6 +37,13 @@ func (r *mutationResolver) IngestCertifyVulns(ctx context.Context, pkgs []*model
 // CertifyVuln is the resolver for the CertifyVuln field.
 func (r *queryResolver) CertifyVuln(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
+
+	if certifyVulnSpec.Vulnerability.NoVuln != nil && !*certifyVulnSpec.Vulnerability.NoVuln {
+		if certifyVulnSpec.Vulnerability.Type != nil && *certifyVulnSpec.Vulnerability.Type == noVulnType {
+			return []*model.CertifyVuln{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
+		}
+	}
+
 	if certifyVulnSpec.Vulnerability != nil {
 		lowercaseVulnFilter := model.VulnerabilitySpec{
 			ID:              certifyVulnSpec.Vulnerability.ID,

--- a/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
@@ -33,8 +33,10 @@ func (r *queryResolver) VulnEqual(ctx context.Context, vulnEqualSpec model.VulnE
 		var lowercaseVulnFilterList []*model.VulnerabilitySpec
 		for _, v := range vulnEqualSpec.Vulnerabilities {
 			lowercaseVulnFilter := model.VulnerabilitySpec{
+				ID:              v.ID,
 				Type:            toLower(v.Type),
 				VulnerabilityID: toLower(v.VulnerabilityID),
+				NoVuln:          v.NoVuln,
 			}
 			lowercaseVulnFilterList = append(lowercaseVulnFilterList, &lowercaseVulnFilter)
 		}

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
+
+const noVulnType string = "novuln"
 
 // IngestVulnerability is the resolver for the ingestVulnerability field.
 func (r *mutationResolver) IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (*model.Vulnerability, error) {
@@ -34,6 +37,13 @@ func (r *mutationResolver) IngestVulnerabilities(ctx context.Context, vulns []*m
 // Vulnerabilities is the resolver for the vulnerabilities field.
 func (r *queryResolver) Vulnerabilities(ctx context.Context, vulnSpec model.VulnerabilitySpec) ([]*model.Vulnerability, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
+
+	if vulnSpec.NoVuln != nil && !*vulnSpec.NoVuln {
+		if vulnSpec.Type != nil && *vulnSpec.Type == noVulnType {
+			return []*model.Vulnerability{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
+		}
+	}
+
 	return r.Backend.Vulnerabilities(ctx, &model.VulnerabilitySpec{ID: vulnSpec.ID, Type: toLower(vulnSpec.Type),
 		VulnerabilityID: toLower(vulnSpec.VulnerabilityID), NoVuln: vulnSpec.NoVuln})
 }

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
@@ -34,5 +34,6 @@ func (r *mutationResolver) IngestVulnerabilities(ctx context.Context, vulns []*m
 // Vulnerabilities is the resolver for the vulnerabilities field.
 func (r *queryResolver) Vulnerabilities(ctx context.Context, vulnSpec model.VulnerabilitySpec) ([]*model.Vulnerability, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
-	return r.Backend.Vulnerabilities(ctx, &model.VulnerabilitySpec{Type: toLower(vulnSpec.Type), VulnerabilityID: toLower(vulnSpec.VulnerabilityID)})
+	return r.Backend.Vulnerabilities(ctx, &model.VulnerabilitySpec{ID: vulnSpec.ID, Type: toLower(vulnSpec.Type),
+		VulnerabilityID: toLower(vulnSpec.VulnerabilityID), NoVuln: vulnSpec.NoVuln})
 }

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
@@ -12,8 +12,6 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-const noVulnType string = "novuln"
-
 // IngestVulnerability is the resolver for the ingestVulnerability field.
 func (r *mutationResolver) IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (*model.Vulnerability, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
@@ -39,7 +37,7 @@ func (r *queryResolver) Vulnerabilities(ctx context.Context, vulnSpec model.Vuln
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 
 	if vulnSpec.NoVuln != nil && !*vulnSpec.NoVuln {
-		if vulnSpec.Type != nil && *vulnSpec.Type == noVulnType {
+		if vulnSpec.Type != nil && *vulnSpec.Type == "novuln" {
 			return []*model.Vulnerability{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
 		}
 	}

--- a/pkg/assembler/graphql/schema/vulnerability.graphql
+++ b/pkg/assembler/graphql/schema/vulnerability.graphql
@@ -70,11 +70,18 @@ Use null to match on all values at that level.
 For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 where every field is null.
 
+Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
+Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
+and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
+with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
+vulnerabilities for the corresponding type and vulnerabilityID.
+
 """
 input VulnerabilitySpec {
   id: ID
   type: String
   vulnerabilityID: String
+  noVuln: Boolean
 }
 
 """

--- a/pkg/assembler/graphql/schema/vulnerability.graphql
+++ b/pkg/assembler/graphql/schema/vulnerability.graphql
@@ -72,9 +72,9 @@ where every field is null.
 
 Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
 Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
-and the it has an empty string for vulnerabilityID. Setting it to false means retrieving only nodes
-with identified vulnerabilities. Setting one of the other fields and omitting the noVuln means retrieving
-vulnerabilities for the corresponding type and vulnerabilityID.
+and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
+Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding 
+type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
 
 """
 input VulnerabilitySpec {


### PR DESCRIPTION
# Description of the PR

Followup to PR https://github.com/guacsec/guac/pull/1147

Adding the functionality back that was introduced in https://github.com/guacsec/guac/pull/1073 to allow for filtering of vulnerabilities (no vulnerability)

```
# Setting noVuln to true return the noVuln node
# Setting noVuln to false return all vulnerabilities nodes
query noVuln {
  vulnerabilities(vulnSpec: {noVuln: true}) {
    ...allVulnerabilityTree
  }
}
```

```
# Setting noVuln to true return all packages that have no vulnerabilities
# Setting noVuln to false return all packages with vulnerabilities
query CertifyNoVuln {
  CertifyVuln(certifyVulnSpec: {
    vulnerability: {noVuln: true}
  }) {
    ...allCertifyVulnTree
  }
}
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
