### PR TITLE
changing mutationAPI to only return IDs instead of whole struct to fi…

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1916,499 +1916,6 @@ func (v *AllCertifyVulnVulnerability) __premarshalJSON() (*__premarshalAllCertif
 	return &retval, nil
 }
 
-// AllHasMetadata includes the GraphQL fields of HasMetadata requested by the fragment AllHasMetadata.
-// The GraphQL type's documentation follows.
-//
-// HasMetadata is an attestation that a package, source, or artifact has a certain
-// attested property (key) with value (value). For example, a source may have
-// metadata "SourceRepo2FAEnabled=true".
-//
-// The intent of this evidence tree predicate is to allow extensibility of metadata
-// expressible within the GUAC ontology. Metadata that is commonly used will then
-// be promoted to a predicate on its own.
-//
-// Justification indicates how the metadata was determined.
-//
-// The metadata applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type AllHasMetadata struct {
-	Id            string                                       `json:"id"`
-	Subject       AllHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
-	Key           string                                       `json:"key"`
-	Value         string                                       `json:"value"`
-	Timestamp     time.Time                                    `json:"timestamp"`
-	Justification string                                       `json:"justification"`
-	Origin        string                                       `json:"origin"`
-	Collector     string                                       `json:"collector"`
-}
-
-// GetId returns AllHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetId() string { return v.Id }
-
-// GetSubject returns AllHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact { return v.Subject }
-
-// GetKey returns AllHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetKey() string { return v.Key }
-
-// GetValue returns AllHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetValue() string { return v.Value }
-
-// GetTimestamp returns AllHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetTimestamp() time.Time { return v.Timestamp }
-
-// GetJustification returns AllHasMetadata.Justification, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetJustification() string { return v.Justification }
-
-// GetOrigin returns AllHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetOrigin() string { return v.Origin }
-
-// GetCollector returns AllHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *AllHasMetadata) GetCollector() string { return v.Collector }
-
-func (v *AllHasMetadata) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*AllHasMetadata
-		Subject json.RawMessage `json:"subject"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.AllHasMetadata = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Subject
-		src := firstPass.Subject
-		if len(src) != 0 && string(src) != "null" {
-			err = __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal AllHasMetadata.Subject: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalAllHasMetadata struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Key string `json:"key"`
-
-	Value string `json:"value"`
-
-	Timestamp time.Time `json:"timestamp"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *AllHasMetadata) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *AllHasMetadata) __premarshalJSON() (*__premarshalAllHasMetadata, error) {
-	var retval __premarshalAllHasMetadata
-
-	retval.Id = v.Id
-	{
-
-		dst := &retval.Subject
-		src := v.Subject
-		var err error
-		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal AllHasMetadata.Subject: %w", err)
-		}
-	}
-	retval.Key = v.Key
-	retval.Value = v.Value
-	retval.Timestamp = v.Timestamp
-	retval.Justification = v.Justification
-	retval.Origin = v.Origin
-	retval.Collector = v.Collector
-	return &retval, nil
-}
-
-// AllHasMetadataSubjectArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type AllHasMetadataSubjectArtifact struct {
-	Typename        *string `json:"__typename"`
-	AllArtifactTree `json:"-"`
-}
-
-// GetTypename returns AllHasMetadataSubjectArtifact.Typename, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectArtifact) GetTypename() *string { return v.Typename }
-
-// GetId returns AllHasMetadataSubjectArtifact.Id, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns AllHasMetadataSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns AllHasMetadataSubjectArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *AllHasMetadataSubjectArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*AllHasMetadataSubjectArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.AllHasMetadataSubjectArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalAllHasMetadataSubjectArtifact struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *AllHasMetadataSubjectArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *AllHasMetadataSubjectArtifact) __premarshalJSON() (*__premarshalAllHasMetadataSubjectArtifact, error) {
-	var retval __premarshalAllHasMetadataSubjectArtifact
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
-
-// AllHasMetadataSubjectPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type AllHasMetadataSubjectPackage struct {
-	Typename   *string `json:"__typename"`
-	AllPkgTree `json:"-"`
-}
-
-// GetTypename returns AllHasMetadataSubjectPackage.Typename, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectPackage) GetTypename() *string { return v.Typename }
-
-// GetId returns AllHasMetadataSubjectPackage.Id, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns AllHasMetadataSubjectPackage.Type, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns AllHasMetadataSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *AllHasMetadataSubjectPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*AllHasMetadataSubjectPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.AllHasMetadataSubjectPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalAllHasMetadataSubjectPackage struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *AllHasMetadataSubjectPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *AllHasMetadataSubjectPackage) __premarshalJSON() (*__premarshalAllHasMetadataSubjectPackage, error) {
-	var retval __premarshalAllHasMetadataSubjectPackage
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// AllHasMetadataSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
-//
-// AllHasMetadataSubjectPackageSourceOrArtifact is implemented by the following types:
-// AllHasMetadataSubjectArtifact
-// AllHasMetadataSubjectPackage
-// AllHasMetadataSubjectSource
-// The GraphQL type's documentation follows.
-//
-// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
-type AllHasMetadataSubjectPackageSourceOrArtifact interface {
-	implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact()
-	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
-	GetTypename() *string
-}
-
-func (v *AllHasMetadataSubjectArtifact) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
-}
-func (v *AllHasMetadataSubjectPackage) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
-}
-func (v *AllHasMetadataSubjectSource) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
-}
-
-func __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(b []byte, v *AllHasMetadataSubjectPackageSourceOrArtifact) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var tn struct {
-		TypeName string `json:"__typename"`
-	}
-	err := json.Unmarshal(b, &tn)
-	if err != nil {
-		return err
-	}
-
-	switch tn.TypeName {
-	case "Artifact":
-		*v = new(AllHasMetadataSubjectArtifact)
-		return json.Unmarshal(b, *v)
-	case "Package":
-		*v = new(AllHasMetadataSubjectPackage)
-		return json.Unmarshal(b, *v)
-	case "Source":
-		*v = new(AllHasMetadataSubjectSource)
-		return json.Unmarshal(b, *v)
-	case "":
-		return fmt.Errorf(
-			"response was missing PackageSourceOrArtifact.__typename")
-	default:
-		return fmt.Errorf(
-			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
-	}
-}
-
-func __marshalAllHasMetadataSubjectPackageSourceOrArtifact(v *AllHasMetadataSubjectPackageSourceOrArtifact) ([]byte, error) {
-
-	var typename string
-	switch v := (*v).(type) {
-	case *AllHasMetadataSubjectArtifact:
-		typename = "Artifact"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalAllHasMetadataSubjectArtifact
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *AllHasMetadataSubjectPackage:
-		typename = "Package"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalAllHasMetadataSubjectPackage
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *AllHasMetadataSubjectSource:
-		typename = "Source"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalAllHasMetadataSubjectSource
-		}{typename, premarshaled}
-		return json.Marshal(result)
-	case nil:
-		return []byte("null"), nil
-	default:
-		return nil, fmt.Errorf(
-			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%T"`, v)
-	}
-}
-
-// AllHasMetadataSubjectSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type AllHasMetadataSubjectSource struct {
-	Typename      *string `json:"__typename"`
-	AllSourceTree `json:"-"`
-}
-
-// GetTypename returns AllHasMetadataSubjectSource.Typename, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectSource) GetTypename() *string { return v.Typename }
-
-// GetId returns AllHasMetadataSubjectSource.Id, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns AllHasMetadataSubjectSource.Type, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns AllHasMetadataSubjectSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *AllHasMetadataSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *AllHasMetadataSubjectSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*AllHasMetadataSubjectSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.AllHasMetadataSubjectSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalAllHasMetadataSubjectSource struct {
-	Typename *string `json:"__typename"`
-
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *AllHasMetadataSubjectSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *AllHasMetadataSubjectSource) __premarshalJSON() (*__premarshalAllHasMetadataSubjectSource, error) {
-	var retval __premarshalAllHasMetadataSubjectSource
-
-	retval.Typename = v.Typename
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
-
 // AllHasSBOMTree includes the GraphQL fields of HasSBOM requested by the fragment AllHasSBOMTree.
 type AllHasSBOMTree struct {
 	Id string `json:"id"`
@@ -5347,239 +4854,23 @@ type BuilderInputSpec struct {
 // GetUri returns BuilderInputSpec.Uri, and is useful for accessing the field via an interface.
 func (v *BuilderInputSpec) GetUri() string { return v.Uri }
 
-// CertifyBadArtifactIngestCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadArtifactIngestCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadArtifactIngestCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactIngestCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadArtifactIngestCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactIngestCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadArtifactIngestCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactIngestCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadArtifactIngestCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactIngestCertifyBad) GetOrigin() string { return v.AllCertifyBad.Origin }
-
-// GetCollector returns CertifyBadArtifactIngestCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactIngestCertifyBad) GetCollector() string { return v.AllCertifyBad.Collector }
-
-func (v *CertifyBadArtifactIngestCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadArtifactIngestCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadArtifactIngestCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadArtifactIngestCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadArtifactIngestCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadArtifactIngestCertifyBad) __premarshalJSON() (*__premarshalCertifyBadArtifactIngestCertifyBad, error) {
-	var retval __premarshalCertifyBadArtifactIngestCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadArtifactIngestCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
-
 // CertifyBadArtifactResponse is returned by CertifyBadArtifact on success.
 type CertifyBadArtifactResponse struct {
 	// Adds a certification that a package, source or artifact is considered bad.
-	IngestCertifyBad CertifyBadArtifactIngestCertifyBad `json:"ingestCertifyBad"`
+	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
 // GetIngestCertifyBad returns CertifyBadArtifactResponse.IngestCertifyBad, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactResponse) GetIngestCertifyBad() CertifyBadArtifactIngestCertifyBad {
-	return v.IngestCertifyBad
-}
-
-// CertifyBadArtifactsIngestCertifyBadsCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadArtifactsIngestCertifyBadsCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadArtifactsIngestCertifyBadsCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadArtifactsIngestCertifyBadsCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadArtifactsIngestCertifyBadsCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadArtifactsIngestCertifyBadsCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) GetOrigin() string {
-	return v.AllCertifyBad.Origin
-}
-
-// GetCollector returns CertifyBadArtifactsIngestCertifyBadsCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) GetCollector() string {
-	return v.AllCertifyBad.Collector
-}
-
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadArtifactsIngestCertifyBadsCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadArtifactsIngestCertifyBadsCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadArtifactsIngestCertifyBadsCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadArtifactsIngestCertifyBadsCertifyBad) __premarshalJSON() (*__premarshalCertifyBadArtifactsIngestCertifyBadsCertifyBad, error) {
-	var retval __premarshalCertifyBadArtifactsIngestCertifyBadsCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadArtifactsIngestCertifyBadsCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
+func (v *CertifyBadArtifactResponse) GetIngestCertifyBad() string { return v.IngestCertifyBad }
 
 // CertifyBadArtifactsResponse is returned by CertifyBadArtifacts on success.
 type CertifyBadArtifactsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered bad.
-	IngestCertifyBads []CertifyBadArtifactsIngestCertifyBadsCertifyBad `json:"ingestCertifyBads"`
+	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
 // GetIngestCertifyBads returns CertifyBadArtifactsResponse.IngestCertifyBads, and is useful for accessing the field via an interface.
-func (v *CertifyBadArtifactsResponse) GetIngestCertifyBads() []CertifyBadArtifactsIngestCertifyBadsCertifyBad {
-	return v.IngestCertifyBads
-}
+func (v *CertifyBadArtifactsResponse) GetIngestCertifyBads() []string { return v.IngestCertifyBads }
 
 // CertifyBadInputSpec represents the mutation input to ingest a CertifyBad
 // evidence.
@@ -5598,237 +4889,23 @@ func (v *CertifyBadInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns CertifyBadInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyBadInputSpec) GetCollector() string { return v.Collector }
 
-// CertifyBadPkgIngestCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadPkgIngestCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadPkgIngestCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgIngestCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadPkgIngestCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgIngestCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadPkgIngestCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgIngestCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadPkgIngestCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgIngestCertifyBad) GetOrigin() string { return v.AllCertifyBad.Origin }
-
-// GetCollector returns CertifyBadPkgIngestCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgIngestCertifyBad) GetCollector() string { return v.AllCertifyBad.Collector }
-
-func (v *CertifyBadPkgIngestCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadPkgIngestCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadPkgIngestCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadPkgIngestCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadPkgIngestCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadPkgIngestCertifyBad) __premarshalJSON() (*__premarshalCertifyBadPkgIngestCertifyBad, error) {
-	var retval __premarshalCertifyBadPkgIngestCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadPkgIngestCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
-
 // CertifyBadPkgResponse is returned by CertifyBadPkg on success.
 type CertifyBadPkgResponse struct {
 	// Adds a certification that a package, source or artifact is considered bad.
-	IngestCertifyBad CertifyBadPkgIngestCertifyBad `json:"ingestCertifyBad"`
+	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
 // GetIngestCertifyBad returns CertifyBadPkgResponse.IngestCertifyBad, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgResponse) GetIngestCertifyBad() CertifyBadPkgIngestCertifyBad {
-	return v.IngestCertifyBad
-}
-
-// CertifyBadPkgsIngestCertifyBadsCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadPkgsIngestCertifyBadsCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadPkgsIngestCertifyBadsCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadPkgsIngestCertifyBadsCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadPkgsIngestCertifyBadsCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadPkgsIngestCertifyBadsCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) GetOrigin() string { return v.AllCertifyBad.Origin }
-
-// GetCollector returns CertifyBadPkgsIngestCertifyBadsCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) GetCollector() string {
-	return v.AllCertifyBad.Collector
-}
-
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadPkgsIngestCertifyBadsCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadPkgsIngestCertifyBadsCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadPkgsIngestCertifyBadsCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadPkgsIngestCertifyBadsCertifyBad) __premarshalJSON() (*__premarshalCertifyBadPkgsIngestCertifyBadsCertifyBad, error) {
-	var retval __premarshalCertifyBadPkgsIngestCertifyBadsCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadPkgsIngestCertifyBadsCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
+func (v *CertifyBadPkgResponse) GetIngestCertifyBad() string { return v.IngestCertifyBad }
 
 // CertifyBadPkgsResponse is returned by CertifyBadPkgs on success.
 type CertifyBadPkgsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered bad.
-	IngestCertifyBads []CertifyBadPkgsIngestCertifyBadsCertifyBad `json:"ingestCertifyBads"`
+	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
 // GetIngestCertifyBads returns CertifyBadPkgsResponse.IngestCertifyBads, and is useful for accessing the field via an interface.
-func (v *CertifyBadPkgsResponse) GetIngestCertifyBads() []CertifyBadPkgsIngestCertifyBadsCertifyBad {
-	return v.IngestCertifyBads
-}
+func (v *CertifyBadPkgsResponse) GetIngestCertifyBads() []string { return v.IngestCertifyBads }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
 // query.
@@ -5862,237 +4939,23 @@ func (v *CertifyBadSpec) GetOrigin() *string { return v.Origin }
 // GetCollector returns CertifyBadSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyBadSpec) GetCollector() *string { return v.Collector }
 
-// CertifyBadSrcIngestCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadSrcIngestCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadSrcIngestCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcIngestCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadSrcIngestCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcIngestCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadSrcIngestCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcIngestCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadSrcIngestCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcIngestCertifyBad) GetOrigin() string { return v.AllCertifyBad.Origin }
-
-// GetCollector returns CertifyBadSrcIngestCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcIngestCertifyBad) GetCollector() string { return v.AllCertifyBad.Collector }
-
-func (v *CertifyBadSrcIngestCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadSrcIngestCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadSrcIngestCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadSrcIngestCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadSrcIngestCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadSrcIngestCertifyBad) __premarshalJSON() (*__premarshalCertifyBadSrcIngestCertifyBad, error) {
-	var retval __premarshalCertifyBadSrcIngestCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadSrcIngestCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
-
 // CertifyBadSrcResponse is returned by CertifyBadSrc on success.
 type CertifyBadSrcResponse struct {
 	// Adds a certification that a package, source or artifact is considered bad.
-	IngestCertifyBad CertifyBadSrcIngestCertifyBad `json:"ingestCertifyBad"`
+	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
 // GetIngestCertifyBad returns CertifyBadSrcResponse.IngestCertifyBad, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcResponse) GetIngestCertifyBad() CertifyBadSrcIngestCertifyBad {
-	return v.IngestCertifyBad
-}
-
-// CertifyBadSrcsIngestCertifyBadsCertifyBad includes the requested fields of the GraphQL type CertifyBad.
-// The GraphQL type's documentation follows.
-//
-// CertifyBad is an attestation that a package, source, or artifact is considered
-// bad.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyBadSrcsIngestCertifyBadsCertifyBad struct {
-	AllCertifyBad `json:"-"`
-}
-
-// GetId returns CertifyBadSrcsIngestCertifyBadsCertifyBad.Id, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) GetId() string { return v.AllCertifyBad.Id }
-
-// GetJustification returns CertifyBadSrcsIngestCertifyBadsCertifyBad.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) GetJustification() string {
-	return v.AllCertifyBad.Justification
-}
-
-// GetSubject returns CertifyBadSrcsIngestCertifyBadsCertifyBad.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) GetSubject() AllCertifyBadSubjectPackageSourceOrArtifact {
-	return v.AllCertifyBad.Subject
-}
-
-// GetOrigin returns CertifyBadSrcsIngestCertifyBadsCertifyBad.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) GetOrigin() string { return v.AllCertifyBad.Origin }
-
-// GetCollector returns CertifyBadSrcsIngestCertifyBadsCertifyBad.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) GetCollector() string {
-	return v.AllCertifyBad.Collector
-}
-
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyBadSrcsIngestCertifyBadsCertifyBad
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyBadSrcsIngestCertifyBadsCertifyBad = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyBad)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyBadSrcsIngestCertifyBadsCertifyBad struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyBadSrcsIngestCertifyBadsCertifyBad) __premarshalJSON() (*__premarshalCertifyBadSrcsIngestCertifyBadsCertifyBad, error) {
-	var retval __premarshalCertifyBadSrcsIngestCertifyBadsCertifyBad
-
-	retval.Id = v.AllCertifyBad.Id
-	retval.Justification = v.AllCertifyBad.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyBad.Subject
-		var err error
-		*dst, err = __marshalAllCertifyBadSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyBadSrcsIngestCertifyBadsCertifyBad.AllCertifyBad.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyBad.Origin
-	retval.Collector = v.AllCertifyBad.Collector
-	return &retval, nil
-}
+func (v *CertifyBadSrcResponse) GetIngestCertifyBad() string { return v.IngestCertifyBad }
 
 // CertifyBadSrcsResponse is returned by CertifyBadSrcs on success.
 type CertifyBadSrcsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered bad.
-	IngestCertifyBads []CertifyBadSrcsIngestCertifyBadsCertifyBad `json:"ingestCertifyBads"`
+	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
 // GetIngestCertifyBads returns CertifyBadSrcsResponse.IngestCertifyBads, and is useful for accessing the field via an interface.
-func (v *CertifyBadSrcsResponse) GetIngestCertifyBads() []CertifyBadSrcsIngestCertifyBadsCertifyBad {
-	return v.IngestCertifyBads
-}
+func (v *CertifyBadSrcsResponse) GetIngestCertifyBads() []string { return v.IngestCertifyBads }
 
 // CertifyBadsCertifyBad includes the requested fields of the GraphQL type CertifyBad.
 // The GraphQL type's documentation follows.
@@ -6205,243 +5068,23 @@ type CertifyBadsResponse struct {
 // GetCertifyBad returns CertifyBadsResponse.CertifyBad, and is useful for accessing the field via an interface.
 func (v *CertifyBadsResponse) GetCertifyBad() []CertifyBadsCertifyBad { return v.CertifyBad }
 
-// CertifyGoodArtifactIngestCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodArtifactIngestCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodArtifactIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
-
-// GetJustification returns CertifyGoodArtifactIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodArtifactIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodArtifactIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
-
-// GetCollector returns CertifyGoodArtifactIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactIngestCertifyGood) GetCollector() string {
-	return v.AllCertifyGood.Collector
-}
-
-func (v *CertifyGoodArtifactIngestCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodArtifactIngestCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodArtifactIngestCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodArtifactIngestCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodArtifactIngestCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodArtifactIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodArtifactIngestCertifyGood, error) {
-	var retval __premarshalCertifyGoodArtifactIngestCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodArtifactIngestCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
-
 // CertifyGoodArtifactResponse is returned by CertifyGoodArtifact on success.
 type CertifyGoodArtifactResponse struct {
 	// Adds a certification that a package, source or artifact is considered good.
-	IngestCertifyGood CertifyGoodArtifactIngestCertifyGood `json:"ingestCertifyGood"`
+	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
 // GetIngestCertifyGood returns CertifyGoodArtifactResponse.IngestCertifyGood, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactResponse) GetIngestCertifyGood() CertifyGoodArtifactIngestCertifyGood {
-	return v.IngestCertifyGood
-}
-
-// CertifyGoodArtifactsIngestCertifyGoodsCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodArtifactsIngestCertifyGoodsCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) GetId() string {
-	return v.AllCertifyGood.Id
-}
-
-// GetJustification returns CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) GetOrigin() string {
-	return v.AllCertifyGood.Origin
-}
-
-// GetCollector returns CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) GetCollector() string {
-	return v.AllCertifyGood.Collector
-}
-
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodArtifactsIngestCertifyGoodsCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodArtifactsIngestCertifyGoodsCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodArtifactsIngestCertifyGoodsCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodArtifactsIngestCertifyGoodsCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodArtifactsIngestCertifyGoodsCertifyGood, error) {
-	var retval __premarshalCertifyGoodArtifactsIngestCertifyGoodsCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodArtifactsIngestCertifyGoodsCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
+func (v *CertifyGoodArtifactResponse) GetIngestCertifyGood() string { return v.IngestCertifyGood }
 
 // CertifyGoodArtifactsResponse is returned by CertifyGoodArtifacts on success.
 type CertifyGoodArtifactsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered good.
-	IngestCertifyGoods []CertifyGoodArtifactsIngestCertifyGoodsCertifyGood `json:"ingestCertifyGoods"`
+	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
 // GetIngestCertifyGoods returns CertifyGoodArtifactsResponse.IngestCertifyGoods, and is useful for accessing the field via an interface.
-func (v *CertifyGoodArtifactsResponse) GetIngestCertifyGoods() []CertifyGoodArtifactsIngestCertifyGoodsCertifyGood {
-	return v.IngestCertifyGoods
-}
+func (v *CertifyGoodArtifactsResponse) GetIngestCertifyGoods() []string { return v.IngestCertifyGoods }
 
 // CertifyGoodInputSpec represents the mutation input to ingest a CertifyGood evidence.
 type CertifyGoodInputSpec struct {
@@ -6459,1135 +5102,95 @@ func (v *CertifyGoodInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns CertifyGoodInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 
-// CertifyGoodPkgIngestCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodPkgIngestCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodPkgIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
-
-// GetJustification returns CertifyGoodPkgIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodPkgIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodPkgIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
-
-// GetCollector returns CertifyGoodPkgIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgIngestCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
-
-func (v *CertifyGoodPkgIngestCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodPkgIngestCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodPkgIngestCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodPkgIngestCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodPkgIngestCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodPkgIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodPkgIngestCertifyGood, error) {
-	var retval __premarshalCertifyGoodPkgIngestCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodPkgIngestCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
-
 // CertifyGoodPkgResponse is returned by CertifyGoodPkg on success.
 type CertifyGoodPkgResponse struct {
 	// Adds a certification that a package, source or artifact is considered good.
-	IngestCertifyGood CertifyGoodPkgIngestCertifyGood `json:"ingestCertifyGood"`
+	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
 // GetIngestCertifyGood returns CertifyGoodPkgResponse.IngestCertifyGood, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgResponse) GetIngestCertifyGood() CertifyGoodPkgIngestCertifyGood {
-	return v.IngestCertifyGood
-}
-
-// CertifyGoodPkgsIngestCertifyGoodsCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodPkgsIngestCertifyGoodsCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodPkgsIngestCertifyGoodsCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) GetId() string { return v.AllCertifyGood.Id }
-
-// GetJustification returns CertifyGoodPkgsIngestCertifyGoodsCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodPkgsIngestCertifyGoodsCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodPkgsIngestCertifyGoodsCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) GetOrigin() string {
-	return v.AllCertifyGood.Origin
-}
-
-// GetCollector returns CertifyGoodPkgsIngestCertifyGoodsCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) GetCollector() string {
-	return v.AllCertifyGood.Collector
-}
-
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodPkgsIngestCertifyGoodsCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodPkgsIngestCertifyGoodsCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodPkgsIngestCertifyGoodsCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodPkgsIngestCertifyGoodsCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodPkgsIngestCertifyGoodsCertifyGood, error) {
-	var retval __premarshalCertifyGoodPkgsIngestCertifyGoodsCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodPkgsIngestCertifyGoodsCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
+func (v *CertifyGoodPkgResponse) GetIngestCertifyGood() string { return v.IngestCertifyGood }
 
 // CertifyGoodPkgsResponse is returned by CertifyGoodPkgs on success.
 type CertifyGoodPkgsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered good.
-	IngestCertifyGoods []CertifyGoodPkgsIngestCertifyGoodsCertifyGood `json:"ingestCertifyGoods"`
+	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
 // GetIngestCertifyGoods returns CertifyGoodPkgsResponse.IngestCertifyGoods, and is useful for accessing the field via an interface.
-func (v *CertifyGoodPkgsResponse) GetIngestCertifyGoods() []CertifyGoodPkgsIngestCertifyGoodsCertifyGood {
-	return v.IngestCertifyGoods
-}
-
-// CertifyGoodSrcIngestCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodSrcIngestCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodSrcIngestCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetId() string { return v.AllCertifyGood.Id }
-
-// GetJustification returns CertifyGoodSrcIngestCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodSrcIngestCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodSrcIngestCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetOrigin() string { return v.AllCertifyGood.Origin }
-
-// GetCollector returns CertifyGoodSrcIngestCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcIngestCertifyGood) GetCollector() string { return v.AllCertifyGood.Collector }
-
-func (v *CertifyGoodSrcIngestCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodSrcIngestCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodSrcIngestCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodSrcIngestCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodSrcIngestCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodSrcIngestCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodSrcIngestCertifyGood, error) {
-	var retval __premarshalCertifyGoodSrcIngestCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodSrcIngestCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
+func (v *CertifyGoodPkgsResponse) GetIngestCertifyGoods() []string { return v.IngestCertifyGoods }
 
 // CertifyGoodSrcResponse is returned by CertifyGoodSrc on success.
 type CertifyGoodSrcResponse struct {
 	// Adds a certification that a package, source or artifact is considered good.
-	IngestCertifyGood CertifyGoodSrcIngestCertifyGood `json:"ingestCertifyGood"`
+	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
 // GetIngestCertifyGood returns CertifyGoodSrcResponse.IngestCertifyGood, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcResponse) GetIngestCertifyGood() CertifyGoodSrcIngestCertifyGood {
-	return v.IngestCertifyGood
-}
-
-// CertifyGoodSrcsIngestCertifyGoodsCertifyGood includes the requested fields of the GraphQL type CertifyGood.
-// The GraphQL type's documentation follows.
-//
-// CertifyGood is an attestation that a package, source, or artifact is considered
-// good.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The certification applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type CertifyGoodSrcsIngestCertifyGoodsCertifyGood struct {
-	AllCertifyGood `json:"-"`
-}
-
-// GetId returns CertifyGoodSrcsIngestCertifyGoodsCertifyGood.Id, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) GetId() string { return v.AllCertifyGood.Id }
-
-// GetJustification returns CertifyGoodSrcsIngestCertifyGoodsCertifyGood.Justification, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) GetJustification() string {
-	return v.AllCertifyGood.Justification
-}
-
-// GetSubject returns CertifyGoodSrcsIngestCertifyGoodsCertifyGood.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) GetSubject() AllCertifyGoodSubjectPackageSourceOrArtifact {
-	return v.AllCertifyGood.Subject
-}
-
-// GetOrigin returns CertifyGoodSrcsIngestCertifyGoodsCertifyGood.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) GetOrigin() string {
-	return v.AllCertifyGood.Origin
-}
-
-// GetCollector returns CertifyGoodSrcsIngestCertifyGoodsCertifyGood.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) GetCollector() string {
-	return v.AllCertifyGood.Collector
-}
-
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyGoodSrcsIngestCertifyGoodsCertifyGood
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyGoodSrcsIngestCertifyGoodsCertifyGood = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyGood)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyGoodSrcsIngestCertifyGoodsCertifyGood struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyGoodSrcsIngestCertifyGoodsCertifyGood) __premarshalJSON() (*__premarshalCertifyGoodSrcsIngestCertifyGoodsCertifyGood, error) {
-	var retval __premarshalCertifyGoodSrcsIngestCertifyGoodsCertifyGood
-
-	retval.Id = v.AllCertifyGood.Id
-	retval.Justification = v.AllCertifyGood.Justification
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyGood.Subject
-		var err error
-		*dst, err = __marshalAllCertifyGoodSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyGoodSrcsIngestCertifyGoodsCertifyGood.AllCertifyGood.Subject: %w", err)
-		}
-	}
-	retval.Origin = v.AllCertifyGood.Origin
-	retval.Collector = v.AllCertifyGood.Collector
-	return &retval, nil
-}
+func (v *CertifyGoodSrcResponse) GetIngestCertifyGood() string { return v.IngestCertifyGood }
 
 // CertifyGoodSrcsResponse is returned by CertifyGoodSrcs on success.
 type CertifyGoodSrcsResponse struct {
 	// Adds bulk certifications that a package, source or artifact is considered good.
-	IngestCertifyGoods []CertifyGoodSrcsIngestCertifyGoodsCertifyGood `json:"ingestCertifyGoods"`
+	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
 // GetIngestCertifyGoods returns CertifyGoodSrcsResponse.IngestCertifyGoods, and is useful for accessing the field via an interface.
-func (v *CertifyGoodSrcsResponse) GetIngestCertifyGoods() []CertifyGoodSrcsIngestCertifyGoodsCertifyGood {
-	return v.IngestCertifyGoods
-}
-
-// CertifyScorecardIngestScorecardCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
-// The GraphQL type's documentation follows.
-//
-// CertifyScorecard is an attestation to attach a Scorecard analysis to a
-// particular source repository.
-type CertifyScorecardIngestScorecardCertifyScorecard struct {
-	AllCertifyScorecard `json:"-"`
-}
-
-// GetId returns CertifyScorecardIngestScorecardCertifyScorecard.Id, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetId() string {
-	return v.AllCertifyScorecard.Id
-}
-
-// GetSource returns CertifyScorecardIngestScorecardCertifyScorecard.Source, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetSource() AllCertifyScorecardSource {
-	return v.AllCertifyScorecard.Source
-}
-
-// GetScorecard returns CertifyScorecardIngestScorecardCertifyScorecard.Scorecard, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) GetScorecard() AllCertifyScorecardScorecard {
-	return v.AllCertifyScorecard.Scorecard
-}
-
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyScorecardIngestScorecardCertifyScorecard
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyScorecardIngestScorecardCertifyScorecard = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyScorecard)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyScorecardIngestScorecardCertifyScorecard struct {
-	Id string `json:"id"`
-
-	Source AllCertifyScorecardSource `json:"source"`
-
-	Scorecard AllCertifyScorecardScorecard `json:"scorecard"`
-}
-
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyScorecardIngestScorecardCertifyScorecard) __premarshalJSON() (*__premarshalCertifyScorecardIngestScorecardCertifyScorecard, error) {
-	var retval __premarshalCertifyScorecardIngestScorecardCertifyScorecard
-
-	retval.Id = v.AllCertifyScorecard.Id
-	retval.Source = v.AllCertifyScorecard.Source
-	retval.Scorecard = v.AllCertifyScorecard.Scorecard
-	return &retval, nil
-}
+func (v *CertifyGoodSrcsResponse) GetIngestCertifyGoods() []string { return v.IngestCertifyGoods }
 
 // CertifyScorecardResponse is returned by CertifyScorecard on success.
 type CertifyScorecardResponse struct {
 	// Adds a certification that a source repository has a Scorecard.
-	IngestScorecard CertifyScorecardIngestScorecardCertifyScorecard `json:"ingestScorecard"`
+	IngestScorecard string `json:"ingestScorecard"`
 }
 
 // GetIngestScorecard returns CertifyScorecardResponse.IngestScorecard, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardResponse) GetIngestScorecard() CertifyScorecardIngestScorecardCertifyScorecard {
-	return v.IngestScorecard
-}
-
-// CertifyScorecardsIngestScorecardsCertifyScorecard includes the requested fields of the GraphQL type CertifyScorecard.
-// The GraphQL type's documentation follows.
-//
-// CertifyScorecard is an attestation to attach a Scorecard analysis to a
-// particular source repository.
-type CertifyScorecardsIngestScorecardsCertifyScorecard struct {
-	AllCertifyScorecard `json:"-"`
-}
-
-// GetId returns CertifyScorecardsIngestScorecardsCertifyScorecard.Id, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetId() string {
-	return v.AllCertifyScorecard.Id
-}
-
-// GetSource returns CertifyScorecardsIngestScorecardsCertifyScorecard.Source, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetSource() AllCertifyScorecardSource {
-	return v.AllCertifyScorecard.Source
-}
-
-// GetScorecard returns CertifyScorecardsIngestScorecardsCertifyScorecard.Scorecard, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) GetScorecard() AllCertifyScorecardScorecard {
-	return v.AllCertifyScorecard.Scorecard
-}
-
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyScorecardsIngestScorecardsCertifyScorecard
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyScorecardsIngestScorecardsCertifyScorecard = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyScorecard)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyScorecardsIngestScorecardsCertifyScorecard struct {
-	Id string `json:"id"`
-
-	Source AllCertifyScorecardSource `json:"source"`
-
-	Scorecard AllCertifyScorecardScorecard `json:"scorecard"`
-}
-
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyScorecardsIngestScorecardsCertifyScorecard) __premarshalJSON() (*__premarshalCertifyScorecardsIngestScorecardsCertifyScorecard, error) {
-	var retval __premarshalCertifyScorecardsIngestScorecardsCertifyScorecard
-
-	retval.Id = v.AllCertifyScorecard.Id
-	retval.Source = v.AllCertifyScorecard.Source
-	retval.Scorecard = v.AllCertifyScorecard.Scorecard
-	return &retval, nil
-}
+func (v *CertifyScorecardResponse) GetIngestScorecard() string { return v.IngestScorecard }
 
 // CertifyScorecardsResponse is returned by CertifyScorecards on success.
 type CertifyScorecardsResponse struct {
 	// Adds bulk certifications that a source repository has a Scorecard.
-	IngestScorecards []CertifyScorecardsIngestScorecardsCertifyScorecard `json:"ingestScorecards"`
+	IngestScorecards []string `json:"ingestScorecards"`
 }
 
 // GetIngestScorecards returns CertifyScorecardsResponse.IngestScorecards, and is useful for accessing the field via an interface.
-func (v *CertifyScorecardsResponse) GetIngestScorecards() []CertifyScorecardsIngestScorecardsCertifyScorecard {
-	return v.IngestScorecards
-}
-
-// CertifyVexArtifactIngestVEXStatementCertifyVEXStatement includes the requested fields of the GraphQL type CertifyVEXStatement.
-// The GraphQL type's documentation follows.
-//
-// CertifyVEXStatement is an attestation to attach VEX statements to a package or
-// artifact to clarify the impact of a specific vulnerability.
-type CertifyVexArtifactIngestVEXStatementCertifyVEXStatement struct {
-	AllCertifyVEXStatement `json:"-"`
-}
-
-// GetId returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.AllCertifyVEXStatement.Id
-}
-
-// GetSubject returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.AllCertifyVEXStatement.Subject
-}
-
-// GetVulnerability returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
-	return v.AllCertifyVEXStatement.Vulnerability
-}
-
-// GetStatus returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.AllCertifyVEXStatement.Status
-}
-
-// GetVexJustification returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.AllCertifyVEXStatement.VexJustification
-}
-
-// GetStatement returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.AllCertifyVEXStatement.Statement
-}
-
-// GetStatusNotes returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.AllCertifyVEXStatement.StatusNotes
-}
-
-// GetKnownSince returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.AllCertifyVEXStatement.KnownSince
-}
-
-// GetOrigin returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.AllCertifyVEXStatement.Origin
-}
-
-// GetCollector returns CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.AllCertifyVEXStatement.Collector
-}
-
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyVexArtifactIngestVEXStatementCertifyVEXStatement
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyVexArtifactIngestVEXStatementCertifyVEXStatement = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyVEXStatement)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyVexArtifactIngestVEXStatementCertifyVEXStatement struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Vulnerability AllCertifyVEXStatementVulnerability `json:"vulnerability"`
-
-	Status VexStatus `json:"status"`
-
-	VexJustification VexJustification `json:"vexJustification"`
-
-	Statement string `json:"statement"`
-
-	StatusNotes string `json:"statusNotes"`
-
-	KnownSince time.Time `json:"knownSince"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyVexArtifactIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalCertifyVexArtifactIngestVEXStatementCertifyVEXStatement, error) {
-	var retval __premarshalCertifyVexArtifactIngestVEXStatementCertifyVEXStatement
-
-	retval.Id = v.AllCertifyVEXStatement.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyVEXStatement.Subject
-		var err error
-		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyVexArtifactIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
-		}
-	}
-	retval.Vulnerability = v.AllCertifyVEXStatement.Vulnerability
-	retval.Status = v.AllCertifyVEXStatement.Status
-	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
-	retval.Statement = v.AllCertifyVEXStatement.Statement
-	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
-	retval.Origin = v.AllCertifyVEXStatement.Origin
-	retval.Collector = v.AllCertifyVEXStatement.Collector
-	return &retval, nil
-}
+func (v *CertifyScorecardsResponse) GetIngestScorecards() []string { return v.IngestScorecards }
 
 // CertifyVexArtifactResponse is returned by CertifyVexArtifact on success.
 type CertifyVexArtifactResponse struct {
 	// Adds a VEX certification for a package.
-	IngestVEXStatement CertifyVexArtifactIngestVEXStatementCertifyVEXStatement `json:"ingestVEXStatement"`
+	IngestVEXStatement string `json:"ingestVEXStatement"`
 }
 
 // GetIngestVEXStatement returns CertifyVexArtifactResponse.IngestVEXStatement, and is useful for accessing the field via an interface.
-func (v *CertifyVexArtifactResponse) GetIngestVEXStatement() CertifyVexArtifactIngestVEXStatementCertifyVEXStatement {
-	return v.IngestVEXStatement
-}
-
-// CertifyVexPkgIngestVEXStatementCertifyVEXStatement includes the requested fields of the GraphQL type CertifyVEXStatement.
-// The GraphQL type's documentation follows.
-//
-// CertifyVEXStatement is an attestation to attach VEX statements to a package or
-// artifact to clarify the impact of a specific vulnerability.
-type CertifyVexPkgIngestVEXStatementCertifyVEXStatement struct {
-	AllCertifyVEXStatement `json:"-"`
-}
-
-// GetId returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Id, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetId() string {
-	return v.AllCertifyVEXStatement.Id
-}
-
-// GetSubject returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Subject, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetSubject() AllCertifyVEXStatementSubjectPackageOrArtifact {
-	return v.AllCertifyVEXStatement.Subject
-}
-
-// GetVulnerability returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Vulnerability, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetVulnerability() AllCertifyVEXStatementVulnerability {
-	return v.AllCertifyVEXStatement.Vulnerability
-}
-
-// GetStatus returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Status, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetStatus() VexStatus {
-	return v.AllCertifyVEXStatement.Status
-}
-
-// GetVexJustification returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.VexJustification, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetVexJustification() VexJustification {
-	return v.AllCertifyVEXStatement.VexJustification
-}
-
-// GetStatement returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Statement, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetStatement() string {
-	return v.AllCertifyVEXStatement.Statement
-}
-
-// GetStatusNotes returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.StatusNotes, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetStatusNotes() string {
-	return v.AllCertifyVEXStatement.StatusNotes
-}
-
-// GetKnownSince returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.KnownSince, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetKnownSince() time.Time {
-	return v.AllCertifyVEXStatement.KnownSince
-}
-
-// GetOrigin returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Origin, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetOrigin() string {
-	return v.AllCertifyVEXStatement.Origin
-}
-
-// GetCollector returns CertifyVexPkgIngestVEXStatementCertifyVEXStatement.Collector, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) GetCollector() string {
-	return v.AllCertifyVEXStatement.Collector
-}
-
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyVexPkgIngestVEXStatementCertifyVEXStatement
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyVexPkgIngestVEXStatementCertifyVEXStatement = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyVEXStatement)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyVexPkgIngestVEXStatementCertifyVEXStatement struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Vulnerability AllCertifyVEXStatementVulnerability `json:"vulnerability"`
-
-	Status VexStatus `json:"status"`
-
-	VexJustification VexJustification `json:"vexJustification"`
-
-	Statement string `json:"statement"`
-
-	StatusNotes string `json:"statusNotes"`
-
-	KnownSince time.Time `json:"knownSince"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyVexPkgIngestVEXStatementCertifyVEXStatement) __premarshalJSON() (*__premarshalCertifyVexPkgIngestVEXStatementCertifyVEXStatement, error) {
-	var retval __premarshalCertifyVexPkgIngestVEXStatementCertifyVEXStatement
-
-	retval.Id = v.AllCertifyVEXStatement.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllCertifyVEXStatement.Subject
-		var err error
-		*dst, err = __marshalAllCertifyVEXStatementSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal CertifyVexPkgIngestVEXStatementCertifyVEXStatement.AllCertifyVEXStatement.Subject: %w", err)
-		}
-	}
-	retval.Vulnerability = v.AllCertifyVEXStatement.Vulnerability
-	retval.Status = v.AllCertifyVEXStatement.Status
-	retval.VexJustification = v.AllCertifyVEXStatement.VexJustification
-	retval.Statement = v.AllCertifyVEXStatement.Statement
-	retval.StatusNotes = v.AllCertifyVEXStatement.StatusNotes
-	retval.KnownSince = v.AllCertifyVEXStatement.KnownSince
-	retval.Origin = v.AllCertifyVEXStatement.Origin
-	retval.Collector = v.AllCertifyVEXStatement.Collector
-	return &retval, nil
-}
+func (v *CertifyVexArtifactResponse) GetIngestVEXStatement() string { return v.IngestVEXStatement }
 
 // CertifyVexPkgResponse is returned by CertifyVexPkg on success.
 type CertifyVexPkgResponse struct {
 	// Adds a VEX certification for a package.
-	IngestVEXStatement CertifyVexPkgIngestVEXStatementCertifyVEXStatement `json:"ingestVEXStatement"`
+	IngestVEXStatement string `json:"ingestVEXStatement"`
 }
 
 // GetIngestVEXStatement returns CertifyVexPkgResponse.IngestVEXStatement, and is useful for accessing the field via an interface.
-func (v *CertifyVexPkgResponse) GetIngestVEXStatement() CertifyVexPkgIngestVEXStatementCertifyVEXStatement {
-	return v.IngestVEXStatement
-}
-
-// CertifyVulnPkgIngestCertifyVuln includes the requested fields of the GraphQL type CertifyVuln.
-// The GraphQL type's documentation follows.
-//
-// CertifyVuln is an attestation to attach vulnerability information to a package.
-//
-// This information is obtained via a scanner. If there is no vulnerability
-// detected, we attach the a vulnerability with "NoVuln" type and an empty string
-// for the vulnerability ID.
-type CertifyVulnPkgIngestCertifyVuln struct {
-	AllCertifyVuln `json:"-"`
-}
-
-// GetId returns CertifyVulnPkgIngestCertifyVuln.Id, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgIngestCertifyVuln) GetId() string { return v.AllCertifyVuln.Id }
-
-// GetPackage returns CertifyVulnPkgIngestCertifyVuln.Package, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgIngestCertifyVuln) GetPackage() AllCertifyVulnPackage {
-	return v.AllCertifyVuln.Package
-}
-
-// GetVulnerability returns CertifyVulnPkgIngestCertifyVuln.Vulnerability, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgIngestCertifyVuln) GetVulnerability() AllCertifyVulnVulnerability {
-	return v.AllCertifyVuln.Vulnerability
-}
-
-// GetMetadata returns CertifyVulnPkgIngestCertifyVuln.Metadata, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgIngestCertifyVuln) GetMetadata() AllCertifyVulnMetadataScanMetadata {
-	return v.AllCertifyVuln.Metadata
-}
-
-func (v *CertifyVulnPkgIngestCertifyVuln) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyVulnPkgIngestCertifyVuln
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyVulnPkgIngestCertifyVuln = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyVuln)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyVulnPkgIngestCertifyVuln struct {
-	Id string `json:"id"`
-
-	Package AllCertifyVulnPackage `json:"package"`
-
-	Vulnerability AllCertifyVulnVulnerability `json:"vulnerability"`
-
-	Metadata AllCertifyVulnMetadataScanMetadata `json:"metadata"`
-}
-
-func (v *CertifyVulnPkgIngestCertifyVuln) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyVulnPkgIngestCertifyVuln) __premarshalJSON() (*__premarshalCertifyVulnPkgIngestCertifyVuln, error) {
-	var retval __premarshalCertifyVulnPkgIngestCertifyVuln
-
-	retval.Id = v.AllCertifyVuln.Id
-	retval.Package = v.AllCertifyVuln.Package
-	retval.Vulnerability = v.AllCertifyVuln.Vulnerability
-	retval.Metadata = v.AllCertifyVuln.Metadata
-	return &retval, nil
-}
+func (v *CertifyVexPkgResponse) GetIngestVEXStatement() string { return v.IngestVEXStatement }
 
 // CertifyVulnPkgResponse is returned by CertifyVulnPkg on success.
 type CertifyVulnPkgResponse struct {
 	// Adds a certification that a package has been scanned for vulnerabilities.
-	IngestCertifyVuln CertifyVulnPkgIngestCertifyVuln `json:"ingestCertifyVuln"`
+	IngestCertifyVuln string `json:"ingestCertifyVuln"`
 }
 
 // GetIngestCertifyVuln returns CertifyVulnPkgResponse.IngestCertifyVuln, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgResponse) GetIngestCertifyVuln() CertifyVulnPkgIngestCertifyVuln {
-	return v.IngestCertifyVuln
-}
-
-// CertifyVulnPkgsIngestCertifyVulnsCertifyVuln includes the requested fields of the GraphQL type CertifyVuln.
-// The GraphQL type's documentation follows.
-//
-// CertifyVuln is an attestation to attach vulnerability information to a package.
-//
-// This information is obtained via a scanner. If there is no vulnerability
-// detected, we attach the a vulnerability with "NoVuln" type and an empty string
-// for the vulnerability ID.
-type CertifyVulnPkgsIngestCertifyVulnsCertifyVuln struct {
-	AllCertifyVuln `json:"-"`
-}
-
-// GetId returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Id, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetId() string { return v.AllCertifyVuln.Id }
-
-// GetPackage returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Package, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetPackage() AllCertifyVulnPackage {
-	return v.AllCertifyVuln.Package
-}
-
-// GetVulnerability returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Vulnerability, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetVulnerability() AllCertifyVulnVulnerability {
-	return v.AllCertifyVuln.Vulnerability
-}
-
-// GetMetadata returns CertifyVulnPkgsIngestCertifyVulnsCertifyVuln.Metadata, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) GetMetadata() AllCertifyVulnMetadataScanMetadata {
-	return v.AllCertifyVuln.Metadata
-}
-
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*CertifyVulnPkgsIngestCertifyVulnsCertifyVuln
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.CertifyVulnPkgsIngestCertifyVulnsCertifyVuln = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllCertifyVuln)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln struct {
-	Id string `json:"id"`
-
-	Package AllCertifyVulnPackage `json:"package"`
-
-	Vulnerability AllCertifyVulnVulnerability `json:"vulnerability"`
-
-	Metadata AllCertifyVulnMetadataScanMetadata `json:"metadata"`
-}
-
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *CertifyVulnPkgsIngestCertifyVulnsCertifyVuln) __premarshalJSON() (*__premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln, error) {
-	var retval __premarshalCertifyVulnPkgsIngestCertifyVulnsCertifyVuln
-
-	retval.Id = v.AllCertifyVuln.Id
-	retval.Package = v.AllCertifyVuln.Package
-	retval.Vulnerability = v.AllCertifyVuln.Vulnerability
-	retval.Metadata = v.AllCertifyVuln.Metadata
-	return &retval, nil
-}
+func (v *CertifyVulnPkgResponse) GetIngestCertifyVuln() string { return v.IngestCertifyVuln }
 
 // CertifyVulnPkgsResponse is returned by CertifyVulnPkgs on success.
 type CertifyVulnPkgsResponse struct {
 	// Bulk add certifications that a package has been scanned for vulnerabilities.
-	IngestCertifyVulns []CertifyVulnPkgsIngestCertifyVulnsCertifyVuln `json:"ingestCertifyVulns"`
+	IngestCertifyVulns []string `json:"ingestCertifyVulns"`
 }
 
 // GetIngestCertifyVulns returns CertifyVulnPkgsResponse.IngestCertifyVulns, and is useful for accessing the field via an interface.
-func (v *CertifyVulnPkgsResponse) GetIngestCertifyVulns() []CertifyVulnPkgsIngestCertifyVulnsCertifyVuln {
-	return v.IngestCertifyVulns
-}
+func (v *CertifyVulnPkgsResponse) GetIngestCertifyVulns() []string { return v.IngestCertifyVulns }
 
 // DependencyType determines the type of the dependency.
 type DependencyType string
@@ -8140,145 +5743,14 @@ func (v *FindSoftwareResponse) __premarshalJSON() (*__premarshalFindSoftwareResp
 	return &retval, nil
 }
 
-// HasMetadataArtifactIngestHasMetadata includes the requested fields of the GraphQL type HasMetadata.
-// The GraphQL type's documentation follows.
-//
-// HasMetadata is an attestation that a package, source, or artifact has a certain
-// attested property (key) with value (value). For example, a source may have
-// metadata "SourceRepo2FAEnabled=true".
-//
-// The intent of this evidence tree predicate is to allow extensibility of metadata
-// expressible within the GUAC ontology. Metadata that is commonly used will then
-// be promoted to a predicate on its own.
-//
-// Justification indicates how the metadata was determined.
-//
-// The metadata applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type HasMetadataArtifactIngestHasMetadata struct {
-	AllHasMetadata `json:"-"`
-}
-
-// GetId returns HasMetadataArtifactIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
-
-// GetSubject returns HasMetadataArtifactIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
-	return v.AllHasMetadata.Subject
-}
-
-// GetKey returns HasMetadataArtifactIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
-
-// GetValue returns HasMetadataArtifactIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
-
-// GetTimestamp returns HasMetadataArtifactIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetTimestamp() time.Time {
-	return v.AllHasMetadata.Timestamp
-}
-
-// GetJustification returns HasMetadataArtifactIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetJustification() string {
-	return v.AllHasMetadata.Justification
-}
-
-// GetOrigin returns HasMetadataArtifactIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
-
-// GetCollector returns HasMetadataArtifactIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactIngestHasMetadata) GetCollector() string {
-	return v.AllHasMetadata.Collector
-}
-
-func (v *HasMetadataArtifactIngestHasMetadata) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasMetadataArtifactIngestHasMetadata
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasMetadataArtifactIngestHasMetadata = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasMetadata)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasMetadataArtifactIngestHasMetadata struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Key string `json:"key"`
-
-	Value string `json:"value"`
-
-	Timestamp time.Time `json:"timestamp"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasMetadataArtifactIngestHasMetadata) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasMetadataArtifactIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataArtifactIngestHasMetadata, error) {
-	var retval __premarshalHasMetadataArtifactIngestHasMetadata
-
-	retval.Id = v.AllHasMetadata.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasMetadata.Subject
-		var err error
-		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataArtifactIngestHasMetadata.AllHasMetadata.Subject: %w", err)
-		}
-	}
-	retval.Key = v.AllHasMetadata.Key
-	retval.Value = v.AllHasMetadata.Value
-	retval.Timestamp = v.AllHasMetadata.Timestamp
-	retval.Justification = v.AllHasMetadata.Justification
-	retval.Origin = v.AllHasMetadata.Origin
-	retval.Collector = v.AllHasMetadata.Collector
-	return &retval, nil
-}
-
 // HasMetadataArtifactResponse is returned by HasMetadataArtifact on success.
 type HasMetadataArtifactResponse struct {
 	// Adds metadata about a package, source or artifact.
-	IngestHasMetadata HasMetadataArtifactIngestHasMetadata `json:"ingestHasMetadata"`
+	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
 // GetIngestHasMetadata returns HasMetadataArtifactResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
-func (v *HasMetadataArtifactResponse) GetIngestHasMetadata() HasMetadataArtifactIngestHasMetadata {
-	return v.IngestHasMetadata
-}
+func (v *HasMetadataArtifactResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
 
 // HasMetadataInputSpec represents the mutation input to ingest a CertifyGood evidence.
 type HasMetadataInputSpec struct {
@@ -8308,521 +5780,41 @@ func (v *HasMetadataInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns HasMetadataInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
 
-// HasMetadataPkgIngestHasMetadata includes the requested fields of the GraphQL type HasMetadata.
-// The GraphQL type's documentation follows.
-//
-// HasMetadata is an attestation that a package, source, or artifact has a certain
-// attested property (key) with value (value). For example, a source may have
-// metadata "SourceRepo2FAEnabled=true".
-//
-// The intent of this evidence tree predicate is to allow extensibility of metadata
-// expressible within the GUAC ontology. Metadata that is commonly used will then
-// be promoted to a predicate on its own.
-//
-// Justification indicates how the metadata was determined.
-//
-// The metadata applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type HasMetadataPkgIngestHasMetadata struct {
-	AllHasMetadata `json:"-"`
-}
-
-// GetId returns HasMetadataPkgIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
-
-// GetSubject returns HasMetadataPkgIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
-	return v.AllHasMetadata.Subject
-}
-
-// GetKey returns HasMetadataPkgIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
-
-// GetValue returns HasMetadataPkgIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
-
-// GetTimestamp returns HasMetadataPkgIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
-
-// GetJustification returns HasMetadataPkgIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetJustification() string {
-	return v.AllHasMetadata.Justification
-}
-
-// GetOrigin returns HasMetadataPkgIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
-
-// GetCollector returns HasMetadataPkgIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgIngestHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
-
-func (v *HasMetadataPkgIngestHasMetadata) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasMetadataPkgIngestHasMetadata
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasMetadataPkgIngestHasMetadata = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasMetadata)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasMetadataPkgIngestHasMetadata struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Key string `json:"key"`
-
-	Value string `json:"value"`
-
-	Timestamp time.Time `json:"timestamp"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasMetadataPkgIngestHasMetadata) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasMetadataPkgIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataPkgIngestHasMetadata, error) {
-	var retval __premarshalHasMetadataPkgIngestHasMetadata
-
-	retval.Id = v.AllHasMetadata.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasMetadata.Subject
-		var err error
-		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataPkgIngestHasMetadata.AllHasMetadata.Subject: %w", err)
-		}
-	}
-	retval.Key = v.AllHasMetadata.Key
-	retval.Value = v.AllHasMetadata.Value
-	retval.Timestamp = v.AllHasMetadata.Timestamp
-	retval.Justification = v.AllHasMetadata.Justification
-	retval.Origin = v.AllHasMetadata.Origin
-	retval.Collector = v.AllHasMetadata.Collector
-	return &retval, nil
-}
-
 // HasMetadataPkgResponse is returned by HasMetadataPkg on success.
 type HasMetadataPkgResponse struct {
 	// Adds metadata about a package, source or artifact.
-	IngestHasMetadata HasMetadataPkgIngestHasMetadata `json:"ingestHasMetadata"`
+	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
 // GetIngestHasMetadata returns HasMetadataPkgResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
-func (v *HasMetadataPkgResponse) GetIngestHasMetadata() HasMetadataPkgIngestHasMetadata {
-	return v.IngestHasMetadata
-}
-
-// HasMetadataSrcIngestHasMetadata includes the requested fields of the GraphQL type HasMetadata.
-// The GraphQL type's documentation follows.
-//
-// HasMetadata is an attestation that a package, source, or artifact has a certain
-// attested property (key) with value (value). For example, a source may have
-// metadata "SourceRepo2FAEnabled=true".
-//
-// The intent of this evidence tree predicate is to allow extensibility of metadata
-// expressible within the GUAC ontology. Metadata that is commonly used will then
-// be promoted to a predicate on its own.
-//
-// Justification indicates how the metadata was determined.
-//
-// The metadata applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-type HasMetadataSrcIngestHasMetadata struct {
-	AllHasMetadata `json:"-"`
-}
-
-// GetId returns HasMetadataSrcIngestHasMetadata.Id, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetId() string { return v.AllHasMetadata.Id }
-
-// GetSubject returns HasMetadataSrcIngestHasMetadata.Subject, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
-	return v.AllHasMetadata.Subject
-}
-
-// GetKey returns HasMetadataSrcIngestHasMetadata.Key, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
-
-// GetValue returns HasMetadataSrcIngestHasMetadata.Value, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
-
-// GetTimestamp returns HasMetadataSrcIngestHasMetadata.Timestamp, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
-
-// GetJustification returns HasMetadataSrcIngestHasMetadata.Justification, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetJustification() string {
-	return v.AllHasMetadata.Justification
-}
-
-// GetOrigin returns HasMetadataSrcIngestHasMetadata.Origin, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
-
-// GetCollector returns HasMetadataSrcIngestHasMetadata.Collector, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcIngestHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
-
-func (v *HasMetadataSrcIngestHasMetadata) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasMetadataSrcIngestHasMetadata
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasMetadataSrcIngestHasMetadata = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasMetadata)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasMetadataSrcIngestHasMetadata struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Key string `json:"key"`
-
-	Value string `json:"value"`
-
-	Timestamp time.Time `json:"timestamp"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasMetadataSrcIngestHasMetadata) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasMetadataSrcIngestHasMetadata) __premarshalJSON() (*__premarshalHasMetadataSrcIngestHasMetadata, error) {
-	var retval __premarshalHasMetadataSrcIngestHasMetadata
-
-	retval.Id = v.AllHasMetadata.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasMetadata.Subject
-		var err error
-		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasMetadataSrcIngestHasMetadata.AllHasMetadata.Subject: %w", err)
-		}
-	}
-	retval.Key = v.AllHasMetadata.Key
-	retval.Value = v.AllHasMetadata.Value
-	retval.Timestamp = v.AllHasMetadata.Timestamp
-	retval.Justification = v.AllHasMetadata.Justification
-	retval.Origin = v.AllHasMetadata.Origin
-	retval.Collector = v.AllHasMetadata.Collector
-	return &retval, nil
-}
+func (v *HasMetadataPkgResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
 
 // HasMetadataSrcResponse is returned by HasMetadataSrc on success.
 type HasMetadataSrcResponse struct {
 	// Adds metadata about a package, source or artifact.
-	IngestHasMetadata HasMetadataSrcIngestHasMetadata `json:"ingestHasMetadata"`
+	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
 // GetIngestHasMetadata returns HasMetadataSrcResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
-func (v *HasMetadataSrcResponse) GetIngestHasMetadata() HasMetadataSrcIngestHasMetadata {
-	return v.IngestHasMetadata
-}
-
-// HasSBOMArtifactIngestHasSBOM includes the requested fields of the GraphQL type HasSBOM.
-type HasSBOMArtifactIngestHasSBOM struct {
-	AllHasSBOMTree `json:"-"`
-}
-
-// GetId returns HasSBOMArtifactIngestHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
-
-// GetSubject returns HasSBOMArtifactIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
-	return v.AllHasSBOMTree.Subject
-}
-
-// GetUri returns HasSBOMArtifactIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
-
-// GetAlgorithm returns HasSBOMArtifactIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
-
-// GetDigest returns HasSBOMArtifactIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
-
-// GetDownloadLocation returns HasSBOMArtifactIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetDownloadLocation() string {
-	return v.AllHasSBOMTree.DownloadLocation
-}
-
-// GetOrigin returns HasSBOMArtifactIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
-
-// GetCollector returns HasSBOMArtifactIngestHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactIngestHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
-
-func (v *HasSBOMArtifactIngestHasSBOM) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasSBOMArtifactIngestHasSBOM
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasSBOMArtifactIngestHasSBOM = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasSBOMTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasSBOMArtifactIngestHasSBOM struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Uri string `json:"uri"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-
-	DownloadLocation string `json:"downloadLocation"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasSBOMArtifactIngestHasSBOM) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasSBOMArtifactIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMArtifactIngestHasSBOM, error) {
-	var retval __premarshalHasSBOMArtifactIngestHasSBOM
-
-	retval.Id = v.AllHasSBOMTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasSBOMTree.Subject
-		var err error
-		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMArtifactIngestHasSBOM.AllHasSBOMTree.Subject: %w", err)
-		}
-	}
-	retval.Uri = v.AllHasSBOMTree.Uri
-	retval.Algorithm = v.AllHasSBOMTree.Algorithm
-	retval.Digest = v.AllHasSBOMTree.Digest
-	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
-	retval.Origin = v.AllHasSBOMTree.Origin
-	retval.Collector = v.AllHasSBOMTree.Collector
-	return &retval, nil
-}
+func (v *HasMetadataSrcResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
 
 // HasSBOMArtifactResponse is returned by HasSBOMArtifact on success.
 type HasSBOMArtifactResponse struct {
 	// Certifies that a package or artifact has an SBOM.
-	IngestHasSBOM HasSBOMArtifactIngestHasSBOM `json:"ingestHasSBOM"`
+	IngestHasSBOM string `json:"ingestHasSBOM"`
 }
 
 // GetIngestHasSBOM returns HasSBOMArtifactResponse.IngestHasSBOM, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactResponse) GetIngestHasSBOM() HasSBOMArtifactIngestHasSBOM {
-	return v.IngestHasSBOM
-}
-
-// HasSBOMArtifactsIngestHasSBOMsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
-type HasSBOMArtifactsIngestHasSBOMsHasSBOM struct {
-	AllHasSBOMTree `json:"-"`
-}
-
-// GetId returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
-
-// GetSubject returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
-	return v.AllHasSBOMTree.Subject
-}
-
-// GetUri returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
-
-// GetAlgorithm returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetAlgorithm() string {
-	return v.AllHasSBOMTree.Algorithm
-}
-
-// GetDigest returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
-
-// GetDownloadLocation returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetDownloadLocation() string {
-	return v.AllHasSBOMTree.DownloadLocation
-}
-
-// GetOrigin returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
-
-// GetCollector returns HasSBOMArtifactsIngestHasSBOMsHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) GetCollector() string {
-	return v.AllHasSBOMTree.Collector
-}
-
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasSBOMArtifactsIngestHasSBOMsHasSBOM
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasSBOMArtifactsIngestHasSBOMsHasSBOM = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasSBOMTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasSBOMArtifactsIngestHasSBOMsHasSBOM struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Uri string `json:"uri"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-
-	DownloadLocation string `json:"downloadLocation"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasSBOMArtifactsIngestHasSBOMsHasSBOM) __premarshalJSON() (*__premarshalHasSBOMArtifactsIngestHasSBOMsHasSBOM, error) {
-	var retval __premarshalHasSBOMArtifactsIngestHasSBOMsHasSBOM
-
-	retval.Id = v.AllHasSBOMTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasSBOMTree.Subject
-		var err error
-		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMArtifactsIngestHasSBOMsHasSBOM.AllHasSBOMTree.Subject: %w", err)
-		}
-	}
-	retval.Uri = v.AllHasSBOMTree.Uri
-	retval.Algorithm = v.AllHasSBOMTree.Algorithm
-	retval.Digest = v.AllHasSBOMTree.Digest
-	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
-	retval.Origin = v.AllHasSBOMTree.Origin
-	retval.Collector = v.AllHasSBOMTree.Collector
-	return &retval, nil
-}
+func (v *HasSBOMArtifactResponse) GetIngestHasSBOM() string { return v.IngestHasSBOM }
 
 // HasSBOMArtifactsResponse is returned by HasSBOMArtifacts on success.
 type HasSBOMArtifactsResponse struct {
 	// Bulk ingest that package or artifact has an SBOM.
-	IngestHasSBOMs []HasSBOMArtifactsIngestHasSBOMsHasSBOM `json:"ingestHasSBOMs"`
+	IngestHasSBOMs []string `json:"ingestHasSBOMs"`
 }
 
 // GetIngestHasSBOMs returns HasSBOMArtifactsResponse.IngestHasSBOMs, and is useful for accessing the field via an interface.
-func (v *HasSBOMArtifactsResponse) GetIngestHasSBOMs() []HasSBOMArtifactsIngestHasSBOMsHasSBOM {
-	return v.IngestHasSBOMs
-}
+func (v *HasSBOMArtifactsResponse) GetIngestHasSBOMs() []string { return v.IngestHasSBOMs }
 
 // HasSBOMInputSpec is the same as HasSBOM but for mutation input.
 type HasSBOMInputSpec struct {
@@ -8852,340 +5844,23 @@ func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns HasSBOMInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
-// HasSBOMPkgIngestHasSBOM includes the requested fields of the GraphQL type HasSBOM.
-type HasSBOMPkgIngestHasSBOM struct {
-	AllHasSBOMTree `json:"-"`
-}
-
-// GetId returns HasSBOMPkgIngestHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
-
-// GetSubject returns HasSBOMPkgIngestHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
-	return v.AllHasSBOMTree.Subject
-}
-
-// GetUri returns HasSBOMPkgIngestHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
-
-// GetAlgorithm returns HasSBOMPkgIngestHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
-
-// GetDigest returns HasSBOMPkgIngestHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
-
-// GetDownloadLocation returns HasSBOMPkgIngestHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetDownloadLocation() string {
-	return v.AllHasSBOMTree.DownloadLocation
-}
-
-// GetOrigin returns HasSBOMPkgIngestHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
-
-// GetCollector returns HasSBOMPkgIngestHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgIngestHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
-
-func (v *HasSBOMPkgIngestHasSBOM) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasSBOMPkgIngestHasSBOM
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasSBOMPkgIngestHasSBOM = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasSBOMTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasSBOMPkgIngestHasSBOM struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Uri string `json:"uri"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-
-	DownloadLocation string `json:"downloadLocation"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasSBOMPkgIngestHasSBOM) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasSBOMPkgIngestHasSBOM) __premarshalJSON() (*__premarshalHasSBOMPkgIngestHasSBOM, error) {
-	var retval __premarshalHasSBOMPkgIngestHasSBOM
-
-	retval.Id = v.AllHasSBOMTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasSBOMTree.Subject
-		var err error
-		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMPkgIngestHasSBOM.AllHasSBOMTree.Subject: %w", err)
-		}
-	}
-	retval.Uri = v.AllHasSBOMTree.Uri
-	retval.Algorithm = v.AllHasSBOMTree.Algorithm
-	retval.Digest = v.AllHasSBOMTree.Digest
-	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
-	retval.Origin = v.AllHasSBOMTree.Origin
-	retval.Collector = v.AllHasSBOMTree.Collector
-	return &retval, nil
-}
-
 // HasSBOMPkgResponse is returned by HasSBOMPkg on success.
 type HasSBOMPkgResponse struct {
 	// Certifies that a package or artifact has an SBOM.
-	IngestHasSBOM HasSBOMPkgIngestHasSBOM `json:"ingestHasSBOM"`
+	IngestHasSBOM string `json:"ingestHasSBOM"`
 }
 
 // GetIngestHasSBOM returns HasSBOMPkgResponse.IngestHasSBOM, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgResponse) GetIngestHasSBOM() HasSBOMPkgIngestHasSBOM { return v.IngestHasSBOM }
-
-// HasSBOMPkgsIngestHasSBOMsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
-type HasSBOMPkgsIngestHasSBOMsHasSBOM struct {
-	AllHasSBOMTree `json:"-"`
-}
-
-// GetId returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Id, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
-
-// GetSubject returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Subject, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
-	return v.AllHasSBOMTree.Subject
-}
-
-// GetUri returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Uri, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
-
-// GetAlgorithm returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Algorithm, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
-
-// GetDigest returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Digest, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
-
-// GetDownloadLocation returns HasSBOMPkgsIngestHasSBOMsHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetDownloadLocation() string {
-	return v.AllHasSBOMTree.DownloadLocation
-}
-
-// GetOrigin returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Origin, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
-
-// GetCollector returns HasSBOMPkgsIngestHasSBOMsHasSBOM.Collector, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
-
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasSBOMPkgsIngestHasSBOMsHasSBOM
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasSBOMPkgsIngestHasSBOMsHasSBOM = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasSBOMTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasSBOMPkgsIngestHasSBOMsHasSBOM struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Uri string `json:"uri"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-
-	DownloadLocation string `json:"downloadLocation"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasSBOMPkgsIngestHasSBOMsHasSBOM) __premarshalJSON() (*__premarshalHasSBOMPkgsIngestHasSBOMsHasSBOM, error) {
-	var retval __premarshalHasSBOMPkgsIngestHasSBOMsHasSBOM
-
-	retval.Id = v.AllHasSBOMTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllHasSBOMTree.Subject
-		var err error
-		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal HasSBOMPkgsIngestHasSBOMsHasSBOM.AllHasSBOMTree.Subject: %w", err)
-		}
-	}
-	retval.Uri = v.AllHasSBOMTree.Uri
-	retval.Algorithm = v.AllHasSBOMTree.Algorithm
-	retval.Digest = v.AllHasSBOMTree.Digest
-	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
-	retval.Origin = v.AllHasSBOMTree.Origin
-	retval.Collector = v.AllHasSBOMTree.Collector
-	return &retval, nil
-}
+func (v *HasSBOMPkgResponse) GetIngestHasSBOM() string { return v.IngestHasSBOM }
 
 // HasSBOMPkgsResponse is returned by HasSBOMPkgs on success.
 type HasSBOMPkgsResponse struct {
 	// Bulk ingest that package or artifact has an SBOM.
-	IngestHasSBOMs []HasSBOMPkgsIngestHasSBOMsHasSBOM `json:"ingestHasSBOMs"`
+	IngestHasSBOMs []string `json:"ingestHasSBOMs"`
 }
 
 // GetIngestHasSBOMs returns HasSBOMPkgsResponse.IngestHasSBOMs, and is useful for accessing the field via an interface.
-func (v *HasSBOMPkgsResponse) GetIngestHasSBOMs() []HasSBOMPkgsIngestHasSBOMsHasSBOM {
-	return v.IngestHasSBOMs
-}
-
-// HasSourceAtIngestHasSourceAt includes the requested fields of the GraphQL type HasSourceAt.
-// The GraphQL type's documentation follows.
-//
-// HasSourceAt records that a package's repository is a given source.
-type HasSourceAtIngestHasSourceAt struct {
-	AllHasSourceAt `json:"-"`
-}
-
-// GetId returns HasSourceAtIngestHasSourceAt.Id, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetId() string { return v.AllHasSourceAt.Id }
-
-// GetJustification returns HasSourceAtIngestHasSourceAt.Justification, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetJustification() string {
-	return v.AllHasSourceAt.Justification
-}
-
-// GetKnownSince returns HasSourceAtIngestHasSourceAt.KnownSince, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetKnownSince() time.Time { return v.AllHasSourceAt.KnownSince }
-
-// GetPackage returns HasSourceAtIngestHasSourceAt.Package, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetPackage() AllHasSourceAtPackage {
-	return v.AllHasSourceAt.Package
-}
-
-// GetSource returns HasSourceAtIngestHasSourceAt.Source, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetSource() AllHasSourceAtSource {
-	return v.AllHasSourceAt.Source
-}
-
-// GetOrigin returns HasSourceAtIngestHasSourceAt.Origin, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetOrigin() string { return v.AllHasSourceAt.Origin }
-
-// GetCollector returns HasSourceAtIngestHasSourceAt.Collector, and is useful for accessing the field via an interface.
-func (v *HasSourceAtIngestHasSourceAt) GetCollector() string { return v.AllHasSourceAt.Collector }
-
-func (v *HasSourceAtIngestHasSourceAt) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HasSourceAtIngestHasSourceAt
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HasSourceAtIngestHasSourceAt = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHasSourceAt)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHasSourceAtIngestHasSourceAt struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	KnownSince time.Time `json:"knownSince"`
-
-	Package AllHasSourceAtPackage `json:"package"`
-
-	Source AllHasSourceAtSource `json:"source"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HasSourceAtIngestHasSourceAt) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HasSourceAtIngestHasSourceAt) __premarshalJSON() (*__premarshalHasSourceAtIngestHasSourceAt, error) {
-	var retval __premarshalHasSourceAtIngestHasSourceAt
-
-	retval.Id = v.AllHasSourceAt.Id
-	retval.Justification = v.AllHasSourceAt.Justification
-	retval.KnownSince = v.AllHasSourceAt.KnownSince
-	retval.Package = v.AllHasSourceAt.Package
-	retval.Source = v.AllHasSourceAt.Source
-	retval.Origin = v.AllHasSourceAt.Origin
-	retval.Collector = v.AllHasSourceAt.Collector
-	return &retval, nil
-}
+func (v *HasSBOMPkgsResponse) GetIngestHasSBOMs() []string { return v.IngestHasSBOMs }
 
 // HasSourceAtInputSpec is the same as HasSourceAt but for mutation input.
 type HasSourceAtInputSpec struct {
@@ -9210,94 +5885,11 @@ func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 // HasSourceAtResponse is returned by HasSourceAt on success.
 type HasSourceAtResponse struct {
 	// Adds a certification that a package (PackageName or PackageVersion) is built from the source.
-	IngestHasSourceAt HasSourceAtIngestHasSourceAt `json:"ingestHasSourceAt"`
+	IngestHasSourceAt string `json:"ingestHasSourceAt"`
 }
 
 // GetIngestHasSourceAt returns HasSourceAtResponse.IngestHasSourceAt, and is useful for accessing the field via an interface.
-func (v *HasSourceAtResponse) GetIngestHasSourceAt() HasSourceAtIngestHasSourceAt {
-	return v.IngestHasSourceAt
-}
-
-// HashEqualIngestHashEqual includes the requested fields of the GraphQL type HashEqual.
-// The GraphQL type's documentation follows.
-//
-// HashEqual is an attestation that a set of artifacts are identical.
-type HashEqualIngestHashEqual struct {
-	AllHashEqualTree `json:"-"`
-}
-
-// GetId returns HashEqualIngestHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetId() string { return v.AllHashEqualTree.Id }
-
-// GetJustification returns HashEqualIngestHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetJustification() string { return v.AllHashEqualTree.Justification }
-
-// GetArtifacts returns HashEqualIngestHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
-	return v.AllHashEqualTree.Artifacts
-}
-
-// GetOrigin returns HashEqualIngestHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
-
-// GetCollector returns HashEqualIngestHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *HashEqualIngestHashEqual) GetCollector() string { return v.AllHashEqualTree.Collector }
-
-func (v *HashEqualIngestHashEqual) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HashEqualIngestHashEqual
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HashEqualIngestHashEqual = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHashEqualTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHashEqualIngestHashEqual struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HashEqualIngestHashEqual) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HashEqualIngestHashEqual) __premarshalJSON() (*__premarshalHashEqualIngestHashEqual, error) {
-	var retval __premarshalHashEqualIngestHashEqual
-
-	retval.Id = v.AllHashEqualTree.Id
-	retval.Justification = v.AllHashEqualTree.Justification
-	retval.Artifacts = v.AllHashEqualTree.Artifacts
-	retval.Origin = v.AllHashEqualTree.Origin
-	retval.Collector = v.AllHashEqualTree.Collector
-	return &retval, nil
-}
+func (v *HasSourceAtResponse) GetIngestHasSourceAt() string { return v.IngestHasSourceAt }
 
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
@@ -9318,1132 +5910,121 @@ func (v *HashEqualInputSpec) GetCollector() string { return v.Collector }
 // HashEqualResponse is returned by HashEqual on success.
 type HashEqualResponse struct {
 	// Adds a certification that two artifacts are equal.
-	IngestHashEqual HashEqualIngestHashEqual `json:"ingestHashEqual"`
+	IngestHashEqual string `json:"ingestHashEqual"`
 }
 
 // GetIngestHashEqual returns HashEqualResponse.IngestHashEqual, and is useful for accessing the field via an interface.
-func (v *HashEqualResponse) GetIngestHashEqual() HashEqualIngestHashEqual { return v.IngestHashEqual }
-
-// HashEqualsIngestHashEqualsHashEqual includes the requested fields of the GraphQL type HashEqual.
-// The GraphQL type's documentation follows.
-//
-// HashEqual is an attestation that a set of artifacts are identical.
-type HashEqualsIngestHashEqualsHashEqual struct {
-	AllHashEqualTree `json:"-"`
-}
-
-// GetId returns HashEqualsIngestHashEqualsHashEqual.Id, and is useful for accessing the field via an interface.
-func (v *HashEqualsIngestHashEqualsHashEqual) GetId() string { return v.AllHashEqualTree.Id }
-
-// GetJustification returns HashEqualsIngestHashEqualsHashEqual.Justification, and is useful for accessing the field via an interface.
-func (v *HashEqualsIngestHashEqualsHashEqual) GetJustification() string {
-	return v.AllHashEqualTree.Justification
-}
-
-// GetArtifacts returns HashEqualsIngestHashEqualsHashEqual.Artifacts, and is useful for accessing the field via an interface.
-func (v *HashEqualsIngestHashEqualsHashEqual) GetArtifacts() []AllHashEqualTreeArtifactsArtifact {
-	return v.AllHashEqualTree.Artifacts
-}
-
-// GetOrigin returns HashEqualsIngestHashEqualsHashEqual.Origin, and is useful for accessing the field via an interface.
-func (v *HashEqualsIngestHashEqualsHashEqual) GetOrigin() string { return v.AllHashEqualTree.Origin }
-
-// GetCollector returns HashEqualsIngestHashEqualsHashEqual.Collector, and is useful for accessing the field via an interface.
-func (v *HashEqualsIngestHashEqualsHashEqual) GetCollector() string {
-	return v.AllHashEqualTree.Collector
-}
-
-func (v *HashEqualsIngestHashEqualsHashEqual) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*HashEqualsIngestHashEqualsHashEqual
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.HashEqualsIngestHashEqualsHashEqual = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllHashEqualTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalHashEqualsIngestHashEqualsHashEqual struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Artifacts []AllHashEqualTreeArtifactsArtifact `json:"artifacts"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *HashEqualsIngestHashEqualsHashEqual) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *HashEqualsIngestHashEqualsHashEqual) __premarshalJSON() (*__premarshalHashEqualsIngestHashEqualsHashEqual, error) {
-	var retval __premarshalHashEqualsIngestHashEqualsHashEqual
-
-	retval.Id = v.AllHashEqualTree.Id
-	retval.Justification = v.AllHashEqualTree.Justification
-	retval.Artifacts = v.AllHashEqualTree.Artifacts
-	retval.Origin = v.AllHashEqualTree.Origin
-	retval.Collector = v.AllHashEqualTree.Collector
-	return &retval, nil
-}
+func (v *HashEqualResponse) GetIngestHashEqual() string { return v.IngestHashEqual }
 
 // HashEqualsResponse is returned by HashEquals on success.
 type HashEqualsResponse struct {
 	// Bulk ingest certifications that two artifacts are equal.
-	IngestHashEquals []HashEqualsIngestHashEqualsHashEqual `json:"ingestHashEquals"`
+	IngestHashEquals []string `json:"ingestHashEquals"`
 }
 
 // GetIngestHashEquals returns HashEqualsResponse.IngestHashEquals, and is useful for accessing the field via an interface.
-func (v *HashEqualsResponse) GetIngestHashEquals() []HashEqualsIngestHashEqualsHashEqual {
-	return v.IngestHashEquals
-}
-
-// IngestArtifactIngestArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type IngestArtifactIngestArtifact struct {
-	AllArtifactTree `json:"-"`
-}
-
-// GetId returns IngestArtifactIngestArtifact.Id, and is useful for accessing the field via an interface.
-func (v *IngestArtifactIngestArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns IngestArtifactIngestArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *IngestArtifactIngestArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
-
-// GetDigest returns IngestArtifactIngestArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *IngestArtifactIngestArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *IngestArtifactIngestArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestArtifactIngestArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestArtifactIngestArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestArtifactIngestArtifact struct {
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *IngestArtifactIngestArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestArtifactIngestArtifact) __premarshalJSON() (*__premarshalIngestArtifactIngestArtifact, error) {
-	var retval __premarshalIngestArtifactIngestArtifact
-
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
+func (v *HashEqualsResponse) GetIngestHashEquals() []string { return v.IngestHashEquals }
 
 // IngestArtifactResponse is returned by IngestArtifact on success.
 type IngestArtifactResponse struct {
 	// Ingests a new artifact and returns it.
-	IngestArtifact IngestArtifactIngestArtifact `json:"ingestArtifact"`
+	IngestArtifact string `json:"ingestArtifact"`
 }
 
 // GetIngestArtifact returns IngestArtifactResponse.IngestArtifact, and is useful for accessing the field via an interface.
-func (v *IngestArtifactResponse) GetIngestArtifact() IngestArtifactIngestArtifact {
-	return v.IngestArtifact
-}
-
-// IngestArtifactsIngestArtifactsArtifact includes the requested fields of the GraphQL type Artifact.
-// The GraphQL type's documentation follows.
-//
-// Artifact represents an artifact identified by a checksum hash.
-//
-// The checksum is split into the digest value and the algorithm used to generate
-// it. Both fields are mandatory and canonicalized to be lowercase.
-//
-// If having a checksum Go object, algorithm can be
-// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
-type IngestArtifactsIngestArtifactsArtifact struct {
-	AllArtifactTree `json:"-"`
-}
-
-// GetId returns IngestArtifactsIngestArtifactsArtifact.Id, and is useful for accessing the field via an interface.
-func (v *IngestArtifactsIngestArtifactsArtifact) GetId() string { return v.AllArtifactTree.Id }
-
-// GetAlgorithm returns IngestArtifactsIngestArtifactsArtifact.Algorithm, and is useful for accessing the field via an interface.
-func (v *IngestArtifactsIngestArtifactsArtifact) GetAlgorithm() string {
-	return v.AllArtifactTree.Algorithm
-}
-
-// GetDigest returns IngestArtifactsIngestArtifactsArtifact.Digest, and is useful for accessing the field via an interface.
-func (v *IngestArtifactsIngestArtifactsArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
-
-func (v *IngestArtifactsIngestArtifactsArtifact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestArtifactsIngestArtifactsArtifact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestArtifactsIngestArtifactsArtifact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllArtifactTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestArtifactsIngestArtifactsArtifact struct {
-	Id string `json:"id"`
-
-	Algorithm string `json:"algorithm"`
-
-	Digest string `json:"digest"`
-}
-
-func (v *IngestArtifactsIngestArtifactsArtifact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestArtifactsIngestArtifactsArtifact) __premarshalJSON() (*__premarshalIngestArtifactsIngestArtifactsArtifact, error) {
-	var retval __premarshalIngestArtifactsIngestArtifactsArtifact
-
-	retval.Id = v.AllArtifactTree.Id
-	retval.Algorithm = v.AllArtifactTree.Algorithm
-	retval.Digest = v.AllArtifactTree.Digest
-	return &retval, nil
-}
+func (v *IngestArtifactResponse) GetIngestArtifact() string { return v.IngestArtifact }
 
 // IngestArtifactsResponse is returned by IngestArtifacts on success.
 type IngestArtifactsResponse struct {
 	// Bulk ingests new artifacts and returns a list of them.
-	IngestArtifacts []IngestArtifactsIngestArtifactsArtifact `json:"ingestArtifacts"`
+	IngestArtifacts []string `json:"ingestArtifacts"`
 }
 
 // GetIngestArtifacts returns IngestArtifactsResponse.IngestArtifacts, and is useful for accessing the field via an interface.
-func (v *IngestArtifactsResponse) GetIngestArtifacts() []IngestArtifactsIngestArtifactsArtifact {
-	return v.IngestArtifacts
-}
-
-// IngestBuilderIngestBuilder includes the requested fields of the GraphQL type Builder.
-// The GraphQL type's documentation follows.
-//
-// Builder represents the builder (e.g., FRSCA or GitHub Actions).
-//
-// Currently builders are identified by the uri field.
-type IngestBuilderIngestBuilder struct {
-	Uri string `json:"uri"`
-}
-
-// GetUri returns IngestBuilderIngestBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *IngestBuilderIngestBuilder) GetUri() string { return v.Uri }
+func (v *IngestArtifactsResponse) GetIngestArtifacts() []string { return v.IngestArtifacts }
 
 // IngestBuilderResponse is returned by IngestBuilder on success.
 type IngestBuilderResponse struct {
 	// Ingests a new builder and returns it.
-	IngestBuilder IngestBuilderIngestBuilder `json:"ingestBuilder"`
+	IngestBuilder string `json:"ingestBuilder"`
 }
 
 // GetIngestBuilder returns IngestBuilderResponse.IngestBuilder, and is useful for accessing the field via an interface.
-func (v *IngestBuilderResponse) GetIngestBuilder() IngestBuilderIngestBuilder { return v.IngestBuilder }
-
-// IngestBuildersIngestBuildersBuilder includes the requested fields of the GraphQL type Builder.
-// The GraphQL type's documentation follows.
-//
-// Builder represents the builder (e.g., FRSCA or GitHub Actions).
-//
-// Currently builders are identified by the uri field.
-type IngestBuildersIngestBuildersBuilder struct {
-	Uri string `json:"uri"`
-}
-
-// GetUri returns IngestBuildersIngestBuildersBuilder.Uri, and is useful for accessing the field via an interface.
-func (v *IngestBuildersIngestBuildersBuilder) GetUri() string { return v.Uri }
+func (v *IngestBuilderResponse) GetIngestBuilder() string { return v.IngestBuilder }
 
 // IngestBuildersResponse is returned by IngestBuilders on success.
 type IngestBuildersResponse struct {
 	// Bulk ingests new builders and returns a list of them.
-	IngestBuilders []IngestBuildersIngestBuildersBuilder `json:"ingestBuilders"`
+	IngestBuilders []string `json:"ingestBuilders"`
 }
 
 // GetIngestBuilders returns IngestBuildersResponse.IngestBuilders, and is useful for accessing the field via an interface.
-func (v *IngestBuildersResponse) GetIngestBuilders() []IngestBuildersIngestBuildersBuilder {
-	return v.IngestBuilders
-}
-
-// IngestPackageIngestPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type IngestPackageIngestPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns IngestPackageIngestPackage.Id, and is useful for accessing the field via an interface.
-func (v *IngestPackageIngestPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns IngestPackageIngestPackage.Type, and is useful for accessing the field via an interface.
-func (v *IngestPackageIngestPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns IngestPackageIngestPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *IngestPackageIngestPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *IngestPackageIngestPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestPackageIngestPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestPackageIngestPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestPackageIngestPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *IngestPackageIngestPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestPackageIngestPackage) __premarshalJSON() (*__premarshalIngestPackageIngestPackage, error) {
-	var retval __premarshalIngestPackageIngestPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
+func (v *IngestBuildersResponse) GetIngestBuilders() []string { return v.IngestBuilders }
 
 // IngestPackageResponse is returned by IngestPackage on success.
 type IngestPackageResponse struct {
 	// Ingests a new package and returns the corresponding package trie path.
-	IngestPackage IngestPackageIngestPackage `json:"ingestPackage"`
+	IngestPackage string `json:"ingestPackage"`
 }
 
 // GetIngestPackage returns IngestPackageResponse.IngestPackage, and is useful for accessing the field via an interface.
-func (v *IngestPackageResponse) GetIngestPackage() IngestPackageIngestPackage { return v.IngestPackage }
-
-// IngestPackagesIngestPackagesPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type IngestPackagesIngestPackagesPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns IngestPackagesIngestPackagesPackage.Id, and is useful for accessing the field via an interface.
-func (v *IngestPackagesIngestPackagesPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns IngestPackagesIngestPackagesPackage.Type, and is useful for accessing the field via an interface.
-func (v *IngestPackagesIngestPackagesPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns IngestPackagesIngestPackagesPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *IngestPackagesIngestPackagesPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *IngestPackagesIngestPackagesPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestPackagesIngestPackagesPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestPackagesIngestPackagesPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestPackagesIngestPackagesPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *IngestPackagesIngestPackagesPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestPackagesIngestPackagesPackage) __premarshalJSON() (*__premarshalIngestPackagesIngestPackagesPackage, error) {
-	var retval __premarshalIngestPackagesIngestPackagesPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
+func (v *IngestPackageResponse) GetIngestPackage() string { return v.IngestPackage }
 
 // IngestPackagesResponse is returned by IngestPackages on success.
 type IngestPackagesResponse struct {
 	// Bulk ingests packages and returns the list of corresponding package trie path.
-	IngestPackages []IngestPackagesIngestPackagesPackage `json:"ingestPackages"`
+	IngestPackages []string `json:"ingestPackages"`
 }
 
 // GetIngestPackages returns IngestPackagesResponse.IngestPackages, and is useful for accessing the field via an interface.
-func (v *IngestPackagesResponse) GetIngestPackages() []IngestPackagesIngestPackagesPackage {
-	return v.IngestPackages
-}
-
-// IngestSourceIngestSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type IngestSourceIngestSource struct {
-	AllSourceTree `json:"-"`
-}
-
-// GetId returns IngestSourceIngestSource.Id, and is useful for accessing the field via an interface.
-func (v *IngestSourceIngestSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns IngestSourceIngestSource.Type, and is useful for accessing the field via an interface.
-func (v *IngestSourceIngestSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns IngestSourceIngestSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *IngestSourceIngestSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *IngestSourceIngestSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestSourceIngestSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestSourceIngestSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestSourceIngestSource struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *IngestSourceIngestSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestSourceIngestSource) __premarshalJSON() (*__premarshalIngestSourceIngestSource, error) {
-	var retval __premarshalIngestSourceIngestSource
-
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
+func (v *IngestPackagesResponse) GetIngestPackages() []string { return v.IngestPackages }
 
 // IngestSourceResponse is returned by IngestSource on success.
 type IngestSourceResponse struct {
 	// Ingests a new source and returns the corresponding source trie path.
-	IngestSource IngestSourceIngestSource `json:"ingestSource"`
+	IngestSource string `json:"ingestSource"`
 }
 
 // GetIngestSource returns IngestSourceResponse.IngestSource, and is useful for accessing the field via an interface.
-func (v *IngestSourceResponse) GetIngestSource() IngestSourceIngestSource { return v.IngestSource }
-
-// IngestSourcesIngestSourcesSource includes the requested fields of the GraphQL type Source.
-// The GraphQL type's documentation follows.
-//
-// Source represents the root of the source trie/tree.
-//
-// We map source information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type, namespace, name and an optional
-// qualifier that stands for tag/commit information.
-//
-// This node represents the type part of the trie path. It is used to represent
-// the version control system that is being used.
-//
-// Since this node is at the root of the source trie, it is named Source, not
-// SourceType.
-type IngestSourcesIngestSourcesSource struct {
-	AllSourceTree `json:"-"`
-}
-
-// GetId returns IngestSourcesIngestSourcesSource.Id, and is useful for accessing the field via an interface.
-func (v *IngestSourcesIngestSourcesSource) GetId() string { return v.AllSourceTree.Id }
-
-// GetType returns IngestSourcesIngestSourcesSource.Type, and is useful for accessing the field via an interface.
-func (v *IngestSourcesIngestSourcesSource) GetType() string { return v.AllSourceTree.Type }
-
-// GetNamespaces returns IngestSourcesIngestSourcesSource.Namespaces, and is useful for accessing the field via an interface.
-func (v *IngestSourcesIngestSourcesSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
-	return v.AllSourceTree.Namespaces
-}
-
-func (v *IngestSourcesIngestSourcesSource) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestSourcesIngestSourcesSource
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestSourcesIngestSourcesSource = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSourceTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestSourcesIngestSourcesSource struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
-}
-
-func (v *IngestSourcesIngestSourcesSource) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestSourcesIngestSourcesSource) __premarshalJSON() (*__premarshalIngestSourcesIngestSourcesSource, error) {
-	var retval __premarshalIngestSourcesIngestSourcesSource
-
-	retval.Id = v.AllSourceTree.Id
-	retval.Type = v.AllSourceTree.Type
-	retval.Namespaces = v.AllSourceTree.Namespaces
-	return &retval, nil
-}
+func (v *IngestSourceResponse) GetIngestSource() string { return v.IngestSource }
 
 // IngestSourcesResponse is returned by IngestSources on success.
 type IngestSourcesResponse struct {
 	// Bulk ingests sources and returns the list of corresponding source trie path.
-	IngestSources []IngestSourcesIngestSourcesSource `json:"ingestSources"`
+	IngestSources []string `json:"ingestSources"`
 }
 
 // GetIngestSources returns IngestSourcesResponse.IngestSources, and is useful for accessing the field via an interface.
-func (v *IngestSourcesResponse) GetIngestSources() []IngestSourcesIngestSourcesSource {
-	return v.IngestSources
-}
-
-// IngestVulnerabilitiesIngestVulnerabilitiesVulnerability includes the requested fields of the GraphQL type Vulnerability.
-// The GraphQL type's documentation follows.
-//
-// Vulnerability represents the root of the vulnerability trie/tree.
-//
-// We map vulnerability information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type and a vulnerability ID. This allows for generic
-// representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
-// This would be in the general format: vuln://<general-type>/<vuln-id>
-//
-// Examples:
-//
-// CVE, using path separator: vuln://cve/cve-2023-20753
-// OSV, representing its knowledge of a GHSA: vuln://osv/ghsa-205hk
-// Random vendor: vuln://snyk/sn-whatever
-// NoVuln: vuln://novuln/
-//
-// This node represents the type part of the trie path. It is used to represent
-// the specific type of the vulnerability: cve, ghsa, osv or some other vendor specific
-//
-// Since this node is at the root of the vulnerability trie, it is named Vulnerability, not
-// VulnerabilityType.
-//
-// NoVuln is a special vulnerability node to attest that no vulnerability has been
-// found during a vulnerability scan. It will have the type "novuln" and contain an empty string
-// for vulnerabilityID
-//
-// The resolvers will enforce that both the type and vulnerability IDs are lower case.
-type IngestVulnerabilitiesIngestVulnerabilitiesVulnerability struct {
-	AllVulnerabilityTree `json:"-"`
-}
-
-// GetId returns IngestVulnerabilitiesIngestVulnerabilitiesVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) GetId() string {
-	return v.AllVulnerabilityTree.Id
-}
-
-// GetType returns IngestVulnerabilitiesIngestVulnerabilitiesVulnerability.Type, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) GetType() string {
-	return v.AllVulnerabilityTree.Type
-}
-
-// GetVulnerabilityIDs returns IngestVulnerabilitiesIngestVulnerabilitiesVulnerability.VulnerabilityIDs, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) GetVulnerabilityIDs() []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID {
-	return v.AllVulnerabilityTree.VulnerabilityIDs
-}
-
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestVulnerabilitiesIngestVulnerabilitiesVulnerability
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestVulnerabilitiesIngestVulnerabilitiesVulnerability = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllVulnerabilityTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestVulnerabilitiesIngestVulnerabilitiesVulnerability struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	VulnerabilityIDs []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID `json:"vulnerabilityIDs"`
-}
-
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestVulnerabilitiesIngestVulnerabilitiesVulnerability) __premarshalJSON() (*__premarshalIngestVulnerabilitiesIngestVulnerabilitiesVulnerability, error) {
-	var retval __premarshalIngestVulnerabilitiesIngestVulnerabilitiesVulnerability
-
-	retval.Id = v.AllVulnerabilityTree.Id
-	retval.Type = v.AllVulnerabilityTree.Type
-	retval.VulnerabilityIDs = v.AllVulnerabilityTree.VulnerabilityIDs
-	return &retval, nil
-}
+func (v *IngestSourcesResponse) GetIngestSources() []string { return v.IngestSources }
 
 // IngestVulnerabilitiesResponse is returned by IngestVulnerabilities on success.
 type IngestVulnerabilitiesResponse struct {
 	// Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path.
-	IngestVulnerabilities []IngestVulnerabilitiesIngestVulnerabilitiesVulnerability `json:"ingestVulnerabilities"`
+	IngestVulnerabilities []string `json:"ingestVulnerabilities"`
 }
 
 // GetIngestVulnerabilities returns IngestVulnerabilitiesResponse.IngestVulnerabilities, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilitiesResponse) GetIngestVulnerabilities() []IngestVulnerabilitiesIngestVulnerabilitiesVulnerability {
+func (v *IngestVulnerabilitiesResponse) GetIngestVulnerabilities() []string {
 	return v.IngestVulnerabilities
-}
-
-// IngestVulnerabilityIngestVulnerability includes the requested fields of the GraphQL type Vulnerability.
-// The GraphQL type's documentation follows.
-//
-// Vulnerability represents the root of the vulnerability trie/tree.
-//
-// We map vulnerability information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type and a vulnerability ID. This allows for generic
-// representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
-// This would be in the general format: vuln://<general-type>/<vuln-id>
-//
-// Examples:
-//
-// CVE, using path separator: vuln://cve/cve-2023-20753
-// OSV, representing its knowledge of a GHSA: vuln://osv/ghsa-205hk
-// Random vendor: vuln://snyk/sn-whatever
-// NoVuln: vuln://novuln/
-//
-// This node represents the type part of the trie path. It is used to represent
-// the specific type of the vulnerability: cve, ghsa, osv or some other vendor specific
-//
-// Since this node is at the root of the vulnerability trie, it is named Vulnerability, not
-// VulnerabilityType.
-//
-// NoVuln is a special vulnerability node to attest that no vulnerability has been
-// found during a vulnerability scan. It will have the type "novuln" and contain an empty string
-// for vulnerabilityID
-//
-// The resolvers will enforce that both the type and vulnerability IDs are lower case.
-type IngestVulnerabilityIngestVulnerability struct {
-	AllVulnerabilityTree `json:"-"`
-}
-
-// GetId returns IngestVulnerabilityIngestVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilityIngestVulnerability) GetId() string { return v.AllVulnerabilityTree.Id }
-
-// GetType returns IngestVulnerabilityIngestVulnerability.Type, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilityIngestVulnerability) GetType() string { return v.AllVulnerabilityTree.Type }
-
-// GetVulnerabilityIDs returns IngestVulnerabilityIngestVulnerability.VulnerabilityIDs, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilityIngestVulnerability) GetVulnerabilityIDs() []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID {
-	return v.AllVulnerabilityTree.VulnerabilityIDs
-}
-
-func (v *IngestVulnerabilityIngestVulnerability) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IngestVulnerabilityIngestVulnerability
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IngestVulnerabilityIngestVulnerability = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllVulnerabilityTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIngestVulnerabilityIngestVulnerability struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	VulnerabilityIDs []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID `json:"vulnerabilityIDs"`
-}
-
-func (v *IngestVulnerabilityIngestVulnerability) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IngestVulnerabilityIngestVulnerability) __premarshalJSON() (*__premarshalIngestVulnerabilityIngestVulnerability, error) {
-	var retval __premarshalIngestVulnerabilityIngestVulnerability
-
-	retval.Id = v.AllVulnerabilityTree.Id
-	retval.Type = v.AllVulnerabilityTree.Type
-	retval.VulnerabilityIDs = v.AllVulnerabilityTree.VulnerabilityIDs
-	return &retval, nil
 }
 
 // IngestVulnerabilityResponse is returned by IngestVulnerability on success.
 type IngestVulnerabilityResponse struct {
 	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
-	IngestVulnerability IngestVulnerabilityIngestVulnerability `json:"ingestVulnerability"`
+	IngestVulnerability string `json:"ingestVulnerability"`
 }
 
 // GetIngestVulnerability returns IngestVulnerabilityResponse.IngestVulnerability, and is useful for accessing the field via an interface.
-func (v *IngestVulnerabilityResponse) GetIngestVulnerability() IngestVulnerabilityIngestVulnerability {
-	return v.IngestVulnerability
-}
-
-// IsDependenciesIngestDependenciesIsDependency includes the requested fields of the GraphQL type IsDependency.
-// The GraphQL type's documentation follows.
-//
-// IsDependency is an attestation to record that a package depends on another.
-type IsDependenciesIngestDependenciesIsDependency struct {
-	AllIsDependencyTree `json:"-"`
-}
-
-// GetId returns IsDependenciesIngestDependenciesIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetId() string {
-	return v.AllIsDependencyTree.Id
-}
-
-// GetJustification returns IsDependenciesIngestDependenciesIsDependency.Justification, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetJustification() string {
-	return v.AllIsDependencyTree.Justification
-}
-
-// GetPackage returns IsDependenciesIngestDependenciesIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetPackage() AllIsDependencyTreePackage {
-	return v.AllIsDependencyTree.Package
-}
-
-// GetDependentPackage returns IsDependenciesIngestDependenciesIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
-	return v.AllIsDependencyTree.DependentPackage
-}
-
-// GetDependencyType returns IsDependenciesIngestDependenciesIsDependency.DependencyType, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetDependencyType() DependencyType {
-	return v.AllIsDependencyTree.DependencyType
-}
-
-// GetVersionRange returns IsDependenciesIngestDependenciesIsDependency.VersionRange, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetVersionRange() string {
-	return v.AllIsDependencyTree.VersionRange
-}
-
-// GetOrigin returns IsDependenciesIngestDependenciesIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetOrigin() string {
-	return v.AllIsDependencyTree.Origin
-}
-
-// GetCollector returns IsDependenciesIngestDependenciesIsDependency.Collector, and is useful for accessing the field via an interface.
-func (v *IsDependenciesIngestDependenciesIsDependency) GetCollector() string {
-	return v.AllIsDependencyTree.Collector
-}
-
-func (v *IsDependenciesIngestDependenciesIsDependency) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsDependenciesIngestDependenciesIsDependency
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsDependenciesIngestDependenciesIsDependency = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsDependencyTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsDependenciesIngestDependenciesIsDependency struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Package AllIsDependencyTreePackage `json:"package"`
-
-	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
-
-	DependencyType DependencyType `json:"dependencyType"`
-
-	VersionRange string `json:"versionRange"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsDependenciesIngestDependenciesIsDependency) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsDependenciesIngestDependenciesIsDependency) __premarshalJSON() (*__premarshalIsDependenciesIngestDependenciesIsDependency, error) {
-	var retval __premarshalIsDependenciesIngestDependenciesIsDependency
-
-	retval.Id = v.AllIsDependencyTree.Id
-	retval.Justification = v.AllIsDependencyTree.Justification
-	retval.Package = v.AllIsDependencyTree.Package
-	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
-	retval.DependencyType = v.AllIsDependencyTree.DependencyType
-	retval.VersionRange = v.AllIsDependencyTree.VersionRange
-	retval.Origin = v.AllIsDependencyTree.Origin
-	retval.Collector = v.AllIsDependencyTree.Collector
-	return &retval, nil
-}
+func (v *IngestVulnerabilityResponse) GetIngestVulnerability() string { return v.IngestVulnerability }
 
 // IsDependenciesResponse is returned by IsDependencies on success.
 type IsDependenciesResponse struct {
 	// Bulk adds a dependency between two packages
-	IngestDependencies []IsDependenciesIngestDependenciesIsDependency `json:"ingestDependencies"`
+	IngestDependencies []string `json:"ingestDependencies"`
 }
 
 // GetIngestDependencies returns IsDependenciesResponse.IngestDependencies, and is useful for accessing the field via an interface.
-func (v *IsDependenciesResponse) GetIngestDependencies() []IsDependenciesIngestDependenciesIsDependency {
-	return v.IngestDependencies
-}
-
-// IsDependencyIngestDependencyIsDependency includes the requested fields of the GraphQL type IsDependency.
-// The GraphQL type's documentation follows.
-//
-// IsDependency is an attestation to record that a package depends on another.
-type IsDependencyIngestDependencyIsDependency struct {
-	AllIsDependencyTree `json:"-"`
-}
-
-// GetId returns IsDependencyIngestDependencyIsDependency.Id, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetId() string { return v.AllIsDependencyTree.Id }
-
-// GetJustification returns IsDependencyIngestDependencyIsDependency.Justification, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetJustification() string {
-	return v.AllIsDependencyTree.Justification
-}
-
-// GetPackage returns IsDependencyIngestDependencyIsDependency.Package, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetPackage() AllIsDependencyTreePackage {
-	return v.AllIsDependencyTree.Package
-}
-
-// GetDependentPackage returns IsDependencyIngestDependencyIsDependency.DependentPackage, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetDependentPackage() AllIsDependencyTreeDependentPackage {
-	return v.AllIsDependencyTree.DependentPackage
-}
-
-// GetDependencyType returns IsDependencyIngestDependencyIsDependency.DependencyType, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetDependencyType() DependencyType {
-	return v.AllIsDependencyTree.DependencyType
-}
-
-// GetVersionRange returns IsDependencyIngestDependencyIsDependency.VersionRange, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetVersionRange() string {
-	return v.AllIsDependencyTree.VersionRange
-}
-
-// GetOrigin returns IsDependencyIngestDependencyIsDependency.Origin, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetOrigin() string {
-	return v.AllIsDependencyTree.Origin
-}
-
-// GetCollector returns IsDependencyIngestDependencyIsDependency.Collector, and is useful for accessing the field via an interface.
-func (v *IsDependencyIngestDependencyIsDependency) GetCollector() string {
-	return v.AllIsDependencyTree.Collector
-}
-
-func (v *IsDependencyIngestDependencyIsDependency) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsDependencyIngestDependencyIsDependency
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsDependencyIngestDependencyIsDependency = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsDependencyTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsDependencyIngestDependencyIsDependency struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Package AllIsDependencyTreePackage `json:"package"`
-
-	DependentPackage AllIsDependencyTreeDependentPackage `json:"dependentPackage"`
-
-	DependencyType DependencyType `json:"dependencyType"`
-
-	VersionRange string `json:"versionRange"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsDependencyIngestDependencyIsDependency) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsDependencyIngestDependencyIsDependency) __premarshalJSON() (*__premarshalIsDependencyIngestDependencyIsDependency, error) {
-	var retval __premarshalIsDependencyIngestDependencyIsDependency
-
-	retval.Id = v.AllIsDependencyTree.Id
-	retval.Justification = v.AllIsDependencyTree.Justification
-	retval.Package = v.AllIsDependencyTree.Package
-	retval.DependentPackage = v.AllIsDependencyTree.DependentPackage
-	retval.DependencyType = v.AllIsDependencyTree.DependencyType
-	retval.VersionRange = v.AllIsDependencyTree.VersionRange
-	retval.Origin = v.AllIsDependencyTree.Origin
-	retval.Collector = v.AllIsDependencyTree.Collector
-	return &retval, nil
-}
+func (v *IsDependenciesResponse) GetIngestDependencies() []string { return v.IngestDependencies }
 
 // IsDependencyInputSpec is the input to record a new dependency.
 type IsDependencyInputSpec struct {
@@ -10473,13 +6054,11 @@ func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
 // IsDependencyResponse is returned by IsDependency on success.
 type IsDependencyResponse struct {
 	// Adds a dependency between two packages
-	IngestDependency IsDependencyIngestDependencyIsDependency `json:"ingestDependency"`
+	IngestDependency string `json:"ingestDependency"`
 }
 
 // GetIngestDependency returns IsDependencyResponse.IngestDependency, and is useful for accessing the field via an interface.
-func (v *IsDependencyResponse) GetIngestDependency() IsDependencyIngestDependencyIsDependency {
-	return v.IngestDependency
-}
+func (v *IsDependencyResponse) GetIngestDependency() string { return v.IngestDependency }
 
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
@@ -10497,489 +6076,41 @@ func (v *IsOccurrenceInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns IsOccurrenceInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *IsOccurrenceInputSpec) GetCollector() string { return v.Collector }
 
-// IsOccurrencePkgIngestOccurrenceIsOccurrence includes the requested fields of the GraphQL type IsOccurrence.
-// The GraphQL type's documentation follows.
-//
-// IsOccurrence is an attestation to link an artifact to a package or source.
-//
-// Attestation must occur at the PackageVersion or at the SourceName.
-type IsOccurrencePkgIngestOccurrenceIsOccurrence struct {
-	AllIsOccurrencesTree `json:"-"`
-}
-
-// GetId returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Id, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetId() string {
-	return v.AllIsOccurrencesTree.Id
-}
-
-// GetSubject returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Subject, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetSubject() AllIsOccurrencesTreeSubjectPackageOrSource {
-	return v.AllIsOccurrencesTree.Subject
-}
-
-// GetArtifact returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Artifact, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetArtifact() AllIsOccurrencesTreeArtifact {
-	return v.AllIsOccurrencesTree.Artifact
-}
-
-// GetJustification returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Justification, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetJustification() string {
-	return v.AllIsOccurrencesTree.Justification
-}
-
-// GetOrigin returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Origin, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetOrigin() string {
-	return v.AllIsOccurrencesTree.Origin
-}
-
-// GetCollector returns IsOccurrencePkgIngestOccurrenceIsOccurrence.Collector, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) GetCollector() string {
-	return v.AllIsOccurrencesTree.Collector
-}
-
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsOccurrencePkgIngestOccurrenceIsOccurrence
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsOccurrencePkgIngestOccurrenceIsOccurrence = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsOccurrencesTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Artifact AllIsOccurrencesTreeArtifact `json:"artifact"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsOccurrencePkgIngestOccurrenceIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence, error) {
-	var retval __premarshalIsOccurrencePkgIngestOccurrenceIsOccurrence
-
-	retval.Id = v.AllIsOccurrencesTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllIsOccurrencesTree.Subject
-		var err error
-		*dst, err = __marshalAllIsOccurrencesTreeSubjectPackageOrSource(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal IsOccurrencePkgIngestOccurrenceIsOccurrence.AllIsOccurrencesTree.Subject: %w", err)
-		}
-	}
-	retval.Artifact = v.AllIsOccurrencesTree.Artifact
-	retval.Justification = v.AllIsOccurrencesTree.Justification
-	retval.Origin = v.AllIsOccurrencesTree.Origin
-	retval.Collector = v.AllIsOccurrencesTree.Collector
-	return &retval, nil
-}
-
 // IsOccurrencePkgResponse is returned by IsOccurrencePkg on success.
 type IsOccurrencePkgResponse struct {
 	// Ingest that an artifact is produced from a package or source.
-	IngestOccurrence IsOccurrencePkgIngestOccurrenceIsOccurrence `json:"ingestOccurrence"`
+	IngestOccurrence string `json:"ingestOccurrence"`
 }
 
 // GetIngestOccurrence returns IsOccurrencePkgResponse.IngestOccurrence, and is useful for accessing the field via an interface.
-func (v *IsOccurrencePkgResponse) GetIngestOccurrence() IsOccurrencePkgIngestOccurrenceIsOccurrence {
-	return v.IngestOccurrence
-}
-
-// IsOccurrenceSrcIngestOccurrenceIsOccurrence includes the requested fields of the GraphQL type IsOccurrence.
-// The GraphQL type's documentation follows.
-//
-// IsOccurrence is an attestation to link an artifact to a package or source.
-//
-// Attestation must occur at the PackageVersion or at the SourceName.
-type IsOccurrenceSrcIngestOccurrenceIsOccurrence struct {
-	AllIsOccurrencesTree `json:"-"`
-}
-
-// GetId returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Id, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetId() string {
-	return v.AllIsOccurrencesTree.Id
-}
-
-// GetSubject returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Subject, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetSubject() AllIsOccurrencesTreeSubjectPackageOrSource {
-	return v.AllIsOccurrencesTree.Subject
-}
-
-// GetArtifact returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Artifact, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetArtifact() AllIsOccurrencesTreeArtifact {
-	return v.AllIsOccurrencesTree.Artifact
-}
-
-// GetJustification returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Justification, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetJustification() string {
-	return v.AllIsOccurrencesTree.Justification
-}
-
-// GetOrigin returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Origin, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetOrigin() string {
-	return v.AllIsOccurrencesTree.Origin
-}
-
-// GetCollector returns IsOccurrenceSrcIngestOccurrenceIsOccurrence.Collector, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) GetCollector() string {
-	return v.AllIsOccurrencesTree.Collector
-}
-
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsOccurrenceSrcIngestOccurrenceIsOccurrence
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsOccurrenceSrcIngestOccurrenceIsOccurrence = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsOccurrencesTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Artifact AllIsOccurrencesTreeArtifact `json:"artifact"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsOccurrenceSrcIngestOccurrenceIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence, error) {
-	var retval __premarshalIsOccurrenceSrcIngestOccurrenceIsOccurrence
-
-	retval.Id = v.AllIsOccurrencesTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllIsOccurrencesTree.Subject
-		var err error
-		*dst, err = __marshalAllIsOccurrencesTreeSubjectPackageOrSource(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal IsOccurrenceSrcIngestOccurrenceIsOccurrence.AllIsOccurrencesTree.Subject: %w", err)
-		}
-	}
-	retval.Artifact = v.AllIsOccurrencesTree.Artifact
-	retval.Justification = v.AllIsOccurrencesTree.Justification
-	retval.Origin = v.AllIsOccurrencesTree.Origin
-	retval.Collector = v.AllIsOccurrencesTree.Collector
-	return &retval, nil
-}
+func (v *IsOccurrencePkgResponse) GetIngestOccurrence() string { return v.IngestOccurrence }
 
 // IsOccurrenceSrcResponse is returned by IsOccurrenceSrc on success.
 type IsOccurrenceSrcResponse struct {
 	// Ingest that an artifact is produced from a package or source.
-	IngestOccurrence IsOccurrenceSrcIngestOccurrenceIsOccurrence `json:"ingestOccurrence"`
+	IngestOccurrence string `json:"ingestOccurrence"`
 }
 
 // GetIngestOccurrence returns IsOccurrenceSrcResponse.IngestOccurrence, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceSrcResponse) GetIngestOccurrence() IsOccurrenceSrcIngestOccurrenceIsOccurrence {
-	return v.IngestOccurrence
-}
-
-// IsOccurrencesPkgIngestOccurrencesIsOccurrence includes the requested fields of the GraphQL type IsOccurrence.
-// The GraphQL type's documentation follows.
-//
-// IsOccurrence is an attestation to link an artifact to a package or source.
-//
-// Attestation must occur at the PackageVersion or at the SourceName.
-type IsOccurrencesPkgIngestOccurrencesIsOccurrence struct {
-	AllIsOccurrencesTree `json:"-"`
-}
-
-// GetId returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Id, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetId() string {
-	return v.AllIsOccurrencesTree.Id
-}
-
-// GetSubject returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Subject, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetSubject() AllIsOccurrencesTreeSubjectPackageOrSource {
-	return v.AllIsOccurrencesTree.Subject
-}
-
-// GetArtifact returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Artifact, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetArtifact() AllIsOccurrencesTreeArtifact {
-	return v.AllIsOccurrencesTree.Artifact
-}
-
-// GetJustification returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Justification, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetJustification() string {
-	return v.AllIsOccurrencesTree.Justification
-}
-
-// GetOrigin returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Origin, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetOrigin() string {
-	return v.AllIsOccurrencesTree.Origin
-}
-
-// GetCollector returns IsOccurrencesPkgIngestOccurrencesIsOccurrence.Collector, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) GetCollector() string {
-	return v.AllIsOccurrencesTree.Collector
-}
-
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsOccurrencesPkgIngestOccurrencesIsOccurrence
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsOccurrencesPkgIngestOccurrencesIsOccurrence = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsOccurrencesTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsOccurrencesPkgIngestOccurrencesIsOccurrence struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Artifact AllIsOccurrencesTreeArtifact `json:"artifact"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsOccurrencesPkgIngestOccurrencesIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrencesPkgIngestOccurrencesIsOccurrence, error) {
-	var retval __premarshalIsOccurrencesPkgIngestOccurrencesIsOccurrence
-
-	retval.Id = v.AllIsOccurrencesTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllIsOccurrencesTree.Subject
-		var err error
-		*dst, err = __marshalAllIsOccurrencesTreeSubjectPackageOrSource(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal IsOccurrencesPkgIngestOccurrencesIsOccurrence.AllIsOccurrencesTree.Subject: %w", err)
-		}
-	}
-	retval.Artifact = v.AllIsOccurrencesTree.Artifact
-	retval.Justification = v.AllIsOccurrencesTree.Justification
-	retval.Origin = v.AllIsOccurrencesTree.Origin
-	retval.Collector = v.AllIsOccurrencesTree.Collector
-	return &retval, nil
-}
+func (v *IsOccurrenceSrcResponse) GetIngestOccurrence() string { return v.IngestOccurrence }
 
 // IsOccurrencesPkgResponse is returned by IsOccurrencesPkg on success.
 type IsOccurrencesPkgResponse struct {
 	// Bulk ingest that an artifact is produced from a package or source.
-	IngestOccurrences []IsOccurrencesPkgIngestOccurrencesIsOccurrence `json:"ingestOccurrences"`
+	IngestOccurrences []string `json:"ingestOccurrences"`
 }
 
 // GetIngestOccurrences returns IsOccurrencesPkgResponse.IngestOccurrences, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesPkgResponse) GetIngestOccurrences() []IsOccurrencesPkgIngestOccurrencesIsOccurrence {
-	return v.IngestOccurrences
-}
-
-// IsOccurrencesSrcIngestOccurrencesIsOccurrence includes the requested fields of the GraphQL type IsOccurrence.
-// The GraphQL type's documentation follows.
-//
-// IsOccurrence is an attestation to link an artifact to a package or source.
-//
-// Attestation must occur at the PackageVersion or at the SourceName.
-type IsOccurrencesSrcIngestOccurrencesIsOccurrence struct {
-	AllIsOccurrencesTree `json:"-"`
-}
-
-// GetId returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Id, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetId() string {
-	return v.AllIsOccurrencesTree.Id
-}
-
-// GetSubject returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Subject, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetSubject() AllIsOccurrencesTreeSubjectPackageOrSource {
-	return v.AllIsOccurrencesTree.Subject
-}
-
-// GetArtifact returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Artifact, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetArtifact() AllIsOccurrencesTreeArtifact {
-	return v.AllIsOccurrencesTree.Artifact
-}
-
-// GetJustification returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Justification, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetJustification() string {
-	return v.AllIsOccurrencesTree.Justification
-}
-
-// GetOrigin returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Origin, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetOrigin() string {
-	return v.AllIsOccurrencesTree.Origin
-}
-
-// GetCollector returns IsOccurrencesSrcIngestOccurrencesIsOccurrence.Collector, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) GetCollector() string {
-	return v.AllIsOccurrencesTree.Collector
-}
-
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*IsOccurrencesSrcIngestOccurrencesIsOccurrence
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.IsOccurrencesSrcIngestOccurrencesIsOccurrence = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllIsOccurrencesTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalIsOccurrencesSrcIngestOccurrencesIsOccurrence struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Artifact AllIsOccurrencesTreeArtifact `json:"artifact"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *IsOccurrencesSrcIngestOccurrencesIsOccurrence) __premarshalJSON() (*__premarshalIsOccurrencesSrcIngestOccurrencesIsOccurrence, error) {
-	var retval __premarshalIsOccurrencesSrcIngestOccurrencesIsOccurrence
-
-	retval.Id = v.AllIsOccurrencesTree.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllIsOccurrencesTree.Subject
-		var err error
-		*dst, err = __marshalAllIsOccurrencesTreeSubjectPackageOrSource(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal IsOccurrencesSrcIngestOccurrencesIsOccurrence.AllIsOccurrencesTree.Subject: %w", err)
-		}
-	}
-	retval.Artifact = v.AllIsOccurrencesTree.Artifact
-	retval.Justification = v.AllIsOccurrencesTree.Justification
-	retval.Origin = v.AllIsOccurrencesTree.Origin
-	retval.Collector = v.AllIsOccurrencesTree.Collector
-	return &retval, nil
-}
+func (v *IsOccurrencesPkgResponse) GetIngestOccurrences() []string { return v.IngestOccurrences }
 
 // IsOccurrencesSrcResponse is returned by IsOccurrencesSrc on success.
 type IsOccurrencesSrcResponse struct {
 	// Bulk ingest that an artifact is produced from a package or source.
-	IngestOccurrences []IsOccurrencesSrcIngestOccurrencesIsOccurrence `json:"ingestOccurrences"`
+	IngestOccurrences []string `json:"ingestOccurrences"`
 }
 
 // GetIngestOccurrences returns IsOccurrencesSrcResponse.IngestOccurrences, and is useful for accessing the field via an interface.
-func (v *IsOccurrencesSrcResponse) GetIngestOccurrences() []IsOccurrencesSrcIngestOccurrencesIsOccurrence {
-	return v.IngestOccurrences
-}
+func (v *IsOccurrencesSrcResponse) GetIngestOccurrences() []string { return v.IngestOccurrences }
 
 // MatchFlags is used to input the PkgMatchType enum.
 type MatchFlags struct {
@@ -21558,87 +16689,6 @@ func (v *PathResponse) __premarshalJSON() (*__premarshalPathResponse, error) {
 	return &retval, nil
 }
 
-// PkgEqualIngestPkgEqual includes the requested fields of the GraphQL type PkgEqual.
-// The GraphQL type's documentation follows.
-//
-// PkgEqual is an attestation that a set of packages are similar.
-type PkgEqualIngestPkgEqual struct {
-	AllPkgEqual `json:"-"`
-}
-
-// GetId returns PkgEqualIngestPkgEqual.Id, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetId() string { return v.AllPkgEqual.Id }
-
-// GetJustification returns PkgEqualIngestPkgEqual.Justification, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetJustification() string { return v.AllPkgEqual.Justification }
-
-// GetPackages returns PkgEqualIngestPkgEqual.Packages, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetPackages() []AllPkgEqualPackagesPackage {
-	return v.AllPkgEqual.Packages
-}
-
-// GetOrigin returns PkgEqualIngestPkgEqual.Origin, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetOrigin() string { return v.AllPkgEqual.Origin }
-
-// GetCollector returns PkgEqualIngestPkgEqual.Collector, and is useful for accessing the field via an interface.
-func (v *PkgEqualIngestPkgEqual) GetCollector() string { return v.AllPkgEqual.Collector }
-
-func (v *PkgEqualIngestPkgEqual) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PkgEqualIngestPkgEqual
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PkgEqualIngestPkgEqual = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgEqual)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPkgEqualIngestPkgEqual struct {
-	Id string `json:"id"`
-
-	Justification string `json:"justification"`
-
-	Packages []AllPkgEqualPackagesPackage `json:"packages"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *PkgEqualIngestPkgEqual) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PkgEqualIngestPkgEqual) __premarshalJSON() (*__premarshalPkgEqualIngestPkgEqual, error) {
-	var retval __premarshalPkgEqualIngestPkgEqual
-
-	retval.Id = v.AllPkgEqual.Id
-	retval.Justification = v.AllPkgEqual.Justification
-	retval.Packages = v.AllPkgEqual.Packages
-	retval.Origin = v.AllPkgEqual.Origin
-	retval.Collector = v.AllPkgEqual.Collector
-	return &retval, nil
-}
-
 // PkgEqualInputSpec represents the input to certify that packages are similar.
 type PkgEqualInputSpec struct {
 	Justification string `json:"justification"`
@@ -21655,188 +16705,24 @@ func (v *PkgEqualInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns PkgEqualInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *PkgEqualInputSpec) GetCollector() string { return v.Collector }
 
-// PkgEqualOtherPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type PkgEqualOtherPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns PkgEqualOtherPackage.Id, and is useful for accessing the field via an interface.
-func (v *PkgEqualOtherPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns PkgEqualOtherPackage.Type, and is useful for accessing the field via an interface.
-func (v *PkgEqualOtherPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns PkgEqualOtherPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *PkgEqualOtherPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *PkgEqualOtherPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PkgEqualOtherPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PkgEqualOtherPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPkgEqualOtherPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *PkgEqualOtherPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PkgEqualOtherPackage) __premarshalJSON() (*__premarshalPkgEqualOtherPackage, error) {
-	var retval __premarshalPkgEqualOtherPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
-// PkgEqualPkgPackage includes the requested fields of the GraphQL type Package.
-// The GraphQL type's documentation follows.
-//
-// Package represents the root of the package trie/tree.
-//
-// We map package information to a trie, closely matching the pURL specification
-// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
-// but deviating from it where GUAC heuristics allow for better representation of
-// package information. Each path in the trie fully represents a package; we split
-// the trie based on the pURL components.
-//
-// This node matches a pkg:<type> partial pURL. The type field matches the
-// pURL types but we might also use "guac" for the cases where the pURL
-// representation is not complete or when we have custom rules.
-//
-// Since this node is at the root of the package trie, it is named Package, not
-// PackageType.
-type PkgEqualPkgPackage struct {
-	AllPkgTree `json:"-"`
-}
-
-// GetId returns PkgEqualPkgPackage.Id, and is useful for accessing the field via an interface.
-func (v *PkgEqualPkgPackage) GetId() string { return v.AllPkgTree.Id }
-
-// GetType returns PkgEqualPkgPackage.Type, and is useful for accessing the field via an interface.
-func (v *PkgEqualPkgPackage) GetType() string { return v.AllPkgTree.Type }
-
-// GetNamespaces returns PkgEqualPkgPackage.Namespaces, and is useful for accessing the field via an interface.
-func (v *PkgEqualPkgPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
-	return v.AllPkgTree.Namespaces
-}
-
-func (v *PkgEqualPkgPackage) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PkgEqualPkgPackage
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PkgEqualPkgPackage = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPkgTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPkgEqualPkgPackage struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
-}
-
-func (v *PkgEqualPkgPackage) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PkgEqualPkgPackage) __premarshalJSON() (*__premarshalPkgEqualPkgPackage, error) {
-	var retval __premarshalPkgEqualPkgPackage
-
-	retval.Id = v.AllPkgTree.Id
-	retval.Type = v.AllPkgTree.Type
-	retval.Namespaces = v.AllPkgTree.Namespaces
-	return &retval, nil
-}
-
 // PkgEqualResponse is returned by PkgEqual on success.
 type PkgEqualResponse struct {
 	// Ingests a new package and returns the corresponding package trie path.
-	Pkg PkgEqualPkgPackage `json:"pkg"`
+	Pkg string `json:"pkg"`
 	// Ingests a new package and returns the corresponding package trie path.
-	OtherPackage PkgEqualOtherPackage `json:"otherPackage"`
+	OtherPackage string `json:"otherPackage"`
 	// Adds a certification that two packages are similar.
-	IngestPkgEqual PkgEqualIngestPkgEqual `json:"ingestPkgEqual"`
+	IngestPkgEqual string `json:"ingestPkgEqual"`
 }
 
 // GetPkg returns PkgEqualResponse.Pkg, and is useful for accessing the field via an interface.
-func (v *PkgEqualResponse) GetPkg() PkgEqualPkgPackage { return v.Pkg }
+func (v *PkgEqualResponse) GetPkg() string { return v.Pkg }
 
 // GetOtherPackage returns PkgEqualResponse.OtherPackage, and is useful for accessing the field via an interface.
-func (v *PkgEqualResponse) GetOtherPackage() PkgEqualOtherPackage { return v.OtherPackage }
+func (v *PkgEqualResponse) GetOtherPackage() string { return v.OtherPackage }
 
 // GetIngestPkgEqual returns PkgEqualResponse.IngestPkgEqual, and is useful for accessing the field via an interface.
-func (v *PkgEqualResponse) GetIngestPkgEqual() PkgEqualIngestPkgEqual { return v.IngestPkgEqual }
+func (v *PkgEqualResponse) GetIngestPkgEqual() string { return v.IngestPkgEqual }
 
 // PkgInputSpec specifies a package for mutations.
 //
@@ -21925,156 +16811,14 @@ func (v *PkgSpec) GetMatchOnlyEmptyQualifiers() *bool { return v.MatchOnlyEmptyQ
 // GetSubpath returns PkgSpec.Subpath, and is useful for accessing the field via an interface.
 func (v *PkgSpec) GetSubpath() *string { return v.Subpath }
 
-// PointOfContactArtifactIngestPointOfContact includes the requested fields of the GraphQL type PointOfContact.
-// The GraphQL type's documentation follows.
-//
-// PointOfContact is an attestation of how to get in touch with the person(s) responsible
-// for a package, source, or artifact.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The attestation applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-//
-// email is the email address (singular) of the point of contact.
-//
-// info is additional contact information other than email address. This is free
-// form.
-//
-// NOTE: the identifiers for point of contact should be part of software trees.
-// This will benefit from identifier look up and traversal as well as organization
-// hierarchy. However, until the use case arises, PointOfContact will be a flat
-// reference to the contact details.
-type PointOfContactArtifactIngestPointOfContact struct {
-	AllPointOfContact `json:"-"`
-}
-
-// GetId returns PointOfContactArtifactIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
-
-// GetSubject returns PointOfContactArtifactIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
-	return v.AllPointOfContact.Subject
-}
-
-// GetEmail returns PointOfContactArtifactIngestPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetEmail() string {
-	return v.AllPointOfContact.Email
-}
-
-// GetInfo returns PointOfContactArtifactIngestPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetInfo() string {
-	return v.AllPointOfContact.Info
-}
-
-// GetSince returns PointOfContactArtifactIngestPointOfContact.Since, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetSince() time.Time {
-	return v.AllPointOfContact.Since
-}
-
-// GetJustification returns PointOfContactArtifactIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetJustification() string {
-	return v.AllPointOfContact.Justification
-}
-
-// GetOrigin returns PointOfContactArtifactIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetOrigin() string {
-	return v.AllPointOfContact.Origin
-}
-
-// GetCollector returns PointOfContactArtifactIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactIngestPointOfContact) GetCollector() string {
-	return v.AllPointOfContact.Collector
-}
-
-func (v *PointOfContactArtifactIngestPointOfContact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PointOfContactArtifactIngestPointOfContact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PointOfContactArtifactIngestPointOfContact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPointOfContact)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPointOfContactArtifactIngestPointOfContact struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Email string `json:"email"`
-
-	Info string `json:"info"`
-
-	Since time.Time `json:"since"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *PointOfContactArtifactIngestPointOfContact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PointOfContactArtifactIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactArtifactIngestPointOfContact, error) {
-	var retval __premarshalPointOfContactArtifactIngestPointOfContact
-
-	retval.Id = v.AllPointOfContact.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllPointOfContact.Subject
-		var err error
-		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactArtifactIngestPointOfContact.AllPointOfContact.Subject: %w", err)
-		}
-	}
-	retval.Email = v.AllPointOfContact.Email
-	retval.Info = v.AllPointOfContact.Info
-	retval.Since = v.AllPointOfContact.Since
-	retval.Justification = v.AllPointOfContact.Justification
-	retval.Origin = v.AllPointOfContact.Origin
-	retval.Collector = v.AllPointOfContact.Collector
-	return &retval, nil
-}
-
 // PointOfContactArtifactResponse is returned by PointOfContactArtifact on success.
 type PointOfContactArtifactResponse struct {
 	// Adds a PointOfContact attestation to a package, source or artifact.
-	IngestPointOfContact PointOfContactArtifactIngestPointOfContact `json:"ingestPointOfContact"`
+	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
 // GetIngestPointOfContact returns PointOfContactArtifactResponse.IngestPointOfContact, and is useful for accessing the field via an interface.
-func (v *PointOfContactArtifactResponse) GetIngestPointOfContact() PointOfContactArtifactIngestPointOfContact {
+func (v *PointOfContactArtifactResponse) GetIngestPointOfContact() string {
 	return v.IngestPointOfContact
 }
 
@@ -22106,459 +16850,41 @@ func (v *PointOfContactInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns PointOfContactInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 
-// PointOfContactPkgIngestPointOfContact includes the requested fields of the GraphQL type PointOfContact.
-// The GraphQL type's documentation follows.
-//
-// PointOfContact is an attestation of how to get in touch with the person(s) responsible
-// for a package, source, or artifact.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The attestation applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-//
-// email is the email address (singular) of the point of contact.
-//
-// info is additional contact information other than email address. This is free
-// form.
-//
-// NOTE: the identifiers for point of contact should be part of software trees.
-// This will benefit from identifier look up and traversal as well as organization
-// hierarchy. However, until the use case arises, PointOfContact will be a flat
-// reference to the contact details.
-type PointOfContactPkgIngestPointOfContact struct {
-	AllPointOfContact `json:"-"`
-}
-
-// GetId returns PointOfContactPkgIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
-
-// GetSubject returns PointOfContactPkgIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
-	return v.AllPointOfContact.Subject
-}
-
-// GetEmail returns PointOfContactPkgIngestPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
-
-// GetInfo returns PointOfContactPkgIngestPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
-
-// GetSince returns PointOfContactPkgIngestPointOfContact.Since, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetSince() time.Time {
-	return v.AllPointOfContact.Since
-}
-
-// GetJustification returns PointOfContactPkgIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetJustification() string {
-	return v.AllPointOfContact.Justification
-}
-
-// GetOrigin returns PointOfContactPkgIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
-
-// GetCollector returns PointOfContactPkgIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgIngestPointOfContact) GetCollector() string {
-	return v.AllPointOfContact.Collector
-}
-
-func (v *PointOfContactPkgIngestPointOfContact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PointOfContactPkgIngestPointOfContact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PointOfContactPkgIngestPointOfContact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPointOfContact)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPointOfContactPkgIngestPointOfContact struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Email string `json:"email"`
-
-	Info string `json:"info"`
-
-	Since time.Time `json:"since"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *PointOfContactPkgIngestPointOfContact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PointOfContactPkgIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactPkgIngestPointOfContact, error) {
-	var retval __premarshalPointOfContactPkgIngestPointOfContact
-
-	retval.Id = v.AllPointOfContact.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllPointOfContact.Subject
-		var err error
-		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactPkgIngestPointOfContact.AllPointOfContact.Subject: %w", err)
-		}
-	}
-	retval.Email = v.AllPointOfContact.Email
-	retval.Info = v.AllPointOfContact.Info
-	retval.Since = v.AllPointOfContact.Since
-	retval.Justification = v.AllPointOfContact.Justification
-	retval.Origin = v.AllPointOfContact.Origin
-	retval.Collector = v.AllPointOfContact.Collector
-	return &retval, nil
-}
-
 // PointOfContactPkgResponse is returned by PointOfContactPkg on success.
 type PointOfContactPkgResponse struct {
 	// Adds a PointOfContact attestation to a package, source or artifact.
-	IngestPointOfContact PointOfContactPkgIngestPointOfContact `json:"ingestPointOfContact"`
+	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
 // GetIngestPointOfContact returns PointOfContactPkgResponse.IngestPointOfContact, and is useful for accessing the field via an interface.
-func (v *PointOfContactPkgResponse) GetIngestPointOfContact() PointOfContactPkgIngestPointOfContact {
-	return v.IngestPointOfContact
-}
-
-// PointOfContactSrcIngestPointOfContact includes the requested fields of the GraphQL type PointOfContact.
-// The GraphQL type's documentation follows.
-//
-// PointOfContact is an attestation of how to get in touch with the person(s) responsible
-// for a package, source, or artifact.
-//
-// All evidence trees record a justification for the property they represent as
-// well as the document that contains the attestation (origin) and the collector
-// that collected the document (collector).
-//
-// The attestation applies to a subject which is a package, source, or artifact.
-// If the attestation targets a package, it must target a PackageName or a
-// PackageVersion. If the attestation targets a source, it must target a
-// SourceName.
-//
-// email is the email address (singular) of the point of contact.
-//
-// info is additional contact information other than email address. This is free
-// form.
-//
-// NOTE: the identifiers for point of contact should be part of software trees.
-// This will benefit from identifier look up and traversal as well as organization
-// hierarchy. However, until the use case arises, PointOfContact will be a flat
-// reference to the contact details.
-type PointOfContactSrcIngestPointOfContact struct {
-	AllPointOfContact `json:"-"`
-}
-
-// GetId returns PointOfContactSrcIngestPointOfContact.Id, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetId() string { return v.AllPointOfContact.Id }
-
-// GetSubject returns PointOfContactSrcIngestPointOfContact.Subject, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetSubject() AllPointOfContactSubjectPackageSourceOrArtifact {
-	return v.AllPointOfContact.Subject
-}
-
-// GetEmail returns PointOfContactSrcIngestPointOfContact.Email, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetEmail() string { return v.AllPointOfContact.Email }
-
-// GetInfo returns PointOfContactSrcIngestPointOfContact.Info, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetInfo() string { return v.AllPointOfContact.Info }
-
-// GetSince returns PointOfContactSrcIngestPointOfContact.Since, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetSince() time.Time {
-	return v.AllPointOfContact.Since
-}
-
-// GetJustification returns PointOfContactSrcIngestPointOfContact.Justification, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetJustification() string {
-	return v.AllPointOfContact.Justification
-}
-
-// GetOrigin returns PointOfContactSrcIngestPointOfContact.Origin, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetOrigin() string { return v.AllPointOfContact.Origin }
-
-// GetCollector returns PointOfContactSrcIngestPointOfContact.Collector, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcIngestPointOfContact) GetCollector() string {
-	return v.AllPointOfContact.Collector
-}
-
-func (v *PointOfContactSrcIngestPointOfContact) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*PointOfContactSrcIngestPointOfContact
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.PointOfContactSrcIngestPointOfContact = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllPointOfContact)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalPointOfContactSrcIngestPointOfContact struct {
-	Id string `json:"id"`
-
-	Subject json.RawMessage `json:"subject"`
-
-	Email string `json:"email"`
-
-	Info string `json:"info"`
-
-	Since time.Time `json:"since"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *PointOfContactSrcIngestPointOfContact) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *PointOfContactSrcIngestPointOfContact) __premarshalJSON() (*__premarshalPointOfContactSrcIngestPointOfContact, error) {
-	var retval __premarshalPointOfContactSrcIngestPointOfContact
-
-	retval.Id = v.AllPointOfContact.Id
-	{
-
-		dst := &retval.Subject
-		src := v.AllPointOfContact.Subject
-		var err error
-		*dst, err = __marshalAllPointOfContactSubjectPackageSourceOrArtifact(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal PointOfContactSrcIngestPointOfContact.AllPointOfContact.Subject: %w", err)
-		}
-	}
-	retval.Email = v.AllPointOfContact.Email
-	retval.Info = v.AllPointOfContact.Info
-	retval.Since = v.AllPointOfContact.Since
-	retval.Justification = v.AllPointOfContact.Justification
-	retval.Origin = v.AllPointOfContact.Origin
-	retval.Collector = v.AllPointOfContact.Collector
-	return &retval, nil
-}
+func (v *PointOfContactPkgResponse) GetIngestPointOfContact() string { return v.IngestPointOfContact }
 
 // PointOfContactSrcResponse is returned by PointOfContactSrc on success.
 type PointOfContactSrcResponse struct {
 	// Adds a PointOfContact attestation to a package, source or artifact.
-	IngestPointOfContact PointOfContactSrcIngestPointOfContact `json:"ingestPointOfContact"`
+	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
 // GetIngestPointOfContact returns PointOfContactSrcResponse.IngestPointOfContact, and is useful for accessing the field via an interface.
-func (v *PointOfContactSrcResponse) GetIngestPointOfContact() PointOfContactSrcIngestPointOfContact {
-	return v.IngestPointOfContact
-}
-
-// SLSAForArtifactIngestSLSAHasSLSA includes the requested fields of the GraphQL type HasSLSA.
-// The GraphQL type's documentation follows.
-//
-// HasSLSA records that a subject node has a SLSA attestation.
-type SLSAForArtifactIngestSLSAHasSLSA struct {
-	AllSLSATree `json:"-"`
-}
-
-// GetId returns SLSAForArtifactIngestSLSAHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetId() string { return v.AllSLSATree.Id }
-
-// GetSubject returns SLSAForArtifactIngestSLSAHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSubject() AllSLSATreeSubjectArtifact {
-	return v.AllSLSATree.Subject
-}
-
-// GetSlsa returns SLSAForArtifactIngestSLSAHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactIngestSLSAHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
-
-func (v *SLSAForArtifactIngestSLSAHasSLSA) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*SLSAForArtifactIngestSLSAHasSLSA
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.SLSAForArtifactIngestSLSAHasSLSA = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSLSATree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalSLSAForArtifactIngestSLSAHasSLSA struct {
-	Id string `json:"id"`
-
-	Subject AllSLSATreeSubjectArtifact `json:"subject"`
-
-	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
-}
-
-func (v *SLSAForArtifactIngestSLSAHasSLSA) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *SLSAForArtifactIngestSLSAHasSLSA) __premarshalJSON() (*__premarshalSLSAForArtifactIngestSLSAHasSLSA, error) {
-	var retval __premarshalSLSAForArtifactIngestSLSAHasSLSA
-
-	retval.Id = v.AllSLSATree.Id
-	retval.Subject = v.AllSLSATree.Subject
-	retval.Slsa = v.AllSLSATree.Slsa
-	return &retval, nil
-}
+func (v *PointOfContactSrcResponse) GetIngestPointOfContact() string { return v.IngestPointOfContact }
 
 // SLSAForArtifactResponse is returned by SLSAForArtifact on success.
 type SLSAForArtifactResponse struct {
 	// Ingests a SLSA attestation
-	IngestSLSA SLSAForArtifactIngestSLSAHasSLSA `json:"ingestSLSA"`
+	IngestSLSA string `json:"ingestSLSA"`
 }
 
 // GetIngestSLSA returns SLSAForArtifactResponse.IngestSLSA, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactResponse) GetIngestSLSA() SLSAForArtifactIngestSLSAHasSLSA {
-	return v.IngestSLSA
-}
-
-// SLSAForArtifactsIngestSLSAsHasSLSA includes the requested fields of the GraphQL type HasSLSA.
-// The GraphQL type's documentation follows.
-//
-// HasSLSA records that a subject node has a SLSA attestation.
-type SLSAForArtifactsIngestSLSAsHasSLSA struct {
-	AllSLSATree `json:"-"`
-}
-
-// GetId returns SLSAForArtifactsIngestSLSAsHasSLSA.Id, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetId() string { return v.AllSLSATree.Id }
-
-// GetSubject returns SLSAForArtifactsIngestSLSAsHasSLSA.Subject, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSubject() AllSLSATreeSubjectArtifact {
-	return v.AllSLSATree.Subject
-}
-
-// GetSlsa returns SLSAForArtifactsIngestSLSAsHasSLSA.Slsa, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) GetSlsa() AllSLSATreeSlsaSLSA { return v.AllSLSATree.Slsa }
-
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*SLSAForArtifactsIngestSLSAsHasSLSA
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.SLSAForArtifactsIngestSLSAsHasSLSA = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllSLSATree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalSLSAForArtifactsIngestSLSAsHasSLSA struct {
-	Id string `json:"id"`
-
-	Subject AllSLSATreeSubjectArtifact `json:"subject"`
-
-	Slsa AllSLSATreeSlsaSLSA `json:"slsa"`
-}
-
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *SLSAForArtifactsIngestSLSAsHasSLSA) __premarshalJSON() (*__premarshalSLSAForArtifactsIngestSLSAsHasSLSA, error) {
-	var retval __premarshalSLSAForArtifactsIngestSLSAsHasSLSA
-
-	retval.Id = v.AllSLSATree.Id
-	retval.Subject = v.AllSLSATree.Subject
-	retval.Slsa = v.AllSLSATree.Slsa
-	return &retval, nil
-}
+func (v *SLSAForArtifactResponse) GetIngestSLSA() string { return v.IngestSLSA }
 
 // SLSAForArtifactsResponse is returned by SLSAForArtifacts on success.
 type SLSAForArtifactsResponse struct {
 	// Bulk Ingest SLSA attestations
-	IngestSLSAs []SLSAForArtifactsIngestSLSAsHasSLSA `json:"ingestSLSAs"`
+	IngestSLSAs []string `json:"ingestSLSAs"`
 }
 
 // GetIngestSLSAs returns SLSAForArtifactsResponse.IngestSLSAs, and is useful for accessing the field via an interface.
-func (v *SLSAForArtifactsResponse) GetIngestSLSAs() []SLSAForArtifactsIngestSLSAsHasSLSA {
-	return v.IngestSLSAs
-}
+func (v *SLSAForArtifactsResponse) GetIngestSLSAs() []string { return v.IngestSLSAs }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
 type SLSAInputSpec struct {
@@ -22889,89 +17215,6 @@ const (
 	VexStatusUnderInvestigation VexStatus = "UNDER_INVESTIGATION"
 )
 
-// VulnEqualIngestVulnEqual includes the requested fields of the GraphQL type VulnEqual.
-// The GraphQL type's documentation follows.
-//
-// VulnEqual is an attestation to link two vulnerabilities together as being equal"
-//
-// Note that setting noVuln vulnerability type is invalid for VulnEqual!
-type VulnEqualIngestVulnEqual struct {
-	AllVulnEqual `json:"-"`
-}
-
-// GetId returns VulnEqualIngestVulnEqual.Id, and is useful for accessing the field via an interface.
-func (v *VulnEqualIngestVulnEqual) GetId() string { return v.AllVulnEqual.Id }
-
-// GetVulnerabilities returns VulnEqualIngestVulnEqual.Vulnerabilities, and is useful for accessing the field via an interface.
-func (v *VulnEqualIngestVulnEqual) GetVulnerabilities() []AllVulnEqualVulnerabilitiesVulnerability {
-	return v.AllVulnEqual.Vulnerabilities
-}
-
-// GetJustification returns VulnEqualIngestVulnEqual.Justification, and is useful for accessing the field via an interface.
-func (v *VulnEqualIngestVulnEqual) GetJustification() string { return v.AllVulnEqual.Justification }
-
-// GetOrigin returns VulnEqualIngestVulnEqual.Origin, and is useful for accessing the field via an interface.
-func (v *VulnEqualIngestVulnEqual) GetOrigin() string { return v.AllVulnEqual.Origin }
-
-// GetCollector returns VulnEqualIngestVulnEqual.Collector, and is useful for accessing the field via an interface.
-func (v *VulnEqualIngestVulnEqual) GetCollector() string { return v.AllVulnEqual.Collector }
-
-func (v *VulnEqualIngestVulnEqual) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*VulnEqualIngestVulnEqual
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.VulnEqualIngestVulnEqual = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllVulnEqual)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalVulnEqualIngestVulnEqual struct {
-	Id string `json:"id"`
-
-	Vulnerabilities []AllVulnEqualVulnerabilitiesVulnerability `json:"vulnerabilities"`
-
-	Justification string `json:"justification"`
-
-	Origin string `json:"origin"`
-
-	Collector string `json:"collector"`
-}
-
-func (v *VulnEqualIngestVulnEqual) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *VulnEqualIngestVulnEqual) __premarshalJSON() (*__premarshalVulnEqualIngestVulnEqual, error) {
-	var retval __premarshalVulnEqualIngestVulnEqual
-
-	retval.Id = v.AllVulnEqual.Id
-	retval.Vulnerabilities = v.AllVulnEqual.Vulnerabilities
-	retval.Justification = v.AllVulnEqual.Justification
-	retval.Origin = v.AllVulnEqual.Origin
-	retval.Collector = v.AllVulnEqual.Collector
-	return &retval, nil
-}
-
 // VulnEqualInputSpec represents the input to link vulnerabilities to each other.
 type VulnEqualInputSpec struct {
 	Justification string `json:"justification"`
@@ -22988,210 +17231,24 @@ func (v *VulnEqualInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns VulnEqualInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *VulnEqualInputSpec) GetCollector() string { return v.Collector }
 
-// VulnEqualOtherVulnVulnerability includes the requested fields of the GraphQL type Vulnerability.
-// The GraphQL type's documentation follows.
-//
-// Vulnerability represents the root of the vulnerability trie/tree.
-//
-// We map vulnerability information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type and a vulnerability ID. This allows for generic
-// representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
-// This would be in the general format: vuln://<general-type>/<vuln-id>
-//
-// Examples:
-//
-// CVE, using path separator: vuln://cve/cve-2023-20753
-// OSV, representing its knowledge of a GHSA: vuln://osv/ghsa-205hk
-// Random vendor: vuln://snyk/sn-whatever
-// NoVuln: vuln://novuln/
-//
-// This node represents the type part of the trie path. It is used to represent
-// the specific type of the vulnerability: cve, ghsa, osv or some other vendor specific
-//
-// Since this node is at the root of the vulnerability trie, it is named Vulnerability, not
-// VulnerabilityType.
-//
-// NoVuln is a special vulnerability node to attest that no vulnerability has been
-// found during a vulnerability scan. It will have the type "novuln" and contain an empty string
-// for vulnerabilityID
-//
-// The resolvers will enforce that both the type and vulnerability IDs are lower case.
-type VulnEqualOtherVulnVulnerability struct {
-	AllVulnerabilityTree `json:"-"`
-}
-
-// GetId returns VulnEqualOtherVulnVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *VulnEqualOtherVulnVulnerability) GetId() string { return v.AllVulnerabilityTree.Id }
-
-// GetType returns VulnEqualOtherVulnVulnerability.Type, and is useful for accessing the field via an interface.
-func (v *VulnEqualOtherVulnVulnerability) GetType() string { return v.AllVulnerabilityTree.Type }
-
-// GetVulnerabilityIDs returns VulnEqualOtherVulnVulnerability.VulnerabilityIDs, and is useful for accessing the field via an interface.
-func (v *VulnEqualOtherVulnVulnerability) GetVulnerabilityIDs() []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID {
-	return v.AllVulnerabilityTree.VulnerabilityIDs
-}
-
-func (v *VulnEqualOtherVulnVulnerability) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*VulnEqualOtherVulnVulnerability
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.VulnEqualOtherVulnVulnerability = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllVulnerabilityTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalVulnEqualOtherVulnVulnerability struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	VulnerabilityIDs []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID `json:"vulnerabilityIDs"`
-}
-
-func (v *VulnEqualOtherVulnVulnerability) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *VulnEqualOtherVulnVulnerability) __premarshalJSON() (*__premarshalVulnEqualOtherVulnVulnerability, error) {
-	var retval __premarshalVulnEqualOtherVulnVulnerability
-
-	retval.Id = v.AllVulnerabilityTree.Id
-	retval.Type = v.AllVulnerabilityTree.Type
-	retval.VulnerabilityIDs = v.AllVulnerabilityTree.VulnerabilityIDs
-	return &retval, nil
-}
-
 // VulnEqualResponse is returned by VulnEqual on success.
 type VulnEqualResponse struct {
 	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
-	Vuln VulnEqualVulnVulnerability `json:"vuln"`
+	Vuln string `json:"vuln"`
 	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
-	OtherVuln VulnEqualOtherVulnVulnerability `json:"otherVuln"`
+	OtherVuln string `json:"otherVuln"`
 	// Ingest a mapping between vulnerabilities.
-	IngestVulnEqual VulnEqualIngestVulnEqual `json:"ingestVulnEqual"`
+	IngestVulnEqual string `json:"ingestVulnEqual"`
 }
 
 // GetVuln returns VulnEqualResponse.Vuln, and is useful for accessing the field via an interface.
-func (v *VulnEqualResponse) GetVuln() VulnEqualVulnVulnerability { return v.Vuln }
+func (v *VulnEqualResponse) GetVuln() string { return v.Vuln }
 
 // GetOtherVuln returns VulnEqualResponse.OtherVuln, and is useful for accessing the field via an interface.
-func (v *VulnEqualResponse) GetOtherVuln() VulnEqualOtherVulnVulnerability { return v.OtherVuln }
+func (v *VulnEqualResponse) GetOtherVuln() string { return v.OtherVuln }
 
 // GetIngestVulnEqual returns VulnEqualResponse.IngestVulnEqual, and is useful for accessing the field via an interface.
-func (v *VulnEqualResponse) GetIngestVulnEqual() VulnEqualIngestVulnEqual { return v.IngestVulnEqual }
-
-// VulnEqualVulnVulnerability includes the requested fields of the GraphQL type Vulnerability.
-// The GraphQL type's documentation follows.
-//
-// Vulnerability represents the root of the vulnerability trie/tree.
-//
-// We map vulnerability information to a trie, as a derivative of the pURL specification:
-// each path in the trie represents a type and a vulnerability ID. This allows for generic
-// representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
-// This would be in the general format: vuln://<general-type>/<vuln-id>
-//
-// Examples:
-//
-// CVE, using path separator: vuln://cve/cve-2023-20753
-// OSV, representing its knowledge of a GHSA: vuln://osv/ghsa-205hk
-// Random vendor: vuln://snyk/sn-whatever
-// NoVuln: vuln://novuln/
-//
-// This node represents the type part of the trie path. It is used to represent
-// the specific type of the vulnerability: cve, ghsa, osv or some other vendor specific
-//
-// Since this node is at the root of the vulnerability trie, it is named Vulnerability, not
-// VulnerabilityType.
-//
-// NoVuln is a special vulnerability node to attest that no vulnerability has been
-// found during a vulnerability scan. It will have the type "novuln" and contain an empty string
-// for vulnerabilityID
-//
-// The resolvers will enforce that both the type and vulnerability IDs are lower case.
-type VulnEqualVulnVulnerability struct {
-	AllVulnerabilityTree `json:"-"`
-}
-
-// GetId returns VulnEqualVulnVulnerability.Id, and is useful for accessing the field via an interface.
-func (v *VulnEqualVulnVulnerability) GetId() string { return v.AllVulnerabilityTree.Id }
-
-// GetType returns VulnEqualVulnVulnerability.Type, and is useful for accessing the field via an interface.
-func (v *VulnEqualVulnVulnerability) GetType() string { return v.AllVulnerabilityTree.Type }
-
-// GetVulnerabilityIDs returns VulnEqualVulnVulnerability.VulnerabilityIDs, and is useful for accessing the field via an interface.
-func (v *VulnEqualVulnVulnerability) GetVulnerabilityIDs() []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID {
-	return v.AllVulnerabilityTree.VulnerabilityIDs
-}
-
-func (v *VulnEqualVulnVulnerability) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*VulnEqualVulnVulnerability
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.VulnEqualVulnVulnerability = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AllVulnerabilityTree)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type __premarshalVulnEqualVulnVulnerability struct {
-	Id string `json:"id"`
-
-	Type string `json:"type"`
-
-	VulnerabilityIDs []AllVulnerabilityTreeVulnerabilityIDsVulnerabilityID `json:"vulnerabilityIDs"`
-}
-
-func (v *VulnEqualVulnVulnerability) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *VulnEqualVulnVulnerability) __premarshalJSON() (*__premarshalVulnEqualVulnVulnerability, error) {
-	var retval __premarshalVulnEqualVulnVulnerability
-
-	retval.Id = v.AllVulnerabilityTree.Id
-	retval.Type = v.AllVulnerabilityTree.Type
-	retval.VulnerabilityIDs = v.AllVulnerabilityTree.VulnerabilityIDs
-	return &retval, nil
-}
+func (v *VulnEqualResponse) GetIngestVulnEqual() string { return v.IngestVulnEqual }
 
 // VulnHasMetadataResponse is returned by VulnHasMetadata on success.
 type VulnHasMetadataResponse struct {
@@ -24297,67 +18354,7 @@ func Artifacts(
 // The query or mutation executed by CertifyBadArtifact.
 const CertifyBadArtifact_Operation = `
 mutation CertifyBadArtifact ($artifact: ArtifactInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-	ingestCertifyBad(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBad: $certifyBad) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBad(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBad: $certifyBad)
 }
 `
 
@@ -24392,67 +18389,7 @@ func CertifyBadArtifact(
 // The query or mutation executed by CertifyBadArtifacts.
 const CertifyBadArtifacts_Operation = `
 mutation CertifyBadArtifacts ($artifacts: [ArtifactInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-	ingestCertifyBads(subjects: {artifacts:$artifacts}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBads: $certifyBads) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBads(subjects: {artifacts:$artifacts}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBads: $certifyBads)
 }
 `
 
@@ -24487,67 +18424,7 @@ func CertifyBadArtifacts(
 // The query or mutation executed by CertifyBadPkg.
 const CertifyBadPkg_Operation = `
 mutation CertifyBadPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyBad: CertifyBadInputSpec!) {
-	ingestCertifyBad(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, certifyBad: $certifyBad) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBad(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, certifyBad: $certifyBad)
 }
 `
 
@@ -24584,67 +18461,7 @@ func CertifyBadPkg(
 // The query or mutation executed by CertifyBadPkgs.
 const CertifyBadPkgs_Operation = `
 mutation CertifyBadPkgs ($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyBads: [CertifyBadInputSpec!]!) {
-	ingestCertifyBads(subjects: {packages:$pkgs}, pkgMatchType: $pkgMatchType, certifyBads: $certifyBads) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBads(subjects: {packages:$pkgs}, pkgMatchType: $pkgMatchType, certifyBads: $certifyBads)
 }
 `
 
@@ -24681,67 +18498,7 @@ func CertifyBadPkgs(
 // The query or mutation executed by CertifyBadSrc.
 const CertifyBadSrc_Operation = `
 mutation CertifyBadSrc ($source: SourceInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-	ingestCertifyBad(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBad: $certifyBad) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBad(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBad: $certifyBad)
 }
 `
 
@@ -24776,67 +18533,7 @@ func CertifyBadSrc(
 // The query or mutation executed by CertifyBadSrcs.
 const CertifyBadSrcs_Operation = `
 mutation CertifyBadSrcs ($sources: [SourceInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-	ingestCertifyBads(subjects: {sources:$sources}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBads: $certifyBads) {
-		... AllCertifyBad
-	}
-}
-fragment AllCertifyBad on CertifyBad {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyBads(subjects: {sources:$sources}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyBads: $certifyBads)
 }
 `
 
@@ -24964,67 +18661,7 @@ func CertifyBads(
 // The query or mutation executed by CertifyGoodArtifact.
 const CertifyGoodArtifact_Operation = `
 mutation CertifyGoodArtifact ($artifact: ArtifactInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-	ingestCertifyGood(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGood: $certifyGood) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGood(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGood: $certifyGood)
 }
 `
 
@@ -25059,67 +18696,7 @@ func CertifyGoodArtifact(
 // The query or mutation executed by CertifyGoodArtifacts.
 const CertifyGoodArtifacts_Operation = `
 mutation CertifyGoodArtifacts ($artifacts: [ArtifactInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-	ingestCertifyGoods(subjects: {artifacts:$artifacts}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGoods: $certifyGoods) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGoods(subjects: {artifacts:$artifacts}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGoods: $certifyGoods)
 }
 `
 
@@ -25154,67 +18731,7 @@ func CertifyGoodArtifacts(
 // The query or mutation executed by CertifyGoodPkg.
 const CertifyGoodPkg_Operation = `
 mutation CertifyGoodPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyGood: CertifyGoodInputSpec!) {
-	ingestCertifyGood(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGood(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood)
 }
 `
 
@@ -25251,67 +18768,7 @@ func CertifyGoodPkg(
 // The query or mutation executed by CertifyGoodPkgs.
 const CertifyGoodPkgs_Operation = `
 mutation CertifyGoodPkgs ($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-	ingestCertifyGoods(subjects: {packages:$pkgs}, pkgMatchType: $pkgMatchType, certifyGoods: $certifyGoods) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGoods(subjects: {packages:$pkgs}, pkgMatchType: $pkgMatchType, certifyGoods: $certifyGoods)
 }
 `
 
@@ -25348,67 +18805,7 @@ func CertifyGoodPkgs(
 // The query or mutation executed by CertifyGoodSrc.
 const CertifyGoodSrc_Operation = `
 mutation CertifyGoodSrc ($source: SourceInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-	ingestCertifyGood(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGood: $certifyGood) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGood(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGood: $certifyGood)
 }
 `
 
@@ -25443,67 +18840,7 @@ func CertifyGoodSrc(
 // The query or mutation executed by CertifyGoodSrcs.
 const CertifyGoodSrcs_Operation = `
 mutation CertifyGoodSrcs ($sources: [SourceInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-	ingestCertifyGoods(subjects: {sources:$sources}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGoods: $certifyGoods) {
-		... AllCertifyGood
-	}
-}
-fragment AllCertifyGood on CertifyGood {
-	id
-	justification
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestCertifyGoods(subjects: {sources:$sources}, pkgMatchType: {pkg:ALL_VERSIONS}, certifyGoods: $certifyGoods)
 }
 `
 
@@ -25538,41 +18875,7 @@ func CertifyGoodSrcs(
 // The query or mutation executed by CertifyScorecard.
 const CertifyScorecard_Operation = `
 mutation CertifyScorecard ($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
-	ingestScorecard(source: $source, scorecard: $scorecard) {
-		... AllCertifyScorecard
-	}
-}
-fragment AllCertifyScorecard on CertifyScorecard {
-	id
-	source {
-		... AllSourceTree
-	}
-	scorecard {
-		timeScanned
-		aggregateScore
-		checks {
-			check
-			score
-		}
-		scorecardVersion
-		scorecardCommit
-		origin
-		collector
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
+	ingestScorecard(source: $source, scorecard: $scorecard)
 }
 `
 
@@ -25607,41 +18910,7 @@ func CertifyScorecard(
 // The query or mutation executed by CertifyScorecards.
 const CertifyScorecards_Operation = `
 mutation CertifyScorecards ($sources: [SourceInputSpec!]!, $scorecards: [ScorecardInputSpec!]!) {
-	ingestScorecards(sources: $sources, scorecards: $scorecards) {
-		... AllCertifyScorecard
-	}
-}
-fragment AllCertifyScorecard on CertifyScorecard {
-	id
-	source {
-		... AllSourceTree
-	}
-	scorecard {
-		timeScanned
-		aggregateScore
-		checks {
-			check
-			score
-		}
-		scorecardVersion
-		scorecardCommit
-		origin
-		collector
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
+	ingestScorecards(sources: $sources, scorecards: $scorecards)
 }
 `
 
@@ -25676,65 +18945,7 @@ func CertifyScorecards(
 // The query or mutation executed by CertifyVexArtifact.
 const CertifyVexArtifact_Operation = `
 mutation CertifyVexArtifact ($artifact: ArtifactInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-	ingestVEXStatement(subject: {artifact:$artifact}, vulnerability: $vulnerability, vexStatement: $vexStatement) {
-		... AllCertifyVEXStatement
-	}
-}
-fragment AllCertifyVEXStatement on CertifyVEXStatement {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	vulnerability {
-		... AllVulnerabilityTree
-	}
-	status
-	vexJustification
-	statement
-	statusNotes
-	knownSince
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestVEXStatement(subject: {artifact:$artifact}, vulnerability: $vulnerability, vexStatement: $vexStatement)
 }
 `
 
@@ -25771,65 +18982,7 @@ func CertifyVexArtifact(
 // The query or mutation executed by CertifyVexPkg.
 const CertifyVexPkg_Operation = `
 mutation CertifyVexPkg ($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-	ingestVEXStatement(subject: {package:$pkg}, vulnerability: $vulnerability, vexStatement: $vexStatement) {
-		... AllCertifyVEXStatement
-	}
-}
-fragment AllCertifyVEXStatement on CertifyVEXStatement {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	vulnerability {
-		... AllVulnerabilityTree
-	}
-	status
-	vexJustification
-	statement
-	statusNotes
-	knownSince
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestVEXStatement(subject: {package:$pkg}, vulnerability: $vulnerability, vexStatement: $vexStatement)
 }
 `
 
@@ -25866,56 +19019,7 @@ func CertifyVexPkg(
 // The query or mutation executed by CertifyVulnPkg.
 const CertifyVulnPkg_Operation = `
 mutation CertifyVulnPkg ($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $certifyVuln: ScanMetadataInput!) {
-	ingestCertifyVuln(pkg: $pkg, vulnerability: $vulnerability, certifyVuln: $certifyVuln) {
-		... AllCertifyVuln
-	}
-}
-fragment AllCertifyVuln on CertifyVuln {
-	id
-	package {
-		... AllPkgTree
-	}
-	vulnerability {
-		... AllVulnerabilityTree
-	}
-	metadata {
-		dbUri
-		dbVersion
-		scannerUri
-		scannerVersion
-		timeScanned
-		origin
-		collector
-	}
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestCertifyVuln(pkg: $pkg, vulnerability: $vulnerability, certifyVuln: $certifyVuln)
 }
 `
 
@@ -25952,56 +19056,7 @@ func CertifyVulnPkg(
 // The query or mutation executed by CertifyVulnPkgs.
 const CertifyVulnPkgs_Operation = `
 mutation CertifyVulnPkgs ($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $certifyVulns: [ScanMetadataInput!]!) {
-	ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns) {
-		... AllCertifyVuln
-	}
-}
-fragment AllCertifyVuln on CertifyVuln {
-	id
-	package {
-		... AllPkgTree
-	}
-	vulnerability {
-		... AllVulnerabilityTree
-	}
-	metadata {
-		dbUri
-		dbVersion
-		scannerUri
-		scannerVersion
-		timeScanned
-		origin
-		collector
-	}
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns)
 }
 `
 
@@ -26122,70 +19177,7 @@ func FindSoftware(
 // The query or mutation executed by HasMetadataArtifact.
 const HasMetadataArtifact_Operation = `
 mutation HasMetadataArtifact ($artifact: ArtifactInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-	ingestHasMetadata(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadata: $hasMetadata) {
-		... AllHasMetadata
-	}
-}
-fragment AllHasMetadata on HasMetadata {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	key
-	value
-	timestamp
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestHasMetadata(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadata: $hasMetadata)
 }
 `
 
@@ -26220,70 +19212,7 @@ func HasMetadataArtifact(
 // The query or mutation executed by HasMetadataPkg.
 const HasMetadataPkg_Operation = `
 mutation HasMetadataPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $hasMetadata: HasMetadataInputSpec!) {
-	ingestHasMetadata(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata) {
-		... AllHasMetadata
-	}
-}
-fragment AllHasMetadata on HasMetadata {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	key
-	value
-	timestamp
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestHasMetadata(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata)
 }
 `
 
@@ -26320,70 +19249,7 @@ func HasMetadataPkg(
 // The query or mutation executed by HasMetadataSrc.
 const HasMetadataSrc_Operation = `
 mutation HasMetadataSrc ($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-	ingestHasMetadata(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadata: $hasMetadata) {
-		... AllHasMetadata
-	}
-}
-fragment AllHasMetadata on HasMetadata {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	key
-	value
-	timestamp
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestHasMetadata(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadata: $hasMetadata)
 }
 `
 
@@ -26418,53 +19284,7 @@ func HasMetadataSrc(
 // The query or mutation executed by HasSBOMArtifact.
 const HasSBOMArtifact_Operation = `
 mutation HasSBOMArtifact ($artifact: ArtifactInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-	ingestHasSBOM(subject: {artifact:$artifact}, hasSBOM: $hasSBOM) {
-		... AllHasSBOMTree
-	}
-}
-fragment AllHasSBOMTree on HasSBOM {
-	id
-	subject {
-		__typename
-		... on Artifact {
-			... AllArtifactTree
-		}
-		... on Package {
-			... AllPkgTree
-		}
-	}
-	uri
-	algorithm
-	digest
-	downloadLocation
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestHasSBOM(subject: {artifact:$artifact}, hasSBOM: $hasSBOM)
 }
 `
 
@@ -26499,53 +19319,7 @@ func HasSBOMArtifact(
 // The query or mutation executed by HasSBOMArtifacts.
 const HasSBOMArtifacts_Operation = `
 mutation HasSBOMArtifacts ($artifacts: [ArtifactInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-	ingestHasSBOMs(subjects: {artifacts:$artifacts}, hasSBOMs: $hasSBOMs) {
-		... AllHasSBOMTree
-	}
-}
-fragment AllHasSBOMTree on HasSBOM {
-	id
-	subject {
-		__typename
-		... on Artifact {
-			... AllArtifactTree
-		}
-		... on Package {
-			... AllPkgTree
-		}
-	}
-	uri
-	algorithm
-	digest
-	downloadLocation
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestHasSBOMs(subjects: {artifacts:$artifacts}, hasSBOMs: $hasSBOMs)
 }
 `
 
@@ -26580,53 +19354,7 @@ func HasSBOMArtifacts(
 // The query or mutation executed by HasSBOMPkg.
 const HasSBOMPkg_Operation = `
 mutation HasSBOMPkg ($pkg: PkgInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-	ingestHasSBOM(subject: {package:$pkg}, hasSBOM: $hasSBOM) {
-		... AllHasSBOMTree
-	}
-}
-fragment AllHasSBOMTree on HasSBOM {
-	id
-	subject {
-		__typename
-		... on Artifact {
-			... AllArtifactTree
-		}
-		... on Package {
-			... AllPkgTree
-		}
-	}
-	uri
-	algorithm
-	digest
-	downloadLocation
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestHasSBOM(subject: {package:$pkg}, hasSBOM: $hasSBOM)
 }
 `
 
@@ -26661,53 +19389,7 @@ func HasSBOMPkg(
 // The query or mutation executed by HasSBOMPkgs.
 const HasSBOMPkgs_Operation = `
 mutation HasSBOMPkgs ($pkgs: [PkgInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-	ingestHasSBOMs(subjects: {packages:$pkgs}, hasSBOMs: $hasSBOMs) {
-		... AllHasSBOMTree
-	}
-}
-fragment AllHasSBOMTree on HasSBOM {
-	id
-	subject {
-		__typename
-		... on Artifact {
-			... AllArtifactTree
-		}
-		... on Package {
-			... AllPkgTree
-		}
-	}
-	uri
-	algorithm
-	digest
-	downloadLocation
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestHasSBOMs(subjects: {packages:$pkgs}, hasSBOMs: $hasSBOMs)
 }
 `
 
@@ -26742,57 +19424,7 @@ func HasSBOMPkgs(
 // The query or mutation executed by HasSourceAt.
 const HasSourceAt_Operation = `
 mutation HasSourceAt ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
-	ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt) {
-		... AllHasSourceAt
-	}
-}
-fragment AllHasSourceAt on HasSourceAt {
-	id
-	justification
-	knownSince
-	package {
-		... AllPkgTree
-	}
-	source {
-		... AllSourceTree
-	}
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
+	ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt)
 }
 `
 
@@ -26831,23 +19463,7 @@ func HasSourceAt(
 // The query or mutation executed by HashEqual.
 const HashEqual_Operation = `
 mutation HashEqual ($artifact: ArtifactInputSpec!, $otherArtifact: ArtifactInputSpec!, $hashEqual: HashEqualInputSpec!) {
-	ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual) {
-		... AllHashEqualTree
-	}
-}
-fragment AllHashEqualTree on HashEqual {
-	id
-	justification
-	artifacts {
-		... AllArtifactTree
-	}
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual)
 }
 `
 
@@ -26884,23 +19500,7 @@ func HashEqual(
 // The query or mutation executed by HashEquals.
 const HashEquals_Operation = `
 mutation HashEquals ($artifacts: [ArtifactInputSpec!]!, $otherArtifacts: [ArtifactInputSpec!]!, $hashEquals: [HashEqualInputSpec!]!) {
-	ingestHashEquals(artifacts: $artifacts, otherArtifacts: $otherArtifacts, hashEquals: $hashEquals) {
-		... AllHashEqualTree
-	}
-}
-fragment AllHashEqualTree on HashEqual {
-	id
-	justification
-	artifacts {
-		... AllArtifactTree
-	}
-	origin
-	collector
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestHashEquals(artifacts: $artifacts, otherArtifacts: $otherArtifacts, hashEquals: $hashEquals)
 }
 `
 
@@ -26937,14 +19537,7 @@ func HashEquals(
 // The query or mutation executed by IngestArtifact.
 const IngestArtifact_Operation = `
 mutation IngestArtifact ($artifact: ArtifactInputSpec!) {
-	ingestArtifact(artifact: $artifact) {
-		... AllArtifactTree
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestArtifact(artifact: $artifact)
 }
 `
 
@@ -26977,14 +19570,7 @@ func IngestArtifact(
 // The query or mutation executed by IngestArtifacts.
 const IngestArtifacts_Operation = `
 mutation IngestArtifacts ($artifacts: [ArtifactInputSpec!]!) {
-	ingestArtifacts(artifacts: $artifacts) {
-		... AllArtifactTree
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestArtifacts(artifacts: $artifacts)
 }
 `
 
@@ -27017,9 +19603,7 @@ func IngestArtifacts(
 // The query or mutation executed by IngestBuilder.
 const IngestBuilder_Operation = `
 mutation IngestBuilder ($builder: BuilderInputSpec!) {
-	ingestBuilder(builder: $builder) {
-		uri
-	}
+	ingestBuilder(builder: $builder)
 }
 `
 
@@ -27052,9 +19636,7 @@ func IngestBuilder(
 // The query or mutation executed by IngestBuilders.
 const IngestBuilders_Operation = `
 mutation IngestBuilders ($builders: [BuilderInputSpec!]!) {
-	ingestBuilders(builders: $builders) {
-		uri
-	}
+	ingestBuilders(builders: $builders)
 }
 `
 
@@ -27087,30 +19669,7 @@ func IngestBuilders(
 // The query or mutation executed by IngestPackage.
 const IngestPackage_Operation = `
 mutation IngestPackage ($pkg: PkgInputSpec!) {
-	ingestPackage(pkg: $pkg) {
-		... AllPkgTree
-	}
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestPackage(pkg: $pkg)
 }
 `
 
@@ -27143,30 +19702,7 @@ func IngestPackage(
 // The query or mutation executed by IngestPackages.
 const IngestPackages_Operation = `
 mutation IngestPackages ($pkgs: [PkgInputSpec!]!) {
-	ingestPackages(pkgs: $pkgs) {
-		... AllPkgTree
-	}
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestPackages(pkgs: $pkgs)
 }
 `
 
@@ -27199,23 +19735,7 @@ func IngestPackages(
 // The query or mutation executed by IngestSource.
 const IngestSource_Operation = `
 mutation IngestSource ($source: SourceInputSpec!) {
-	ingestSource(source: $source) {
-		... AllSourceTree
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
+	ingestSource(source: $source)
 }
 `
 
@@ -27248,23 +19768,7 @@ func IngestSource(
 // The query or mutation executed by IngestSources.
 const IngestSources_Operation = `
 mutation IngestSources ($sources: [SourceInputSpec!]!) {
-	ingestSources(sources: $sources) {
-		... AllSourceTree
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
+	ingestSources(sources: $sources)
 }
 `
 
@@ -27297,17 +19801,7 @@ func IngestSources(
 // The query or mutation executed by IngestVulnerabilities.
 const IngestVulnerabilities_Operation = `
 mutation IngestVulnerabilities ($vulns: [VulnerabilityInputSpec!]!) {
-	ingestVulnerabilities(vulns: $vulns) {
-		... AllVulnerabilityTree
-	}
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestVulnerabilities(vulns: $vulns)
 }
 `
 
@@ -27340,17 +19834,7 @@ func IngestVulnerabilities(
 // The query or mutation executed by IngestVulnerability.
 const IngestVulnerability_Operation = `
 mutation IngestVulnerability ($vuln: VulnerabilityInputSpec!) {
-	ingestVulnerability(vuln: $vuln) {
-		... AllVulnerabilityTree
-	}
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
+	ingestVulnerability(vuln: $vuln)
 }
 `
 
@@ -27383,44 +19867,7 @@ func IngestVulnerability(
 // The query or mutation executed by IsDependencies.
 const IsDependencies_Operation = `
 mutation IsDependencies ($pkgs: [PkgInputSpec!]!, $depPkgs: [PkgInputSpec!]!, $depPkgMatchType: MatchFlags!, $dependencies: [IsDependencyInputSpec!]!) {
-	ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, depPkgMatchType: $depPkgMatchType, dependencies: $dependencies) {
-		... AllIsDependencyTree
-	}
-}
-fragment AllIsDependencyTree on IsDependency {
-	id
-	justification
-	package {
-		... AllPkgTree
-	}
-	dependentPackage {
-		... AllPkgTree
-	}
-	dependencyType
-	versionRange
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, depPkgMatchType: $depPkgMatchType, dependencies: $dependencies)
 }
 `
 
@@ -27459,44 +19906,7 @@ func IsDependencies(
 // The query or mutation executed by IsDependency.
 const IsDependency_Operation = `
 mutation IsDependency ($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $depPkgMatchType: MatchFlags!, $dependency: IsDependencyInputSpec!) {
-	ingestDependency(pkg: $pkg, depPkg: $depPkg, depPkgMatchType: $depPkgMatchType, dependency: $dependency) {
-		... AllIsDependencyTree
-	}
-}
-fragment AllIsDependencyTree on IsDependency {
-	id
-	justification
-	package {
-		... AllPkgTree
-	}
-	dependentPackage {
-		... AllPkgTree
-	}
-	dependencyType
-	versionRange
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
+	ingestDependency(pkg: $pkg, depPkg: $depPkg, depPkgMatchType: $depPkgMatchType, dependency: $dependency)
 }
 `
 
@@ -27535,67 +19945,7 @@ func IsDependency(
 // The query or mutation executed by IsOccurrencePkg.
 const IsOccurrencePkg_Operation = `
 mutation IsOccurrencePkg ($pkg: PkgInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-	ingestOccurrence(subject: {package:$pkg}, artifact: $artifact, occurrence: $occurrence) {
-		... AllIsOccurrencesTree
-	}
-}
-fragment AllIsOccurrencesTree on IsOccurrence {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-	}
-	artifact {
-		... AllArtifactTree
-	}
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestOccurrence(subject: {package:$pkg}, artifact: $artifact, occurrence: $occurrence)
 }
 `
 
@@ -27632,67 +19982,7 @@ func IsOccurrencePkg(
 // The query or mutation executed by IsOccurrenceSrc.
 const IsOccurrenceSrc_Operation = `
 mutation IsOccurrenceSrc ($source: SourceInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-	ingestOccurrence(subject: {source:$source}, artifact: $artifact, occurrence: $occurrence) {
-		... AllIsOccurrencesTree
-	}
-}
-fragment AllIsOccurrencesTree on IsOccurrence {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-	}
-	artifact {
-		... AllArtifactTree
-	}
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestOccurrence(subject: {source:$source}, artifact: $artifact, occurrence: $occurrence)
 }
 `
 
@@ -27729,67 +20019,7 @@ func IsOccurrenceSrc(
 // The query or mutation executed by IsOccurrencesPkg.
 const IsOccurrencesPkg_Operation = `
 mutation IsOccurrencesPkg ($pkgs: [PkgInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-	ingestOccurrences(subjects: {packages:$pkgs}, artifacts: $artifacts, occurrences: $occurrences) {
-		... AllIsOccurrencesTree
-	}
-}
-fragment AllIsOccurrencesTree on IsOccurrence {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-	}
-	artifact {
-		... AllArtifactTree
-	}
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestOccurrences(subjects: {packages:$pkgs}, artifacts: $artifacts, occurrences: $occurrences)
 }
 `
 
@@ -27826,67 +20056,7 @@ func IsOccurrencesPkg(
 // The query or mutation executed by IsOccurrencesSrc.
 const IsOccurrencesSrc_Operation = `
 mutation IsOccurrencesSrc ($sources: [SourceInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-	ingestOccurrences(subjects: {sources:$sources}, artifacts: $artifacts, occurrences: $occurrences) {
-		... AllIsOccurrencesTree
-	}
-}
-fragment AllIsOccurrencesTree on IsOccurrence {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-	}
-	artifact {
-		... AllArtifactTree
-	}
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestOccurrences(subjects: {sources:$sources}, artifacts: $artifacts, occurrences: $occurrences)
 }
 `
 
@@ -29744,45 +21914,9 @@ func Path(
 // The query or mutation executed by PkgEqual.
 const PkgEqual_Operation = `
 mutation PkgEqual ($pkg: PkgInputSpec!, $otherPackage: PkgInputSpec!, $pkgEqual: PkgEqualInputSpec!) {
-	pkg: ingestPackage(pkg: $pkg) {
-		... AllPkgTree
-	}
-	otherPackage: ingestPackage(pkg: $otherPackage) {
-		... AllPkgTree
-	}
-	ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual) {
-		... AllPkgEqual
-	}
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllPkgEqual on PkgEqual {
-	id
-	justification
-	packages {
-		... AllPkgTree
-	}
-	origin
-	collector
+	pkg: ingestPackage(pkg: $pkg)
+	otherPackage: ingestPackage(pkg: $otherPackage)
+	ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual)
 }
 `
 
@@ -29819,70 +21953,7 @@ func PkgEqual(
 // The query or mutation executed by PointOfContactArtifact.
 const PointOfContactArtifact_Operation = `
 mutation PointOfContactArtifact ($artifact: ArtifactInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-	ingestPointOfContact(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, pointOfContact: $pointOfContact) {
-		... AllPointOfContact
-	}
-}
-fragment AllPointOfContact on PointOfContact {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	email
-	info
-	since
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestPointOfContact(subject: {artifact:$artifact}, pkgMatchType: {pkg:ALL_VERSIONS}, pointOfContact: $pointOfContact)
 }
 `
 
@@ -29917,70 +21988,7 @@ func PointOfContactArtifact(
 // The query or mutation executed by PointOfContactPkg.
 const PointOfContactPkg_Operation = `
 mutation PointOfContactPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $pointOfContact: PointOfContactInputSpec!) {
-	ingestPointOfContact(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact) {
-		... AllPointOfContact
-	}
-}
-fragment AllPointOfContact on PointOfContact {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	email
-	info
-	since
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestPointOfContact(subject: {package:$pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact)
 }
 `
 
@@ -30017,70 +22025,7 @@ func PointOfContactPkg(
 // The query or mutation executed by PointOfContactSrc.
 const PointOfContactSrc_Operation = `
 mutation PointOfContactSrc ($source: SourceInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-	ingestPointOfContact(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, pointOfContact: $pointOfContact) {
-		... AllPointOfContact
-	}
-}
-fragment AllPointOfContact on PointOfContact {
-	id
-	subject {
-		__typename
-		... on Package {
-			... AllPkgTree
-		}
-		... on Source {
-			... AllSourceTree
-		}
-		... on Artifact {
-			... AllArtifactTree
-		}
-	}
-	email
-	info
-	since
-	justification
-	origin
-	collector
-}
-fragment AllPkgTree on Package {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			versions {
-				id
-				version
-				qualifiers {
-					key
-					value
-				}
-				subpath
-			}
-		}
-	}
-}
-fragment AllSourceTree on Source {
-	id
-	type
-	namespaces {
-		id
-		namespace
-		names {
-			id
-			name
-			tag
-			commit
-		}
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestPointOfContact(subject: {source:$source}, pkgMatchType: {pkg:ALL_VERSIONS}, pointOfContact: $pointOfContact)
 }
 `
 
@@ -30115,39 +22060,7 @@ func PointOfContactSrc(
 // The query or mutation executed by SLSAForArtifact.
 const SLSAForArtifact_Operation = `
 mutation SLSAForArtifact ($artifact: ArtifactInputSpec!, $materials: [ArtifactInputSpec!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
-	ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
-		... AllSLSATree
-	}
-}
-fragment AllSLSATree on HasSLSA {
-	id
-	subject {
-		... AllArtifactTree
-	}
-	slsa {
-		builtFrom {
-			... AllArtifactTree
-		}
-		builtBy {
-			id
-			uri
-		}
-		buildType
-		slsaPredicate {
-			key
-			value
-		}
-		slsaVersion
-		startedOn
-		finishedOn
-		origin
-		collector
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa)
 }
 `
 
@@ -30186,39 +22099,7 @@ func SLSAForArtifact(
 // The query or mutation executed by SLSAForArtifacts.
 const SLSAForArtifacts_Operation = `
 mutation SLSAForArtifacts ($artifacts: [ArtifactInputSpec!]!, $materialsList: [[ArtifactInputSpec!]!]!, $builders: [BuilderInputSpec!]!, $slsaList: [SLSAInputSpec!]!) {
-	ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList) {
-		... AllSLSATree
-	}
-}
-fragment AllSLSATree on HasSLSA {
-	id
-	subject {
-		... AllArtifactTree
-	}
-	slsa {
-		builtFrom {
-			... AllArtifactTree
-		}
-		builtBy {
-			id
-			uri
-		}
-		buildType
-		slsaPredicate {
-			key
-			value
-		}
-		slsaVersion
-		startedOn
-		finishedOn
-		origin
-		collector
-	}
-}
-fragment AllArtifactTree on Artifact {
-	id
-	algorithm
-	digest
+	ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList)
 }
 `
 
@@ -30306,32 +22187,9 @@ func Sources(
 // The query or mutation executed by VulnEqual.
 const VulnEqual_Operation = `
 mutation VulnEqual ($vulnerability: VulnerabilityInputSpec!, $otherVulnerability: VulnerabilityInputSpec!, $vulnEqual: VulnEqualInputSpec!) {
-	vuln: ingestVulnerability(vuln: $vulnerability) {
-		... AllVulnerabilityTree
-	}
-	otherVuln: ingestVulnerability(vuln: $otherVulnerability) {
-		... AllVulnerabilityTree
-	}
-	ingestVulnEqual(vulnerability: $vulnerability, otherVulnerability: $otherVulnerability, vulnEqual: $vulnEqual) {
-		... AllVulnEqual
-	}
-}
-fragment AllVulnerabilityTree on Vulnerability {
-	id
-	type
-	vulnerabilityIDs {
-		id
-		vulnerabilityID
-	}
-}
-fragment AllVulnEqual on VulnEqual {
-	id
-	vulnerabilities {
-		... AllVulnerabilityTree
-	}
-	justification
-	origin
-	collector
+	vuln: ingestVulnerability(vuln: $vulnerability)
+	otherVuln: ingestVulnerability(vuln: $otherVulnerability)
+	ingestVulnEqual(vulnerability: $vulnerability, otherVulnerability: $otherVulnerability, vulnEqual: $vulnEqual)
 }
 `
 

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1916,6 +1916,499 @@ func (v *AllCertifyVulnVulnerability) __premarshalJSON() (*__premarshalAllCertif
 	return &retval, nil
 }
 
+// AllHasMetadata includes the GraphQL fields of HasMetadata requested by the fragment AllHasMetadata.
+// The GraphQL type's documentation follows.
+//
+// HasMetadata is an attestation that a package, source, or artifact has a certain
+// attested property (key) with value (value). For example, a source may have
+// metadata "SourceRepo2FAEnabled=true".
+//
+// The intent of this evidence tree predicate is to allow extensibility of metadata
+// expressible within the GUAC ontology. Metadata that is commonly used will then
+// be promoted to a predicate on its own.
+//
+// Justification indicates how the metadata was determined.
+//
+// The metadata applies to a subject which is a package, source, or artifact.
+// If the attestation targets a package, it must target a PackageName or a
+// PackageVersion. If the attestation targets a source, it must target a
+// SourceName.
+type AllHasMetadata struct {
+	Id            string                                       `json:"id"`
+	Subject       AllHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
+	Key           string                                       `json:"key"`
+	Value         string                                       `json:"value"`
+	Timestamp     time.Time                                    `json:"timestamp"`
+	Justification string                                       `json:"justification"`
+	Origin        string                                       `json:"origin"`
+	Collector     string                                       `json:"collector"`
+}
+
+// GetId returns AllHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetId() string { return v.Id }
+
+// GetSubject returns AllHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact { return v.Subject }
+
+// GetKey returns AllHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetKey() string { return v.Key }
+
+// GetValue returns AllHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetValue() string { return v.Value }
+
+// GetTimestamp returns AllHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetTimestamp() time.Time { return v.Timestamp }
+
+// GetJustification returns AllHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetJustification() string { return v.Justification }
+
+// GetOrigin returns AllHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetOrigin() string { return v.Origin }
+
+// GetCollector returns AllHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *AllHasMetadata) GetCollector() string { return v.Collector }
+
+func (v *AllHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadata
+		Subject json.RawMessage `json:"subject"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Subject
+		src := firstPass.Subject
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal AllHasMetadata.Subject: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadata struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *AllHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadata) __premarshalJSON() (*__premarshalAllHasMetadata, error) {
+	var retval __premarshalAllHasMetadata
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Subject
+		src := v.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.Key
+	retval.Value = v.Value
+	retval.Timestamp = v.Timestamp
+	retval.Justification = v.Justification
+	retval.Origin = v.Origin
+	retval.Collector = v.Collector
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectArtifact includes the requested fields of the GraphQL type Artifact.
+// The GraphQL type's documentation follows.
+//
+// Artifact represents an artifact identified by a checksum hash.
+//
+// The checksum is split into the digest value and the algorithm used to generate
+// it. Both fields are mandatory and canonicalized to be lowercase.
+//
+// If having a checksum Go object, algorithm can be
+// strings.ToLower(string(checksum.Algorithm)) and digest can be checksum.Value.
+type AllHasMetadataSubjectArtifact struct {
+	Typename        *string `json:"__typename"`
+	AllArtifactTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectArtifact.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectArtifact.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetId() string { return v.AllArtifactTree.Id }
+
+// GetAlgorithm returns AllHasMetadataSubjectArtifact.Algorithm, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetAlgorithm() string { return v.AllArtifactTree.Algorithm }
+
+// GetDigest returns AllHasMetadataSubjectArtifact.Digest, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectArtifact) GetDigest() string { return v.AllArtifactTree.Digest }
+
+func (v *AllHasMetadataSubjectArtifact) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectArtifact
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectArtifact = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllArtifactTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectArtifact struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+}
+
+func (v *AllHasMetadataSubjectArtifact) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectArtifact) __premarshalJSON() (*__premarshalAllHasMetadataSubjectArtifact, error) {
+	var retval __premarshalAllHasMetadataSubjectArtifact
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllArtifactTree.Id
+	retval.Algorithm = v.AllArtifactTree.Algorithm
+	retval.Digest = v.AllArtifactTree.Digest
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectPackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type AllHasMetadataSubjectPackage struct {
+	Typename   *string `json:"__typename"`
+	AllPkgTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectPackage.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectPackage.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetId() string { return v.AllPkgTree.Id }
+
+// GetType returns AllHasMetadataSubjectPackage.Type, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetType() string { return v.AllPkgTree.Type }
+
+// GetNamespaces returns AllHasMetadataSubjectPackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectPackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *AllHasMetadataSubjectPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectPackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectPackage struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *AllHasMetadataSubjectPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectPackage) __premarshalJSON() (*__premarshalAllHasMetadataSubjectPackage, error) {
+	var retval __premarshalAllHasMetadataSubjectPackage
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// AllHasMetadataSubjectPackageSourceOrArtifact includes the requested fields of the GraphQL interface PackageSourceOrArtifact.
+//
+// AllHasMetadataSubjectPackageSourceOrArtifact is implemented by the following types:
+// AllHasMetadataSubjectArtifact
+// AllHasMetadataSubjectPackage
+// AllHasMetadataSubjectSource
+// The GraphQL type's documentation follows.
+//
+// PackageSourceOrArtifact is a union of Package, Source, and Artifact.
+type AllHasMetadataSubjectPackageSourceOrArtifact interface {
+	implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *AllHasMetadataSubjectArtifact) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+func (v *AllHasMetadataSubjectPackage) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+func (v *AllHasMetadataSubjectSource) implementsGraphQLInterfaceAllHasMetadataSubjectPackageSourceOrArtifact() {
+}
+
+func __unmarshalAllHasMetadataSubjectPackageSourceOrArtifact(b []byte, v *AllHasMetadataSubjectPackageSourceOrArtifact) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Artifact":
+		*v = new(AllHasMetadataSubjectArtifact)
+		return json.Unmarshal(b, *v)
+	case "Package":
+		*v = new(AllHasMetadataSubjectPackage)
+		return json.Unmarshal(b, *v)
+	case "Source":
+		*v = new(AllHasMetadataSubjectSource)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing PackageSourceOrArtifact.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAllHasMetadataSubjectPackageSourceOrArtifact(v *AllHasMetadataSubjectPackageSourceOrArtifact) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AllHasMetadataSubjectArtifact:
+		typename = "Artifact"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectArtifact
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllHasMetadataSubjectPackage:
+		typename = "Package"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectPackage
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AllHasMetadataSubjectSource:
+		typename = "Source"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAllHasMetadataSubjectSource
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AllHasMetadataSubjectPackageSourceOrArtifact: "%T"`, v)
+	}
+}
+
+// AllHasMetadataSubjectSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type AllHasMetadataSubjectSource struct {
+	Typename      *string `json:"__typename"`
+	AllSourceTree `json:"-"`
+}
+
+// GetTypename returns AllHasMetadataSubjectSource.Typename, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetTypename() *string { return v.Typename }
+
+// GetId returns AllHasMetadataSubjectSource.Id, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetId() string { return v.AllSourceTree.Id }
+
+// GetType returns AllHasMetadataSubjectSource.Type, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetType() string { return v.AllSourceTree.Type }
+
+// GetNamespaces returns AllHasMetadataSubjectSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *AllHasMetadataSubjectSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *AllHasMetadataSubjectSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AllHasMetadataSubjectSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AllHasMetadataSubjectSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAllHasMetadataSubjectSource struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *AllHasMetadataSubjectSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AllHasMetadataSubjectSource) __premarshalJSON() (*__premarshalAllHasMetadataSubjectSource, error) {
+	var retval __premarshalAllHasMetadataSubjectSource
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
 // AllHasSBOMTree includes the GraphQL fields of HasSBOM requested by the fragment AllHasSBOMTree.
 type AllHasSBOMTree struct {
 	Id string `json:"id"`
@@ -6825,11 +7318,119 @@ func (v *NeighborsNeighborsCertifyVuln) __premarshalJSON() (*__premarshalNeighbo
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type NeighborsNeighborsHasMetadata struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetTypename returns NeighborsNeighborsHasMetadata.Typename, and is useful for accessing the field via an interface.
 func (v *NeighborsNeighborsHasMetadata) GetTypename() *string { return v.Typename }
+
+// GetId returns NeighborsNeighborsHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetId() string { return v.AllHasMetadata.Id }
+
+// GetSubject returns NeighborsNeighborsHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
+}
+
+// GetKey returns NeighborsNeighborsHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
+
+// GetValue returns NeighborsNeighborsHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
+
+// GetTimestamp returns NeighborsNeighborsHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
+
+// GetJustification returns NeighborsNeighborsHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetJustification() string {
+	return v.AllHasMetadata.Justification
+}
+
+// GetOrigin returns NeighborsNeighborsHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
+
+// GetCollector returns NeighborsNeighborsHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *NeighborsNeighborsHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
+
+func (v *NeighborsNeighborsHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NeighborsNeighborsHasMetadata
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NeighborsNeighborsHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllHasMetadata)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNeighborsNeighborsHasMetadata struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NeighborsNeighborsHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NeighborsNeighborsHasMetadata) __premarshalJSON() (*__premarshalNeighborsNeighborsHasMetadata, error) {
+	var retval __premarshalNeighborsNeighborsHasMetadata
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllHasMetadata.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllHasMetadata.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NeighborsNeighborsHasMetadata.AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
+	return &retval, nil
+}
 
 // NeighborsNeighborsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NeighborsNeighborsHasSBOM struct {
@@ -7683,10 +8284,14 @@ func __marshalNeighborsNeighborsNode(v *NeighborsNeighborsNode) ([]byte, error) 
 	case *NeighborsNeighborsHasMetadata:
 		typename = "HasMetadata"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NeighborsNeighborsHasMetadata
-		}{typename, v}
+			*__premarshalNeighborsNeighborsHasMetadata
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NeighborsNeighborsHasSBOM:
 		typename = "HasSBOM"
@@ -8901,10 +9506,14 @@ func __marshalNodeNode(v *NodeNode) ([]byte, error) {
 	case *NodeNodeHasMetadata:
 		typename = "HasMetadata"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NodeNodeHasMetadata
-		}{typename, v}
+			*__premarshalNodeNodeHasMetadata
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NodeNodeHasSBOM:
 		typename = "HasSBOM"
@@ -9765,11 +10374,117 @@ func (v *NodeNodeCertifyVuln) __premarshalJSON() (*__premarshalNodeNodeCertifyVu
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type NodeNodeHasMetadata struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetTypename returns NodeNodeHasMetadata.Typename, and is useful for accessing the field via an interface.
 func (v *NodeNodeHasMetadata) GetTypename() *string { return v.Typename }
+
+// GetId returns NodeNodeHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetId() string { return v.AllHasMetadata.Id }
+
+// GetSubject returns NodeNodeHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
+}
+
+// GetKey returns NodeNodeHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
+
+// GetValue returns NodeNodeHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
+
+// GetTimestamp returns NodeNodeHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
+
+// GetJustification returns NodeNodeHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetJustification() string { return v.AllHasMetadata.Justification }
+
+// GetOrigin returns NodeNodeHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
+
+// GetCollector returns NodeNodeHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *NodeNodeHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
+
+func (v *NodeNodeHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NodeNodeHasMetadata
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NodeNodeHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllHasMetadata)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNodeNodeHasMetadata struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NodeNodeHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NodeNodeHasMetadata) __premarshalJSON() (*__premarshalNodeNodeHasMetadata, error) {
+	var retval __premarshalNodeNodeHasMetadata
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllHasMetadata.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllHasMetadata.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NodeNodeHasMetadata.AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
+	return &retval, nil
+}
 
 // NodeNodeHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NodeNodeHasSBOM struct {
@@ -11847,11 +12562,117 @@ func (v *NodesNodesCertifyVuln) __premarshalJSON() (*__premarshalNodesNodesCerti
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type NodesNodesHasMetadata struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetTypename returns NodesNodesHasMetadata.Typename, and is useful for accessing the field via an interface.
 func (v *NodesNodesHasMetadata) GetTypename() *string { return v.Typename }
+
+// GetId returns NodesNodesHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetId() string { return v.AllHasMetadata.Id }
+
+// GetSubject returns NodesNodesHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
+}
+
+// GetKey returns NodesNodesHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
+
+// GetValue returns NodesNodesHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
+
+// GetTimestamp returns NodesNodesHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
+
+// GetJustification returns NodesNodesHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetJustification() string { return v.AllHasMetadata.Justification }
+
+// GetOrigin returns NodesNodesHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
+
+// GetCollector returns NodesNodesHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *NodesNodesHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
+
+func (v *NodesNodesHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*NodesNodesHasMetadata
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.NodesNodesHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllHasMetadata)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalNodesNodesHasMetadata struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *NodesNodesHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *NodesNodesHasMetadata) __premarshalJSON() (*__premarshalNodesNodesHasMetadata, error) {
+	var retval __premarshalNodesNodesHasMetadata
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllHasMetadata.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllHasMetadata.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal NodesNodesHasMetadata.AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
+	return &retval, nil
+}
 
 // NodesNodesHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type NodesNodesHasSBOM struct {
@@ -12686,10 +13507,14 @@ func __marshalNodesNodesNode(v *NodesNodesNode) ([]byte, error) {
 	case *NodesNodesHasMetadata:
 		typename = "HasMetadata"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*NodesNodesHasMetadata
-		}{typename, v}
+			*__premarshalNodesNodesHasMetadata
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *NodesNodesHasSBOM:
 		typename = "HasSBOM"
@@ -14881,11 +15706,117 @@ func (v *PathPathCertifyVuln) __premarshalJSON() (*__premarshalPathPathCertifyVu
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type PathPathHasMetadata struct {
-	Typename *string `json:"__typename"`
+	Typename       *string `json:"__typename"`
+	AllHasMetadata `json:"-"`
 }
 
 // GetTypename returns PathPathHasMetadata.Typename, and is useful for accessing the field via an interface.
 func (v *PathPathHasMetadata) GetTypename() *string { return v.Typename }
+
+// GetId returns PathPathHasMetadata.Id, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetId() string { return v.AllHasMetadata.Id }
+
+// GetSubject returns PathPathHasMetadata.Subject, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetSubject() AllHasMetadataSubjectPackageSourceOrArtifact {
+	return v.AllHasMetadata.Subject
+}
+
+// GetKey returns PathPathHasMetadata.Key, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetKey() string { return v.AllHasMetadata.Key }
+
+// GetValue returns PathPathHasMetadata.Value, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetValue() string { return v.AllHasMetadata.Value }
+
+// GetTimestamp returns PathPathHasMetadata.Timestamp, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetTimestamp() time.Time { return v.AllHasMetadata.Timestamp }
+
+// GetJustification returns PathPathHasMetadata.Justification, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetJustification() string { return v.AllHasMetadata.Justification }
+
+// GetOrigin returns PathPathHasMetadata.Origin, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetOrigin() string { return v.AllHasMetadata.Origin }
+
+// GetCollector returns PathPathHasMetadata.Collector, and is useful for accessing the field via an interface.
+func (v *PathPathHasMetadata) GetCollector() string { return v.AllHasMetadata.Collector }
+
+func (v *PathPathHasMetadata) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*PathPathHasMetadata
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.PathPathHasMetadata = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllHasMetadata)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalPathPathHasMetadata struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Key string `json:"key"`
+
+	Value string `json:"value"`
+
+	Timestamp time.Time `json:"timestamp"`
+
+	Justification string `json:"justification"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+}
+
+func (v *PathPathHasMetadata) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *PathPathHasMetadata) __premarshalJSON() (*__premarshalPathPathHasMetadata, error) {
+	var retval __premarshalPathPathHasMetadata
+
+	retval.Typename = v.Typename
+	retval.Id = v.AllHasMetadata.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllHasMetadata.Subject
+		var err error
+		*dst, err = __marshalAllHasMetadataSubjectPackageSourceOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal PathPathHasMetadata.AllHasMetadata.Subject: %w", err)
+		}
+	}
+	retval.Key = v.AllHasMetadata.Key
+	retval.Value = v.AllHasMetadata.Value
+	retval.Timestamp = v.AllHasMetadata.Timestamp
+	retval.Justification = v.AllHasMetadata.Justification
+	retval.Origin = v.AllHasMetadata.Origin
+	retval.Collector = v.AllHasMetadata.Collector
+	return &retval, nil
+}
 
 // PathPathHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type PathPathHasSBOM struct {
@@ -15716,10 +16647,14 @@ func __marshalPathPathNode(v *PathPathNode) ([]byte, error) {
 	case *PathPathHasMetadata:
 		typename = "HasMetadata"
 
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 		result := struct {
 			TypeName string `json:"__typename"`
-			*PathPathHasMetadata
-		}{typename, v}
+			*__premarshalPathPathHasMetadata
+		}{typename, premarshaled}
 		return json.Marshal(result)
 	case *PathPathHasSBOM:
 		typename = "HasSBOM"
@@ -20158,6 +21093,9 @@ query Neighbors ($node: ID!, $usingOnly: [Edge!]!) {
 		... on VulnerabilityMetadata {
 			... AllVulnMetadataTree
 		}
+		... on HasMetadata {
+			... AllHasMetadata
+		}
 	}
 }
 fragment AllPkgTree on Package {
@@ -20455,6 +21393,27 @@ fragment AllVulnMetadataTree on VulnerabilityMetadata {
 	scoreType
 	scoreValue
 	timestamp
+	origin
+	collector
+}
+fragment AllHasMetadata on HasMetadata {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	key
+	value
+	timestamp
+	justification
 	origin
 	collector
 }
@@ -20556,6 +21515,9 @@ query Node ($node: ID!) {
 		... on VulnerabilityMetadata {
 			... AllVulnMetadataTree
 		}
+		... on HasMetadata {
+			... AllHasMetadata
+		}
 	}
 }
 fragment AllPkgTree on Package {
@@ -20853,6 +21815,27 @@ fragment AllVulnMetadataTree on VulnerabilityMetadata {
 	scoreType
 	scoreValue
 	timestamp
+	origin
+	collector
+}
+fragment AllHasMetadata on HasMetadata {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	key
+	value
+	timestamp
+	justification
 	origin
 	collector
 }
@@ -20952,6 +21935,9 @@ query Nodes ($nodes: [ID!]!) {
 		... on VulnerabilityMetadata {
 			... AllVulnMetadataTree
 		}
+		... on HasMetadata {
+			... AllHasMetadata
+		}
 	}
 }
 fragment AllPkgTree on Package {
@@ -21249,6 +22235,27 @@ fragment AllVulnMetadataTree on VulnerabilityMetadata {
 	scoreType
 	scoreValue
 	timestamp
+	origin
+	collector
+}
+fragment AllHasMetadata on HasMetadata {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	key
+	value
+	timestamp
+	justification
 	origin
 	collector
 }
@@ -21577,6 +22584,9 @@ query Path ($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge
 		... on VulnerabilityMetadata {
 			... AllVulnMetadataTree
 		}
+		... on HasMetadata {
+			... AllHasMetadata
+		}
 	}
 }
 fragment AllPkgTree on Package {
@@ -21874,6 +22884,27 @@ fragment AllVulnMetadataTree on VulnerabilityMetadata {
 	scoreType
 	scoreValue
 	timestamp
+	origin
+	collector
+}
+fragment AllHasMetadata on HasMetadata {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+		... on Artifact {
+			... AllArtifactTree
+		}
+	}
+	key
+	value
+	timestamp
+	justification
 	origin
 	collector
 }

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5349,7 +5349,7 @@ func (v *BuilderInputSpec) GetUri() string { return v.Uri }
 
 // CertifyBadArtifactResponse is returned by CertifyBadArtifact on success.
 type CertifyBadArtifactResponse struct {
-	// Adds a certification that a package, source or artifact is considered bad.
+	// Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string.
 	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
@@ -5358,7 +5358,7 @@ func (v *CertifyBadArtifactResponse) GetIngestCertifyBad() string { return v.Ing
 
 // CertifyBadArtifactsResponse is returned by CertifyBadArtifacts on success.
 type CertifyBadArtifactsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered bad.
+	// Adds bulk certifications that a package, source or artifact is considered bad. The returned array of IDs can be a an array of empty string.
 	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
@@ -5384,7 +5384,7 @@ func (v *CertifyBadInputSpec) GetCollector() string { return v.Collector }
 
 // CertifyBadPkgResponse is returned by CertifyBadPkg on success.
 type CertifyBadPkgResponse struct {
-	// Adds a certification that a package, source or artifact is considered bad.
+	// Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string.
 	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
@@ -5393,7 +5393,7 @@ func (v *CertifyBadPkgResponse) GetIngestCertifyBad() string { return v.IngestCe
 
 // CertifyBadPkgsResponse is returned by CertifyBadPkgs on success.
 type CertifyBadPkgsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered bad.
+	// Adds bulk certifications that a package, source or artifact is considered bad. The returned array of IDs can be a an array of empty string.
 	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
@@ -5434,7 +5434,7 @@ func (v *CertifyBadSpec) GetCollector() *string { return v.Collector }
 
 // CertifyBadSrcResponse is returned by CertifyBadSrc on success.
 type CertifyBadSrcResponse struct {
-	// Adds a certification that a package, source or artifact is considered bad.
+	// Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string.
 	IngestCertifyBad string `json:"ingestCertifyBad"`
 }
 
@@ -5443,7 +5443,7 @@ func (v *CertifyBadSrcResponse) GetIngestCertifyBad() string { return v.IngestCe
 
 // CertifyBadSrcsResponse is returned by CertifyBadSrcs on success.
 type CertifyBadSrcsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered bad.
+	// Adds bulk certifications that a package, source or artifact is considered bad. The returned array of IDs can be a an array of empty string.
 	IngestCertifyBads []string `json:"ingestCertifyBads"`
 }
 
@@ -5563,7 +5563,7 @@ func (v *CertifyBadsResponse) GetCertifyBad() []CertifyBadsCertifyBad { return v
 
 // CertifyGoodArtifactResponse is returned by CertifyGoodArtifact on success.
 type CertifyGoodArtifactResponse struct {
-	// Adds a certification that a package, source or artifact is considered good.
+	// Adds a certification that a package, source or artifact is considered good. The returned ID can be empty string.
 	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
@@ -5572,7 +5572,7 @@ func (v *CertifyGoodArtifactResponse) GetIngestCertifyGood() string { return v.I
 
 // CertifyGoodArtifactsResponse is returned by CertifyGoodArtifacts on success.
 type CertifyGoodArtifactsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered good.
+	// Adds bulk certifications that a package, source or artifact is considered good. The returned array of IDs can be a an array of empty string.
 	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
@@ -5597,7 +5597,7 @@ func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 
 // CertifyGoodPkgResponse is returned by CertifyGoodPkg on success.
 type CertifyGoodPkgResponse struct {
-	// Adds a certification that a package, source or artifact is considered good.
+	// Adds a certification that a package, source or artifact is considered good. The returned ID can be empty string.
 	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
@@ -5606,7 +5606,7 @@ func (v *CertifyGoodPkgResponse) GetIngestCertifyGood() string { return v.Ingest
 
 // CertifyGoodPkgsResponse is returned by CertifyGoodPkgs on success.
 type CertifyGoodPkgsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered good.
+	// Adds bulk certifications that a package, source or artifact is considered good. The returned array of IDs can be a an array of empty string.
 	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
@@ -5615,7 +5615,7 @@ func (v *CertifyGoodPkgsResponse) GetIngestCertifyGoods() []string { return v.In
 
 // CertifyGoodSrcResponse is returned by CertifyGoodSrc on success.
 type CertifyGoodSrcResponse struct {
-	// Adds a certification that a package, source or artifact is considered good.
+	// Adds a certification that a package, source or artifact is considered good. The returned ID can be empty string.
 	IngestCertifyGood string `json:"ingestCertifyGood"`
 }
 
@@ -5624,7 +5624,7 @@ func (v *CertifyGoodSrcResponse) GetIngestCertifyGood() string { return v.Ingest
 
 // CertifyGoodSrcsResponse is returned by CertifyGoodSrcs on success.
 type CertifyGoodSrcsResponse struct {
-	// Adds bulk certifications that a package, source or artifact is considered good.
+	// Adds bulk certifications that a package, source or artifact is considered good. The returned array of IDs can be a an array of empty string.
 	IngestCertifyGoods []string `json:"ingestCertifyGoods"`
 }
 
@@ -5633,7 +5633,7 @@ func (v *CertifyGoodSrcsResponse) GetIngestCertifyGoods() []string { return v.In
 
 // CertifyScorecardResponse is returned by CertifyScorecard on success.
 type CertifyScorecardResponse struct {
-	// Adds a certification that a source repository has a Scorecard.
+	// Adds a certification that a source repository has a Scorecard. The returned ID can be empty string.
 	IngestScorecard string `json:"ingestScorecard"`
 }
 
@@ -5642,7 +5642,7 @@ func (v *CertifyScorecardResponse) GetIngestScorecard() string { return v.Ingest
 
 // CertifyScorecardsResponse is returned by CertifyScorecards on success.
 type CertifyScorecardsResponse struct {
-	// Adds bulk certifications that a source repository has a Scorecard.
+	// Adds bulk certifications that a source repository has a Scorecard. The returned array of IDs can be a an array of empty string.
 	IngestScorecards []string `json:"ingestScorecards"`
 }
 
@@ -5651,7 +5651,7 @@ func (v *CertifyScorecardsResponse) GetIngestScorecards() []string { return v.In
 
 // CertifyVexArtifactResponse is returned by CertifyVexArtifact on success.
 type CertifyVexArtifactResponse struct {
-	// Adds a VEX certification for a package.
+	// Adds a VEX certification for a package. The returned ID can be empty string.
 	IngestVEXStatement string `json:"ingestVEXStatement"`
 }
 
@@ -5660,7 +5660,7 @@ func (v *CertifyVexArtifactResponse) GetIngestVEXStatement() string { return v.I
 
 // CertifyVexPkgResponse is returned by CertifyVexPkg on success.
 type CertifyVexPkgResponse struct {
-	// Adds a VEX certification for a package.
+	// Adds a VEX certification for a package. The returned ID can be empty string.
 	IngestVEXStatement string `json:"ingestVEXStatement"`
 }
 
@@ -5669,7 +5669,7 @@ func (v *CertifyVexPkgResponse) GetIngestVEXStatement() string { return v.Ingest
 
 // CertifyVulnPkgResponse is returned by CertifyVulnPkg on success.
 type CertifyVulnPkgResponse struct {
-	// Adds a certification that a package has been scanned for vulnerabilities.
+	// Adds a certification that a package has been scanned for vulnerabilities. The returned ID can be empty string.
 	IngestCertifyVuln string `json:"ingestCertifyVuln"`
 }
 
@@ -5678,7 +5678,7 @@ func (v *CertifyVulnPkgResponse) GetIngestCertifyVuln() string { return v.Ingest
 
 // CertifyVulnPkgsResponse is returned by CertifyVulnPkgs on success.
 type CertifyVulnPkgsResponse struct {
-	// Bulk add certifications that a package has been scanned for vulnerabilities.
+	// Bulk add certifications that a package has been scanned for vulnerabilities. The returned array of IDs can be a an array of empty string.
 	IngestCertifyVulns []string `json:"ingestCertifyVulns"`
 }
 
@@ -6238,7 +6238,7 @@ func (v *FindSoftwareResponse) __premarshalJSON() (*__premarshalFindSoftwareResp
 
 // HasMetadataArtifactResponse is returned by HasMetadataArtifact on success.
 type HasMetadataArtifactResponse struct {
-	// Adds metadata about a package, source or artifact.
+	// Adds metadata about a package, source or artifact. The returned ID can be empty string.
 	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
@@ -6275,7 +6275,7 @@ func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
 
 // HasMetadataPkgResponse is returned by HasMetadataPkg on success.
 type HasMetadataPkgResponse struct {
-	// Adds metadata about a package, source or artifact.
+	// Adds metadata about a package, source or artifact. The returned ID can be empty string.
 	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
@@ -6284,7 +6284,7 @@ func (v *HasMetadataPkgResponse) GetIngestHasMetadata() string { return v.Ingest
 
 // HasMetadataSrcResponse is returned by HasMetadataSrc on success.
 type HasMetadataSrcResponse struct {
-	// Adds metadata about a package, source or artifact.
+	// Adds metadata about a package, source or artifact. The returned ID can be empty string.
 	IngestHasMetadata string `json:"ingestHasMetadata"`
 }
 
@@ -6293,7 +6293,7 @@ func (v *HasMetadataSrcResponse) GetIngestHasMetadata() string { return v.Ingest
 
 // HasSBOMArtifactResponse is returned by HasSBOMArtifact on success.
 type HasSBOMArtifactResponse struct {
-	// Certifies that a package or artifact has an SBOM.
+	// Certifies that a package or artifact has an SBOM. The returned ID can be empty string.
 	IngestHasSBOM string `json:"ingestHasSBOM"`
 }
 
@@ -6302,7 +6302,7 @@ func (v *HasSBOMArtifactResponse) GetIngestHasSBOM() string { return v.IngestHas
 
 // HasSBOMArtifactsResponse is returned by HasSBOMArtifacts on success.
 type HasSBOMArtifactsResponse struct {
-	// Bulk ingest that package or artifact has an SBOM.
+	// Bulk ingest that package or artifact has an SBOM. The returned array of IDs can be a an array of empty string.
 	IngestHasSBOMs []string `json:"ingestHasSBOMs"`
 }
 
@@ -6339,7 +6339,7 @@ func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
 // HasSBOMPkgResponse is returned by HasSBOMPkg on success.
 type HasSBOMPkgResponse struct {
-	// Certifies that a package or artifact has an SBOM.
+	// Certifies that a package or artifact has an SBOM. The returned ID can be empty string.
 	IngestHasSBOM string `json:"ingestHasSBOM"`
 }
 
@@ -6348,7 +6348,7 @@ func (v *HasSBOMPkgResponse) GetIngestHasSBOM() string { return v.IngestHasSBOM 
 
 // HasSBOMPkgsResponse is returned by HasSBOMPkgs on success.
 type HasSBOMPkgsResponse struct {
-	// Bulk ingest that package or artifact has an SBOM.
+	// Bulk ingest that package or artifact has an SBOM. The returned array of IDs can be a an array of empty string.
 	IngestHasSBOMs []string `json:"ingestHasSBOMs"`
 }
 
@@ -6377,7 +6377,7 @@ func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 
 // HasSourceAtResponse is returned by HasSourceAt on success.
 type HasSourceAtResponse struct {
-	// Adds a certification that a package (PackageName or PackageVersion) is built from the source.
+	// Adds a certification that a package (PackageName or PackageVersion) is built from the source. The returned ID can be empty string.
 	IngestHasSourceAt string `json:"ingestHasSourceAt"`
 }
 
@@ -6402,7 +6402,7 @@ func (v *HashEqualInputSpec) GetCollector() string { return v.Collector }
 
 // HashEqualResponse is returned by HashEqual on success.
 type HashEqualResponse struct {
-	// Adds a certification that two artifacts are equal.
+	// Adds a certification that two artifacts are equal. The returned ID can be empty string.
 	IngestHashEqual string `json:"ingestHashEqual"`
 }
 
@@ -6411,7 +6411,7 @@ func (v *HashEqualResponse) GetIngestHashEqual() string { return v.IngestHashEqu
 
 // HashEqualsResponse is returned by HashEquals on success.
 type HashEqualsResponse struct {
-	// Bulk ingest certifications that two artifacts are equal.
+	// Bulk ingest certifications that two artifacts are equal. The returned array of IDs can be a an array of empty string.
 	IngestHashEquals []string `json:"ingestHashEquals"`
 }
 
@@ -6420,7 +6420,7 @@ func (v *HashEqualsResponse) GetIngestHashEquals() []string { return v.IngestHas
 
 // IngestArtifactResponse is returned by IngestArtifact on success.
 type IngestArtifactResponse struct {
-	// Ingests a new artifact and returns it.
+	// Ingests a new artifact and returns it. The returned ID can be empty string.
 	IngestArtifact string `json:"ingestArtifact"`
 }
 
@@ -6429,7 +6429,7 @@ func (v *IngestArtifactResponse) GetIngestArtifact() string { return v.IngestArt
 
 // IngestArtifactsResponse is returned by IngestArtifacts on success.
 type IngestArtifactsResponse struct {
-	// Bulk ingests new artifacts and returns a list of them.
+	// Bulk ingests new artifacts and returns a list of them. The returned array of IDs can be a an array of empty string.
 	IngestArtifacts []string `json:"ingestArtifacts"`
 }
 
@@ -6438,7 +6438,7 @@ func (v *IngestArtifactsResponse) GetIngestArtifacts() []string { return v.Inges
 
 // IngestBuilderResponse is returned by IngestBuilder on success.
 type IngestBuilderResponse struct {
-	// Ingests a new builder and returns it.
+	// Ingests a new builder and returns it. The returned ID can be empty string.
 	IngestBuilder string `json:"ingestBuilder"`
 }
 
@@ -6456,7 +6456,7 @@ func (v *IngestBuildersResponse) GetIngestBuilders() []string { return v.IngestB
 
 // IngestPackageResponse is returned by IngestPackage on success.
 type IngestPackageResponse struct {
-	// Ingests a new package and returns the corresponding package trie path.
+	// Ingests a new package and returns the corresponding package trie path. The returned ID can be empty string.
 	IngestPackage string `json:"ingestPackage"`
 }
 
@@ -6465,7 +6465,7 @@ func (v *IngestPackageResponse) GetIngestPackage() string { return v.IngestPacka
 
 // IngestPackagesResponse is returned by IngestPackages on success.
 type IngestPackagesResponse struct {
-	// Bulk ingests packages and returns the list of corresponding package trie path.
+	// Bulk ingests packages and returns the list of corresponding package trie path. The returned array of IDs can be a an array of empty string.
 	IngestPackages []string `json:"ingestPackages"`
 }
 
@@ -6474,7 +6474,7 @@ func (v *IngestPackagesResponse) GetIngestPackages() []string { return v.IngestP
 
 // IngestSourceResponse is returned by IngestSource on success.
 type IngestSourceResponse struct {
-	// Ingests a new source and returns the corresponding source trie path.
+	// Ingests a new source and returns the corresponding source trie path. The returned ID can be empty string.
 	IngestSource string `json:"ingestSource"`
 }
 
@@ -6483,7 +6483,7 @@ func (v *IngestSourceResponse) GetIngestSource() string { return v.IngestSource 
 
 // IngestSourcesResponse is returned by IngestSources on success.
 type IngestSourcesResponse struct {
-	// Bulk ingests sources and returns the list of corresponding source trie path.
+	// Bulk ingests sources and returns the list of corresponding source trie path. The returned array of IDs can be a an array of empty string.
 	IngestSources []string `json:"ingestSources"`
 }
 
@@ -6492,7 +6492,7 @@ func (v *IngestSourcesResponse) GetIngestSources() []string { return v.IngestSou
 
 // IngestVulnerabilitiesResponse is returned by IngestVulnerabilities on success.
 type IngestVulnerabilitiesResponse struct {
-	// Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path.
+	// Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path. The returned array of IDs can be a an array of empty string.
 	IngestVulnerabilities []string `json:"ingestVulnerabilities"`
 }
 
@@ -6503,7 +6503,7 @@ func (v *IngestVulnerabilitiesResponse) GetIngestVulnerabilities() []string {
 
 // IngestVulnerabilityResponse is returned by IngestVulnerability on success.
 type IngestVulnerabilityResponse struct {
-	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
+	// Ingests a new vulnerability and returns the corresponding vulnerability trie path. The returned ID can be empty string.
 	IngestVulnerability string `json:"ingestVulnerability"`
 }
 
@@ -6512,7 +6512,7 @@ func (v *IngestVulnerabilityResponse) GetIngestVulnerability() string { return v
 
 // IsDependenciesResponse is returned by IsDependencies on success.
 type IsDependenciesResponse struct {
-	// Bulk adds a dependency between two packages
+	// Bulk adds a dependency between two packages. The returned array of IDs can be a an array of empty string.
 	IngestDependencies []string `json:"ingestDependencies"`
 }
 
@@ -6546,7 +6546,7 @@ func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
 
 // IsDependencyResponse is returned by IsDependency on success.
 type IsDependencyResponse struct {
-	// Adds a dependency between two packages
+	// Adds a dependency between two packages. The returned ID can be empty string.
 	IngestDependency string `json:"ingestDependency"`
 }
 
@@ -6571,7 +6571,7 @@ func (v *IsOccurrenceInputSpec) GetCollector() string { return v.Collector }
 
 // IsOccurrencePkgResponse is returned by IsOccurrencePkg on success.
 type IsOccurrencePkgResponse struct {
-	// Ingest that an artifact is produced from a package or source.
+	// Ingest that an artifact is produced from a package or source. The returned ID can be empty string.
 	IngestOccurrence string `json:"ingestOccurrence"`
 }
 
@@ -6580,7 +6580,7 @@ func (v *IsOccurrencePkgResponse) GetIngestOccurrence() string { return v.Ingest
 
 // IsOccurrenceSrcResponse is returned by IsOccurrenceSrc on success.
 type IsOccurrenceSrcResponse struct {
-	// Ingest that an artifact is produced from a package or source.
+	// Ingest that an artifact is produced from a package or source. The returned ID can be empty string.
 	IngestOccurrence string `json:"ingestOccurrence"`
 }
 
@@ -6589,7 +6589,7 @@ func (v *IsOccurrenceSrcResponse) GetIngestOccurrence() string { return v.Ingest
 
 // IsOccurrencesPkgResponse is returned by IsOccurrencesPkg on success.
 type IsOccurrencesPkgResponse struct {
-	// Bulk ingest that an artifact is produced from a package or source.
+	// Bulk ingest that an artifact is produced from a package or source. The returned array of IDs can be a an array of empty string.
 	IngestOccurrences []string `json:"ingestOccurrences"`
 }
 
@@ -6598,7 +6598,7 @@ func (v *IsOccurrencesPkgResponse) GetIngestOccurrences() []string { return v.In
 
 // IsOccurrencesSrcResponse is returned by IsOccurrencesSrc on success.
 type IsOccurrencesSrcResponse struct {
-	// Bulk ingest that an artifact is produced from a package or source.
+	// Bulk ingest that an artifact is produced from a package or source. The returned array of IDs can be a an array of empty string.
 	IngestOccurrences []string `json:"ingestOccurrences"`
 }
 
@@ -17642,11 +17642,11 @@ func (v *PkgEqualInputSpec) GetCollector() string { return v.Collector }
 
 // PkgEqualResponse is returned by PkgEqual on success.
 type PkgEqualResponse struct {
-	// Ingests a new package and returns the corresponding package trie path.
+	// Ingests a new package and returns the corresponding package trie path. The returned ID can be empty string.
 	Pkg string `json:"pkg"`
-	// Ingests a new package and returns the corresponding package trie path.
+	// Ingests a new package and returns the corresponding package trie path. The returned ID can be empty string.
 	OtherPackage string `json:"otherPackage"`
-	// Adds a certification that two packages are similar.
+	// Adds a certification that two packages are similar. The returned ID can be empty string.
 	IngestPkgEqual string `json:"ingestPkgEqual"`
 }
 
@@ -17748,7 +17748,7 @@ func (v *PkgSpec) GetSubpath() *string { return v.Subpath }
 
 // PointOfContactArtifactResponse is returned by PointOfContactArtifact on success.
 type PointOfContactArtifactResponse struct {
-	// Adds a PointOfContact attestation to a package, source or artifact.
+	// Adds a PointOfContact attestation to a package, source or artifact. The returned ID can be empty string.
 	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
@@ -17787,7 +17787,7 @@ func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 
 // PointOfContactPkgResponse is returned by PointOfContactPkg on success.
 type PointOfContactPkgResponse struct {
-	// Adds a PointOfContact attestation to a package, source or artifact.
+	// Adds a PointOfContact attestation to a package, source or artifact. The returned ID can be empty string.
 	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
@@ -17796,7 +17796,7 @@ func (v *PointOfContactPkgResponse) GetIngestPointOfContact() string { return v.
 
 // PointOfContactSrcResponse is returned by PointOfContactSrc on success.
 type PointOfContactSrcResponse struct {
-	// Adds a PointOfContact attestation to a package, source or artifact.
+	// Adds a PointOfContact attestation to a package, source or artifact. The returned ID can be empty string.
 	IngestPointOfContact string `json:"ingestPointOfContact"`
 }
 
@@ -17805,7 +17805,7 @@ func (v *PointOfContactSrcResponse) GetIngestPointOfContact() string { return v.
 
 // SLSAForArtifactResponse is returned by SLSAForArtifact on success.
 type SLSAForArtifactResponse struct {
-	// Ingests a SLSA attestation
+	// Ingests a SLSA attestation. The returned ID can be empty string.
 	IngestSLSA string `json:"ingestSLSA"`
 }
 
@@ -17814,7 +17814,7 @@ func (v *SLSAForArtifactResponse) GetIngestSLSA() string { return v.IngestSLSA }
 
 // SLSAForArtifactsResponse is returned by SLSAForArtifacts on success.
 type SLSAForArtifactsResponse struct {
-	// Bulk Ingest SLSA attestations
+	// Bulk Ingest SLSA attestations. The returned array of IDs can be a an array of empty string.
 	IngestSLSAs []string `json:"ingestSLSAs"`
 }
 
@@ -18168,11 +18168,11 @@ func (v *VulnEqualInputSpec) GetCollector() string { return v.Collector }
 
 // VulnEqualResponse is returned by VulnEqual on success.
 type VulnEqualResponse struct {
-	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
+	// Ingests a new vulnerability and returns the corresponding vulnerability trie path. The returned ID can be empty string.
 	Vuln string `json:"vuln"`
-	// Ingests a new vulnerability and returns the corresponding vulnerability trie path.
+	// Ingests a new vulnerability and returns the corresponding vulnerability trie path. The returned ID can be empty string.
 	OtherVuln string `json:"otherVuln"`
-	// Ingest a mapping between vulnerabilities.
+	// Ingest a mapping between vulnerabilities. The returned ID can be empty string.
 	IngestVulnEqual string `json:"ingestVulnEqual"`
 }
 
@@ -18187,7 +18187,7 @@ func (v *VulnEqualResponse) GetIngestVulnEqual() string { return v.IngestVulnEqu
 
 // VulnHasMetadataResponse is returned by VulnHasMetadata on success.
 type VulnHasMetadataResponse struct {
-	// Adds metadata about a vulnerability.
+	// Adds metadata about a vulnerability. The returned ID can be empty string.
 	IngestVulnerabilityMetadata string `json:"ingestVulnerabilityMetadata"`
 }
 
@@ -18198,7 +18198,7 @@ func (v *VulnHasMetadataResponse) GetIngestVulnerabilityMetadata() string {
 
 // VulnHasMetadatasResponse is returned by VulnHasMetadatas on success.
 type VulnHasMetadatasResponse struct {
-	// Bulk add certifications that vulnerability has a specific score.
+	// Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string.
 	IngestVulnerabilityMetadatas []string `json:"ingestVulnerabilityMetadatas"`
 }
 

--- a/pkg/assembler/clients/operations/artifact.graphql
+++ b/pkg/assembler/clients/operations/artifact.graphql
@@ -18,19 +18,14 @@
 # Ingest Artifact
 
 mutation IngestArtifact($artifact: ArtifactInputSpec!) {
-  ingestArtifact(artifact: $artifact) {
-    ...AllArtifactTree
-  }
+  ingestArtifact(artifact: $artifact)
 }
 
 # Bulk Ingest Artifacts
 
 mutation IngestArtifacts($artifacts: [ArtifactInputSpec!]!) {
-  ingestArtifacts(artifacts: $artifacts) {
-    ...AllArtifactTree
-  }
+  ingestArtifacts(artifacts: $artifacts)
 }
-
 # Exposes GraphQL queries to retrieve GUAC sources
 
 query Artifacts($filter: ArtifactSpec!) {

--- a/pkg/assembler/clients/operations/builder.graphql
+++ b/pkg/assembler/clients/operations/builder.graphql
@@ -18,15 +18,11 @@
 # Ingest Builder
 
 mutation IngestBuilder($builder: BuilderInputSpec!) {
-  ingestBuilder(builder: $builder) {
-    uri
-  }
+  ingestBuilder(builder: $builder)
 }
 
 # Bulk Ingest Builder
 
 mutation IngestBuilders($builders: [BuilderInputSpec!]!) {
-  ingestBuilders(builders: $builders) {
-    uri
-  }
+  ingestBuilders(builders: $builders)
 }

--- a/pkg/assembler/clients/operations/certifyBad.graphql
+++ b/pkg/assembler/clients/operations/certifyBad.graphql
@@ -17,30 +17,74 @@
 
 # Defines the GraphQL operations to ingest a CertifyBad into GUAC
 
-mutation CertifyBadPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyBad: $certifyBad)
+mutation CertifyBadPkg(
+  $pkg: PkgInputSpec!
+  $pkgMatchType: MatchFlags!
+  $certifyBad: CertifyBadInputSpec!
+) {
+  ingestCertifyBad(
+    subject: { package: $pkg }
+    pkgMatchType: $pkgMatchType
+    certifyBad: $certifyBad
+  )
 }
 
-mutation CertifyBadSrc($source: SourceInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad)
+mutation CertifyBadSrc(
+  $source: SourceInputSpec!
+  $certifyBad: CertifyBadInputSpec!
+) {
+  ingestCertifyBad(
+    subject: { source: $source }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyBad: $certifyBad
+  )
 }
 
-mutation CertifyBadArtifact($artifact: ArtifactInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad)
+mutation CertifyBadArtifact(
+  $artifact: ArtifactInputSpec!
+  $certifyBad: CertifyBadInputSpec!
+) {
+  ingestCertifyBad(
+    subject: { artifact: $artifact }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyBad: $certifyBad
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest a CertifyBad into GUAC
 
-mutation CertifyBadPkgs($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyBads: $certifyBads)
+mutation CertifyBadPkgs(
+  $pkgs: [PkgInputSpec!]!
+  $pkgMatchType: MatchFlags!
+  $certifyBads: [CertifyBadInputSpec!]!
+) {
+  ingestCertifyBads(
+    subjects: { packages: $pkgs }
+    pkgMatchType: $pkgMatchType
+    certifyBads: $certifyBads
+  )
 }
 
-mutation CertifyBadSrcs($sources: [SourceInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads)
+mutation CertifyBadSrcs(
+  $sources: [SourceInputSpec!]!
+  $certifyBads: [CertifyBadInputSpec!]!
+) {
+  ingestCertifyBads(
+    subjects: { sources: $sources }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyBads: $certifyBads
+  )
 }
 
-mutation CertifyBadArtifacts($artifacts: [ArtifactInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads)
+mutation CertifyBadArtifacts(
+  $artifacts: [ArtifactInputSpec!]!
+  $certifyBads: [CertifyBadInputSpec!]!
+) {
+  ingestCertifyBads(
+    subjects: { artifacts: $artifacts }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyBads: $certifyBads
+  )
 }
 
 # Exposes GraphQL queries to retrieve GUAC CertifyBads

--- a/pkg/assembler/clients/operations/certifyBad.graphql
+++ b/pkg/assembler/clients/operations/certifyBad.graphql
@@ -18,41 +18,29 @@
 # Defines the GraphQL operations to ingest a CertifyBad into GUAC
 
 mutation CertifyBadPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyBad: $certifyBad) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBad(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyBad: $certifyBad)
 }
 
 mutation CertifyBadSrc($source: SourceInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBad(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad)
 }
 
 mutation CertifyBadArtifact($artifact: ArtifactInputSpec!, $certifyBad: CertifyBadInputSpec!) {
-  ingestCertifyBad(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBad(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBad: $certifyBad)
 }
 
 # Defines the GraphQL operations to bulk ingest a CertifyBad into GUAC
 
 mutation CertifyBadPkgs($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyBads: $certifyBads) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBads(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyBads: $certifyBads)
 }
 
 mutation CertifyBadSrcs($sources: [SourceInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBads(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads)
 }
 
 mutation CertifyBadArtifacts($artifacts: [ArtifactInputSpec!]!, $certifyBads: [CertifyBadInputSpec!]!) {
-  ingestCertifyBads(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads) {
-    ...AllCertifyBad
-  }
+  ingestCertifyBads(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyBads: $certifyBads)
 }
 
 # Exposes GraphQL queries to retrieve GUAC CertifyBads

--- a/pkg/assembler/clients/operations/certifyGood.graphql
+++ b/pkg/assembler/clients/operations/certifyGood.graphql
@@ -18,40 +18,28 @@
 # Defines the GraphQL operations to ingest a CertifyGood into GUAC
 
 mutation CertifyGoodPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGood(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood)
 }
 
 mutation CertifyGoodSrc($source: SourceInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGood(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood)
 }
 
 mutation CertifyGoodArtifact($artifact: ArtifactInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGood(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood)
 }
 
 # Defines the GraphQL operations to bulk ingest a CertifyGood into GUAC
 
 mutation CertifyGoodPkgs($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyGoods: $certifyGoods) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGoods(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyGoods: $certifyGoods)
 }
 
 mutation CertifyGoodSrcs($sources: [SourceInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGoods(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods)
 }
 
 mutation CertifyGoodArtifacts($artifacts: [ArtifactInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods) {
-    ...AllCertifyGood
-  }
+  ingestCertifyGoods(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods)
 }
 

--- a/pkg/assembler/clients/operations/certifyGood.graphql
+++ b/pkg/assembler/clients/operations/certifyGood.graphql
@@ -17,29 +17,72 @@
 
 # Defines the GraphQL operations to ingest a CertifyGood into GUAC
 
-mutation CertifyGoodPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, certifyGood: $certifyGood)
+mutation CertifyGoodPkg(
+  $pkg: PkgInputSpec!
+  $pkgMatchType: MatchFlags!
+  $certifyGood: CertifyGoodInputSpec!
+) {
+  ingestCertifyGood(
+    subject: { package: $pkg }
+    pkgMatchType: $pkgMatchType
+    certifyGood: $certifyGood
+  )
 }
 
-mutation CertifyGoodSrc($source: SourceInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood)
+mutation CertifyGoodSrc(
+  $source: SourceInputSpec!
+  $certifyGood: CertifyGoodInputSpec!
+) {
+  ingestCertifyGood(
+    subject: { source: $source }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyGood: $certifyGood
+  )
 }
 
-mutation CertifyGoodArtifact($artifact: ArtifactInputSpec!, $certifyGood: CertifyGoodInputSpec!) {
-  ingestCertifyGood(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGood: $certifyGood)
+mutation CertifyGoodArtifact(
+  $artifact: ArtifactInputSpec!
+  $certifyGood: CertifyGoodInputSpec!
+) {
+  ingestCertifyGood(
+    subject: { artifact: $artifact }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyGood: $certifyGood
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest a CertifyGood into GUAC
 
-mutation CertifyGoodPkgs($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {packages: $pkgs}, pkgMatchType: $pkgMatchType, certifyGoods: $certifyGoods)
+mutation CertifyGoodPkgs(
+  $pkgs: [PkgInputSpec!]!
+  $pkgMatchType: MatchFlags!
+  $certifyGoods: [CertifyGoodInputSpec!]!
+) {
+  ingestCertifyGoods(
+    subjects: { packages: $pkgs }
+    pkgMatchType: $pkgMatchType
+    certifyGoods: $certifyGoods
+  )
 }
 
-mutation CertifyGoodSrcs($sources: [SourceInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {sources: $sources}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods)
+mutation CertifyGoodSrcs(
+  $sources: [SourceInputSpec!]!
+  $certifyGoods: [CertifyGoodInputSpec!]!
+) {
+  ingestCertifyGoods(
+    subjects: { sources: $sources }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyGoods: $certifyGoods
+  )
 }
 
-mutation CertifyGoodArtifacts($artifacts: [ArtifactInputSpec!]!, $certifyGoods: [CertifyGoodInputSpec!]!) {
-  ingestCertifyGoods(subjects: {artifacts: $artifacts}, pkgMatchType: {pkg: ALL_VERSIONS}, certifyGoods: $certifyGoods)
+mutation CertifyGoodArtifacts(
+  $artifacts: [ArtifactInputSpec!]!
+  $certifyGoods: [CertifyGoodInputSpec!]!
+) {
+  ingestCertifyGoods(
+    subjects: { artifacts: $artifacts }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    certifyGoods: $certifyGoods
+  )
 }
-

--- a/pkg/assembler/clients/operations/certifyScorecard.graphql
+++ b/pkg/assembler/clients/operations/certifyScorecard.graphql
@@ -18,15 +18,11 @@
 # Defines the GraphQL operations to ingest a Scorecard certification into GUAC
 
 mutation CertifyScorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
-  ingestScorecard(source: $source, scorecard: $scorecard) {
-    ...AllCertifyScorecard
-  }
+  ingestScorecard(source: $source, scorecard: $scorecard)
 }
 
 # Defines the GraphQL operations to bulk ingest Scorecard certifications into GUAC
 
 mutation CertifyScorecards($sources: [SourceInputSpec!]!, $scorecards: [ScorecardInputSpec!]!) {
-  ingestScorecards(sources: $sources, scorecards: $scorecards) {
-    ...AllCertifyScorecard
-  }
+  ingestScorecards(sources: $sources, scorecards: $scorecards)
 }

--- a/pkg/assembler/clients/operations/certifyScorecard.graphql
+++ b/pkg/assembler/clients/operations/certifyScorecard.graphql
@@ -17,12 +17,18 @@
 
 # Defines the GraphQL operations to ingest a Scorecard certification into GUAC
 
-mutation CertifyScorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
+mutation CertifyScorecard(
+  $source: SourceInputSpec!
+  $scorecard: ScorecardInputSpec!
+) {
   ingestScorecard(source: $source, scorecard: $scorecard)
 }
 
 # Defines the GraphQL operations to bulk ingest Scorecard certifications into GUAC
 
-mutation CertifyScorecards($sources: [SourceInputSpec!]!, $scorecards: [ScorecardInputSpec!]!) {
+mutation CertifyScorecards(
+  $sources: [SourceInputSpec!]!
+  $scorecards: [ScorecardInputSpec!]!
+) {
   ingestScorecards(sources: $sources, scorecards: $scorecards)
 }

--- a/pkg/assembler/clients/operations/certifyVEXStatement.graphql
+++ b/pkg/assembler/clients/operations/certifyVEXStatement.graphql
@@ -17,10 +17,26 @@
 
 # Defines the GraphQL operations to ingest VEX statements into GUAC
 
-mutation CertifyVexPkg($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-  ingestVEXStatement(subject: {package: $pkg}, vulnerability: $vulnerability, vexStatement: $vexStatement)
+mutation CertifyVexPkg(
+  $pkg: PkgInputSpec!
+  $vulnerability: VulnerabilityInputSpec!
+  $vexStatement: VexStatementInputSpec!
+) {
+  ingestVEXStatement(
+    subject: { package: $pkg }
+    vulnerability: $vulnerability
+    vexStatement: $vexStatement
+  )
 }
 
-mutation CertifyVexArtifact($artifact: ArtifactInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-  ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: $vulnerability,, vexStatement: $vexStatement)
+mutation CertifyVexArtifact(
+  $artifact: ArtifactInputSpec!
+  $vulnerability: VulnerabilityInputSpec!
+  $vexStatement: VexStatementInputSpec!
+) {
+  ingestVEXStatement(
+    subject: { artifact: $artifact }
+    vulnerability: $vulnerability
+    vexStatement: $vexStatement
+  )
 }

--- a/pkg/assembler/clients/operations/certifyVEXStatement.graphql
+++ b/pkg/assembler/clients/operations/certifyVEXStatement.graphql
@@ -18,13 +18,9 @@
 # Defines the GraphQL operations to ingest VEX statements into GUAC
 
 mutation CertifyVexPkg($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-  ingestVEXStatement(subject: {package: $pkg}, vulnerability: $vulnerability, vexStatement: $vexStatement) {
-    ...AllCertifyVEXStatement
-  }
+  ingestVEXStatement(subject: {package: $pkg}, vulnerability: $vulnerability, vexStatement: $vexStatement)
 }
 
 mutation CertifyVexArtifact($artifact: ArtifactInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
-  ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: $vulnerability,, vexStatement: $vexStatement) {
-    ...AllCertifyVEXStatement
-  }
+  ingestVEXStatement(subject: {artifact: $artifact}, vulnerability: $vulnerability,, vexStatement: $vexStatement)
 }

--- a/pkg/assembler/clients/operations/certifyVuln.graphql
+++ b/pkg/assembler/clients/operations/certifyVuln.graphql
@@ -18,15 +18,11 @@
 # Defines the GraphQL operations to ingest a vulnerability certification into GUAC
 
 mutation CertifyVulnPkg($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $certifyVuln: ScanMetadataInput!) {
-  ingestCertifyVuln(pkg: $pkg, vulnerability: $vulnerability, certifyVuln: $certifyVuln) {
-    ...AllCertifyVuln
-  }
+  ingestCertifyVuln(pkg: $pkg, vulnerability: $vulnerability, certifyVuln: $certifyVuln)
 }
 
 # Defines the GraphQL operations to bulk ingest vulnerability certifications into GUAC
 
 mutation CertifyVulnPkgs($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $certifyVulns: [ScanMetadataInput!]!) {
-  ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns) {
-    ...AllCertifyVuln
-  }
+  ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns)
 }

--- a/pkg/assembler/clients/operations/certifyVuln.graphql
+++ b/pkg/assembler/clients/operations/certifyVuln.graphql
@@ -17,12 +17,28 @@
 
 # Defines the GraphQL operations to ingest a vulnerability certification into GUAC
 
-mutation CertifyVulnPkg($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $certifyVuln: ScanMetadataInput!) {
-  ingestCertifyVuln(pkg: $pkg, vulnerability: $vulnerability, certifyVuln: $certifyVuln)
+mutation CertifyVulnPkg(
+  $pkg: PkgInputSpec!
+  $vulnerability: VulnerabilityInputSpec!
+  $certifyVuln: ScanMetadataInput!
+) {
+  ingestCertifyVuln(
+    pkg: $pkg
+    vulnerability: $vulnerability
+    certifyVuln: $certifyVuln
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest vulnerability certifications into GUAC
 
-mutation CertifyVulnPkgs($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $certifyVulns: [ScanMetadataInput!]!) {
-  ingestCertifyVulns(pkgs: $pkgs, vulnerabilities: $vulnerabilities, certifyVulns: $certifyVulns)
+mutation CertifyVulnPkgs(
+  $pkgs: [PkgInputSpec!]!
+  $vulnerabilities: [VulnerabilityInputSpec!]!
+  $certifyVulns: [ScanMetadataInput!]!
+) {
+  ingestCertifyVulns(
+    pkgs: $pkgs
+    vulnerabilities: $vulnerabilities
+    certifyVulns: $certifyVulns
+  )
 }

--- a/pkg/assembler/clients/operations/contact.graphql
+++ b/pkg/assembler/clients/operations/contact.graphql
@@ -17,14 +17,36 @@
 
 # Defines the GraphQL operations to ingest a PointOfContact into GUAC
 
-mutation PointOfContactPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact)
+mutation PointOfContactPkg(
+  $pkg: PkgInputSpec!
+  $pkgMatchType: MatchFlags!
+  $pointOfContact: PointOfContactInputSpec!
+) {
+  ingestPointOfContact(
+    subject: { package: $pkg }
+    pkgMatchType: $pkgMatchType
+    pointOfContact: $pointOfContact
+  )
 }
 
-mutation PointOfContactSrc($source: SourceInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact)
+mutation PointOfContactSrc(
+  $source: SourceInputSpec!
+  $pointOfContact: PointOfContactInputSpec!
+) {
+  ingestPointOfContact(
+    subject: { source: $source }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    pointOfContact: $pointOfContact
+  )
 }
 
-mutation PointOfContactArtifact($artifact: ArtifactInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact)
+mutation PointOfContactArtifact(
+  $artifact: ArtifactInputSpec!
+  $pointOfContact: PointOfContactInputSpec!
+) {
+  ingestPointOfContact(
+    subject: { artifact: $artifact }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    pointOfContact: $pointOfContact
+  )
 }

--- a/pkg/assembler/clients/operations/contact.graphql
+++ b/pkg/assembler/clients/operations/contact.graphql
@@ -18,19 +18,13 @@
 # Defines the GraphQL operations to ingest a PointOfContact into GUAC
 
 mutation PointOfContactPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact) {
-    ...AllPointOfContact
-  }
+  ingestPointOfContact(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, pointOfContact: $pointOfContact)
 }
 
 mutation PointOfContactSrc($source: SourceInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact) {
-    ...AllPointOfContact
-  }
+  ingestPointOfContact(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact)
 }
 
 mutation PointOfContactArtifact($artifact: ArtifactInputSpec!, $pointOfContact: PointOfContactInputSpec!) {
-  ingestPointOfContact(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact) {
-    ...AllPointOfContact
-  }
+  ingestPointOfContact(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, pointOfContact: $pointOfContact)
 }

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -18,20 +18,25 @@
 # Defines the GraphQL operations to ingest that a package or source has an SBOM (specified by a URI) into GUAC
 
 mutation HasSBOMPkg($pkg: PkgInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-  ingestHasSBOM(subject: {package: $pkg}, hasSBOM: $hasSBOM)
+  ingestHasSBOM(subject: { package: $pkg }, hasSBOM: $hasSBOM)
 }
 
-mutation HasSBOMArtifact($artifact: ArtifactInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-  ingestHasSBOM(subject: {artifact: $artifact}, hasSBOM: $hasSBOM)
+mutation HasSBOMArtifact(
+  $artifact: ArtifactInputSpec!
+  $hasSBOM: HasSBOMInputSpec!
+) {
+  ingestHasSBOM(subject: { artifact: $artifact }, hasSBOM: $hasSBOM)
 }
 
 # Defines the GraphQL operations to bulk ingest hasSBOM information into GUAC
 
 mutation HasSBOMPkgs($pkgs: [PkgInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-  ingestHasSBOMs(subjects: {packages: $pkgs}, hasSBOMs: $hasSBOMs)
+  ingestHasSBOMs(subjects: { packages: $pkgs }, hasSBOMs: $hasSBOMs)
 }
 
-mutation HasSBOMArtifacts($artifacts: [ArtifactInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-  ingestHasSBOMs(subjects: {artifacts: $artifacts}, hasSBOMs: $hasSBOMs)
+mutation HasSBOMArtifacts(
+  $artifacts: [ArtifactInputSpec!]!
+  $hasSBOMs: [HasSBOMInputSpec!]!
+) {
+  ingestHasSBOMs(subjects: { artifacts: $artifacts }, hasSBOMs: $hasSBOMs)
 }
-

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -18,28 +18,20 @@
 # Defines the GraphQL operations to ingest that a package or source has an SBOM (specified by a URI) into GUAC
 
 mutation HasSBOMPkg($pkg: PkgInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-  ingestHasSBOM(subject: {package: $pkg}, hasSBOM: $hasSBOM) {
-    ...AllHasSBOMTree
-  }
+  ingestHasSBOM(subject: {package: $pkg}, hasSBOM: $hasSBOM)
 }
 
 mutation HasSBOMArtifact($artifact: ArtifactInputSpec!, $hasSBOM: HasSBOMInputSpec!) {
-  ingestHasSBOM(subject: {artifact: $artifact}, hasSBOM: $hasSBOM) {
-    ...AllHasSBOMTree
-  }
+  ingestHasSBOM(subject: {artifact: $artifact}, hasSBOM: $hasSBOM)
 }
 
 # Defines the GraphQL operations to bulk ingest hasSBOM information into GUAC
 
 mutation HasSBOMPkgs($pkgs: [PkgInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-  ingestHasSBOMs(subjects: {packages: $pkgs}, hasSBOMs: $hasSBOMs) {
-    ...AllHasSBOMTree
-  }
+  ingestHasSBOMs(subjects: {packages: $pkgs}, hasSBOMs: $hasSBOMs)
 }
 
 mutation HasSBOMArtifacts($artifacts: [ArtifactInputSpec!]!, $hasSBOMs: [HasSBOMInputSpec!]!) {
-  ingestHasSBOMs(subjects: {artifacts: $artifacts}, hasSBOMs: $hasSBOMs) {
-    ...AllHasSBOMTree
-  }
+  ingestHasSBOMs(subjects: {artifacts: $artifacts}, hasSBOMs: $hasSBOMs)
 }
 

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -18,15 +18,11 @@
 # Defines the GraphQL operations to ingest SLSA attestation into GUAC
 
 mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $materials: [ArtifactInputSpec!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
-  ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa) {
-    ...AllSLSATree
-  }
+  ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa)
 }
 
 # Defines the GraphQL operations to bulk ingest SLSA attestations into GUAC
 
 mutation SLSAForArtifacts($artifacts: [ArtifactInputSpec!]!, $materialsList: [[ArtifactInputSpec!]!]!, $builders: [BuilderInputSpec!]!, $slsaList: [SLSAInputSpec!]!) {
-  ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList) {
-    ...AllSLSATree
-  }
+  ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList)
 }

--- a/pkg/assembler/clients/operations/hasSLSA.graphql
+++ b/pkg/assembler/clients/operations/hasSLSA.graphql
@@ -17,12 +17,32 @@
 
 # Defines the GraphQL operations to ingest SLSA attestation into GUAC
 
-mutation SLSAForArtifact($artifact: ArtifactInputSpec!, $materials: [ArtifactInputSpec!]!, $builder: BuilderInputSpec!, $slsa: SLSAInputSpec!) {
-  ingestSLSA(subject: $artifact, builtFrom: $materials, builtBy: $builder, slsa: $slsa)
+mutation SLSAForArtifact(
+  $artifact: ArtifactInputSpec!
+  $materials: [ArtifactInputSpec!]!
+  $builder: BuilderInputSpec!
+  $slsa: SLSAInputSpec!
+) {
+  ingestSLSA(
+    subject: $artifact
+    builtFrom: $materials
+    builtBy: $builder
+    slsa: $slsa
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest SLSA attestations into GUAC
 
-mutation SLSAForArtifacts($artifacts: [ArtifactInputSpec!]!, $materialsList: [[ArtifactInputSpec!]!]!, $builders: [BuilderInputSpec!]!, $slsaList: [SLSAInputSpec!]!) {
-  ingestSLSAs(subjects: $artifacts, builtFromList: $materialsList, builtByList: $builders, slsaList: $slsaList)
+mutation SLSAForArtifacts(
+  $artifacts: [ArtifactInputSpec!]!
+  $materialsList: [[ArtifactInputSpec!]!]!
+  $builders: [BuilderInputSpec!]!
+  $slsaList: [SLSAInputSpec!]!
+) {
+  ingestSLSAs(
+    subjects: $artifacts
+    builtFromList: $materialsList
+    builtByList: $builders
+    slsaList: $slsaList
+  )
 }

--- a/pkg/assembler/clients/operations/hasSourceAt.graphql
+++ b/pkg/assembler/clients/operations/hasSourceAt.graphql
@@ -18,7 +18,5 @@
 # Defines the GraphQL operations to ingest that a package (either at the package version or package name level) has the specified source into GUAC
 
 mutation HasSourceAt($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
-  ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt) {
-    ...AllHasSourceAt
-  }
+  ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt)
 }

--- a/pkg/assembler/clients/operations/hasSourceAt.graphql
+++ b/pkg/assembler/clients/operations/hasSourceAt.graphql
@@ -17,6 +17,16 @@
 
 # Defines the GraphQL operations to ingest that a package (either at the package version or package name level) has the specified source into GUAC
 
-mutation HasSourceAt($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
-  ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt)
+mutation HasSourceAt(
+  $pkg: PkgInputSpec!
+  $pkgMatchType: MatchFlags!
+  $source: SourceInputSpec!
+  $hasSourceAt: HasSourceAtInputSpec!
+) {
+  ingestHasSourceAt(
+    pkg: $pkg
+    pkgMatchType: $pkgMatchType
+    source: $source
+    hasSourceAt: $hasSourceAt
+  )
 }

--- a/pkg/assembler/clients/operations/hashEqual.graphql
+++ b/pkg/assembler/clients/operations/hashEqual.graphql
@@ -18,15 +18,11 @@
 # Defines the GraphQL operations to certify that two artifacts are identical
 
 mutation HashEqual($artifact: ArtifactInputSpec!, $otherArtifact: ArtifactInputSpec!, $hashEqual: HashEqualInputSpec!) {
-  ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual) {
-    ...AllHashEqualTree
-  }
+  ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual)
 }
 
 # Defines the GraphQL operations to bulk ingest hasEqual information into GUAC
 
 mutation HashEquals($artifacts: [ArtifactInputSpec!]!, $otherArtifacts: [ArtifactInputSpec!]!, $hashEquals: [HashEqualInputSpec!]!) {
-  ingestHashEquals(artifacts: $artifacts, otherArtifacts: $otherArtifacts, hashEquals: $hashEquals) {
-    ...AllHashEqualTree
-  }
+  ingestHashEquals(artifacts: $artifacts, otherArtifacts: $otherArtifacts, hashEquals: $hashEquals)
 }

--- a/pkg/assembler/clients/operations/hashEqual.graphql
+++ b/pkg/assembler/clients/operations/hashEqual.graphql
@@ -17,12 +17,28 @@
 
 # Defines the GraphQL operations to certify that two artifacts are identical
 
-mutation HashEqual($artifact: ArtifactInputSpec!, $otherArtifact: ArtifactInputSpec!, $hashEqual: HashEqualInputSpec!) {
-  ingestHashEqual(artifact: $artifact, otherArtifact: $otherArtifact, hashEqual: $hashEqual)
+mutation HashEqual(
+  $artifact: ArtifactInputSpec!
+  $otherArtifact: ArtifactInputSpec!
+  $hashEqual: HashEqualInputSpec!
+) {
+  ingestHashEqual(
+    artifact: $artifact
+    otherArtifact: $otherArtifact
+    hashEqual: $hashEqual
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest hasEqual information into GUAC
 
-mutation HashEquals($artifacts: [ArtifactInputSpec!]!, $otherArtifacts: [ArtifactInputSpec!]!, $hashEquals: [HashEqualInputSpec!]!) {
-  ingestHashEquals(artifacts: $artifacts, otherArtifacts: $otherArtifacts, hashEquals: $hashEquals)
+mutation HashEquals(
+  $artifacts: [ArtifactInputSpec!]!
+  $otherArtifacts: [ArtifactInputSpec!]!
+  $hashEquals: [HashEqualInputSpec!]!
+) {
+  ingestHashEquals(
+    artifacts: $artifacts
+    otherArtifacts: $otherArtifacts
+    hashEquals: $hashEquals
+  )
 }

--- a/pkg/assembler/clients/operations/isDependency.graphql
+++ b/pkg/assembler/clients/operations/isDependency.graphql
@@ -17,12 +17,32 @@
 
 # Defines the GraphQL operations to ingest dependency information into GUAC
 
-mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $depPkgMatchType: MatchFlags!, $dependency: IsDependencyInputSpec!) {
-  ingestDependency(pkg: $pkg, depPkg: $depPkg, depPkgMatchType: $depPkgMatchType, dependency: $dependency)
+mutation IsDependency(
+  $pkg: PkgInputSpec!
+  $depPkg: PkgInputSpec!
+  $depPkgMatchType: MatchFlags!
+  $dependency: IsDependencyInputSpec!
+) {
+  ingestDependency(
+    pkg: $pkg
+    depPkg: $depPkg
+    depPkgMatchType: $depPkgMatchType
+    dependency: $dependency
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest dependencies information into GUAC
 
-mutation IsDependencies($pkgs: [PkgInputSpec!]!, $depPkgs: [PkgInputSpec!]!, $depPkgMatchType: MatchFlags!, $dependencies: [IsDependencyInputSpec!]!) {
-  ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, depPkgMatchType: $depPkgMatchType, dependencies: $dependencies)
+mutation IsDependencies(
+  $pkgs: [PkgInputSpec!]!
+  $depPkgs: [PkgInputSpec!]!
+  $depPkgMatchType: MatchFlags!
+  $dependencies: [IsDependencyInputSpec!]!
+) {
+  ingestDependencies(
+    pkgs: $pkgs
+    depPkgs: $depPkgs
+    depPkgMatchType: $depPkgMatchType
+    dependencies: $dependencies
+  )
 }

--- a/pkg/assembler/clients/operations/isDependency.graphql
+++ b/pkg/assembler/clients/operations/isDependency.graphql
@@ -18,15 +18,11 @@
 # Defines the GraphQL operations to ingest dependency information into GUAC
 
 mutation IsDependency($pkg: PkgInputSpec!, $depPkg: PkgInputSpec!, $depPkgMatchType: MatchFlags!, $dependency: IsDependencyInputSpec!) {
-  ingestDependency(pkg: $pkg, depPkg: $depPkg, depPkgMatchType: $depPkgMatchType, dependency: $dependency) {
-    ...AllIsDependencyTree
-  }
+  ingestDependency(pkg: $pkg, depPkg: $depPkg, depPkgMatchType: $depPkgMatchType, dependency: $dependency)
 }
 
 # Defines the GraphQL operations to bulk ingest dependencies information into GUAC
 
 mutation IsDependencies($pkgs: [PkgInputSpec!]!, $depPkgs: [PkgInputSpec!]!, $depPkgMatchType: MatchFlags!, $dependencies: [IsDependencyInputSpec!]!) {
-  ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, depPkgMatchType: $depPkgMatchType, dependencies: $dependencies) {
-    ...AllIsDependencyTree
-  }
+  ingestDependencies(pkgs: $pkgs, depPkgs: $depPkgs, depPkgMatchType: $depPkgMatchType, dependencies: $dependencies)
 }

--- a/pkg/assembler/clients/operations/isOccurrence.graphql
+++ b/pkg/assembler/clients/operations/isOccurrence.graphql
@@ -17,20 +17,52 @@
 
 # Defines the GraphQL operations to ingest occurrence information into GUAC
 
-mutation IsOccurrencePkg($pkg: PkgInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-  ingestOccurrence(subject: {package: $pkg}, artifact: $artifact, occurrence: $occurrence)
+mutation IsOccurrencePkg(
+  $pkg: PkgInputSpec!
+  $artifact: ArtifactInputSpec!
+  $occurrence: IsOccurrenceInputSpec!
+) {
+  ingestOccurrence(
+    subject: { package: $pkg }
+    artifact: $artifact
+    occurrence: $occurrence
+  )
 }
 
-mutation IsOccurrenceSrc($source: SourceInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-  ingestOccurrence(subject: {source: $source}, artifact: $artifact, occurrence: $occurrence)
+mutation IsOccurrenceSrc(
+  $source: SourceInputSpec!
+  $artifact: ArtifactInputSpec!
+  $occurrence: IsOccurrenceInputSpec!
+) {
+  ingestOccurrence(
+    subject: { source: $source }
+    artifact: $artifact
+    occurrence: $occurrence
+  )
 }
 
 # Defines the GraphQL operations to bulk ingest occurrences information into GUAC
 
-mutation IsOccurrencesPkg($pkgs: [PkgInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-  ingestOccurrences(subjects: {packages: $pkgs}, artifacts: $artifacts, occurrences: $occurrences)
+mutation IsOccurrencesPkg(
+  $pkgs: [PkgInputSpec!]!
+  $artifacts: [ArtifactInputSpec!]!
+  $occurrences: [IsOccurrenceInputSpec!]!
+) {
+  ingestOccurrences(
+    subjects: { packages: $pkgs }
+    artifacts: $artifacts
+    occurrences: $occurrences
+  )
 }
 
-mutation IsOccurrencesSrc($sources: [SourceInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-  ingestOccurrences(subjects: {sources: $sources}, artifacts: $artifacts, occurrences: $occurrences)
+mutation IsOccurrencesSrc(
+  $sources: [SourceInputSpec!]!
+  $artifacts: [ArtifactInputSpec!]!
+  $occurrences: [IsOccurrenceInputSpec!]!
+) {
+  ingestOccurrences(
+    subjects: { sources: $sources }
+    artifacts: $artifacts
+    occurrences: $occurrences
+  )
 }

--- a/pkg/assembler/clients/operations/isOccurrence.graphql
+++ b/pkg/assembler/clients/operations/isOccurrence.graphql
@@ -18,27 +18,19 @@
 # Defines the GraphQL operations to ingest occurrence information into GUAC
 
 mutation IsOccurrencePkg($pkg: PkgInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-  ingestOccurrence(subject: {package: $pkg}, artifact: $artifact, occurrence: $occurrence) {
-    ...AllIsOccurrencesTree
-  }
+  ingestOccurrence(subject: {package: $pkg}, artifact: $artifact, occurrence: $occurrence)
 }
 
 mutation IsOccurrenceSrc($source: SourceInputSpec!, $artifact: ArtifactInputSpec!, $occurrence: IsOccurrenceInputSpec!) {
-  ingestOccurrence(subject: {source: $source}, artifact: $artifact, occurrence: $occurrence) {
-    ...AllIsOccurrencesTree
-  }
+  ingestOccurrence(subject: {source: $source}, artifact: $artifact, occurrence: $occurrence)
 }
 
 # Defines the GraphQL operations to bulk ingest occurrences information into GUAC
 
 mutation IsOccurrencesPkg($pkgs: [PkgInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-  ingestOccurrences(subjects: {packages: $pkgs}, artifacts: $artifacts, occurrences: $occurrences) {
-    ...AllIsOccurrencesTree
-  }
+  ingestOccurrences(subjects: {packages: $pkgs}, artifacts: $artifacts, occurrences: $occurrences)
 }
 
 mutation IsOccurrencesSrc($sources: [SourceInputSpec!]!, $artifacts: [ArtifactInputSpec!]!, $occurrences: [IsOccurrenceInputSpec!]!) {
-  ingestOccurrences(subjects: {sources: $sources}, artifacts: $artifacts, occurrences: $occurrences) {
-    ...AllIsOccurrencesTree
-  }
+  ingestOccurrences(subjects: {sources: $sources}, artifacts: $artifacts, occurrences: $occurrences)
 }

--- a/pkg/assembler/clients/operations/metadata.graphql
+++ b/pkg/assembler/clients/operations/metadata.graphql
@@ -18,19 +18,13 @@
 # Defines the GraphQL operations to ingest a HasMetadata into GUAC
 
 mutation HasMetadataPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata) {
-    ...AllHasMetadata
-  }
+  ingestHasMetadata(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata)
 }
 
 mutation HasMetadataSrc($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata) {
-    ...AllHasMetadata
-  }
+  ingestHasMetadata(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata)
 }
 
 mutation HasMetadataArtifact($artifact: ArtifactInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata) {
-    ...AllHasMetadata
-  }
+  ingestHasMetadata(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata) 
 }

--- a/pkg/assembler/clients/operations/metadata.graphql
+++ b/pkg/assembler/clients/operations/metadata.graphql
@@ -17,14 +17,36 @@
 
 # Defines the GraphQL operations to ingest a HasMetadata into GUAC
 
-mutation HasMetadataPkg($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {package: $pkg}, pkgMatchType: $pkgMatchType, hasMetadata: $hasMetadata)
+mutation HasMetadataPkg(
+  $pkg: PkgInputSpec!
+  $pkgMatchType: MatchFlags!
+  $hasMetadata: HasMetadataInputSpec!
+) {
+  ingestHasMetadata(
+    subject: { package: $pkg }
+    pkgMatchType: $pkgMatchType
+    hasMetadata: $hasMetadata
+  )
 }
 
-mutation HasMetadataSrc($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {source: $source}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata)
+mutation HasMetadataSrc(
+  $source: SourceInputSpec!
+  $hasMetadata: HasMetadataInputSpec!
+) {
+  ingestHasMetadata(
+    subject: { source: $source }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    hasMetadata: $hasMetadata
+  )
 }
 
-mutation HasMetadataArtifact($artifact: ArtifactInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
-  ingestHasMetadata(subject: {artifact: $artifact}, pkgMatchType: {pkg: ALL_VERSIONS}, hasMetadata: $hasMetadata) 
+mutation HasMetadataArtifact(
+  $artifact: ArtifactInputSpec!
+  $hasMetadata: HasMetadataInputSpec!
+) {
+  ingestHasMetadata(
+    subject: { artifact: $artifact }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    hasMetadata: $hasMetadata
+  )
 }

--- a/pkg/assembler/clients/operations/package.graphql
+++ b/pkg/assembler/clients/operations/package.graphql
@@ -18,17 +18,13 @@
 # Ingest Package
 
 mutation IngestPackage($pkg: PkgInputSpec!) {
-  ingestPackage(pkg: $pkg) {
-    ...AllPkgTree
-  }
+  ingestPackage(pkg: $pkg)
 }
 
 # Bulk Ingest Packages
 
 mutation IngestPackages($pkgs: [PkgInputSpec!]!) {
-  ingestPackages(pkgs: $pkgs) {
-    ...AllPkgTree
-  }
+  ingestPackages(pkgs: $pkgs)
 }
 
 # Exposes GraphQL queries to retrieve GUAC packages

--- a/pkg/assembler/clients/operations/package.graphql
+++ b/pkg/assembler/clients/operations/package.graphql
@@ -36,58 +36,58 @@ query Packages($filter: PkgSpec!) {
 }
 
 query PackageTypes($filter: PkgSpec!) {
-  packages(pkgSpec: $filter){
+  packages(pkgSpec: $filter) {
     id
     type
   }
 }
 
 query PackageNamespaces($filter: PkgSpec!) {
-  packages(pkgSpec: $filter){
+  packages(pkgSpec: $filter) {
     id
     type
     namespaces {
-        id
-        namespace
+      id
+      namespace
     }
   }
 }
 
 query PackageNames($filter: PkgSpec!) {
-  packages(pkgSpec: $filter){
+  packages(pkgSpec: $filter) {
     id
     type
     namespaces {
+      id
+      namespace
+      names {
         id
-        namespace
-        names {
-            id
-            name
-        }
+        name
+      }
     }
   }
 }
 
 query PackageVersions($filter: PkgSpec!) {
-  packages(pkgSpec: $filter){
+  packages(pkgSpec: $filter) {
     id
     type
     namespaces {
+      id
+      namespace
+      names {
         id
-        namespace
-        names {
-            id
-            name
-            versions {
-                id
-                version
-                qualifiers {                  
-                  key
-                  value
-                }
-                subpath
-            }
+        name
+        versions {
+          id
+          version
+          qualifiers {
+            key
+            value
+          }
+          subpath
         }
+      }
     }
   }
 }

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -93,6 +93,9 @@ query Path(
     ... on VulnerabilityMetadata {
       ...AllVulnMetadataTree
     }
+    ... on HasMetadata {
+      ...AllHasMetadata
+    }
   }
 }
 
@@ -161,6 +164,9 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
     }
     ... on VulnerabilityMetadata {
       ...AllVulnMetadataTree
+    }
+    ... on HasMetadata {
+      ...AllHasMetadata
     }
   }
 }
@@ -231,6 +237,9 @@ query Node($node: ID!) {
     ... on VulnerabilityMetadata {
       ...AllVulnMetadataTree
     }
+    ... on HasMetadata {
+      ...AllHasMetadata
+    }
   }
 }
 
@@ -299,6 +308,9 @@ query Nodes($nodes: [ID!]!) {
     }
     ... on VulnerabilityMetadata {
       ...AllVulnMetadataTree
+    }
+    ... on HasMetadata {
+      ...AllHasMetadata
     }
   }
 }

--- a/pkg/assembler/clients/operations/path.graphql
+++ b/pkg/assembler/clients/operations/path.graphql
@@ -17,14 +17,24 @@
 
 # Exposes GraphQL queries to retrieve GUAC graph connectivity data
 
-query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!]!) {
-  path(subject: $subject, target: $target, maxPathLength: $maxPathLength, usingOnly: $usingOnly) {
+query Path(
+  $subject: ID!
+  $target: ID!
+  $maxPathLength: Int!
+  $usingOnly: [Edge!]!
+) {
+  path(
+    subject: $subject
+    target: $target
+    maxPathLength: $maxPathLength
+    usingOnly: $usingOnly
+  ) {
     __typename
     ... on Package {
-      ... AllPkgTree
+      ...AllPkgTree
     }
     ... on Source {
-      ... AllSourceTree
+      ...AllSourceTree
     }
     ... on Artifact {
       ...AllArtifactTree
@@ -65,7 +75,7 @@ query Path($subject: ID!, $target: ID!, $maxPathLength: Int!, $usingOnly: [Edge!
     ... on HasSourceAt {
       ...AllHasSourceAt
     }
-    ... on PointOfContact{
+    ... on PointOfContact {
       ...AllPointOfContact
     }
     ... on CertifyVuln {
@@ -90,10 +100,10 @@ query Neighbors($node: ID!, $usingOnly: [Edge!]!) {
   neighbors(node: $node, usingOnly: $usingOnly) {
     __typename
     ... on Package {
-      ... AllPkgTree
+      ...AllPkgTree
     }
     ... on Source {
-      ... AllSourceTree
+      ...AllSourceTree
     }
     ... on Artifact {
       ...AllArtifactTree
@@ -159,10 +169,10 @@ query Node($node: ID!) {
   node(node: $node) {
     __typename
     ... on Package {
-      ... AllPkgTree
+      ...AllPkgTree
     }
     ... on Source {
-      ... AllSourceTree
+      ...AllSourceTree
     }
     ... on Artifact {
       ...AllArtifactTree
@@ -228,10 +238,10 @@ query Nodes($nodes: [ID!]!) {
   nodes(nodes: $nodes) {
     __typename
     ... on Package {
-      ... AllPkgTree
+      ...AllPkgTree
     }
     ... on Source {
-      ... AllSourceTree
+      ...AllSourceTree
     }
     ... on Artifact {
       ...AllArtifactTree
@@ -272,7 +282,7 @@ query Nodes($nodes: [ID!]!) {
     ... on HasSourceAt {
       ...AllHasSourceAt
     }
-    ... on PointOfContact{
+    ... on PointOfContact {
       ...AllPointOfContact
     }
     ... on CertifyVuln {

--- a/pkg/assembler/clients/operations/pkgEqual.graphql
+++ b/pkg/assembler/clients/operations/pkgEqual.graphql
@@ -18,13 +18,7 @@
 # Defines the GraphQL operations to certify that two packages are identical
 
 mutation PkgEqual($pkg: PkgInputSpec!, $otherPackage: PkgInputSpec!, $pkgEqual: PkgEqualInputSpec!) {
-  pkg: ingestPackage(pkg: $pkg) {
-    ...AllPkgTree
-  }
-  otherPackage: ingestPackage(pkg: $otherPackage) {
-    ...AllPkgTree
-  }
-  ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual) {
-    ...AllPkgEqual
-  }
+  pkg: ingestPackage(pkg: $pkg)
+  otherPackage: ingestPackage(pkg: $otherPackage)
+  ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual)
 }

--- a/pkg/assembler/clients/operations/pkgEqual.graphql
+++ b/pkg/assembler/clients/operations/pkgEqual.graphql
@@ -17,7 +17,11 @@
 
 # Defines the GraphQL operations to certify that two packages are identical
 
-mutation PkgEqual($pkg: PkgInputSpec!, $otherPackage: PkgInputSpec!, $pkgEqual: PkgEqualInputSpec!) {
+mutation PkgEqual(
+  $pkg: PkgInputSpec!
+  $otherPackage: PkgInputSpec!
+  $pkgEqual: PkgEqualInputSpec!
+) {
   pkg: ingestPackage(pkg: $pkg)
   otherPackage: ingestPackage(pkg: $otherPackage)
   ingestPkgEqual(pkg: $pkg, otherPackage: $otherPackage, pkgEqual: $pkgEqual)

--- a/pkg/assembler/clients/operations/search.graphql
+++ b/pkg/assembler/clients/operations/search.graphql
@@ -15,12 +15,12 @@
 
 query FindSoftware($searchText: String!) {
   findSoftware(searchText: $searchText) {
-     __typename
+    __typename
     ... on Package {
-      ... AllPkgTree
+      ...AllPkgTree
     }
     ... on Source {
-      ... AllSourceTree
+      ...AllSourceTree
     }
     ... on Artifact {
       ...AllArtifactTree

--- a/pkg/assembler/clients/operations/source.graphql
+++ b/pkg/assembler/clients/operations/source.graphql
@@ -18,17 +18,13 @@
 # Ingest Source
 
 mutation IngestSource($source: SourceInputSpec!) {
-  ingestSource(source: $source) {
-    ...AllSourceTree
-  }
+  ingestSource(source: $source)
 }
 
 # Bulk Ingest Sources
 
 mutation IngestSources($sources: [SourceInputSpec!]!) {
-  ingestSources(sources: $sources) {
-    ...AllSourceTree
-  }
+  ingestSources(sources: $sources)
 }
 
 # Exposes GraphQL queries to retrieve GUAC sources

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -116,10 +116,10 @@ fragment AllIsOccurrencesTree on IsOccurrence {
   id
   subject {
     __typename
-    ...on Package {
+    ... on Package {
       ...AllPkgTree
     }
-   ...on Source {
+    ... on Source {
       ...AllSourceTree
     }
   }
@@ -259,7 +259,7 @@ fragment AllCertifyVuln on CertifyVuln {
     ...AllPkgTree
   }
   vulnerability {
-      ...AllVulnerabilityTree
+    ...AllVulnerabilityTree
   }
   metadata {
     dbUri
@@ -339,24 +339,24 @@ fragment AllCertifyVEXStatement on CertifyVEXStatement {
 # }
 
 fragment AllPointOfContact on PointOfContact {
-    id
-    subject {
-      __typename
-      ... on Package {
-        ...AllPkgTree
-      }
-      ... on Source {
-        ...AllSourceTree
-      }
-      ... on Artifact {
-        ...AllArtifactTree
-      }
+  id
+  subject {
+    __typename
+    ... on Package {
+      ...AllPkgTree
     }
+    ... on Source {
+      ...AllSourceTree
+    }
+    ... on Artifact {
+      ...AllArtifactTree
+    }
+  }
 
-    email
-    info
-    since
-    justification
-    origin
-    collector
+  email
+  info
+  since
+  justification
+  origin
+  collector
 }

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -315,28 +315,28 @@ fragment AllCertifyVEXStatement on CertifyVEXStatement {
   collector
 }
 
-fragment AllHasMetadata on HasMetadata {
-    id
-    subject {
-      __typename
-      ... on Package {
-        ...AllPkgTree
-      }
-      ... on Source {
-        ...AllSourceTree
-      }
-      ... on Artifact {
-        ...AllArtifactTree
-      }
-    }
+# fragment AllHasMetadata on HasMetadata {
+#     id
+#     subject {
+#       __typename
+#       ... on Package {
+#         ...AllPkgTree
+#       }
+#       ... on Source {
+#         ...AllSourceTree
+#       }
+#       ... on Artifact {
+#         ...AllArtifactTree
+#       }
+#     }
 
-    key
-    value
-    timestamp
-    justification
-    origin
-    collector
-}
+#     key
+#     value
+#     timestamp
+#     justification
+#     origin
+#     collector
+# }
 
 fragment AllPointOfContact on PointOfContact {
     id

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -315,28 +315,28 @@ fragment AllCertifyVEXStatement on CertifyVEXStatement {
   collector
 }
 
-# fragment AllHasMetadata on HasMetadata {
-#     id
-#     subject {
-#       __typename
-#       ... on Package {
-#         ...AllPkgTree
-#       }
-#       ... on Source {
-#         ...AllSourceTree
-#       }
-#       ... on Artifact {
-#         ...AllArtifactTree
-#       }
-#     }
+fragment AllHasMetadata on HasMetadata {
+    id
+    subject {
+      __typename
+      ... on Package {
+        ...AllPkgTree
+      }
+      ... on Source {
+        ...AllSourceTree
+      }
+      ... on Artifact {
+        ...AllArtifactTree
+      }
+    }
 
-#     key
-#     value
-#     timestamp
-#     justification
-#     origin
-#     collector
-# }
+    key
+    value
+    timestamp
+    justification
+    origin
+    collector
+}
 
 fragment AllPointOfContact on PointOfContact {
   id

--- a/pkg/assembler/clients/operations/vulnEqual.graphql
+++ b/pkg/assembler/clients/operations/vulnEqual.graphql
@@ -18,13 +18,7 @@
 # Defines the GraphQL operations to certify that two vulnerabilities are identical
 
 mutation VulnEqual($vulnerability: VulnerabilityInputSpec!, $otherVulnerability: VulnerabilityInputSpec!, $vulnEqual: VulnEqualInputSpec!) {
-  vuln: ingestVulnerability(vuln: $vulnerability) {
-    ...AllVulnerabilityTree
-  }
-  otherVuln: ingestVulnerability(vuln: $otherVulnerability) {
-    ...AllVulnerabilityTree
-  }
-  ingestVulnEqual(vulnerability: $vulnerability, otherVulnerability: $otherVulnerability, vulnEqual: $vulnEqual) {
-    ...AllVulnEqual
-  }
+  vuln: ingestVulnerability(vuln: $vulnerability)
+  otherVuln: ingestVulnerability(vuln: $otherVulnerability)
+  ingestVulnEqual(vulnerability: $vulnerability, otherVulnerability: $otherVulnerability, vulnEqual: $vulnEqual)
 }

--- a/pkg/assembler/clients/operations/vulnEqual.graphql
+++ b/pkg/assembler/clients/operations/vulnEqual.graphql
@@ -17,8 +17,16 @@
 
 # Defines the GraphQL operations to certify that two vulnerabilities are identical
 
-mutation VulnEqual($vulnerability: VulnerabilityInputSpec!, $otherVulnerability: VulnerabilityInputSpec!, $vulnEqual: VulnEqualInputSpec!) {
+mutation VulnEqual(
+  $vulnerability: VulnerabilityInputSpec!
+  $otherVulnerability: VulnerabilityInputSpec!
+  $vulnEqual: VulnEqualInputSpec!
+) {
   vuln: ingestVulnerability(vuln: $vulnerability)
   otherVuln: ingestVulnerability(vuln: $otherVulnerability)
-  ingestVulnEqual(vulnerability: $vulnerability, otherVulnerability: $otherVulnerability, vulnEqual: $vulnEqual)
+  ingestVulnEqual(
+    vulnerability: $vulnerability
+    otherVulnerability: $otherVulnerability
+    vulnEqual: $vulnEqual
+  )
 }

--- a/pkg/assembler/clients/operations/vulnerability.graphql
+++ b/pkg/assembler/clients/operations/vulnerability.graphql
@@ -18,17 +18,13 @@
 # Ingest Vulnerability
 
 mutation IngestVulnerability($vuln: VulnerabilityInputSpec!) {
-  ingestVulnerability(vuln: $vuln) {
-    ...AllVulnerabilityTree
-  }
+  ingestVulnerability(vuln: $vuln)
 }
 
 # Bulk Ingest Vulnerability
 
 mutation IngestVulnerabilities($vulns: [VulnerabilityInputSpec!]!) {
-  ingestVulnerabilities(vulns: $vulns) {
-    ...AllVulnerabilityTree
-  }
+  ingestVulnerabilities(vulns: $vulns)
 }
 
 # Exposes GraphQL queries to retrieve GUAC vulnerabilities

--- a/pkg/assembler/graphql/examples/artifact_builder.gql
+++ b/pkg/assembler/graphql/examples/artifact_builder.gql
@@ -12,7 +12,10 @@ query ArtifactQ1 {
 
 query ArtifactQ2 {
   artifacts(
-    artifactSpec: {algorithm: "sha256", digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"}
+    artifactSpec: {
+      algorithm: "sha256"
+      digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
+    }
   ) {
     ...allArtifactTree
   }
@@ -20,39 +23,47 @@ query ArtifactQ2 {
 
 query ArtifactQ3 {
   artifacts(
-    artifactSpec: {digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"}
+    artifactSpec: {
+      digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
+    }
   ) {
     ...allArtifactTree
   }
 }
 
 query ArtifactQ4 {
-  artifacts(artifactSpec: {algorithm: "sha512"}) {
+  artifacts(artifactSpec: { algorithm: "sha512" }) {
     ...allArtifactTree
   }
 }
 
 query ArtifactQ5 {
-  artifacts(artifactSpec: {digest: "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9"}) {
+  artifacts(
+    artifactSpec: { digest: "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9" }
+  ) {
     ...allArtifactTree
   }
 }
 
 mutation ArtifactM1 {
-  ingestArtifact(artifact: {algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf"}) {
+  ingestArtifact(
+    artifact: { algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf" }
+  ) {
     ...allArtifactTree
   }
 }
 
 mutation ArtifactM2 {
-  ingestArtifact(artifact: {algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0"}) {
+  ingestArtifact(
+    artifact: { algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0" }
+  ) {
     ...allArtifactTree
   }
 }
 
 fragment allBuilderTree on Builder {
-    id
-    uri
+  id
+  uri
 }
 
 query BuilderQ1 {
@@ -63,14 +74,16 @@ query BuilderQ1 {
 
 query BuilderQ2 {
   builders(
-    builderSpec: {uri: "https://github.com/Attestations/GitHubHostedActions@v1"}
+    builderSpec: {
+      uri: "https://github.com/Attestations/GitHubHostedActions@v1"
+    }
   ) {
     ...allBuilderTree
   }
 }
 
 mutation BuilderM1 {
-  ingestBuilder(builder: {uri: "https://github.com/Attestations/GitHubHostedActions@v2"}) {
-    ...allBuilderTree
-  }
+  ingestBuilder(
+    builder: { uri: "https://github.com/Attestations/GitHubHostedActions@v2" }
+  )
 }

--- a/pkg/assembler/graphql/examples/certify_bad.gql
+++ b/pkg/assembler/graphql/examples/certify_bad.gql
@@ -55,32 +55,48 @@ query CertifactBadQ1 {
 }
 
 query CertifactBadQ2 {
-  CertifyBad(certifyBadSpec: {origin: "testing backend"}) {
+  CertifyBad(certifyBadSpec: { origin: "testing backend" }) {
     ...allCertifyBadTree
   }
 }
 
 query CertifactBadQ3 {
-  CertifyBad(certifyBadSpec: {subject: {package: {name: "openssl"}}}) {
+  CertifyBad(certifyBadSpec: { subject: { package: { name: "openssl" } } }) {
     ...allCertifyBadTree
   }
 }
 
 query CertifactBadQ4 {
-  CertifyBad(certifyBadSpec: {subject: {source: {name: "github.com/guacsec/guac"}}}) {
+  CertifyBad(
+    certifyBadSpec: { subject: { source: { name: "github.com/guacsec/guac" } } }
+  ) {
     ...allCertifyBadTree
   }
 }
 
 query CertifactBadQ5 {
-  CertifyBad(certifyBadSpec: {subject: {artifact: {digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf", algorithm: "sha256"}}}) {
+  CertifyBad(
+    certifyBadSpec: {
+      subject: {
+        artifact: {
+          digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
+          algorithm: "sha256"
+        }
+      }
+    }
+  ) {
     ...allCertifyBadTree
   }
 }
 
 query CertifactBadQ6 {
   CertifyBad(
-    certifyBadSpec: {subject: {package: {name: "openssl"}, source: {name: "github.com/guacsec/guac"}}}
+    certifyBadSpec: {
+      subject: {
+        package: { name: "openssl" }
+        source: { name: "github.com/guacsec/guac" }
+      }
+    }
   ) {
     ...allCertifyBadTree
   }

--- a/pkg/assembler/graphql/examples/certify_good.gql
+++ b/pkg/assembler/graphql/examples/certify_good.gql
@@ -48,7 +48,6 @@ fragment allCertifyGoodTree on CertifyGood {
   collector
 }
 
-
 query CertifactGoodQ1 {
   CertifyGood(certifyGoodSpec: {}) {
     ...allCertifyGoodTree
@@ -56,32 +55,45 @@ query CertifactGoodQ1 {
 }
 
 query CertifactGoodQ2 {
-  CertifyGood(certifyGoodSpec: {origin: "testing backend"}) {
+  CertifyGood(certifyGoodSpec: { origin: "testing backend" }) {
     ...allCertifyGoodTree
   }
 }
 
 query CertifactGoodQ3 {
-  CertifyGood(certifyGoodSpec: {subject: {package: {name: "openssl"}}}) {
+  CertifyGood(certifyGoodSpec: { subject: { package: { name: "openssl" } } }) {
     ...allCertifyGoodTree
   }
 }
 
 query CertifactGoodQ4 {
-  CertifyGood(certifyGoodSpec: {subject: {source: {name: "github.com/guacsec/guac"}}}) {
+  CertifyGood(
+    certifyGoodSpec: {
+      subject: { source: { name: "github.com/guacsec/guac" } }
+    }
+  ) {
     ...allCertifyGoodTree
   }
 }
 
 query CertifactGoodQ5 {
-  CertifyGood(certifyGoodSpec: {subject: {artifact: {digest: "2b00042f7481c7b056c4b410d28f33cf"}}}) {
+  CertifyGood(
+    certifyGoodSpec: {
+      subject: { artifact: { digest: "2b00042f7481c7b056c4b410d28f33cf" } }
+    }
+  ) {
     ...allCertifyGoodTree
   }
 }
 
 query CertifactGoodQ6 {
   CertifyGood(
-    certifyGoodSpec: {subject: {package: {name: "openssl"}, source: {name: "github.com/guacsec/guac"}}}
+    certifyGoodSpec: {
+      subject: {
+        package: { name: "openssl" }
+        source: { name: "github.com/guacsec/guac" }
+      }
+    }
   ) {
     ...allCertifyGoodTree
   }
@@ -89,28 +101,28 @@ query CertifactGoodQ6 {
 
 mutation CertifyGoodM1 {
   ingestCertifyGood(
-    subject: {artifact: {algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf"}},
-    pkgMatchType: {pkg: ALL_VERSIONS}
+    subject: {
+      artifact: { algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf" }
+    }
+    pkgMatchType: { pkg: ALL_VERSIONS }
     certifyGood: {
-      justification: "why",
-      origin: "testing backend",
+      justification: "why"
+      origin: "testing backend"
       collector: "there"
     }
-  ) {
-    ...allCertifyGoodTree
-  }
+  )
 }
 
 mutation CertifyGoodM2 {
   ingestCertifyGood(
-    subject: {artifact: {algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0"}},
-    pkgMatchType: {pkg: ALL_VERSIONS}
+    subject: {
+      artifact: { algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0" }
+    }
+    pkgMatchType: { pkg: ALL_VERSIONS }
     certifyGood: {
-      justification: "why2",
-      origin: "testing backend",
+      justification: "why2"
+      origin: "testing backend"
       collector: "there"
     }
-  ) {
-    ...allCertifyGoodTree
-  }
+  )
 }

--- a/pkg/assembler/graphql/examples/certify_scorecard.gql
+++ b/pkg/assembler/graphql/examples/certify_scorecard.gql
@@ -39,30 +39,26 @@ query ScorecardQ1 {
 }
 
 query ScorecardQ2 {
-  scorecards(scorecardSpec: {origin: "testing backend"}) {
+  scorecards(scorecardSpec: { origin: "testing backend" }) {
     ...allCertifyScorecardTree
   }
 }
 
 query ScorecardQ3 {
-  scorecards(scorecardSpec: {source: {name: "github.com/tensorflow/tensorflow"}}) {
-    ...allCertifyScorecardTree
-  }
-}
-
-query ScorecardQ4 {
   scorecards(
-    scorecardSpec: {aggregateScore: 2.9}
+    scorecardSpec: { source: { name: "github.com/tensorflow/tensorflow" } }
   ) {
     ...allCertifyScorecardTree
   }
 }
 
-mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
-  ingestSource(source: $source) {
-    ...allSrcTree
-  }
-  ingestScorecard(source: $source, scorecard: $scorecard) {
+query ScorecardQ4 {
+  scorecards(scorecardSpec: { aggregateScore: 2.9 }) {
     ...allCertifyScorecardTree
   }
+}
+
+mutation Scorecard($source: SourceInputSpec!, $scorecard: ScorecardInputSpec!) {
+  ingestSource(source: $source)
+  ingestScorecard(source: $source, scorecard: $scorecard)
 }

--- a/pkg/assembler/graphql/examples/certify_vex.gql
+++ b/pkg/assembler/graphql/examples/certify_vex.gql
@@ -53,14 +53,14 @@ query CertifyVEXStatementQ1 {
 }
 
 query CertifyVEXStatementQ2 {
-  CertifyVEXStatement(certifyVEXStatementSpec: {origin: "testing backend"}) {
+  CertifyVEXStatement(certifyVEXStatementSpec: { origin: "testing backend" }) {
     ...allCertifyVEXStatementTree
   }
 }
 
 query CertifyVEXStatementQ3 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {subject: {package: {name: "openssl"}}}
+    certifyVEXStatementSpec: { subject: { package: { name: "openssl" } } }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -68,7 +68,14 @@ query CertifyVEXStatementQ3 {
 
 query CertifyVEXStatementQ4 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {subject: {artifact: {algorithm: "sha256", digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"}}}
+    certifyVEXStatementSpec: {
+      subject: {
+        artifact: {
+          algorithm: "sha256"
+          digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
+        }
+      }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -76,7 +83,9 @@ query CertifyVEXStatementQ4 {
 
 query CertifyVEXStatementQ5 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "CVE-2019-13110"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "CVE-2019-13110" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -84,7 +93,9 @@ query CertifyVEXStatementQ5 {
 
 query CertifyVEXStatementQ6 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "GHSA-h45f-rjvw-2rv2"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "GHSA-h45f-rjvw-2rv2" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -92,7 +103,9 @@ query CertifyVEXStatementQ6 {
 
 query CertifyVEXStatementQ7 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "CVE-2018-43610"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "CVE-2018-43610" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -100,7 +113,9 @@ query CertifyVEXStatementQ7 {
 
 query CertifyVEXStatementQ8 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "GHSA-hj5f-4gvw-4rv2"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "GHSA-hj5f-4gvw-4rv2" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -108,7 +123,9 @@ query CertifyVEXStatementQ8 {
 
 query CertifyVEXStatementQ9 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "cve-2019-14750"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "cve-2019-14750" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }
@@ -116,7 +133,9 @@ query CertifyVEXStatementQ9 {
 
 query CertifyVEXStatementQ10 {
   CertifyVEXStatement(
-    certifyVEXStatementSpec: {vulnerability: {vulnerabilityID: "cve-2018-15710"}}
+    certifyVEXStatementSpec: {
+      vulnerability: { vulnerabilityID: "cve-2018-15710" }
+    }
   ) {
     ...allCertifyVEXStatementTree
   }

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -47,39 +47,47 @@ query CertifyVulnQ1 {
 }
 
 query CertifyVulnQ2 {
-  CertifyVuln(certifyVulnSpec: {origin: "testing backend"}) {
+  CertifyVuln(certifyVulnSpec: { origin: "testing backend" }) {
     ...allCertifyVulnTree
   }
 }
 
 query CertifyVulnQ3 {
-  CertifyVuln(certifyVulnSpec: {package: {name: "openssl"}}) {
+  CertifyVuln(certifyVulnSpec: { package: { name: "openssl" } }) {
     ...allCertifyVulnTree
   }
 }
 
 query CertifyVulnQ4 {
-  CertifyVuln(certifyVulnSpec: {package: {name: "django"}}) {
+  CertifyVuln(certifyVulnSpec: { package: { name: "django" } }) {
     ...allCertifyVulnTree
   }
 }
 
 query CertifyVulnQ5 {
-  CertifyVuln(certifyVulnSpec: {vulnerability: {vulnerabilityID: "CVE-2019-13110"}}) {
+  CertifyVuln(
+    certifyVulnSpec: { vulnerability: { vulnerabilityID: "CVE-2019-13110" } }
+  ) {
     ...allCertifyVulnTree
   }
 }
 
 query CertifyVulnQ6 {
   CertifyVuln(
-    certifyVulnSpec: {vulnerability: {vulnerabilityID: "GHSA-h45f-rjvw-2rv2"}}
+    certifyVulnSpec: {
+      vulnerability: { vulnerabilityID: "GHSA-h45f-rjvw-2rv2" }
+    }
   ) {
     ...allCertifyVulnTree
   }
 }
 
 query CertifyVulnQ7 {
-  CertifyVuln(certifyVulnSpec: {vulnerability: {type: "osv", vulnerabilityID: "CVE-2019-13110"}}) {
+  CertifyVuln(
+    certifyVulnSpec: {
+      vulnerability: { type: "osv", vulnerabilityID: "CVE-2019-13110" }
+    }
+  ) {
     ...allCertifyVulnTree
   }
 }
@@ -87,9 +95,7 @@ query CertifyVulnQ7 {
 # Setting noVuln to true return all packages that have no vulnerabilities
 # Setting noVuln to false return all packages with vulnerabilities
 query CertifyNoVuln {
-  CertifyVuln(certifyVulnSpec: {
-    vulnerability: {noVuln: true}
-  }) {
+  CertifyVuln(certifyVulnSpec: { vulnerability: { noVuln: true } }) {
     ...allCertifyVulnTree
   }
 }

--- a/pkg/assembler/graphql/examples/has_sbom.gql
+++ b/pkg/assembler/graphql/examples/has_sbom.gql
@@ -44,25 +44,32 @@ query HasSBOMQ1 {
 }
 
 query HasSBOMQ2 {
-  HasSBOM(hasSBOMSpec: {origin: "Demo ingestion"}) {
+  HasSBOM(hasSBOMSpec: { origin: "Demo ingestion" }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ3 {
-  HasSBOM(hasSBOMSpec: {subject: {package: {name: "openssl"}}}) {
+  HasSBOM(hasSBOMSpec: { subject: { package: { name: "openssl" } } }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ4 {
-  HasSBOM(hasSBOMSpec: {subject: {artifact: {algorithm: "sha256"}}}) {
+  HasSBOM(hasSBOMSpec: { subject: { artifact: { algorithm: "sha256" } } }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ5 {
-  HasSBOM(hasSBOMSpec: {subject: {package: {name: "openssl"}, artifact: {algorithm: "sha256"}}}) {
+  HasSBOM(
+    hasSBOMSpec: {
+      subject: {
+        package: { name: "openssl" }
+        artifact: { algorithm: "sha256" }
+      }
+    }
+  ) {
     ...allHasSBOMTree
   }
 }

--- a/pkg/assembler/graphql/examples/has_slsa.gql
+++ b/pkg/assembler/graphql/examples/has_slsa.gql
@@ -1,30 +1,30 @@
 fragment allHasSLSATree on HasSLSA {
   id
   subject {
+    id
+    algorithm
+    digest
+  }
+  slsa {
+    builtFrom {
       id
       algorithm
       digest
-  }
-  slsa {
-      builtFrom {
-          id
-          algorithm
-          digest
-      }
-      builtBy {
-        id
-        uri
-      }
-      buildType
-      slsaPredicate {
-        key
-        value
-      }
-      slsaVersion
-      startedOn
-      finishedOn
-      origin
-      collector
+    }
+    builtBy {
+      id
+      uri
+    }
+    buildType
+    slsaPredicate {
+      key
+      value
+    }
+    slsaVersion
+    startedOn
+    finishedOn
+    origin
+    collector
   }
 }
 
@@ -35,31 +35,38 @@ query SLSAQ1 {
 }
 
 query SLSAQ2 {
-  HasSLSA(hasSLSASpec: {origin: "Demo ingestion"}) {
+  HasSLSA(hasSLSASpec: { origin: "Demo ingestion" }) {
     ...allHasSLSATree
   }
 }
 
 query SLSAQ3 {
-  HasSLSA(hasSLSASpec: {subject: {algorithm: "sha1"}}) {
+  HasSLSA(hasSLSASpec: { subject: { algorithm: "sha1" } }) {
     ...allHasSLSATree
   }
 }
 
 query SLSAQ4 {
-  HasSLSA(hasSLSASpec: {builtFrom: [{algorithm: "sha256"}]}) {
+  HasSLSA(hasSLSASpec: { builtFrom: [{ algorithm: "sha256" }] }) {
     ...allHasSLSATree
   }
 }
 
 query SLSAQ5 {
-  HasSLSA(hasSLSASpec: {id: "47"}) {
+  HasSLSA(hasSLSASpec: { id: "47" }) {
     ...allHasSLSATree
   }
 }
 
 query SLSAQ6 {
-  HasSLSA(hasSLSASpec: {predicate: { key:"buildDefinition.externalParameters.ref", value:"refs/heads/main"}}) {
+  HasSLSA(
+    hasSLSASpec: {
+      predicate: {
+        key: "buildDefinition.externalParameters.ref"
+        value: "refs/heads/main"
+      }
+    }
+  ) {
     ...allHasSLSATree
   }
 }
@@ -72,19 +79,19 @@ fragment allArtifactTree on Artifact {
 
 mutation SLSAM1 {
   ingestSLSA(
-    subject: {algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf"},
-    builtFrom: [{algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0"}],
-    builtBy: {uri: "https://github.com/Attestations/GitHubHostedActions@v2"},
+    subject: { algorithm: "md5", digest: "2b00042f7481c7b056c4b410d28f33cf" }
+    builtFrom: [
+      { algorithm: "md5", digest: "0ABCDEF0FEDCBA01234567890ABCDEF0" }
+    ]
+    builtBy: { uri: "https://github.com/Attestations/GitHubHostedActions@v2" }
     slsa: {
-      buildType: "type",
-      slsaVersion: "v1",
-      origin: "here",
-      collector: "there",
-      startedOn:"2023-03-28T11:01:23-07:00",
-      finishedOn: "2023-03-28T11:01:35-07:00",
-      slsaPredicate: [{key:"key1", value: "value1"}]
+      buildType: "type"
+      slsaVersion: "v1"
+      origin: "here"
+      collector: "there"
+      startedOn: "2023-03-28T11:01:23-07:00"
+      finishedOn: "2023-03-28T11:01:35-07:00"
+      slsaPredicate: [{ key: "key1", value: "value1" }]
     }
-  ){
-    ...allHasSLSATree
-  }
+  )
 }

--- a/pkg/assembler/graphql/examples/has_source_at.gql
+++ b/pkg/assembler/graphql/examples/has_source_at.gql
@@ -48,34 +48,38 @@ query HasSourceAtQ1 {
 }
 
 query HasSourceAtQ2 {
-  HasSourceAt(hasSourceAtSpec: {origin: "testing backend"}) {
+  HasSourceAt(hasSourceAtSpec: { origin: "testing backend" }) {
     ...allHasSourceAtTree
   }
 }
 
 query HasSourceAtQ3 {
-  HasSourceAt(hasSourceAtSpec: {package: {name: "openssl", version: "3.0.3"}})  {
+  HasSourceAt(
+    hasSourceAtSpec: { package: { name: "openssl", version: "3.0.3" } }
+  ) {
     ...allHasSourceAtTree
   }
 }
 
 query HasSourceAtQ4 {
   HasSourceAt(
-    hasSourceAtSpec: {source: {name: "https://github.com/django/django"}}
+    hasSourceAtSpec: { source: { name: "https://github.com/django/django" } }
   ) {
     ...allHasSourceAtTree
   }
 }
 
 query HasSourceAtQ5 {
-  HasSourceAt(hasSourceAtSpec: {package: {name: "kubetest"}}) {
+  HasSourceAt(hasSourceAtSpec: { package: { name: "kubetest" } }) {
     ...allHasSourceAtTree
   }
 }
 
 query HasSourceAtQ6 {
   HasSourceAt(
-    hasSourceAtSpec: {source: {name: "https://github.com/vapor-ware/kubetest"}}
+    hasSourceAtSpec: {
+      source: { name: "https://github.com/vapor-ware/kubetest" }
+    }
   ) {
     ...allHasSourceAtTree
   }

--- a/pkg/assembler/graphql/examples/hash_equal.gql
+++ b/pkg/assembler/graphql/examples/hash_equal.gql
@@ -17,14 +17,21 @@ query HashEqualQ1 {
 }
 
 query HashEqualQ2 {
-  HashEqual(hashEqualSpec: {origin: "testing backend"}) {
+  HashEqual(hashEqualSpec: { origin: "testing backend" }) {
     ...allHashEqualTree
   }
 }
 
 query HashEqualQ3 {
   HashEqual(
-    hashEqualSpec: {artifacts: [{algorithm: "sha1", digest: "7a8f47318e4676dacb0142afa0b83029cd7befd9"}]}
+    hashEqualSpec: {
+      artifacts: [
+        {
+          algorithm: "sha1"
+          digest: "7a8f47318e4676dacb0142afa0b83029cd7befd9"
+        }
+      ]
+    }
   ) {
     ...allHashEqualTree
   }
@@ -32,7 +39,14 @@ query HashEqualQ3 {
 
 query HashEqualQ4 {
   HashEqual(
-    hashEqualSpec: {artifacts: [{algorithm: "sha256", digest: "89bb0da1891646e58eb3e6ed24f3a6fc3c8eb5a0d44824cba581dfa34a0450cf"}]}
+    hashEqualSpec: {
+      artifacts: [
+        {
+          algorithm: "sha256"
+          digest: "89bb0da1891646e58eb3e6ed24f3a6fc3c8eb5a0d44824cba581dfa34a0450cf"
+        }
+      ]
+    }
   ) {
     ...allHashEqualTree
   }
@@ -40,7 +54,14 @@ query HashEqualQ4 {
 
 query HashEqualQ5 {
   HashEqual(
-    hashEqualSpec: {artifacts: [{algorithm: "sha256", digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"}]}
+    hashEqualSpec: {
+      artifacts: [
+        {
+          algorithm: "sha256"
+          digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"
+        }
+      ]
+    }
   ) {
     ...allHashEqualTree
   }
@@ -48,7 +69,14 @@ query HashEqualQ5 {
 
 query HashEqualQ6 {
   HashEqual(
-    hashEqualSpec: {artifacts: [{algorithm: "sha512", digest: "374ab8f711235830769aa5f0b31ce9b72c5670074b34cb302cdafe3b606233ee92ee01e298e5701f15cc7087714cd9abd7ddb838a6e1206b3642de16d9fc9dd7"}]}
+    hashEqualSpec: {
+      artifacts: [
+        {
+          algorithm: "sha512"
+          digest: "374ab8f711235830769aa5f0b31ce9b72c5670074b34cb302cdafe3b606233ee92ee01e298e5701f15cc7087714cd9abd7ddb838a6e1206b3642de16d9fc9dd7"
+        }
+      ]
+    }
   ) {
     ...allHashEqualTree
   }

--- a/pkg/assembler/graphql/examples/is_dependency.gql
+++ b/pkg/assembler/graphql/examples/is_dependency.gql
@@ -22,7 +22,7 @@ fragment allIsDependencyTree on IsDependency {
       }
     }
   }
-dependentPackage {
+  dependentPackage {
     id
     type
     namespaces {
@@ -43,10 +43,10 @@ dependentPackage {
       }
     }
   }
-dependencyType  
-versionRange
-origin
-collector
+  dependencyType
+  versionRange
+  origin
+  collector
 }
 
 query IsDependencyQ1 {
@@ -56,31 +56,33 @@ query IsDependencyQ1 {
 }
 
 query IsDependencyQ2 {
-  IsDependency(isDependencySpec: {origin: "testing backend"}) {
+  IsDependency(isDependencySpec: { origin: "testing backend" }) {
     ...allIsDependencyTree
   }
 }
 
 query IsDependencyQ3 {
-  IsDependency(isDependencySpec: {package: {name: "debian"}}) {
+  IsDependency(isDependencySpec: { package: { name: "debian" } }) {
     ...allIsDependencyTree
   }
 }
 
 query IsDependencyQ4 {
-  IsDependency(isDependencySpec: {package: {name: "dpkg"}}) {
+  IsDependency(isDependencySpec: { package: { name: "dpkg" } }) {
     ...allIsDependencyTree
   }
 }
 # returns nothing as there is no package with openSSL. It is a dependent package
 query IsDependencyQ5 {
-  IsDependency(isDependencySpec: {package: {name: "openssl", version: "3.0.3"}}) {
+  IsDependency(
+    isDependencySpec: { package: { name: "openssl", version: "3.0.3" } }
+  ) {
     ...allIsDependencyTree
   }
 }
 
 query IsDependencyQ6 {
-  IsDependency(isDependencySpec: {dependentPackage: {name: "openssl"}}) {
+  IsDependency(isDependencySpec: { dependentPackage: { name: "openssl" } }) {
     ...allIsDependencyTree
   }
 }

--- a/pkg/assembler/graphql/examples/is_occurence.gql
+++ b/pkg/assembler/graphql/examples/is_occurence.gql
@@ -23,7 +23,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
         }
       }
     }
-   ...on Source {
+    ... on Source {
       id
       type
       namespaces {
@@ -55,32 +55,47 @@ query IsOccurrenceQ1 {
 }
 
 query IsOccurrenceQ2 {
-  IsOccurrence(isOccurrenceSpec: {origin: "testing backend"}) {
+  IsOccurrence(isOccurrenceSpec: { origin: "testing backend" }) {
     ...allIsOccurrencesTree
   }
 }
 
 query IsOccurrenceQ3 {
-  IsOccurrence(isOccurrenceSpec: {subject: {package: {name: "openssl"}}}) {
+  IsOccurrence(
+    isOccurrenceSpec: { subject: { package: { name: "openssl" } } }
+  ) {
     ...allIsOccurrencesTree
   }
 }
 
 query IsOccurrenceQ4 {
-  IsOccurrence(isOccurrenceSpec: {subject: {package: {name: "openssl", version: "3.0.3"}}}) {
+  IsOccurrence(
+    isOccurrenceSpec: {
+      subject: { package: { name: "openssl", version: "3.0.3" } }
+    }
+  ) {
     ...allIsOccurrencesTree
   }
 }
 
 query IsOccurrenceQ5 {
-  IsOccurrence(isOccurrenceSpec: {subject: {source: {name: "github.com/guacsec/guac"}}}) {
+  IsOccurrence(
+    isOccurrenceSpec: {
+      subject: { source: { name: "github.com/guacsec/guac" } }
+    }
+  ) {
     ...allIsOccurrencesTree
   }
 }
 
 query IsOccurrenceQ6 {
   IsOccurrence(
-    isOccurrenceSpec: {subject: {package: {name: "openssl"}, source: {name: "github.com/guacsec/guac"}}}
+    isOccurrenceSpec: {
+      subject: {
+        package: { name: "openssl" }
+        source: { name: "github.com/guacsec/guac" }
+      }
+    }
   ) {
     ...allIsOccurrencesTree
   }

--- a/pkg/assembler/graphql/examples/packages.gql
+++ b/pkg/assembler/graphql/examples/packages.gql
@@ -41,136 +41,159 @@ query PkgQ2 {
 
 # only PyPI packages
 query PkgQ3 {
-  packages(pkgSpec: {type: "pypi"}) {
+  packages(pkgSpec: { type: "pypi" }) {
     ...allPkgTree
   }
 }
 
 # PyPI packages in "debian" namespace (empty)
 query PkgQ4 {
-  packages(pkgSpec: {type: "pypi", namespace: "debian"}) {
+  packages(pkgSpec: { type: "pypi", namespace: "debian" }) {
     ...allPkgTree
   }
 }
 
 # debian packages in "debian" namespace
 query PkgQ5 {
-  packages(pkgSpec: {type: "deb", namespace: "debian"}) {
+  packages(pkgSpec: { type: "deb", namespace: "debian" }) {
     ...allPkgTree
   }
 }
 
 # "dpkg" package from Ubuntu ("ubuntu" namespace on "deb" type)
 query PkgQ6 {
-  packages(pkgSpec: {type: "deb", namespace: "ubuntu", name: "dpkg"}) {
+  packages(pkgSpec: { type: "deb", namespace: "ubuntu", name: "dpkg" }) {
     ...allPkgTree
   }
 }
 
 # All "deb" type packages named "dpkg"
 query PkgQ7 {
-  packages(pkgSpec: {type: "deb", name:"dpkg"}) {
+  packages(pkgSpec: { type: "deb", name: "dpkg" }) {
     ...allPkgTree
   }
 }
 
 # All occurrences of openssl-3.0.3
 query PkgQ8 {
-  packages(pkgSpec: {name:"openssl", version:"3.0.3"}) {
+  packages(pkgSpec: { name: "openssl", version: "3.0.3" }) {
     ...allPkgTree
   }
 }
 
 # All occurrences of openssl
 query PkgQ9 {
-  packages(pkgSpec: {name:"openssl"}) {
+  packages(pkgSpec: { name: "openssl" }) {
     ...allPkgTree
   }
 }
 
 query PkgQA {
-  packages(pkgSpec: {qualifiers: [{key: "arch", value: "amd64"}]}) {
+  packages(pkgSpec: { qualifiers: [{ key: "arch", value: "amd64" }] }) {
     ...allPkgTree
   }
 }
 
 query PkgQB {
   packages(
-    pkgSpec: {qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
+    pkgSpec: {
+      qualifiers: [
+        { key: "arch", value: "amd64" }
+        { key: "distro", value: "stretch" }
+      ]
+    }
   ) {
     ...allPkgTree
   }
 }
 
 query PkgQC {
-  packages(pkgSpec: {subpath: "subpath"}) {
+  packages(pkgSpec: { subpath: "subpath" }) {
     ...allPkgTree
   }
 }
 
 query PkgQD {
-  packages(pkgSpec: {matchOnlyEmptyQualifiers: true}) {
+  packages(pkgSpec: { matchOnlyEmptyQualifiers: true }) {
     ...allPkgTree
   }
 }
 
 mutation PkgM1 {
-  ingestPackage(pkg: {type: "pypi", name: "tensorflow"}) {
-    ...allPkgTree
-  }
+  ingestPackage(pkg: { type: "pypi", name: "tensorflow" })
 }
 
 mutation PkgM2 {
   ingestPackage(
-    pkg: {type: "pypi", name: "tensorflow", qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
-  ) {
-    ...allPkgTree
-  }
+    pkg: {
+      type: "pypi"
+      name: "tensorflow"
+      qualifiers: [
+        { key: "arch", value: "amd64" }
+        { key: "distro", value: "stretch" }
+      ]
+    }
+  )
 }
 
 mutation PkgM3 {
-  ingestPackage(pkg: {type: "pypi", name: "tensorflow", version: "2.12.0"}) {
-    ...allPkgTree
-  }
+  ingestPackage(pkg: { type: "pypi", name: "tensorflow", version: "2.12.0" })
 }
 
 mutation PkgM4 {
   ingestPackage(
-    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", qualifiers: [{key: "arch", value: "amd64"}, {key: "distro", value: "stretch"}]}
-  ) {
-    ...allPkgTree
-  }
+    pkg: {
+      type: "pypi"
+      name: "tensorflow"
+      version: "2.12.0"
+      qualifiers: [
+        { key: "arch", value: "amd64" }
+        { key: "distro", value: "stretch" }
+      ]
+    }
+  )
 }
 
 mutation PkgM5 {
   ingestPackage(
-    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
-  ) {
-    ...allPkgTree
-  }
+    pkg: {
+      type: "pypi"
+      name: "tensorflow"
+      version: "2.12.0"
+      qualifiers: [
+        { key: "distro", value: "stretch" }
+        { key: "arch", value: "amd64" }
+      ]
+    }
+  )
 }
 
 mutation PkgM6 {
   ingestPackage(
-    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", subpath: "foo", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
-  ) {
-    ...allPkgTree
-  }
+    pkg: {
+      type: "pypi"
+      name: "tensorflow"
+      version: "2.12.0"
+      subpath: "foo"
+      qualifiers: [
+        { key: "distro", value: "stretch" }
+        { key: "arch", value: "amd64" }
+      ]
+    }
+  )
 }
 
 mutation PkgM7 {
   ingestPackage(
-    pkg: {type: "pypi", name: "tensorflow", version: "2.12.0", subpath: "foo", qualifiers: [{key: "distro", value: "stretch"}, {key: "arch", value: "amd64"}]}
-  ) {
-    namespaces {
-      names {
-        versions {
-          qualifiers {
-            key
-            value
-          }
-        }
-      }
+    pkg: {
+      type: "pypi"
+      name: "tensorflow"
+      version: "2.12.0"
+      subpath: "foo"
+      qualifiers: [
+        { key: "distro", value: "stretch" }
+        { key: "arch", value: "amd64" }
+      ]
     }
-  }
+  )
 }

--- a/pkg/assembler/graphql/examples/pkg_equal.gql
+++ b/pkg/assembler/graphql/examples/pkg_equal.gql
@@ -33,14 +33,22 @@ query PkgEqualQ1 {
 }
 
 query PkgEqualQ2 {
-  PkgEqual(pkgEqualSpec: {origin: "Demo ingestion"}) {
+  PkgEqual(pkgEqualSpec: { origin: "Demo ingestion" }) {
     ...allPkgEqualTree
   }
 }
 
 query PkgEqualQ3 {
   PkgEqual(
-    pkgEqualSpec: {packages: {type: "conan", namespace: "openssl.org", name: "openssl", version: "3.0.3", subpath: ""}}
+    pkgEqualSpec: {
+      packages: {
+        type: "conan"
+        namespace: "openssl.org"
+        name: "openssl"
+        version: "3.0.3"
+        subpath: ""
+      }
+    }
   ) {
     ...allPkgEqualTree
   }
@@ -48,16 +56,22 @@ query PkgEqualQ3 {
 
 query PkgEqualQ4 {
   PkgEqual(
-    pkgEqualSpec: {packages: {type: "pypi", namespace: "", name: "django", version: "1.11.1", subpath: "subpath"}}
+    pkgEqualSpec: {
+      packages: {
+        type: "pypi"
+        namespace: ""
+        name: "django"
+        version: "1.11.1"
+        subpath: "subpath"
+      }
+    }
   ) {
     ...allPkgEqualTree
   }
 }
 
 query PkgEqualQ5 {
-  PkgEqual(
-    pkgEqualSpec: {packages: {type: "deb", namespace: "debian"}}
-  ) {
+  PkgEqual(pkgEqualSpec: { packages: { type: "deb", namespace: "debian" } }) {
     ...allPkgEqualTree
   }
 }

--- a/pkg/assembler/graphql/examples/source.gql
+++ b/pkg/assembler/graphql/examples/source.gql
@@ -31,100 +31,113 @@ query SrcQ2 {
 
 # Return only sources with neither tag nor commit
 query SrcQ3 {
-  sources(sourceSpec: {tag:"", commit:""}) {
+  sources(sourceSpec: { tag: "", commit: "" }) {
     ...allSrcTree
   }
 }
 
 query SrcQ4 {
-  sources(sourceSpec: {name: "github.com/guacsec/guac"}) {
+  sources(sourceSpec: { name: "github.com/guacsec/guac" }) {
     ...allSrcTree
   }
 }
 
 query SrcQ5 {
-  sources(sourceSpec: {tag: "v0.0.1"}) {
+  sources(sourceSpec: { tag: "v0.0.1" }) {
     ...allSrcTree
   }
 }
 
 query SrcQ6 {
-  sources(
-    sourceSpec: {commit: "fcba958b73e27cad8b5c8655d46439984d27853b"}
-  ) {
+  sources(sourceSpec: { commit: "fcba958b73e27cad8b5c8655d46439984d27853b" }) {
     ...allSrcTree
   }
 }
 
 query SrcQ7 {
-  sources(sourceSpec: {type: "svn"}) {
+  sources(sourceSpec: { type: "svn" }) {
     ...allSrcTree
   }
 }
 
 query SrcQ8 {
-  sources(sourceSpec: {namespace: "gitlab"}) {
+  sources(sourceSpec: { namespace: "gitlab" }) {
     ...allSrcTree
   }
 }
 
 # this should error as both `tag` and `commit` are specified and not empty
 query SrcQ9 {
-  sources(sourceSpec: {tag: "asd", commit: "sad"}) {
+  sources(sourceSpec: { tag: "asd", commit: "sad" }) {
     ...allSrcTree
   }
 }
 
 mutation SrcM1 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow"}
-  ) {
-    ...allSrcTree
-  }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+    }
+  )
 }
 
 mutation SrcM2 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow", commit: "4fd637ad9d674c88c50d56a5d47cd77f6032e609"}
-  ) {
-    ...allSrcTree
-  }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+      commit: "4fd637ad9d674c88c50d56a5d47cd77f6032e609"
+    }
+  )
 }
 
 mutation SrcM3 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow", tag: "v2.12.0"}
-  ) {
-    ...allSrcTree
-  }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+      tag: "v2.12.0"
+    }
+  )
 }
 
 # this should error as both `tag` and `commit` are specified and not empty
 mutation SrcM4 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow", commit: "4fd637ad9d674c88c50d56a5d47cd77f6032e609", tag: "2.12.0"}
-  ) {
-    ...allSrcTree
-  }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+      commit: "4fd637ad9d674c88c50d56a5d47cd77f6032e609"
+      tag: "2.12.0"
+    }
+  )
 }
 
 mutation SrcM5 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow", tag: "v2.12.0"}
-  ) {
-    namespaces {
-      names {
-        name
-      }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+      tag: "v2.12.0"
     }
-  }
+  )
 }
 
 # this should be ok, since we're setting default value
 mutation SrcM6 {
   ingestSource(
-    source: {type: "git", namespace: "github", name: "github.com/tensorflow/tensorflow", commit: "", tag: "v2.12.0"}
-  ) {
-    ...allSrcTree
-  }
+    source: {
+      type: "git"
+      namespace: "github"
+      name: "github.com/tensorflow/tensorflow"
+      commit: ""
+      tag: "v2.12.0"
+    }
+  )
 }

--- a/pkg/assembler/graphql/examples/vulnEqual.gql
+++ b/pkg/assembler/graphql/examples/vulnEqual.gql
@@ -20,19 +20,25 @@ query IsVulnerabilityQ1 {
 }
 
 query IsVulnerabilityQ2 {
-  vulnEqual(vulnEqualSpec: {origin: "testing backend"}) {
+  vulnEqual(vulnEqualSpec: { origin: "testing backend" }) {
     ...allVulnEqualTree
   }
 }
 
 query IsVulnerabilityQ3 {
-  vulnEqual(vulnEqualSpec: {vulnerabilities: {vulnerabilityID: "GHSA-h45f-rjvw-2rv2"}}) {
+  vulnEqual(
+    vulnEqualSpec: {
+      vulnerabilities: { vulnerabilityID: "GHSA-h45f-rjvw-2rv2" }
+    }
+  ) {
     ...allVulnEqualTree
   }
 }
 
 query IsVulnerabilityQ4 {
-  vulnEqual(vulnEqualSpec: {vulnerabilities: {vulnerabilityID: "CVE-2019-13110"}}) {
+  vulnEqual(
+    vulnEqualSpec: { vulnerabilities: { vulnerabilityID: "CVE-2019-13110" } }
+  ) {
     ...allVulnEqualTree
   }
 }

--- a/pkg/assembler/graphql/examples/vulnerability.gql
+++ b/pkg/assembler/graphql/examples/vulnerability.gql
@@ -14,87 +14,81 @@ query CVEQ1 {
 }
 
 query CVEQ2 {
-  vulnerabilities(vulnSpec: {type: "cve"}) {
+  vulnerabilities(vulnSpec: { type: "cve" }) {
     ...allVulnerabilityTree
   }
 }
 
 query CVEQ3 {
-  vulnerabilities(vulnSpec: {vulnerabilityID: "CVE-2014-8139"}) {
+  vulnerabilities(vulnSpec: { vulnerabilityID: "CVE-2014-8139" }) {
     ...allVulnerabilityTree
   }
 }
 
 query CVEQ4 {
-  vulnerabilities(vulnSpec: {type: "cve", vulnerabilityID: "CVE-2014-8140"}) {
+  vulnerabilities(vulnSpec: { type: "cve", vulnerabilityID: "CVE-2014-8140" }) {
     ...allVulnerabilityTree
   }
 }
 
 mutation CVEM1 {
-  ingestVulnerability(vuln: {type: "cve", vulnerabilityID: "CVE-2023-12345"}) {
-    ...allVulnerabilityTree
-  }
+  ingestVulnerability(vuln: { type: "cve", vulnerabilityID: "CVE-2023-12345" })
 }
 
 mutation CVEM2 {
-  ingestVulnerability(vuln: {type: "cve", vulnerabilityID: "cve-2032-12345"}) {
-    ...allVulnerabilityTree
-  }
+  ingestVulnerability(vuln: { type: "cve", vulnerabilityID: "cve-2032-12345" })
 }
 
 query GHSAQ1 {
-  vulnerabilities(vulnSpec: {type: "ghsa"}) {
+  vulnerabilities(vulnSpec: { type: "ghsa" }) {
     ...allVulnerabilityTree
   }
 }
 
 query GHSAQ2 {
-  vulnerabilities(vulnSpec: {vulnerabilityID: "GHSA-h45f-rjvw-2rv2"}) {
+  vulnerabilities(vulnSpec: { vulnerabilityID: "GHSA-h45f-rjvw-2rv2" }) {
     ...allVulnerabilityTree
   }
 }
 
 mutation GHSAM1 {
-  ingestVulnerability(vuln: {type: "ghsa", vulnerabilityID: "GHSA-abcd-efgh-1234"}) {
-    ...allVulnerabilityTree
-  }
+  ingestVulnerability(
+    vuln: { type: "ghsa", vulnerabilityID: "GHSA-abcd-efgh-1234" }
+  )
 }
 
 query OSVQ1 {
-  vulnerabilities(vulnSpec: {type: "osv"}) {
+  vulnerabilities(vulnSpec: { type: "osv" }) {
     ...allVulnerabilityTree
   }
 }
 
 query OSVQ2 {
-  vulnerabilities(vulnSpec: {type: "osv", vulnerabilityID: "CVE-2014-8139"}) {
+  vulnerabilities(vulnSpec: { type: "osv", vulnerabilityID: "CVE-2014-8139" }) {
     ...allVulnerabilityTree
   }
 }
 
 query OSVQ3 {
-  vulnerabilities(vulnSpec: {vulnerabilityID: "ghsa-h45f-rjvw-2rv2"}) {
+  vulnerabilities(vulnSpec: { vulnerabilityID: "ghsa-h45f-rjvw-2rv2" }) {
     ...allVulnerabilityTree
   }
 }
 
 mutation OSVM1 {
-  ingestVulnerability(vuln: {type: "osv", vulnerabilityID: "GHSA-abcd-efgh-1234"}) {
-    ...allVulnerabilityTree
-  }
+  ingestVulnerability(
+    vuln: { type: "osv", vulnerabilityID: "GHSA-abcd-efgh-1234" }
+  )
 }
 
 mutation OSVM2 {
-  ingestVulnerability(vuln: {type: "osv", vulnerabilityID: "CVE-2023-12345"}) {
-    ...allVulnerabilityTree
-  }
+  ingestVulnerability(vuln: { type: "osv", vulnerabilityID: "CVE-2023-12345" })
 }
 
 # Setting noVuln to true return the noVuln node
 # Setting noVuln to false return all vulnerabilities nodes
 query noVuln {
-  vulnerabilities(vulnSpec: {noVuln: true}) {
+  vulnerabilities(vulnSpec: { noVuln: true }) {
     ...allVulnerabilityTree
   }
 }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -19,42 +19,42 @@ import (
 // region    ************************** generated!.gotpl **************************
 
 type MutationResolver interface {
-	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error)
-	IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]*model.Artifact, error)
-	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error)
-	IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error)
-	IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error)
-	IngestCertifyBads(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) ([]*model.CertifyBad, error)
-	IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error)
-	IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]*model.CertifyGood, error)
-	IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error)
-	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error)
-	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
-	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error)
-	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error)
-	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (*model.PointOfContact, error)
-	IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (*model.HasSbom, error)
-	IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error)
-	IngestSlsa(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
-	IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error)
-	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error)
-	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error)
-	IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]*model.HashEqual, error)
-	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (*model.IsDependency, error)
-	IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error)
-	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error)
-	IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error)
-	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error)
-	IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error)
-	IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]*model.Package, error)
-	IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (*model.PkgEqual, error)
-	IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error)
-	IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]*model.Source, error)
-	IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (*model.VulnEqual, error)
+	IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (string, error)
+	IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]string, error)
+	IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (string, error)
+	IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]string, error)
+	IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) (string, error)
+	IngestCertifyBads(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) ([]string, error)
+	IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (string, error)
+	IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]string, error)
+	IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (string, error)
+	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]string, error)
+	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (string, error)
+	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (string, error)
+	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]string, error)
+	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (string, error)
+	IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (string, error)
+	IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]string, error)
+	IngestSlsa(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (string, error)
+	IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]string, error)
+	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (string, error)
+	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (string, error)
+	IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]string, error)
+	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (string, error)
+	IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]string, error)
+	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (string, error)
+	IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]string, error)
+	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (string, error)
+	IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (string, error)
+	IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]string, error)
+	IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (string, error)
+	IngestSource(ctx context.Context, source model.SourceInputSpec) (string, error)
+	IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]string, error)
+	IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (string, error)
 	IngestVulnerabilityMetadata(ctx context.Context, vulnerability model.VulnerabilityInputSpec, vulnerabilityMetadata model.VulnerabilityMetadataInputSpec) (string, error)
 	IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error)
-	IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (*model.Vulnerability, error)
-	IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]*model.Vulnerability, error)
+	IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (string, error)
+	IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]string, error)
 }
 type QueryResolver interface {
 	Artifacts(ctx context.Context, artifactSpec model.ArtifactSpec) ([]*model.Artifact, error)
@@ -1695,9 +1695,9 @@ func (ec *executionContext) _Mutation_ingestArtifact(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Artifact)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNArtifact2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifact(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestArtifact(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1707,15 +1707,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestArtifact(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Artifact_id(ctx, field)
-			case "algorithm":
-				return ec.fieldContext_Artifact_algorithm(ctx, field)
-			case "digest":
-				return ec.fieldContext_Artifact_digest(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Artifact", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -1758,9 +1750,9 @@ func (ec *executionContext) _Mutation_ingestArtifacts(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Artifact)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNArtifact2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifactᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestArtifacts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1770,15 +1762,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestArtifacts(ctx context.Co
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Artifact_id(ctx, field)
-			case "algorithm":
-				return ec.fieldContext_Artifact_algorithm(ctx, field)
-			case "digest":
-				return ec.fieldContext_Artifact_digest(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Artifact", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -1821,9 +1805,9 @@ func (ec *executionContext) _Mutation_ingestBuilder(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Builder)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNBuilder2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilder(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestBuilder(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1833,13 +1817,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestBuilder(ctx context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Builder_id(ctx, field)
-			case "uri":
-				return ec.fieldContext_Builder_uri(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Builder", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -1882,9 +1860,9 @@ func (ec *executionContext) _Mutation_ingestBuilders(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Builder)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNBuilder2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestBuilders(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1894,13 +1872,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestBuilders(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Builder_id(ctx, field)
-			case "uri":
-				return ec.fieldContext_Builder_uri(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Builder", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -1943,9 +1915,9 @@ func (ec *executionContext) _Mutation_ingestCertifyBad(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.CertifyBad)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNCertifyBad2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyBad(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyBad(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1955,19 +1927,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyBad(ctx context.C
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyBad_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_CertifyBad_subject(ctx, field)
-			case "justification":
-				return ec.fieldContext_CertifyBad_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_CertifyBad_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_CertifyBad_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyBad", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2010,9 +1970,9 @@ func (ec *executionContext) _Mutation_ingestCertifyBads(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.CertifyBad)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNCertifyBad2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyBadᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyBads(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2022,19 +1982,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyBads(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyBad_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_CertifyBad_subject(ctx, field)
-			case "justification":
-				return ec.fieldContext_CertifyBad_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_CertifyBad_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_CertifyBad_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyBad", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2077,9 +2025,9 @@ func (ec *executionContext) _Mutation_ingestCertifyGood(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.CertifyGood)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNCertifyGood2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyGood(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyGood(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2089,19 +2037,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyGood(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyGood_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_CertifyGood_subject(ctx, field)
-			case "justification":
-				return ec.fieldContext_CertifyGood_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_CertifyGood_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_CertifyGood_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyGood", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2144,9 +2080,9 @@ func (ec *executionContext) _Mutation_ingestCertifyGoods(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.CertifyGood)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNCertifyGood2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyGoodᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyGoods(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2156,19 +2092,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyGoods(ctx context
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyGood_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_CertifyGood_subject(ctx, field)
-			case "justification":
-				return ec.fieldContext_CertifyGood_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_CertifyGood_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_CertifyGood_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyGood", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2211,9 +2135,9 @@ func (ec *executionContext) _Mutation_ingestScorecard(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.CertifyScorecard)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNCertifyScorecard2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecard(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestScorecard(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2223,15 +2147,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestScorecard(ctx context.Co
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyScorecard_id(ctx, field)
-			case "source":
-				return ec.fieldContext_CertifyScorecard_source(ctx, field)
-			case "scorecard":
-				return ec.fieldContext_CertifyScorecard_scorecard(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyScorecard", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2274,9 +2190,9 @@ func (ec *executionContext) _Mutation_ingestScorecards(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.CertifyScorecard)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNCertifyScorecard2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecardᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestScorecards(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2286,15 +2202,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestScorecards(ctx context.C
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyScorecard_id(ctx, field)
-			case "source":
-				return ec.fieldContext_CertifyScorecard_source(ctx, field)
-			case "scorecard":
-				return ec.fieldContext_CertifyScorecard_scorecard(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyScorecard", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2337,9 +2245,9 @@ func (ec *executionContext) _Mutation_ingestVEXStatement(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.CertifyVEXStatement)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNCertifyVEXStatement2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVEXStatement(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestVEXStatement(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2349,29 +2257,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestVEXStatement(ctx context
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyVEXStatement_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_CertifyVEXStatement_subject(ctx, field)
-			case "vulnerability":
-				return ec.fieldContext_CertifyVEXStatement_vulnerability(ctx, field)
-			case "status":
-				return ec.fieldContext_CertifyVEXStatement_status(ctx, field)
-			case "vexJustification":
-				return ec.fieldContext_CertifyVEXStatement_vexJustification(ctx, field)
-			case "statement":
-				return ec.fieldContext_CertifyVEXStatement_statement(ctx, field)
-			case "statusNotes":
-				return ec.fieldContext_CertifyVEXStatement_statusNotes(ctx, field)
-			case "knownSince":
-				return ec.fieldContext_CertifyVEXStatement_knownSince(ctx, field)
-			case "origin":
-				return ec.fieldContext_CertifyVEXStatement_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_CertifyVEXStatement_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyVEXStatement", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2414,9 +2300,9 @@ func (ec *executionContext) _Mutation_ingestCertifyVuln(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.CertifyVuln)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNCertifyVuln2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVuln(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyVuln(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2426,17 +2312,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyVuln(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyVuln_id(ctx, field)
-			case "package":
-				return ec.fieldContext_CertifyVuln_package(ctx, field)
-			case "vulnerability":
-				return ec.fieldContext_CertifyVuln_vulnerability(ctx, field)
-			case "metadata":
-				return ec.fieldContext_CertifyVuln_metadata(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyVuln", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2479,9 +2355,9 @@ func (ec *executionContext) _Mutation_ingestCertifyVulns(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.CertifyVuln)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNCertifyVuln2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestCertifyVulns(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2491,17 +2367,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestCertifyVulns(ctx context
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_CertifyVuln_id(ctx, field)
-			case "package":
-				return ec.fieldContext_CertifyVuln_package(ctx, field)
-			case "vulnerability":
-				return ec.fieldContext_CertifyVuln_vulnerability(ctx, field)
-			case "metadata":
-				return ec.fieldContext_CertifyVuln_metadata(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyVuln", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2544,9 +2410,9 @@ func (ec *executionContext) _Mutation_ingestPointOfContact(ctx context.Context, 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.PointOfContact)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNPointOfContact2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPointOfContact(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestPointOfContact(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2556,25 +2422,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestPointOfContact(ctx conte
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_PointOfContact_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_PointOfContact_subject(ctx, field)
-			case "email":
-				return ec.fieldContext_PointOfContact_email(ctx, field)
-			case "info":
-				return ec.fieldContext_PointOfContact_info(ctx, field)
-			case "since":
-				return ec.fieldContext_PointOfContact_since(ctx, field)
-			case "justification":
-				return ec.fieldContext_PointOfContact_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_PointOfContact_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_PointOfContact_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PointOfContact", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2617,9 +2465,9 @@ func (ec *executionContext) _Mutation_ingestHasSBOM(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.HasSbom)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNHasSBOM2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSbom(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHasSBOM(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2629,25 +2477,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSBOM(ctx context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasSBOM_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_HasSBOM_subject(ctx, field)
-			case "uri":
-				return ec.fieldContext_HasSBOM_uri(ctx, field)
-			case "algorithm":
-				return ec.fieldContext_HasSBOM_algorithm(ctx, field)
-			case "digest":
-				return ec.fieldContext_HasSBOM_digest(ctx, field)
-			case "downloadLocation":
-				return ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
-			case "origin":
-				return ec.fieldContext_HasSBOM_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HasSBOM_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasSBOM", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2690,9 +2520,9 @@ func (ec *executionContext) _Mutation_ingestHasSBOMs(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.HasSbom)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNHasSBOM2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSbomᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHasSBOMs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2702,25 +2532,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSBOMs(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasSBOM_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_HasSBOM_subject(ctx, field)
-			case "uri":
-				return ec.fieldContext_HasSBOM_uri(ctx, field)
-			case "algorithm":
-				return ec.fieldContext_HasSBOM_algorithm(ctx, field)
-			case "digest":
-				return ec.fieldContext_HasSBOM_digest(ctx, field)
-			case "downloadLocation":
-				return ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
-			case "origin":
-				return ec.fieldContext_HasSBOM_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HasSBOM_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasSBOM", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2763,9 +2575,9 @@ func (ec *executionContext) _Mutation_ingestSLSA(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.HasSlsa)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNHasSLSA2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSlsa(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestSLSA(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2775,15 +2587,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestSLSA(ctx context.Context
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasSLSA_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_HasSLSA_subject(ctx, field)
-			case "slsa":
-				return ec.fieldContext_HasSLSA_slsa(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasSLSA", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2826,9 +2630,9 @@ func (ec *executionContext) _Mutation_ingestSLSAs(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.HasSlsa)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNHasSLSA2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSlsaᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestSLSAs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2838,15 +2642,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestSLSAs(ctx context.Contex
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasSLSA_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_HasSLSA_subject(ctx, field)
-			case "slsa":
-				return ec.fieldContext_HasSLSA_slsa(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasSLSA", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2889,9 +2685,9 @@ func (ec *executionContext) _Mutation_ingestHasSourceAt(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.HasSourceAt)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNHasSourceAt2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAt(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHasSourceAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2901,23 +2697,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSourceAt(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasSourceAt_id(ctx, field)
-			case "package":
-				return ec.fieldContext_HasSourceAt_package(ctx, field)
-			case "source":
-				return ec.fieldContext_HasSourceAt_source(ctx, field)
-			case "knownSince":
-				return ec.fieldContext_HasSourceAt_knownSince(ctx, field)
-			case "justification":
-				return ec.fieldContext_HasSourceAt_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_HasSourceAt_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HasSourceAt_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasSourceAt", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -2960,9 +2740,9 @@ func (ec *executionContext) _Mutation_ingestHashEqual(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.HashEqual)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNHashEqual2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHashEqual(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHashEqual(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2972,19 +2752,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHashEqual(ctx context.Co
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HashEqual_id(ctx, field)
-			case "artifacts":
-				return ec.fieldContext_HashEqual_artifacts(ctx, field)
-			case "justification":
-				return ec.fieldContext_HashEqual_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_HashEqual_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HashEqual_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HashEqual", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3027,9 +2795,9 @@ func (ec *executionContext) _Mutation_ingestHashEquals(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.HashEqual)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNHashEqual2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHashEqualᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHashEquals(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3039,19 +2807,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHashEquals(ctx context.C
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HashEqual_id(ctx, field)
-			case "artifacts":
-				return ec.fieldContext_HashEqual_artifacts(ctx, field)
-			case "justification":
-				return ec.fieldContext_HashEqual_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_HashEqual_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HashEqual_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HashEqual", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3094,9 +2850,9 @@ func (ec *executionContext) _Mutation_ingestDependency(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.IsDependency)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNIsDependency2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependency(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3106,25 +2862,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestDependency(ctx context.C
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_IsDependency_id(ctx, field)
-			case "package":
-				return ec.fieldContext_IsDependency_package(ctx, field)
-			case "dependentPackage":
-				return ec.fieldContext_IsDependency_dependentPackage(ctx, field)
-			case "versionRange":
-				return ec.fieldContext_IsDependency_versionRange(ctx, field)
-			case "dependencyType":
-				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
-			case "justification":
-				return ec.fieldContext_IsDependency_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_IsDependency_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_IsDependency_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3167,9 +2905,9 @@ func (ec *executionContext) _Mutation_ingestDependencies(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.IsDependency)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestDependencies(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3179,25 +2917,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestDependencies(ctx context
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_IsDependency_id(ctx, field)
-			case "package":
-				return ec.fieldContext_IsDependency_package(ctx, field)
-			case "dependentPackage":
-				return ec.fieldContext_IsDependency_dependentPackage(ctx, field)
-			case "versionRange":
-				return ec.fieldContext_IsDependency_versionRange(ctx, field)
-			case "dependencyType":
-				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
-			case "justification":
-				return ec.fieldContext_IsDependency_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_IsDependency_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_IsDependency_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3240,9 +2960,9 @@ func (ec *executionContext) _Mutation_ingestOccurrence(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.IsOccurrence)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNIsOccurrence2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrence(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestOccurrence(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3252,21 +2972,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestOccurrence(ctx context.C
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_IsOccurrence_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_IsOccurrence_subject(ctx, field)
-			case "artifact":
-				return ec.fieldContext_IsOccurrence_artifact(ctx, field)
-			case "justification":
-				return ec.fieldContext_IsOccurrence_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_IsOccurrence_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_IsOccurrence_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type IsOccurrence", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3309,9 +3015,9 @@ func (ec *executionContext) _Mutation_ingestOccurrences(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.IsOccurrence)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNIsOccurrence2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestOccurrences(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3321,21 +3027,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestOccurrences(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_IsOccurrence_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_IsOccurrence_subject(ctx, field)
-			case "artifact":
-				return ec.fieldContext_IsOccurrence_artifact(ctx, field)
-			case "justification":
-				return ec.fieldContext_IsOccurrence_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_IsOccurrence_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_IsOccurrence_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type IsOccurrence", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3378,9 +3070,9 @@ func (ec *executionContext) _Mutation_ingestHasMetadata(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.HasMetadata)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNHasMetadata2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadata(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestHasMetadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3390,25 +3082,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasMetadata(ctx context.
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_HasMetadata_id(ctx, field)
-			case "subject":
-				return ec.fieldContext_HasMetadata_subject(ctx, field)
-			case "key":
-				return ec.fieldContext_HasMetadata_key(ctx, field)
-			case "value":
-				return ec.fieldContext_HasMetadata_value(ctx, field)
-			case "timestamp":
-				return ec.fieldContext_HasMetadata_timestamp(ctx, field)
-			case "justification":
-				return ec.fieldContext_HasMetadata_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_HasMetadata_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_HasMetadata_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type HasMetadata", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3451,9 +3125,9 @@ func (ec *executionContext) _Mutation_ingestPackage(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Package)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNPackage2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackage(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestPackage(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3463,15 +3137,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestPackage(ctx context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Package_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Package_type(ctx, field)
-			case "namespaces":
-				return ec.fieldContext_Package_namespaces(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3514,9 +3180,9 @@ func (ec *executionContext) _Mutation_ingestPackages(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Package)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestPackages(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3526,15 +3192,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestPackages(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Package_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Package_type(ctx, field)
-			case "namespaces":
-				return ec.fieldContext_Package_namespaces(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3577,9 +3235,9 @@ func (ec *executionContext) _Mutation_ingestPkgEqual(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.PkgEqual)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNPkgEqual2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgEqual(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestPkgEqual(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3589,19 +3247,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestPkgEqual(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_PkgEqual_id(ctx, field)
-			case "packages":
-				return ec.fieldContext_PkgEqual_packages(ctx, field)
-			case "justification":
-				return ec.fieldContext_PkgEqual_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_PkgEqual_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_PkgEqual_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PkgEqual", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3644,9 +3290,9 @@ func (ec *executionContext) _Mutation_ingestSource(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Source)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNSource2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSource(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestSource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3656,15 +3302,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestSource(ctx context.Conte
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Source_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Source_type(ctx, field)
-			case "namespaces":
-				return ec.fieldContext_Source_namespaces(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Source", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3707,9 +3345,9 @@ func (ec *executionContext) _Mutation_ingestSources(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Source)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNSource2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestSources(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3719,15 +3357,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestSources(ctx context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Source_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Source_type(ctx, field)
-			case "namespaces":
-				return ec.fieldContext_Source_namespaces(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Source", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3770,9 +3400,9 @@ func (ec *executionContext) _Mutation_ingestVulnEqual(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.VulnEqual)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNVulnEqual2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnEqual(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestVulnEqual(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3782,19 +3412,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnEqual(ctx context.Co
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_VulnEqual_id(ctx, field)
-			case "vulnerabilities":
-				return ec.fieldContext_VulnEqual_vulnerabilities(ctx, field)
-			case "justification":
-				return ec.fieldContext_VulnEqual_justification(ctx, field)
-			case "origin":
-				return ec.fieldContext_VulnEqual_origin(ctx, field)
-			case "collector":
-				return ec.fieldContext_VulnEqual_collector(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type VulnEqual", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -3947,9 +3565,9 @@ func (ec *executionContext) _Mutation_ingestVulnerability(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Vulnerability)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNVulnerability2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerability(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestVulnerability(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3959,15 +3577,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnerability(ctx contex
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Vulnerability_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Vulnerability_type(ctx, field)
-			case "vulnerabilityIDs":
-				return ec.fieldContext_Vulnerability_vulnerabilityIDs(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Vulnerability", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -4010,9 +3620,9 @@ func (ec *executionContext) _Mutation_ingestVulnerabilities(ctx context.Context,
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Vulnerability)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNVulnerability2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_ingestVulnerabilities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4022,15 +3632,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnerabilities(ctx cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Vulnerability_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Vulnerability_type(ctx, field)
-			case "vulnerabilityIDs":
-				return ec.fieldContext_Vulnerability_vulnerabilityIDs(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Vulnerability", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	defer func() {
@@ -6935,10 +6537,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
-
-func (ec *executionContext) marshalNArtifact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifact(ctx context.Context, sel ast.SelectionSet, v model.Artifact) graphql.Marshaler {
-	return ec._Artifact(ctx, sel, &v)
-}
 
 func (ec *executionContext) marshalNArtifact2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐArtifactᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Artifact) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))

--- a/pkg/assembler/graphql/generated/builder.generated.go
+++ b/pkg/assembler/graphql/generated/builder.generated.go
@@ -243,10 +243,6 @@ func (ec *executionContext) _Builder(ctx context.Context, sel ast.SelectionSet, 
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNBuilder2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilder(ctx context.Context, sel ast.SelectionSet, v model.Builder) graphql.Marshaler {
-	return ec._Builder(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNBuilder2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐBuilderᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Builder) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/certifyBad.generated.go
+++ b/pkg/assembler/graphql/generated/certifyBad.generated.go
@@ -636,10 +636,6 @@ func (ec *executionContext) _CertifyBad(ctx context.Context, sel ast.SelectionSe
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNCertifyBad2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyBad(ctx context.Context, sel ast.SelectionSet, v model.CertifyBad) graphql.Marshaler {
-	return ec._CertifyBad(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNCertifyBad2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyBadᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CertifyBad) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/certifyGood.generated.go
+++ b/pkg/assembler/graphql/generated/certifyGood.generated.go
@@ -435,10 +435,6 @@ func (ec *executionContext) _CertifyGood(ctx context.Context, sel ast.SelectionS
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNCertifyGood2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyGood(ctx context.Context, sel ast.SelectionSet, v model.CertifyGood) graphql.Marshaler {
-	return ec._CertifyGood(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNCertifyGood2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyGoodᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CertifyGood) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -1030,10 +1030,6 @@ func (ec *executionContext) _ScorecardCheck(ctx context.Context, sel ast.Selecti
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNCertifyScorecard2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecard(ctx context.Context, sel ast.SelectionSet, v model.CertifyScorecard) graphql.Marshaler {
-	return ec._CertifyScorecard(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNCertifyScorecard2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyScorecardᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CertifyScorecard) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -908,10 +908,6 @@ func (ec *executionContext) _CertifyVEXStatement(ctx context.Context, sel ast.Se
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNCertifyVEXStatement2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVEXStatement(ctx context.Context, sel ast.SelectionSet, v model.CertifyVEXStatement) graphql.Marshaler {
-	return ec._CertifyVEXStatement(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNCertifyVEXStatement2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVEXStatementᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CertifyVEXStatement) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -878,10 +878,6 @@ func (ec *executionContext) _ScanMetadata(ctx context.Context, sel ast.Selection
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNCertifyVuln2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVuln(ctx context.Context, sel ast.SelectionSet, v model.CertifyVuln) graphql.Marshaler {
-	return ec._CertifyVuln(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNCertifyVuln2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CertifyVuln) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/contact.generated.go
+++ b/pkg/assembler/graphql/generated/contact.generated.go
@@ -637,10 +637,6 @@ func (ec *executionContext) _PointOfContact(ctx context.Context, sel ast.Selecti
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNPointOfContact2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPointOfContact(ctx context.Context, sel ast.SelectionSet, v model.PointOfContact) graphql.Marshaler {
-	return ec._PointOfContact(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNPointOfContact2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPointOfContactᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.PointOfContact) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -636,10 +636,6 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNHasSBOM2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSbom(ctx context.Context, sel ast.SelectionSet, v model.HasSbom) graphql.Marshaler {
-	return ec._HasSBOM(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNHasSBOM2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSbomᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HasSbom) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -1152,10 +1152,6 @@ func (ec *executionContext) _SLSAPredicate(ctx context.Context, sel ast.Selectio
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNHasSLSA2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSlsa(ctx context.Context, sel ast.SelectionSet, v model.HasSlsa) graphql.Marshaler {
-	return ec._HasSLSA(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNHasSLSA2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSlsaᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HasSlsa) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -578,10 +578,6 @@ func (ec *executionContext) _HasSourceAt(ctx context.Context, sel ast.SelectionS
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNHasSourceAt2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAt(ctx context.Context, sel ast.SelectionSet, v model.HasSourceAt) graphql.Marshaler {
-	return ec._HasSourceAt(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNHasSourceAt2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HasSourceAt) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/hashEqual.generated.go
+++ b/pkg/assembler/graphql/generated/hashEqual.generated.go
@@ -444,10 +444,6 @@ func (ec *executionContext) _HashEqual(ctx context.Context, sel ast.SelectionSet
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNHashEqual2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHashEqual(ctx context.Context, sel ast.SelectionSet, v model.HashEqual) graphql.Marshaler {
-	return ec._HashEqual(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNHashEqual2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHashEqualᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HashEqual) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -654,10 +654,6 @@ func (ec *executionContext) marshalNDependencyType2githubᚗcomᚋguacsecᚋguac
 	return v
 }
 
-func (ec *executionContext) marshalNIsDependency2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependency(ctx context.Context, sel ast.SelectionSet, v model.IsDependency) graphql.Marshaler {
-	return ec._IsDependency(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.IsDependency) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -639,10 +639,6 @@ func (ec *executionContext) _IsOccurrence(ctx context.Context, sel ast.Selection
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNIsOccurrence2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrence(ctx context.Context, sel ast.SelectionSet, v model.IsOccurrence) graphql.Marshaler {
-	return ec._IsOccurrence(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNIsOccurrence2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.IsOccurrence) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/metadata.generated.go
+++ b/pkg/assembler/graphql/generated/metadata.generated.go
@@ -637,10 +637,6 @@ func (ec *executionContext) _HasMetadata(ctx context.Context, sel ast.SelectionS
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNHasMetadata2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadata(ctx context.Context, sel ast.SelectionSet, v model.HasMetadata) graphql.Marshaler {
-	return ec._HasMetadata(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNHasMetadata2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HasMetadata) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/package.generated.go
+++ b/pkg/assembler/graphql/generated/package.generated.go
@@ -1244,10 +1244,6 @@ func (ec *executionContext) _PackageVersion(ctx context.Context, sel ast.Selecti
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNPackage2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackage(ctx context.Context, sel ast.SelectionSet, v model.Package) graphql.Marshaler {
-	return ec._Package(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNPackage2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Package) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/pkgEqual.generated.go
+++ b/pkg/assembler/graphql/generated/pkgEqual.generated.go
@@ -444,10 +444,6 @@ func (ec *executionContext) _PkgEqual(ctx context.Context, sel ast.SelectionSet,
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNPkgEqual2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgEqual(ctx context.Context, sel ast.SelectionSet, v model.PkgEqual) graphql.Marshaler {
-	return ec._PkgEqual(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNPkgEqual2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgEqualᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.PkgEqual) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2462,9 +2462,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new artifact and returns it."
+  "Ingests a new artifact and returns it. The returned ID can be empty string."
   ingestArtifact(artifact: ArtifactInputSpec): ID!
-  "Bulk ingests new artifacts and returns a list of them."
+  "Bulk ingests new artifacts and returns a list of them. The returned array of IDs can be a an array of empty string."
   ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
@@ -2514,7 +2514,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new builder and returns it."
+  "Ingests a new builder and returns it. The returned ID can be empty string."
   ingestBuilder(builder: BuilderInputSpec): ID!
   "Bulk ingests new builders and returns a list of them."
   ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!
@@ -2648,13 +2648,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package, source or artifact is considered bad."
+  "Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string."
   ingestCertifyBad(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
     certifyBad: CertifyBadInputSpec!
   ): ID!
-  "Adds bulk certifications that a package, source or artifact is considered bad."
+  "Adds bulk certifications that a package, source or artifact is considered bad. The returned array of IDs can be a an array of empty string."
   ingestCertifyBads(
     subjects: PackageSourceOrArtifactInputs!
     pkgMatchType: MatchFlags!
@@ -2736,13 +2736,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package, source or artifact is considered good."
+  "Adds a certification that a package, source or artifact is considered good. The returned ID can be empty string."
   ingestCertifyGood(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
     certifyGood: CertifyGoodInputSpec!
   ): ID!
-  "Adds bulk certifications that a package, source or artifact is considered good."
+  "Adds bulk certifications that a package, source or artifact is considered good. The returned array of IDs can be a an array of empty string."
   ingestCertifyGoods(
     subjects: PackageSourceOrArtifactInputs!
     pkgMatchType: MatchFlags!
@@ -2877,9 +2877,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a source repository has a Scorecard."
+  "Adds a certification that a source repository has a Scorecard. The returned ID can be empty string."
   ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
-  "Adds bulk certifications that a source repository has a Scorecard."
+  "Adds bulk certifications that a source repository has a Scorecard. The returned array of IDs can be a an array of empty string."
   ingestScorecards(
     sources: [SourceInputSpec!]!
     scorecards: [ScorecardInputSpec!]!
@@ -3023,7 +3023,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a VEX certification for a package."
+  "Adds a VEX certification for a package. The returned ID can be empty string."
   ingestVEXStatement(
     subject: PackageOrArtifactInput!
     vulnerability: VulnerabilityInputSpec!
@@ -3132,13 +3132,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package has been scanned for vulnerabilities."
+  "Adds a certification that a package has been scanned for vulnerabilities. The returned ID can be empty string."
   ingestCertifyVuln(
     pkg: PkgInputSpec!
     vulnerability: VulnerabilityInputSpec!
     certifyVuln: ScanMetadataInput!
   ): ID!
-  "Bulk add certifications that a package has been scanned for vulnerabilities."
+  "Bulk add certifications that a package has been scanned for vulnerabilities. The returned array of IDs can be a an array of empty string."
   ingestCertifyVulns(
     pkgs: [PkgInputSpec!]!
     vulnerabilities: [VulnerabilityInputSpec!]!
@@ -3239,7 +3239,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a PointOfContact attestation to a package, source or artifact."
+  "Adds a PointOfContact attestation to a package, source or artifact. The returned ID can be empty string."
   ingestPointOfContact(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
@@ -3316,12 +3316,12 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Certifies that a package or artifact has an SBOM."
+  "Certifies that a package or artifact has an SBOM. The returned ID can be empty string."
   ingestHasSBOM(
     subject: PackageOrArtifactInput!
     hasSBOM: HasSBOMInputSpec!
   ): ID!
-  "Bulk ingest that package or artifact has an SBOM."
+  "Bulk ingest that package or artifact has an SBOM. The returned array of IDs can be a an array of empty string."
   ingestHasSBOMs(
     subjects: PackageOrArtifactInputs!
     hasSBOMs: [HasSBOMInputSpec!]!
@@ -3463,14 +3463,14 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a SLSA attestation"
+  "Ingests a SLSA attestation. The returned ID can be empty string."
   ingestSLSA(
     subject: ArtifactInputSpec!
     builtFrom: [ArtifactInputSpec!]!
     builtBy: BuilderInputSpec!
     slsa: SLSAInputSpec!
   ): ID!
-  "Bulk Ingest SLSA attestations"
+  "Bulk Ingest SLSA attestations. The returned array of IDs can be a an array of empty string."
   ingestSLSAs(
     subjects: [ArtifactInputSpec!]!
     builtFromList: [[ArtifactInputSpec!]!]!
@@ -3540,7 +3540,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
+  "Adds a certification that a package (PackageName or PackageVersion) is built from the source. The returned ID can be empty string."
   ingestHasSourceAt(
     pkg: PkgInputSpec!
     pkgMatchType: MatchFlags!
@@ -3609,13 +3609,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that two artifacts are equal."
+  "Adds a certification that two artifacts are equal. The returned ID can be empty string."
   ingestHashEqual(
     artifact: ArtifactInputSpec!
     otherArtifact: ArtifactInputSpec!
     hashEqual: HashEqualInputSpec!
   ): ID!
-  "Bulk ingest certifications that two artifacts are equal."
+  "Bulk ingest certifications that two artifacts are equal. The returned array of IDs can be a an array of empty string."
   ingestHashEquals(
     artifacts: [ArtifactInputSpec!]!
     otherArtifacts: [ArtifactInputSpec!]!
@@ -3706,14 +3706,14 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a dependency between two packages"
+  "Adds a dependency between two packages. The returned ID can be empty string."
   ingestDependency(
     pkg: PkgInputSpec!
     depPkg: PkgInputSpec!
     depPkgMatchType: MatchFlags!
     dependency: IsDependencyInputSpec!
   ): ID!
-  "Bulk adds a dependency between two packages"
+  "Bulk adds a dependency between two packages. The returned array of IDs can be a an array of empty string."
   ingestDependencies(
     pkgs: [PkgInputSpec!]!
     depPkgs: [PkgInputSpec!]!
@@ -3818,13 +3818,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingest that an artifact is produced from a package or source."
+  "Ingest that an artifact is produced from a package or source. The returned ID can be empty string."
   ingestOccurrence(
     subject: PackageOrSourceInput!
     artifact: ArtifactInputSpec!
     occurrence: IsOccurrenceInputSpec!
   ): ID!
-  "Bulk ingest that an artifact is produced from a package or source."
+  "Bulk ingest that an artifact is produced from a package or source. The returned array of IDs can be a an array of empty string."
   ingestOccurrences(
     subjects: PackageOrSourceInputs!
     artifacts: [ArtifactInputSpec!]!
@@ -3920,7 +3920,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds metadata about a package, source or artifact."
+  "Adds metadata about a package, source or artifact. The returned ID can be empty string."
   ingestHasMetadata(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
@@ -4111,9 +4111,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new package and returns the corresponding package trie path."
+  "Ingests a new package and returns the corresponding package trie path. The returned ID can be empty string."
   ingestPackage(pkg: PkgInputSpec!): ID!
-  "Bulk ingests packages and returns the list of corresponding package trie path."
+  "Bulk ingests packages and returns the list of corresponding package trie path. The returned array of IDs can be a an array of empty string."
   ingestPackages(pkgs: [PkgInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
@@ -4349,7 +4349,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that two packages are similar."
+  "Adds a certification that two packages are similar. The returned ID can be empty string."
   ingestPkgEqual(
     pkg: PkgInputSpec!
     otherPackage: PkgInputSpec!
@@ -4504,9 +4504,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new source and returns the corresponding source trie path."
+  "Ingests a new source and returns the corresponding source trie path. The returned ID can be empty string."
   ingestSource(source: SourceInputSpec!): ID!
-  "Bulk ingests sources and returns the list of corresponding source trie path."
+  "Bulk ingests sources and returns the list of corresponding source trie path. The returned array of IDs can be a an array of empty string."
   ingestSources(sources: [SourceInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
@@ -4571,7 +4571,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingest a mapping between vulnerabilities."
+  "Ingest a mapping between vulnerabilities. The returned ID can be empty string."
   ingestVulnEqual(
     vulnerability: VulnerabilityInputSpec!
     otherVulnerability: VulnerabilityInputSpec!
@@ -4685,9 +4685,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds metadata about a vulnerability."
+  "Adds metadata about a vulnerability. The returned ID can be empty string."
   ingestVulnerabilityMetadata(vulnerability: VulnerabilityInputSpec!, vulnerabilityMetadata: VulnerabilityMetadataInputSpec!): ID!
-  "Bulk add certifications that vulnerability has a specific score."
+  "Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string."
   ingestVulnerabilityMetadatas(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadatas: [VulnerabilityMetadataInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
@@ -4793,9 +4793,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new vulnerability and returns the corresponding vulnerability trie path."
+  "Ingests a new vulnerability and returns the corresponding vulnerability trie path. The returned ID can be empty string."
   ingestVulnerability(vuln: VulnerabilityInputSpec!): ID!
-  "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path."
+  "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path. The returned array of IDs can be a an array of empty string."
   ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2463,9 +2463,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new artifact and returns it."
-  ingestArtifact(artifact: ArtifactInputSpec): Artifact!
+  ingestArtifact(artifact: ArtifactInputSpec): ID!
   "Bulk ingests new artifacts and returns a list of them."
-  ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [Artifact!]!
+  ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/builder.graphql", Input: `#
@@ -2515,9 +2515,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new builder and returns it."
-  ingestBuilder(builder: BuilderInputSpec): Builder!
+  ingestBuilder(builder: BuilderInputSpec): ID!
   "Bulk ingests new builders and returns a list of them."
-  ingestBuilders(builders: [BuilderInputSpec!]!): [Builder!]!
+  ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyBad.graphql", Input: `#
@@ -2649,9 +2649,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered bad."
-  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): CertifyBad!
+  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): ID!
   "Adds bulk certifications that a package, source or artifact is considered bad."
-  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [CertifyBad!]!
+  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyGood.graphql", Input: `#
@@ -2729,9 +2729,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered good."
-  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): CertifyGood!
+  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): ID!
   "Adds bulk certifications that a package, source or artifact is considered good."
-  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [CertifyGood!]!
+  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyScorecard.graphql", Input: `#
@@ -2862,9 +2862,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
-  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
   "Adds bulk certifications that a source repository has a Scorecard."
-  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [CertifyScorecard!]!
+  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVEXStatement.graphql", Input: `#
@@ -3003,7 +3003,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a VEX certification for a package."
-  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): CertifyVEXStatement!
+  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVuln.graphql", Input: `#
@@ -3108,9 +3108,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
-  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): CertifyVuln!
+  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): ID!
   "Bulk add certifications that a package has been scanned for vulnerabilities."
-  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [CertifyVuln!]!
+  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/contact.graphql", Input: `#
@@ -3207,7 +3207,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a PointOfContact attestation to a package, source or artifact."
-  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): PointOfContact!
+  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSBOM.graphql", Input: `#
@@ -3280,9 +3280,9 @@ extend type Query {
 
 extend type Mutation {
   "Certifies that a package or artifact has an SBOM."
-  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): HasSBOM!
+  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): ID!
   "Bulk ingest that package or artifact has an SBOM."
-  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [HasSBOM!]!
+  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSLSA.graphql", Input: `#
@@ -3421,9 +3421,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a SLSA attestation"
-  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): HasSLSA!
+  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): ID!
   "Bulk Ingest SLSA attestations"
-  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [HasSLSA!]!
+  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSourceAt.graphql", Input: `#
@@ -3488,7 +3488,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
-  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): HasSourceAt!
+  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hashEqual.graphql", Input: `#
@@ -3554,9 +3554,9 @@ extend type Query {
 
 extend type Mutation {
  "Adds a certification that two artifacts are equal."
-  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): HashEqual!
+  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): ID!
   "Bulk ingest certifications that two artifacts are equal."
-  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [HashEqual!]!
+  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/isDependency.graphql", Input: `#
@@ -3643,9 +3643,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a dependency between two packages"
-  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): IsDependency!
+  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): ID!
   "Bulk adds a dependency between two packages"
-  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [IsDependency!]!
+  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/isOccurrence.graphql", Input: `#
@@ -3746,9 +3746,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingest that an artifact is produced from a package or source."
-  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): IsOccurrence!
+  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): ID!
   "Bulk ingest that an artifact is produced from a package or source."
-  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [IsOccurrence!]!
+  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/metadata.graphql", Input: `#
@@ -3840,7 +3840,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds metadata about a package, source or artifact."
-  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): HasMetadata!
+  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/package.graphql", Input: `#
@@ -4027,9 +4027,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new package and returns the corresponding package trie path."
-  ingestPackage(pkg: PkgInputSpec!): Package!
+  ingestPackage(pkg: PkgInputSpec!): ID!
   "Bulk ingests packages and returns the list of corresponding package trie path."
-  ingestPackages(pkgs: [PkgInputSpec!]!): [Package!]!
+  ingestPackages(pkgs: [PkgInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/path.graphql", Input: `#
@@ -4260,7 +4260,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that two packages are similar."
-  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): PkgEqual!
+  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/search.graphql", Input: `#
@@ -4411,9 +4411,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new source and returns the corresponding source trie path."
-  ingestSource(source: SourceInputSpec!): Source!
+  ingestSource(source: SourceInputSpec!): ID!
   "Bulk ingests sources and returns the list of corresponding source trie path."
-  ingestSources(sources: [SourceInputSpec!]!): [Source!]!
+  ingestSources(sources: [SourceInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/vulnEqual.graphql", Input: `#
@@ -4479,7 +4479,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a mapping between vulnerabilities."
-  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): VulnEqual!
+  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/vulnMetadata.graphql", Input: `#
@@ -4698,9 +4698,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new vulnerability and returns the corresponding vulnerability trie path."
-  ingestVulnerability(vuln: VulnerabilityInputSpec!): Vulnerability!
+  ingestVulnerability(vuln: VulnerabilityInputSpec!): ID!
   "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path."
-  ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [Vulnerability!]!
+  ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 }

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2649,9 +2649,17 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered bad."
-  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): ID!
+  ingestCertifyBad(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    certifyBad: CertifyBadInputSpec!
+  ): ID!
   "Adds bulk certifications that a package, source or artifact is considered bad."
-  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [ID!]!
+  ingestCertifyBads(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    certifyBads: [CertifyBadInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyGood.graphql", Input: `#
@@ -2729,9 +2737,17 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered good."
-  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): ID!
+  ingestCertifyGood(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    certifyGood: CertifyGoodInputSpec!
+  ): ID!
   "Adds bulk certifications that a package, source or artifact is considered good."
-  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [ID!]!
+  ingestCertifyGoods(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    certifyGoods: [CertifyGoodInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyScorecard.graphql", Input: `#
@@ -2864,7 +2880,10 @@ extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
   ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
   "Adds bulk certifications that a source repository has a Scorecard."
-  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [ID!]!
+  ingestScorecards(
+    sources: [SourceInputSpec!]!
+    scorecards: [ScorecardInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVEXStatement.graphql", Input: `#
@@ -2998,12 +3017,18 @@ input VexStatementInputSpec {
 
 extend type Query {
   "Returns all VEX certifications matching the input filter."
-  CertifyVEXStatement(certifyVEXStatementSpec: CertifyVEXStatementSpec!): [CertifyVEXStatement!]!
+  CertifyVEXStatement(
+    certifyVEXStatementSpec: CertifyVEXStatementSpec!
+  ): [CertifyVEXStatement!]!
 }
 
 extend type Mutation {
   "Adds a VEX certification for a package."
-  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): ID!
+  ingestVEXStatement(
+    subject: PackageOrArtifactInput!
+    vulnerability: VulnerabilityInputSpec!
+    vexStatement: VexStatementInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVuln.graphql", Input: `#
@@ -3029,7 +3054,7 @@ extend type Mutation {
 CertifyVuln is an attestation to attach vulnerability information to a package.
 
 This information is obtained via a scanner. If there is no vulnerability
-detected, we attach the a vulnerability with "NoVuln" type and an empty string 
+detected, we attach the a vulnerability with "NoVuln" type and an empty string
 for the vulnerability ID.
 """
 type CertifyVuln {
@@ -3108,9 +3133,17 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
-  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): ID!
+  ingestCertifyVuln(
+    pkg: PkgInputSpec!
+    vulnerability: VulnerabilityInputSpec!
+    certifyVuln: ScanMetadataInput!
+  ): ID!
   "Bulk add certifications that a package has been scanned for vulnerabilities."
-  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [ID!]!
+  ingestCertifyVulns(
+    pkgs: [PkgInputSpec!]!
+    vulnerabilities: [VulnerabilityInputSpec!]!
+    certifyVulns: [ScanMetadataInput!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/contact.graphql", Input: `#
@@ -3202,12 +3235,16 @@ input PointOfContactInputSpec {
 
 extend type Query {
   "Returns all PointOfContact attestations matching a filter."
-  PointOfContact (pointOfContactSpec: PointOfContactSpec!): [PointOfContact!]!
+  PointOfContact(pointOfContactSpec: PointOfContactSpec!): [PointOfContact!]!
 }
 
 extend type Mutation {
   "Adds a PointOfContact attestation to a package, source or artifact."
-  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): ID!
+  ingestPointOfContact(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    pointOfContact: PointOfContactInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSBOM.graphql", Input: `#
@@ -3280,9 +3317,15 @@ extend type Query {
 
 extend type Mutation {
   "Certifies that a package or artifact has an SBOM."
-  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): ID!
+  ingestHasSBOM(
+    subject: PackageOrArtifactInput!
+    hasSBOM: HasSBOMInputSpec!
+  ): ID!
   "Bulk ingest that package or artifact has an SBOM."
-  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [ID!]!
+  ingestHasSBOMs(
+    subjects: PackageOrArtifactInputs!
+    hasSBOMs: [HasSBOMInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSLSA.graphql", Input: `#
@@ -3421,9 +3464,19 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a SLSA attestation"
-  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): ID!
+  ingestSLSA(
+    subject: ArtifactInputSpec!
+    builtFrom: [ArtifactInputSpec!]!
+    builtBy: BuilderInputSpec!
+    slsa: SLSAInputSpec!
+  ): ID!
   "Bulk Ingest SLSA attestations"
-  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [ID!]!
+  ingestSLSAs(
+    subjects: [ArtifactInputSpec!]!
+    builtFromList: [[ArtifactInputSpec!]!]!
+    builtByList: [BuilderInputSpec!]!
+    slsaList: [SLSAInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hasSourceAt.graphql", Input: `#
@@ -3488,7 +3541,12 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
-  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): ID!
+  ingestHasSourceAt(
+    pkg: PkgInputSpec!
+    pkgMatchType: MatchFlags!
+    source: SourceInputSpec!
+    hasSourceAt: HasSourceAtInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hashEqual.graphql", Input: `#
@@ -3538,7 +3596,6 @@ input HashEqualSpec {
   collector: String
 }
 
-
 "HashEqualInputSpec represents the input to certify that packages are similar."
 input HashEqualInputSpec {
   justification: String!
@@ -3546,17 +3603,24 @@ input HashEqualInputSpec {
   collector: String!
 }
 
-
 extend type Query {
   "Returns all artifact equality statements matching a filter."
   HashEqual(hashEqualSpec: HashEqualSpec!): [HashEqual!]!
 }
 
 extend type Mutation {
- "Adds a certification that two artifacts are equal."
-  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): ID!
+  "Adds a certification that two artifacts are equal."
+  ingestHashEqual(
+    artifact: ArtifactInputSpec!
+    otherArtifact: ArtifactInputSpec!
+    hashEqual: HashEqualInputSpec!
+  ): ID!
   "Bulk ingest certifications that two artifacts are equal."
-  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [ID!]!
+  ingestHashEquals(
+    artifacts: [ArtifactInputSpec!]!
+    otherArtifacts: [ArtifactInputSpec!]!
+    hashEquals: [HashEqualInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/isDependency.graphql", Input: `#
@@ -3643,9 +3707,19 @@ extend type Query {
 
 extend type Mutation {
   "Adds a dependency between two packages"
-  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): ID!
+  ingestDependency(
+    pkg: PkgInputSpec!
+    depPkg: PkgInputSpec!
+    depPkgMatchType: MatchFlags!
+    dependency: IsDependencyInputSpec!
+  ): ID!
   "Bulk adds a dependency between two packages"
-  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [ID!]!
+  ingestDependencies(
+    pkgs: [PkgInputSpec!]!
+    depPkgs: [PkgInputSpec!]!
+    depPkgMatchType: MatchFlags!
+    dependencies: [IsDependencyInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/isOccurrence.graphql", Input: `#
@@ -3699,7 +3773,6 @@ input PackageOrSourceInputs {
   sources: [SourceInputSpec!]
 }
 
-
 """
 IsOccurrence is an attestation to link an artifact to a package or source.
 
@@ -3746,9 +3819,17 @@ extend type Query {
 
 extend type Mutation {
   "Ingest that an artifact is produced from a package or source."
-  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): ID!
+  ingestOccurrence(
+    subject: PackageOrSourceInput!
+    artifact: ArtifactInputSpec!
+    occurrence: IsOccurrenceInputSpec!
+  ): ID!
   "Bulk ingest that an artifact is produced from a package or source."
-  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [ID!]!
+  ingestOccurrences(
+    subjects: PackageOrSourceInputs!
+    artifacts: [ArtifactInputSpec!]!
+    occurrences: [IsOccurrenceInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/metadata.graphql", Input: `#
@@ -3840,7 +3921,11 @@ extend type Query {
 
 extend type Mutation {
   "Adds metadata about a package, source or artifact."
-  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): ID!
+  ingestHasMetadata(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    hasMetadata: HasMetadataInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/package.graphql", Input: `#
@@ -4058,8 +4143,8 @@ It encapsulates the software tree nodes along with the evidence nodes. In a
 path query, all connecting evidence nodes along with their intermediate subject
 nodes need to be returned in order to create a complete graph.
 """
-union Node
-  = Package
+union Node =
+    Package
   | Source
   | Artifact
   | Builder
@@ -4172,7 +4257,12 @@ extend type Query {
   Specifying any Edge value in ` + "`" + `usingOnly` + "`" + ` will make the path only contain the
   corresponding GUAC evidence trees (GUAC verbs).
   """
-  path(subject: ID!, target: ID!, maxPathLength: Int!, usingOnly: [Edge!]!): [Node!]!
+  path(
+    subject: ID!
+    target: ID!
+    maxPathLength: Int!
+    usingOnly: [Edge!]!
+  ): [Node!]!
 
   """
   neighbors returns all the direct neighbors of a node.
@@ -4260,7 +4350,11 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that two packages are similar."
-  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): ID!
+  ingestPkgEqual(
+    pkg: PkgInputSpec!
+    otherPackage: PkgInputSpec!
+    pkgEqual: PkgEqualInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/search.graphql", Input: `#
@@ -4439,7 +4533,6 @@ extend type Mutation {
 VulnEqual is an attestation to link two vulnerabilities together as being equal"
 
 Note that setting noVuln vulnerability type is invalid for VulnEqual!
-
 """
 type VulnEqual {
   id: ID!
@@ -4479,7 +4572,11 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a mapping between vulnerabilities."
-  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): ID!
+  ingestVulnEqual(
+    vulnerability: VulnerabilityInputSpec!
+    otherVulnerability: VulnerabilityInputSpec!
+    vulnEqual: VulnEqualInputSpec!
+  ): ID!
 }
 `, BuiltIn: false},
 	{Name: "../schema/vulnMetadata.graphql", Input: `#
@@ -4618,7 +4715,7 @@ Vulnerability represents the root of the vulnerability trie/tree.
 
 We map vulnerability information to a trie, as a derivative of the pURL specification:
 each path in the trie represents a type and a vulnerability ID. This allows for generic
-representation of the various vulnerabilities and does not limit to just cve, ghsa or osv. 
+representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
 This would be in the general format: vuln://<general-type>/<vuln-id>
 
 Examples:
@@ -4636,7 +4733,7 @@ Since this node is at the root of the vulnerability trie, it is named Vulnerabil
 VulnerabilityType.
 
 NoVuln is a special vulnerability node to attest that no vulnerability has been
-found during a vulnerability scan. It will have the type "novuln" and contain an empty string 
+found during a vulnerability scan. It will have the type "novuln" and contain an empty string
 for vulnerabilityID
 
 The resolvers will enforce that both the type and vulnerability IDs are lower case.
@@ -4662,16 +4759,15 @@ type VulnerabilityID {
 """
 VulnerabilitySpec allows filtering the list of vulnerabilities to return in a query.
 
-Use null to match on all values at that level. 
+Use null to match on all values at that level.
 For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 where every field is null.
 
 Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
-Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
+Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
 and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
-Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding 
+Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding
 type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
-
 """
 input VulnerabilitySpec {
   id: ID

--- a/pkg/assembler/graphql/generated/source.generated.go
+++ b/pkg/assembler/graphql/generated/source.generated.go
@@ -789,10 +789,6 @@ func (ec *executionContext) _SourceNamespace(ctx context.Context, sel ast.Select
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNSource2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSource(ctx context.Context, sel ast.SelectionSet, v model.Source) graphql.Marshaler {
-	return ec._Source(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNSource2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Source) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/vulnEqual.generated.go
+++ b/pkg/assembler/graphql/generated/vulnEqual.generated.go
@@ -444,10 +444,6 @@ func (ec *executionContext) _VulnEqual(ctx context.Context, sel ast.SelectionSet
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNVulnEqual2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnEqual(ctx context.Context, sel ast.SelectionSet, v model.VulnEqual) graphql.Marshaler {
-	return ec._VulnEqual(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNVulnEqual2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnEqualᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.VulnEqual) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/generated/vulnerability.generated.go
+++ b/pkg/assembler/graphql/generated/vulnerability.generated.go
@@ -458,10 +458,6 @@ func (ec *executionContext) _VulnerabilityID(ctx context.Context, sel ast.Select
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNVulnerability2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerability(ctx context.Context, sel ast.SelectionSet, v model.Vulnerability) graphql.Marshaler {
-	return ec._Vulnerability(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNVulnerability2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Vulnerability) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup

--- a/pkg/assembler/graphql/resolvers/artifact.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/artifact.resolvers.go
@@ -12,13 +12,24 @@ import (
 )
 
 // IngestArtifact is the resolver for the ingestArtifact field.
-func (r *mutationResolver) IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (*model.Artifact, error) {
-	return r.Backend.IngestArtifact(ctx, artifact)
+func (r *mutationResolver) IngestArtifact(ctx context.Context, artifact *model.ArtifactInputSpec) (string, error) {
+	ingestedArtifact, err := r.Backend.IngestArtifact(ctx, artifact)
+	if err != nil {
+		return "", err
+	}
+	return ingestedArtifact.ID, err
 }
 
 // IngestArtifacts is the resolver for the ingestArtifacts field.
-func (r *mutationResolver) IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]*model.Artifact, error) {
-	return r.Backend.IngestArtifacts(ctx, artifacts)
+func (r *mutationResolver) IngestArtifacts(ctx context.Context, artifacts []*model.ArtifactInputSpec) ([]string, error) {
+	ingestedArtifacts, err := r.Backend.IngestArtifacts(ctx, artifacts)
+	ingestedArtifactsIDS := []string{}
+	if err == nil {
+		for _, art := range ingestedArtifacts {
+			ingestedArtifactsIDS = append(ingestedArtifactsIDS, art.ID)
+		}
+	}
+	return ingestedArtifactsIDS, err
 }
 
 // Artifacts is the resolver for the artifacts field.

--- a/pkg/assembler/graphql/resolvers/builder.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/builder.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestBuilder is the resolver for the ingestBuilder field.
-func (r *mutationResolver) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (*model.Builder, error) {
-	return r.Backend.IngestBuilder(ctx, builder)
+func (r *mutationResolver) IngestBuilder(ctx context.Context, builder *model.BuilderInputSpec) (string, error) {
+	ingestedBuilder, err := r.Backend.IngestBuilder(ctx, builder)
+	if err != nil {
+		return "", err
+	}
+	return ingestedBuilder.ID, err
 }
 
 // IngestBuilders is the resolver for the ingestBuilders field.
-func (r *mutationResolver) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
-	return r.Backend.IngestBuilders(ctx, builders)
+func (r *mutationResolver) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]string, error) {
+	ingestedBuilders, err := r.Backend.IngestBuilders(ctx, builders)
+	ingestedBuildersIDS := []string{}
+	if err == nil {
+		for _, builder := range ingestedBuilders {
+			ingestedBuildersIDS = append(ingestedBuildersIDS, builder.ID)
+		}
+	}
+	return ingestedBuildersIDS, err
 }
 
 // Builders is the resolver for the builders field.

--- a/pkg/assembler/graphql/resolvers/certifyBad.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyBad.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestCertifyBad is the resolver for the ingestCertifyBad field.
-func (r *mutationResolver) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error) {
-	return r.Backend.IngestCertifyBad(ctx, subject, &pkgMatchType, certifyBad)
+func (r *mutationResolver) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) (string, error) {
+	ingestedCertifyBad, err := r.Backend.IngestCertifyBad(ctx, subject, &pkgMatchType, certifyBad)
+	if err != nil {
+		return "", err
+	}
+	return ingestedCertifyBad.ID, err
 }
 
 // IngestCertifyBads is the resolver for the ingestCertifyBads field.
-func (r *mutationResolver) IngestCertifyBads(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) ([]*model.CertifyBad, error) {
-	return r.Backend.IngestCertifyBads(ctx, subjects, &pkgMatchType, certifyBads)
+func (r *mutationResolver) IngestCertifyBads(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) ([]string, error) {
+	ingestedCertifyBads, err := r.Backend.IngestCertifyBads(ctx, subjects, &pkgMatchType, certifyBads)
+	ingestedCertifyBadsIDS := []string{}
+	if err == nil {
+		for _, certifybad := range ingestedCertifyBads {
+			ingestedCertifyBadsIDS = append(ingestedCertifyBadsIDS, certifybad.ID)
+		}
+	}
+	return ingestedCertifyBadsIDS, err
 }
 
 // CertifyBad is the resolver for the CertifyBad field.

--- a/pkg/assembler/graphql/resolvers/certifyGood.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyGood.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestCertifyGood is the resolver for the ingestCertifyGood field.
-func (r *mutationResolver) IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error) {
-	return r.Backend.IngestCertifyGood(ctx, subject, &pkgMatchType, certifyGood)
+func (r *mutationResolver) IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (string, error) {
+	ingestedCertifyGood, err := r.Backend.IngestCertifyGood(ctx, subject, &pkgMatchType, certifyGood)
+	if err != nil {
+		return "", err
+	}
+	return ingestedCertifyGood.ID, err
 }
 
 // IngestCertifyGoods is the resolver for the ingestCertifyGoods field.
-func (r *mutationResolver) IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]*model.CertifyGood, error) {
-	return r.Backend.IngestCertifyGoods(ctx, subjects, &pkgMatchType, certifyGoods)
+func (r *mutationResolver) IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]string, error) {
+	ingestedCertifyGoods, err := r.Backend.IngestCertifyGoods(ctx, subjects, &pkgMatchType, certifyGoods)
+	ingestedCertifyGoodsIDS := []string{}
+	if err == nil {
+		for _, certifybad := range ingestedCertifyGoods {
+			ingestedCertifyGoodsIDS = append(ingestedCertifyGoodsIDS, certifybad.ID)
+		}
+	}
+	return ingestedCertifyGoodsIDS, err
 }
 
 // CertifyGood is the resolver for the CertifyGood field.

--- a/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestScorecard is the resolver for the ingestScorecard field.
-func (r *mutationResolver) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (*model.CertifyScorecard, error) {
-	return r.Backend.IngestScorecard(ctx, source, scorecard)
+func (r *mutationResolver) IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (string, error) {
+	ingestedScorecard, err := r.Backend.IngestScorecard(ctx, source, scorecard)
+	if err != nil {
+		return "", err
+	}
+	return ingestedScorecard.ID, err
 }
 
 // IngestScorecards is the resolver for the ingestScorecards field.
-func (r *mutationResolver) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
-	return r.Backend.IngestScorecards(ctx, sources, scorecards)
+func (r *mutationResolver) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]string, error) {
+	ingestedScorecards, err := r.Backend.IngestScorecards(ctx, sources, scorecards)
+	ingestedScorecardsIDS := []string{}
+	if err == nil {
+		for _, scorecard := range ingestedScorecards {
+			ingestedScorecardsIDS = append(ingestedScorecardsIDS, scorecard.ID)
+		}
+	}
+	return ingestedScorecardsIDS, err
 }
 
 // Scorecards is the resolver for the scorecards field.

--- a/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
@@ -13,15 +13,18 @@ import (
 )
 
 // IngestVEXStatement is the resolver for the ingestVEXStatement field.
-func (r *mutationResolver) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
+func (r *mutationResolver) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (string, error) {
 	if strings.ToLower(vulnerability.Type) == "novuln" {
-		return nil, gqlerror.Errorf("novuln type cannot be used for VEX")
+		return "", gqlerror.Errorf("novuln type cannot be used for VEX")
 	}
-
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
-	return r.Backend.IngestVEXStatement(ctx, subject,
+	ingestedVEXStatement, err := r.Backend.IngestVEXStatement(ctx, subject,
 		model.VulnerabilityInputSpec{Type: strings.ToLower(vulnerability.Type), VulnerabilityID: strings.ToLower(vulnerability.VulnerabilityID)},
 		vexStatement)
+	if err == nil {
+		return "", err
+	}
+	return ingestedVEXStatement.ID, err
 }
 
 // CertifyVEXStatement is the resolver for the CertifyVEXStatement field.

--- a/pkg/assembler/graphql/resolvers/contact.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/contact.resolvers.go
@@ -11,8 +11,12 @@ import (
 )
 
 // IngestPointOfContact is the resolver for the ingestPointOfContact field.
-func (r *mutationResolver) IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (*model.PointOfContact, error) {
-	return r.Backend.IngestPointOfContact(ctx, subject, &pkgMatchType, pointOfContact)
+func (r *mutationResolver) IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (string, error) {
+	ingestedPOC, err := r.Backend.IngestPointOfContact(ctx, subject, &pkgMatchType, pointOfContact)
+	if err != nil {
+		return "", err
+	}
+	return ingestedPOC.ID, err
 }
 
 // PointOfContact is the resolver for the PointOfContact field.

--- a/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestHasSbom is the resolver for the ingestHasSBOM field.
-func (r *mutationResolver) IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (*model.HasSbom, error) {
-	return r.Backend.IngestHasSbom(ctx, subject, hasSbom)
+func (r *mutationResolver) IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (string, error) {
+	ingestedHasSbom, err := r.Backend.IngestHasSbom(ctx, subject, hasSbom)
+	if err != nil {
+		return "", err
+	}
+	return ingestedHasSbom.ID, err
 }
 
 // IngestHasSBOMs is the resolver for the ingestHasSBOMs field.
-func (r *mutationResolver) IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error) {
-	return r.Backend.IngestHasSBOMs(ctx, subjects, hasSBOMs)
+func (r *mutationResolver) IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]string, error) {
+	ingestedHasSBOMs, err := r.Backend.IngestHasSBOMs(ctx, subjects, hasSBOMs)
+	ingestedHasSBOMSIDS := []string{}
+	if err == nil {
+		for _, hasSBOM := range ingestedHasSBOMs {
+			ingestedHasSBOMSIDS = append(ingestedHasSBOMSIDS, hasSBOM.ID)
+		}
+	}
+	return ingestedHasSBOMSIDS, err
 }
 
 // HasSbom is the resolver for the HasSBOM field.

--- a/pkg/assembler/graphql/resolvers/hasSLSA.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSLSA.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestSlsa is the resolver for the ingestSLSA field.
-func (r *mutationResolver) IngestSlsa(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
-	return r.Backend.IngestSLSA(ctx, subject, builtFrom, builtBy, slsa)
+func (r *mutationResolver) IngestSlsa(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (string, error) {
+	ingestedSLSA, err := r.Backend.IngestSLSA(ctx, subject, builtFrom, builtBy, slsa)
+	if err != nil {
+		return "", err
+	}
+	return ingestedSLSA.ID, err
 }
 
 // IngestSLSAs is the resolver for the ingestSLSAs field.
-func (r *mutationResolver) IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error) {
-	return r.Backend.IngestSLSAs(ctx, subjects, builtFromList, builtByList, slsaList)
+func (r *mutationResolver) IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]string, error) {
+	ingestedSLSAs, err := r.Backend.IngestSLSAs(ctx, subjects, builtFromList, builtByList, slsaList)
+	ingestedSLSAIDS := []string{}
+	if err == nil {
+		for _, SLSA := range ingestedSLSAs {
+			ingestedSLSAIDS = append(ingestedSLSAIDS, SLSA.ID)
+		}
+	}
+	return ingestedSLSAIDS, err
 }
 
 // HasSlsa is the resolver for the HasSLSA field.

--- a/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
@@ -11,8 +11,12 @@ import (
 )
 
 // IngestHasSourceAt is the resolver for the ingestHasSourceAt field.
-func (r *mutationResolver) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
-	return r.Backend.IngestHasSourceAt(ctx, pkg, pkgMatchType, source, hasSourceAt)
+func (r *mutationResolver) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (string, error) {
+	ingestedHasSourceAt, err := r.Backend.IngestHasSourceAt(ctx, pkg, pkgMatchType, source, hasSourceAt)
+	if err != nil {
+		return "", err
+	}
+	return ingestedHasSourceAt.ID, err
 }
 
 // HasSourceAt is the resolver for the HasSourceAt field.

--- a/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestHashEqual is the resolver for the ingestHashEqual field.
-func (r *mutationResolver) IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error) {
-	return r.Backend.IngestHashEqual(ctx, artifact, otherArtifact, hashEqual)
+func (r *mutationResolver) IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (string, error) {
+	ingestedHashEqual, err := r.Backend.IngestHashEqual(ctx, artifact, otherArtifact, hashEqual)
+	if err != nil {
+		return "", err
+	}
+	return ingestedHashEqual.ID, err
 }
 
 // IngestHashEquals is the resolver for the ingestHashEquals field.
-func (r *mutationResolver) IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]*model.HashEqual, error) {
-	return r.Backend.IngestHashEquals(ctx, artifacts, otherArtifacts, hashEquals)
+func (r *mutationResolver) IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]string, error) {
+	ingestedHashEquals, err := r.Backend.IngestHashEquals(ctx, artifacts, otherArtifacts, hashEquals)
+	ingestedHashEqualsIDS := []string{}
+	if err == nil {
+		for _, hashEqual := range ingestedHashEquals {
+			ingestedHashEqualsIDS = append(ingestedHashEqualsIDS, hashEqual.ID)
+		}
+	}
+	return ingestedHashEqualsIDS, err
 }
 
 // HashEqual is the resolver for the HashEqual field.

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestDependency is the resolver for the ingestDependency field.
-func (r *mutationResolver) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
-	return r.Backend.IngestDependency(ctx, pkg, depPkg, depPkgMatchType, dependency)
+func (r *mutationResolver) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (string, error) {
+	ingestedDependency, err := r.Backend.IngestDependency(ctx, pkg, depPkg, depPkgMatchType, dependency)
+	if err != nil {
+		return "", err
+	}
+	return ingestedDependency.ID, err
 }
 
 // IngestDependencies is the resolver for the ingestDependencies field.
-func (r *mutationResolver) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
-	return r.Backend.IngestDependencies(ctx, pkgs, depPkgs, depPkgMatchType, dependencies)
+func (r *mutationResolver) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]string, error) {
+	ingestedDependencies, err := r.Backend.IngestDependencies(ctx, pkgs, depPkgs, depPkgMatchType, dependencies)
+	ingestedDependenciesIDS := []string{}
+	if err == nil {
+		for _, dependency := range ingestedDependencies {
+			ingestedDependenciesIDS = append(ingestedDependenciesIDS, dependency.ID)
+		}
+	}
+	return ingestedDependenciesIDS, err
 }
 
 // IsDependency is the resolver for the IsDependency field.

--- a/pkg/assembler/graphql/resolvers/isOccurrence.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isOccurrence.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestOccurrence is the resolver for the ingestOccurrence field.
-func (r *mutationResolver) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error) {
-	return r.Backend.IngestOccurrence(ctx, subject, artifact, occurrence)
+func (r *mutationResolver) IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (string, error) {
+	ingestedOccurrence, err := r.Backend.IngestOccurrence(ctx, subject, artifact, occurrence)
+	if err != nil {
+		return "", err
+	}
+	return ingestedOccurrence.ID, err
 }
 
 // IngestOccurrences is the resolver for the ingestOccurrences field.
-func (r *mutationResolver) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
-	return r.Backend.IngestOccurrences(ctx, subjects, artifacts, occurrences)
+func (r *mutationResolver) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]string, error) {
+	ingestedOccurences, err := r.Backend.IngestOccurrences(ctx, subjects, artifacts, occurrences)
+	ingestedOccurencesIDs := []string{}
+	if err == nil {
+		for _, occurence := range ingestedOccurences {
+			ingestedOccurencesIDs = append(ingestedOccurencesIDs, occurence.ID)
+		}
+	}
+	return ingestedOccurencesIDs, err
 }
 
 // IsOccurrence is the resolver for the IsOccurrence field.

--- a/pkg/assembler/graphql/resolvers/metadata.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/metadata.resolvers.go
@@ -11,8 +11,12 @@ import (
 )
 
 // IngestHasMetadata is the resolver for the ingestHasMetadata field.
-func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
-	return r.Backend.IngestHasMetadata(ctx, subject, &pkgMatchType, hasMetadata)
+func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (string, error) {
+	ingestedHasMetadata, err := r.Backend.IngestHasMetadata(ctx, subject, &pkgMatchType, hasMetadata)
+	if err != nil {
+		return "", err
+	}
+	return ingestedHasMetadata.ID, err
 }
 
 // HasMetadata is the resolver for the HasMetadata field.

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestPackage is the resolver for the ingestPackage field.
-func (r *mutationResolver) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (*model.Package, error) {
-	return r.Backend.IngestPackage(ctx, pkg)
+func (r *mutationResolver) IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (string, error) {
+	ingestedPackage, err := r.Backend.IngestPackage(ctx, pkg)
+	if err != nil {
+		return "", err
+	}
+	return ingestedPackage.ID, err
 }
 
 // IngestPackages is the resolver for the ingestPackages field.
-func (r *mutationResolver) IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]*model.Package, error) {
-	return r.Backend.IngestPackages(ctx, pkgs)
+func (r *mutationResolver) IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]string, error) {
+	ingestedPackages, err := r.Backend.IngestPackages(ctx, pkgs)
+	ingestedPackagesIDS := []string{}
+	if err == nil {
+		for _, Package := range ingestedPackages {
+			ingestedPackagesIDS = append(ingestedPackagesIDS, Package.ID)
+		}
+	}
+	return ingestedPackagesIDS, err
 }
 
 // Packages is the resolver for the packages field.

--- a/pkg/assembler/graphql/resolvers/pkgEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/pkgEqual.resolvers.go
@@ -11,8 +11,12 @@ import (
 )
 
 // IngestPkgEqual is the resolver for the ingestPkgEqual field.
-func (r *mutationResolver) IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (*model.PkgEqual, error) {
-	return r.Backend.IngestPkgEqual(ctx, pkg, otherPackage, pkgEqual)
+func (r *mutationResolver) IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (string, error) {
+	ingestedPkgEqual, err := r.Backend.IngestPkgEqual(ctx, pkg, otherPackage, pkgEqual)
+	if err != nil {
+		return "", err
+	}
+	return ingestedPkgEqual.ID, err
 }
 
 // PkgEqual is the resolver for the PkgEqual field.

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -11,13 +11,24 @@ import (
 )
 
 // IngestSource is the resolver for the ingestSource field.
-func (r *mutationResolver) IngestSource(ctx context.Context, source model.SourceInputSpec) (*model.Source, error) {
-	return r.Backend.IngestSource(ctx, source)
+func (r *mutationResolver) IngestSource(ctx context.Context, source model.SourceInputSpec) (string, error) {
+	ingestedSource, err := r.Backend.IngestSource(ctx, source)
+	if err != nil {
+		return "", err
+	}
+	return ingestedSource.ID, err
 }
 
 // IngestSources is the resolver for the ingestSources field.
-func (r *mutationResolver) IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]*model.Source, error) {
-	return r.Backend.IngestSources(ctx, sources)
+func (r *mutationResolver) IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]string, error) {
+	ingestedSources, err := r.Backend.IngestSources(ctx, sources)
+	ingestedSourcesIDS := []string{}
+	if err == nil {
+		for _, source := range ingestedSources {
+			ingestedSourcesIDS = append(ingestedSourcesIDS, source.ID)
+		}
+	}
+	return ingestedSourcesIDS, err
 }
 
 // Sources is the resolver for the sources field.

--- a/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
@@ -13,12 +13,16 @@ import (
 )
 
 // IngestVulnEqual is the resolver for the ingestVulnEqual field.
-func (r *mutationResolver) IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (*model.VulnEqual, error) {
+func (r *mutationResolver) IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (string, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
-	return r.Backend.IngestVulnEqual(ctx,
+	ingestedVulnEqual, err := r.Backend.IngestVulnEqual(ctx,
 		model.VulnerabilityInputSpec{Type: strings.ToLower(vulnerability.Type), VulnerabilityID: strings.ToLower(vulnerability.VulnerabilityID)},
 		model.VulnerabilityInputSpec{Type: strings.ToLower(otherVulnerability.Type), VulnerabilityID: strings.ToLower(otherVulnerability.VulnerabilityID)},
 		vulnEqual)
+	if err != nil {
+		return "", err
+	}
+	return ingestedVulnEqual.ID, err
 }
 
 // VulnEqual is the resolver for the vulnEqual field.

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
@@ -13,13 +13,17 @@ import (
 )
 
 // IngestVulnerability is the resolver for the ingestVulnerability field.
-func (r *mutationResolver) IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (*model.Vulnerability, error) {
+func (r *mutationResolver) IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (string, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
-	return r.Backend.IngestVulnerability(ctx, model.VulnerabilityInputSpec{Type: strings.ToLower(vuln.Type), VulnerabilityID: strings.ToLower(vuln.VulnerabilityID)})
+	ingestedVulnerability, err := r.Backend.IngestVulnerability(ctx, model.VulnerabilityInputSpec{Type: strings.ToLower(vuln.Type), VulnerabilityID: strings.ToLower(vuln.VulnerabilityID)})
+	if err != nil {
+		return "", err
+	}
+	return ingestedVulnerability.ID, err
 }
 
 // IngestVulnerabilities is the resolver for the ingestVulnerabilities field.
-func (r *mutationResolver) IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]*model.Vulnerability, error) {
+func (r *mutationResolver) IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]string, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 	var lowercaseVulnInputList []*model.VulnerabilityInputSpec
 	for _, v := range vulns {
@@ -29,7 +33,14 @@ func (r *mutationResolver) IngestVulnerabilities(ctx context.Context, vulns []*m
 		}
 		lowercaseVulnInputList = append(lowercaseVulnInputList, &lowercaseVulnInput)
 	}
-	return r.Backend.IngestVulnerabilities(ctx, lowercaseVulnInputList)
+	ingestedVulnerabilities, err := r.Backend.IngestVulnerabilities(ctx, lowercaseVulnInputList)
+	ingestedVulnerabilitiesIDS := []string{}
+	if err == nil {
+		for _, vulnerability := range ingestedVulnerabilities {
+			ingestedVulnerabilitiesIDS = append(ingestedVulnerabilitiesIDS, vulnerability.ID)
+		}
+	}
+	return ingestedVulnerabilitiesIDS, err
 }
 
 // Vulnerabilities is the resolver for the vulnerabilities field.

--- a/pkg/assembler/graphql/schema/artifact.graphql
+++ b/pkg/assembler/graphql/schema/artifact.graphql
@@ -59,8 +59,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new artifact and returns it."
+  "Ingests a new artifact and returns it. The returned ID can be empty string."
   ingestArtifact(artifact: ArtifactInputSpec): ID!
-  "Bulk ingests new artifacts and returns a list of them."
+  "Bulk ingests new artifacts and returns a list of them. The returned array of IDs can be a an array of empty string."
   ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/artifact.graphql
+++ b/pkg/assembler/graphql/schema/artifact.graphql
@@ -60,7 +60,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new artifact and returns it."
-  ingestArtifact(artifact: ArtifactInputSpec): Artifact!
+  ingestArtifact(artifact: ArtifactInputSpec): ID!
   "Bulk ingests new artifacts and returns a list of them."
-  ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [Artifact!]!
+  ingestArtifacts(artifacts: [ArtifactInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/builder.graphql
+++ b/pkg/assembler/graphql/schema/builder.graphql
@@ -44,7 +44,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new builder and returns it."
+  "Ingests a new builder and returns it. The returned ID can be empty string."
   ingestBuilder(builder: BuilderInputSpec): ID!
   "Bulk ingests new builders and returns a list of them."
   ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!

--- a/pkg/assembler/graphql/schema/builder.graphql
+++ b/pkg/assembler/graphql/schema/builder.graphql
@@ -45,7 +45,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new builder and returns it."
-  ingestBuilder(builder: BuilderInputSpec): Builder!
+  ingestBuilder(builder: BuilderInputSpec): ID!
   "Bulk ingests new builders and returns a list of them."
-  ingestBuilders(builders: [BuilderInputSpec!]!): [Builder!]!
+  ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -127,7 +127,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered bad."
-  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): CertifyBad!
+  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): ID!
   "Adds bulk certifications that a package, source or artifact is considered bad."
-  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [CertifyBad!]!
+  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -126,13 +126,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package, source or artifact is considered bad."
+  "Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string."
   ingestCertifyBad(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
     certifyBad: CertifyBadInputSpec!
   ): ID!
-  "Adds bulk certifications that a package, source or artifact is considered bad."
+  "Adds bulk certifications that a package, source or artifact is considered bad. The returned array of IDs can be a an array of empty string."
   ingestCertifyBads(
     subjects: PackageSourceOrArtifactInputs!
     pkgMatchType: MatchFlags!

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -127,7 +127,15 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered bad."
-  ingestCertifyBad(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyBad: CertifyBadInputSpec!): ID!
+  ingestCertifyBad(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    certifyBad: CertifyBadInputSpec!
+  ): ID!
   "Adds bulk certifications that a package, source or artifact is considered bad."
-  ingestCertifyBads(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyBads: [CertifyBadInputSpec!]!): [ID!]!
+  ingestCertifyBads(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    certifyBads: [CertifyBadInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -73,7 +73,15 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered good."
-  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): ID!
+  ingestCertifyGood(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    certifyGood: CertifyGoodInputSpec!
+  ): ID!
   "Adds bulk certifications that a package, source or artifact is considered good."
-  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [ID!]!
+  ingestCertifyGoods(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    certifyGoods: [CertifyGoodInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -72,13 +72,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package, source or artifact is considered good."
+  "Adds a certification that a package, source or artifact is considered good. The returned ID can be empty string."
   ingestCertifyGood(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!
     certifyGood: CertifyGoodInputSpec!
   ): ID!
-  "Adds bulk certifications that a package, source or artifact is considered good."
+  "Adds bulk certifications that a package, source or artifact is considered good. The returned array of IDs can be a an array of empty string."
   ingestCertifyGoods(
     subjects: PackageSourceOrArtifactInputs!
     pkgMatchType: MatchFlags!

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -73,7 +73,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package, source or artifact is considered good."
-  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): CertifyGood!
+  ingestCertifyGood(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, certifyGood: CertifyGoodInputSpec!): ID!
   "Adds bulk certifications that a package, source or artifact is considered good."
-  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [CertifyGood!]!
+  ingestCertifyGoods(subjects: PackageSourceOrArtifactInputs!, pkgMatchType: MatchFlags!, certifyGoods: [CertifyGoodInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -125,9 +125,9 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a source repository has a Scorecard."
+  "Adds a certification that a source repository has a Scorecard. The returned ID can be empty string."
   ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
-  "Adds bulk certifications that a source repository has a Scorecard."
+  "Adds bulk certifications that a source repository has a Scorecard. The returned array of IDs can be a an array of empty string."
   ingestScorecards(
     sources: [SourceInputSpec!]!
     scorecards: [ScorecardInputSpec!]!

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -128,5 +128,8 @@ extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
   ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
   "Adds bulk certifications that a source repository has a Scorecard."
-  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [ID!]!
+  ingestScorecards(
+    sources: [SourceInputSpec!]!
+    scorecards: [ScorecardInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -126,7 +126,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a source repository has a Scorecard."
-  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): CertifyScorecard!
+  ingestScorecard(source: SourceInputSpec!, scorecard: ScorecardInputSpec!): ID!
   "Adds bulk certifications that a source repository has a Scorecard."
-  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [CertifyScorecard!]!
+  ingestScorecards(sources: [SourceInputSpec!]!, scorecards: [ScorecardInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -134,5 +134,5 @@ extend type Query {
 
 extend type Mutation {
   "Adds a VEX certification for a package."
-  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): CertifyVEXStatement!
+  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -129,10 +129,16 @@ input VexStatementInputSpec {
 
 extend type Query {
   "Returns all VEX certifications matching the input filter."
-  CertifyVEXStatement(certifyVEXStatementSpec: CertifyVEXStatementSpec!): [CertifyVEXStatement!]!
+  CertifyVEXStatement(
+    certifyVEXStatementSpec: CertifyVEXStatementSpec!
+  ): [CertifyVEXStatement!]!
 }
 
 extend type Mutation {
   "Adds a VEX certification for a package."
-  ingestVEXStatement(subject: PackageOrArtifactInput!, vulnerability: VulnerabilityInputSpec!, vexStatement: VexStatementInputSpec!): ID!
+  ingestVEXStatement(
+    subject: PackageOrArtifactInput!
+    vulnerability: VulnerabilityInputSpec!
+    vexStatement: VexStatementInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -135,7 +135,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a VEX certification for a package."
+  "Adds a VEX certification for a package. The returned ID can be empty string."
   ingestVEXStatement(
     subject: PackageOrArtifactInput!
     vulnerability: VulnerabilityInputSpec!

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -21,7 +21,7 @@
 CertifyVuln is an attestation to attach vulnerability information to a package.
 
 This information is obtained via a scanner. If there is no vulnerability
-detected, we attach the a vulnerability with "NoVuln" type and an empty string 
+detected, we attach the a vulnerability with "NoVuln" type and an empty string
 for the vulnerability ID.
 """
 type CertifyVuln {
@@ -100,7 +100,15 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
-  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): ID!
+  ingestCertifyVuln(
+    pkg: PkgInputSpec!
+    vulnerability: VulnerabilityInputSpec!
+    certifyVuln: ScanMetadataInput!
+  ): ID!
   "Bulk add certifications that a package has been scanned for vulnerabilities."
-  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [ID!]!
+  ingestCertifyVulns(
+    pkgs: [PkgInputSpec!]!
+    vulnerabilities: [VulnerabilityInputSpec!]!
+    certifyVulns: [ScanMetadataInput!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -99,13 +99,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package has been scanned for vulnerabilities."
+  "Adds a certification that a package has been scanned for vulnerabilities. The returned ID can be empty string."
   ingestCertifyVuln(
     pkg: PkgInputSpec!
     vulnerability: VulnerabilityInputSpec!
     certifyVuln: ScanMetadataInput!
   ): ID!
-  "Bulk add certifications that a package has been scanned for vulnerabilities."
+  "Bulk add certifications that a package has been scanned for vulnerabilities. The returned array of IDs can be a an array of empty string."
   ingestCertifyVulns(
     pkgs: [PkgInputSpec!]!
     vulnerabilities: [VulnerabilityInputSpec!]!

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -100,7 +100,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package has been scanned for vulnerabilities."
-  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): CertifyVuln!
+  ingestCertifyVuln(pkg: PkgInputSpec!, vulnerability: VulnerabilityInputSpec!, certifyVuln: ScanMetadataInput!): ID!
   "Bulk add certifications that a package has been scanned for vulnerabilities."
-  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [CertifyVuln!]!
+  ingestCertifyVulns(pkgs: [PkgInputSpec!]!, vulnerabilities: [VulnerabilityInputSpec!]!, certifyVulns: [ScanMetadataInput!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -91,7 +91,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a PointOfContact attestation to a package, source or artifact."
+  "Adds a PointOfContact attestation to a package, source or artifact. The returned ID can be empty string."
   ingestPointOfContact(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -87,10 +87,14 @@ input PointOfContactInputSpec {
 
 extend type Query {
   "Returns all PointOfContact attestations matching a filter."
-  PointOfContact (pointOfContactSpec: PointOfContactSpec!): [PointOfContact!]!
+  PointOfContact(pointOfContactSpec: PointOfContactSpec!): [PointOfContact!]!
 }
 
 extend type Mutation {
   "Adds a PointOfContact attestation to a package, source or artifact."
-  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): ID!
+  ingestPointOfContact(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    pointOfContact: PointOfContactInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -92,5 +92,5 @@ extend type Query {
 
 extend type Mutation {
   "Adds a PointOfContact attestation to a package, source or artifact."
-  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): PointOfContact!
+  ingestPointOfContact(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, pointOfContact: PointOfContactInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -67,12 +67,12 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Certifies that a package or artifact has an SBOM."
+  "Certifies that a package or artifact has an SBOM. The returned ID can be empty string."
   ingestHasSBOM(
     subject: PackageOrArtifactInput!
     hasSBOM: HasSBOMInputSpec!
   ): ID!
-  "Bulk ingest that package or artifact has an SBOM."
+  "Bulk ingest that package or artifact has an SBOM. The returned array of IDs can be a an array of empty string."
   ingestHasSBOMs(
     subjects: PackageOrArtifactInputs!
     hasSBOMs: [HasSBOMInputSpec!]!

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -68,7 +68,13 @@ extend type Query {
 
 extend type Mutation {
   "Certifies that a package or artifact has an SBOM."
-  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): ID!
+  ingestHasSBOM(
+    subject: PackageOrArtifactInput!
+    hasSBOM: HasSBOMInputSpec!
+  ): ID!
   "Bulk ingest that package or artifact has an SBOM."
-  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [ID!]!
+  ingestHasSBOMs(
+    subjects: PackageOrArtifactInputs!
+    hasSBOMs: [HasSBOMInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -68,7 +68,7 @@ extend type Query {
 
 extend type Mutation {
   "Certifies that a package or artifact has an SBOM."
-  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): HasSBOM!
+  ingestHasSBOM(subject: PackageOrArtifactInput!, hasSBOM: HasSBOMInputSpec!): ID!
   "Bulk ingest that package or artifact has an SBOM."
-  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [HasSBOM!]!
+  ingestHasSBOMs(subjects: PackageOrArtifactInputs!, hasSBOMs: [HasSBOMInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -134,7 +134,17 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a SLSA attestation"
-  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): ID!
+  ingestSLSA(
+    subject: ArtifactInputSpec!
+    builtFrom: [ArtifactInputSpec!]!
+    builtBy: BuilderInputSpec!
+    slsa: SLSAInputSpec!
+  ): ID!
   "Bulk Ingest SLSA attestations"
-  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [ID!]!
+  ingestSLSAs(
+    subjects: [ArtifactInputSpec!]!
+    builtFromList: [[ArtifactInputSpec!]!]!
+    builtByList: [BuilderInputSpec!]!
+    slsaList: [SLSAInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -134,7 +134,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a SLSA attestation"
-  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): HasSLSA!
+  ingestSLSA(subject: ArtifactInputSpec!, builtFrom: [ArtifactInputSpec!]!, builtBy: BuilderInputSpec!, slsa: SLSAInputSpec!): ID!
   "Bulk Ingest SLSA attestations"
-  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [HasSLSA!]!
+  ingestSLSAs(subjects: [ArtifactInputSpec!]!, builtFromList: [[ArtifactInputSpec!]!]!, builtByList: [BuilderInputSpec!]!, slsaList: [SLSAInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -133,14 +133,14 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a SLSA attestation"
+  "Ingests a SLSA attestation. The returned ID can be empty string."
   ingestSLSA(
     subject: ArtifactInputSpec!
     builtFrom: [ArtifactInputSpec!]!
     builtBy: BuilderInputSpec!
     slsa: SLSAInputSpec!
   ): ID!
-  "Bulk Ingest SLSA attestations"
+  "Bulk Ingest SLSA attestations. The returned array of IDs can be a an array of empty string."
   ingestSLSAs(
     subjects: [ArtifactInputSpec!]!
     builtFromList: [[ArtifactInputSpec!]!]!

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -60,5 +60,10 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
-  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): ID!
+  ingestHasSourceAt(
+    pkg: PkgInputSpec!
+    pkgMatchType: MatchFlags!
+    source: SourceInputSpec!
+    hasSourceAt: HasSourceAtInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -59,7 +59,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
+  "Adds a certification that a package (PackageName or PackageVersion) is built from the source. The returned ID can be empty string."
   ingestHasSourceAt(
     pkg: PkgInputSpec!
     pkgMatchType: MatchFlags!

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -60,5 +60,5 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that a package (PackageName or PackageVersion) is built from the source."
-  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): HasSourceAt!
+  ingestHasSourceAt(pkg: PkgInputSpec!, pkgMatchType: MatchFlags!, source: SourceInputSpec!, hasSourceAt: HasSourceAtInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -61,7 +61,7 @@ extend type Query {
 
 extend type Mutation {
  "Adds a certification that two artifacts are equal."
-  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): HashEqual!
+  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): ID!
   "Bulk ingest certifications that two artifacts are equal."
-  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [HashEqual!]!
+  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -45,7 +45,6 @@ input HashEqualSpec {
   collector: String
 }
 
-
 "HashEqualInputSpec represents the input to certify that packages are similar."
 input HashEqualInputSpec {
   justification: String!
@@ -53,15 +52,22 @@ input HashEqualInputSpec {
   collector: String!
 }
 
-
 extend type Query {
   "Returns all artifact equality statements matching a filter."
   HashEqual(hashEqualSpec: HashEqualSpec!): [HashEqual!]!
 }
 
 extend type Mutation {
- "Adds a certification that two artifacts are equal."
-  ingestHashEqual(artifact: ArtifactInputSpec!, otherArtifact: ArtifactInputSpec!, hashEqual: HashEqualInputSpec!): ID!
+  "Adds a certification that two artifacts are equal."
+  ingestHashEqual(
+    artifact: ArtifactInputSpec!
+    otherArtifact: ArtifactInputSpec!
+    hashEqual: HashEqualInputSpec!
+  ): ID!
   "Bulk ingest certifications that two artifacts are equal."
-  ingestHashEquals(artifacts: [ArtifactInputSpec!]!, otherArtifacts: [ArtifactInputSpec!]!, hashEquals: [HashEqualInputSpec!]!): [ID!]!
+  ingestHashEquals(
+    artifacts: [ArtifactInputSpec!]!
+    otherArtifacts: [ArtifactInputSpec!]!
+    hashEquals: [HashEqualInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -58,13 +58,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that two artifacts are equal."
+  "Adds a certification that two artifacts are equal. The returned ID can be empty string."
   ingestHashEqual(
     artifact: ArtifactInputSpec!
     otherArtifact: ArtifactInputSpec!
     hashEqual: HashEqualInputSpec!
   ): ID!
-  "Bulk ingest certifications that two artifacts are equal."
+  "Bulk ingest certifications that two artifacts are equal. The returned array of IDs can be a an array of empty string."
   ingestHashEquals(
     artifacts: [ArtifactInputSpec!]!
     otherArtifacts: [ArtifactInputSpec!]!

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -82,7 +82,17 @@ extend type Query {
 
 extend type Mutation {
   "Adds a dependency between two packages"
-  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): ID!
+  ingestDependency(
+    pkg: PkgInputSpec!
+    depPkg: PkgInputSpec!
+    depPkgMatchType: MatchFlags!
+    dependency: IsDependencyInputSpec!
+  ): ID!
   "Bulk adds a dependency between two packages"
-  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [ID!]!
+  ingestDependencies(
+    pkgs: [PkgInputSpec!]!
+    depPkgs: [PkgInputSpec!]!
+    depPkgMatchType: MatchFlags!
+    dependencies: [IsDependencyInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -82,7 +82,7 @@ extend type Query {
 
 extend type Mutation {
   "Adds a dependency between two packages"
-  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): IsDependency!
+  ingestDependency(pkg: PkgInputSpec!, depPkg: PkgInputSpec!, depPkgMatchType: MatchFlags!, dependency: IsDependencyInputSpec!): ID!
   "Bulk adds a dependency between two packages"
-  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [IsDependency!]!
+  ingestDependencies(pkgs: [PkgInputSpec!]!, depPkgs: [PkgInputSpec!]!, depPkgMatchType: MatchFlags!, dependencies: [IsDependencyInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -81,14 +81,14 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a dependency between two packages"
+  "Adds a dependency between two packages. The returned ID can be empty string."
   ingestDependency(
     pkg: PkgInputSpec!
     depPkg: PkgInputSpec!
     depPkgMatchType: MatchFlags!
     dependency: IsDependencyInputSpec!
   ): ID!
-  "Bulk adds a dependency between two packages"
+  "Bulk adds a dependency between two packages. The returned array of IDs can be a an array of empty string."
   ingestDependencies(
     pkgs: [PkgInputSpec!]!
     depPkgs: [PkgInputSpec!]!

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -96,7 +96,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingest that an artifact is produced from a package or source."
-  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): IsOccurrence!
+  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): ID!
   "Bulk ingest that an artifact is produced from a package or source."
-  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [IsOccurrence!]!
+  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -49,7 +49,6 @@ input PackageOrSourceInputs {
   sources: [SourceInputSpec!]
 }
 
-
 """
 IsOccurrence is an attestation to link an artifact to a package or source.
 
@@ -96,7 +95,15 @@ extend type Query {
 
 extend type Mutation {
   "Ingest that an artifact is produced from a package or source."
-  ingestOccurrence(subject: PackageOrSourceInput!, artifact: ArtifactInputSpec!, occurrence: IsOccurrenceInputSpec!): ID!
+  ingestOccurrence(
+    subject: PackageOrSourceInput!
+    artifact: ArtifactInputSpec!
+    occurrence: IsOccurrenceInputSpec!
+  ): ID!
   "Bulk ingest that an artifact is produced from a package or source."
-  ingestOccurrences(subjects: PackageOrSourceInputs!, artifacts: [ArtifactInputSpec!]!, occurrences: [IsOccurrenceInputSpec!]!): [ID!]!
+  ingestOccurrences(
+    subjects: PackageOrSourceInputs!
+    artifacts: [ArtifactInputSpec!]!
+    occurrences: [IsOccurrenceInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -94,13 +94,13 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingest that an artifact is produced from a package or source."
+  "Ingest that an artifact is produced from a package or source. The returned ID can be empty string."
   ingestOccurrence(
     subject: PackageOrSourceInput!
     artifact: ArtifactInputSpec!
     occurrence: IsOccurrenceInputSpec!
   ): ID!
-  "Bulk ingest that an artifact is produced from a package or source."
+  "Bulk ingest that an artifact is produced from a package or source. The returned array of IDs can be a an array of empty string."
   ingestOccurrences(
     subjects: PackageOrSourceInputs!
     artifacts: [ArtifactInputSpec!]!

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -86,7 +86,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds metadata about a package, source or artifact."
+  "Adds metadata about a package, source or artifact. The returned ID can be empty string."
   ingestHasMetadata(
     subject: PackageSourceOrArtifactInput!
     pkgMatchType: MatchFlags!

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -87,5 +87,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds metadata about a package, source or artifact."
-  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): ID!
+  ingestHasMetadata(
+    subject: PackageSourceOrArtifactInput!
+    pkgMatchType: MatchFlags!
+    hasMetadata: HasMetadataInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -87,5 +87,5 @@ extend type Query {
 
 extend type Mutation {
   "Adds metadata about a package, source or artifact."
-  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): HasMetadata!
+  ingestHasMetadata(subject: PackageSourceOrArtifactInput!, pkgMatchType: MatchFlags!, hasMetadata: HasMetadataInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -181,8 +181,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new package and returns the corresponding package trie path."
+  "Ingests a new package and returns the corresponding package trie path. The returned ID can be empty string."
   ingestPackage(pkg: PkgInputSpec!): ID!
-  "Bulk ingests packages and returns the list of corresponding package trie path."
+  "Bulk ingests packages and returns the list of corresponding package trie path. The returned array of IDs can be a an array of empty string."
   ingestPackages(pkgs: [PkgInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -182,7 +182,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new package and returns the corresponding package trie path."
-  ingestPackage(pkg: PkgInputSpec!): Package!
+  ingestPackage(pkg: PkgInputSpec!): ID!
   "Bulk ingests packages and returns the list of corresponding package trie path."
-  ingestPackages(pkgs: [PkgInputSpec!]!): [Package!]!
+  ingestPackages(pkgs: [PkgInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/path.graphql
+++ b/pkg/assembler/graphql/schema/path.graphql
@@ -24,8 +24,8 @@ It encapsulates the software tree nodes along with the evidence nodes. In a
 path query, all connecting evidence nodes along with their intermediate subject
 nodes need to be returned in order to create a complete graph.
 """
-union Node
-  = Package
+union Node =
+    Package
   | Source
   | Artifact
   | Builder
@@ -138,7 +138,12 @@ extend type Query {
   Specifying any Edge value in `usingOnly` will make the path only contain the
   corresponding GUAC evidence trees (GUAC verbs).
   """
-  path(subject: ID!, target: ID!, maxPathLength: Int!, usingOnly: [Edge!]!): [Node!]!
+  path(
+    subject: ID!
+    target: ID!
+    maxPathLength: Int!
+    usingOnly: [Edge!]!
+  ): [Node!]!
 
   """
   neighbors returns all the direct neighbors of a node.

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -59,5 +59,9 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that two packages are similar."
-  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): ID!
+  ingestPkgEqual(
+    pkg: PkgInputSpec!
+    otherPackage: PkgInputSpec!
+    pkgEqual: PkgEqualInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -59,5 +59,5 @@ extend type Query {
 
 extend type Mutation {
   "Adds a certification that two packages are similar."
-  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): PkgEqual!
+  ingestPkgEqual(pkg: PkgInputSpec!, otherPackage: PkgInputSpec!, pkgEqual: PkgEqualInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -58,7 +58,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds a certification that two packages are similar."
+  "Adds a certification that two packages are similar. The returned ID can be empty string."
   ingestPkgEqual(
     pkg: PkgInputSpec!
     otherPackage: PkgInputSpec!

--- a/pkg/assembler/graphql/schema/source.graphql
+++ b/pkg/assembler/graphql/schema/source.graphql
@@ -107,8 +107,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new source and returns the corresponding source trie path."
+  "Ingests a new source and returns the corresponding source trie path. The returned ID can be empty string."
   ingestSource(source: SourceInputSpec!): ID!
-  "Bulk ingests sources and returns the list of corresponding source trie path."
+  "Bulk ingests sources and returns the list of corresponding source trie path. The returned array of IDs can be a an array of empty string."
   ingestSources(sources: [SourceInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/source.graphql
+++ b/pkg/assembler/graphql/schema/source.graphql
@@ -108,7 +108,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new source and returns the corresponding source trie path."
-  ingestSource(source: SourceInputSpec!): Source!
+  ingestSource(source: SourceInputSpec!): ID!
   "Bulk ingests sources and returns the list of corresponding source trie path."
-  ingestSources(sources: [SourceInputSpec!]!): [Source!]!
+  ingestSources(sources: [SourceInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -21,7 +21,6 @@
 VulnEqual is an attestation to link two vulnerabilities together as being equal"
 
 Note that setting noVuln vulnerability type is invalid for VulnEqual!
-
 """
 type VulnEqual {
   id: ID!
@@ -61,5 +60,9 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a mapping between vulnerabilities."
-  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): ID!
+  ingestVulnEqual(
+    vulnerability: VulnerabilityInputSpec!
+    otherVulnerability: VulnerabilityInputSpec!
+    vulnEqual: VulnEqualInputSpec!
+  ): ID!
 }

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -59,7 +59,7 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingest a mapping between vulnerabilities."
+  "Ingest a mapping between vulnerabilities. The returned ID can be empty string."
   ingestVulnEqual(
     vulnerability: VulnerabilityInputSpec!
     otherVulnerability: VulnerabilityInputSpec!

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -61,5 +61,5 @@ extend type Query {
 
 extend type Mutation {
   "Ingest a mapping between vulnerabilities."
-  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): VulnEqual!
+  ingestVulnEqual(vulnerability: VulnerabilityInputSpec!, otherVulnerability: VulnerabilityInputSpec!, vulnEqual: VulnEqualInputSpec!): ID!
 }

--- a/pkg/assembler/graphql/schema/vulnMetadata.graphql
+++ b/pkg/assembler/graphql/schema/vulnMetadata.graphql
@@ -104,8 +104,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Adds metadata about a vulnerability."
+  "Adds metadata about a vulnerability. The returned ID can be empty string."
   ingestVulnerabilityMetadata(vulnerability: VulnerabilityInputSpec!, vulnerabilityMetadata: VulnerabilityMetadataInputSpec!): ID!
-  "Bulk add certifications that vulnerability has a specific score."
+  "Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string."
   ingestVulnerabilityMetadatas(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadatas: [VulnerabilityMetadataInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/vulnerability.graphql
+++ b/pkg/assembler/graphql/schema/vulnerability.graphql
@@ -102,7 +102,7 @@ extend type Query {
 
 extend type Mutation {
   "Ingests a new vulnerability and returns the corresponding vulnerability trie path."
-  ingestVulnerability(vuln: VulnerabilityInputSpec!): Vulnerability!
+  ingestVulnerability(vuln: VulnerabilityInputSpec!): ID!
   "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path."
-  ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [Vulnerability!]!
+  ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/vulnerability.graphql
+++ b/pkg/assembler/graphql/schema/vulnerability.graphql
@@ -22,7 +22,7 @@ Vulnerability represents the root of the vulnerability trie/tree.
 
 We map vulnerability information to a trie, as a derivative of the pURL specification:
 each path in the trie represents a type and a vulnerability ID. This allows for generic
-representation of the various vulnerabilities and does not limit to just cve, ghsa or osv. 
+representation of the various vulnerabilities and does not limit to just cve, ghsa or osv.
 This would be in the general format: vuln://<general-type>/<vuln-id>
 
 Examples:
@@ -40,7 +40,7 @@ Since this node is at the root of the vulnerability trie, it is named Vulnerabil
 VulnerabilityType.
 
 NoVuln is a special vulnerability node to attest that no vulnerability has been
-found during a vulnerability scan. It will have the type "novuln" and contain an empty string 
+found during a vulnerability scan. It will have the type "novuln" and contain an empty string
 for vulnerabilityID
 
 The resolvers will enforce that both the type and vulnerability IDs are lower case.
@@ -66,16 +66,15 @@ type VulnerabilityID {
 """
 VulnerabilitySpec allows filtering the list of vulnerabilities to return in a query.
 
-Use null to match on all values at that level. 
+Use null to match on all values at that level.
 For example, to get all vulnerabilities in GUAC backend, use a VulnSpec
 where every field is null.
 
 Setting the noVuln boolean true will ignore the other inputs for type and vulnerabilityID.
-Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln" 
+Setting noVuln to true means retrieving only nodes where the type of the vulnerability is "novuln"
 and the it has an empty string for vulnerabilityID. Setting it to false filters out all results that are "novuln".
-Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding 
+Setting one of the other fields and omitting the noVuln means retrieving vulnerabilities for the corresponding
 type and vulnerabilityID. Omission of noVuln field will return all vulnerabilities and novuln.
-
 """
 input VulnerabilitySpec {
   id: ID

--- a/pkg/assembler/graphql/schema/vulnerability.graphql
+++ b/pkg/assembler/graphql/schema/vulnerability.graphql
@@ -100,8 +100,8 @@ extend type Query {
 }
 
 extend type Mutation {
-  "Ingests a new vulnerability and returns the corresponding vulnerability trie path."
+  "Ingests a new vulnerability and returns the corresponding vulnerability trie path. The returned ID can be empty string."
   ingestVulnerability(vuln: VulnerabilityInputSpec!): ID!
-  "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path."
+  "Bulk ingests vulnerabilities and returns the list of corresponding vulnerability trie path. The returned array of IDs can be a an array of empty string."
   ingestVulnerabilities(vulns: [VulnerabilityInputSpec!]!): [ID!]!
 }


### PR DESCRIPTION
…x #1116

# Description of the PR

Initial changes needed for #1116 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
