### PR TITLE
Add check for docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ check-docker-tool-check:
 # Check that docker buildx is installed.
 .PHONY: check-docker-buildx-tool-check
 check-docker-buildx-tool-check:
-	@if ! docker buildx >/dev/null 2>&1; then \
+	@if ! $(CONTAINER) buildx >/dev/null 2>&1; then \
 		echo "'$(CONTAINER)' buildx is not installed. Please install '$(CONTAINER)' buildx and try again."; \
 		exit 1; \
 	fi
@@ -154,7 +154,7 @@ check-docker-buildx-tool-check:
 # Check that docker compose is installed.
 .PHONY: check-docker-compose-tool-check
 check-docker-compose-tool-check:
-	@if ! docker compose >/dev/null 2>&1; then \
+	@if ! $(CONTAINER) compose >/dev/null 2>&1; then \
 		echo "'$(CONTAINER)' compose is not installed or not correctly linked to. Please install '$(CONTAINER)' compose or link it as a plugin and try again."; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ container: check-docker-tool-check check-docker-buildx-tool-check check-goreleas
 # To run the service, run `make container` and then `make service`
 # making the container is a longer process and thus not a dependency of service.
 .PHONY: start-service
-start-service:
+start-service: check-docker-compose-tool-check
 	# requires force recreate since docker compose reuses containers and neo4j does
 	# not handle that well.
 	#
@@ -148,6 +148,14 @@ check-docker-tool-check:
 check-docker-buildx-tool-check:
 	@if ! docker buildx >/dev/null 2>&1; then \
 		echo "'$(CONTAINER)' buildx is not installed. Please install '$(CONTAINER)' buildx and try again."; \
+		exit 1; \
+	fi
+
+# Check that docker compose is installed.
+.PHONY: check-docker-compose-tool-check
+check-docker-compose-tool-check:
+	@if ! docker compose >/dev/null 2>&1; then \
+		echo "'$(CONTAINER)' compose is not installed or not correctly linked to. Please install '$(CONTAINER)' compose or link it as a plugin and try again."; \
 		exit 1; \
 	fi
 
@@ -184,4 +192,4 @@ check-goreleaser-tool-check:
 
 # Check that all the tools are installed.
 .PHONY: check-tools
-check-tools: check-docker-tool-check check-docker-buildx-tool-check check-protoc-tool-check check-golangci-lint-tool-check check-mockgen-tool-check check-goreleaser-tool-check
+check-tools: check-docker-tool-check check-docker-buildx-tool-check check-docker-compose-tool-check check-protoc-tool-check check-golangci-lint-tool-check check-mockgen-tool-check check-goreleaser-tool-check


### PR DESCRIPTION
# Description of the PR

If you don't have docker compose correctly linked to in the `~/.docker/cli-plugins` directory you get a misleading error message: `unknown flag: --force-recreate`.

The additional check gives a more helpful (I hope) error message.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
~~- [ ] All new changes are covered by tests~~
~~- [ ] If GraphQL schema is changed, `make generate` has been run~~
~~- [ ] If `collectsub` protobuf has been changed, `make proto` has been run~~
- [x] All CI checks are passing (tests and formatting)
~~- [ ] All dependent PRs have already been merged~~
