### PR TITLE
[Feature] add ingestion (including bulk) and query for VEX in Arango and inmem

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -47,19 +47,20 @@ func ingestData(port int) {
 	ingestDependency(ctx, gqlclient)
 	ingestOccurrence(ctx, gqlclient)
 	ingestVulnerability(ctx, gqlclient)
-	ingestVulnerabilities(ctx, gqlclient)
+	bulkIngestVulnerabilities(ctx, gqlclient)
 	ingestVulnerabilityMetadata(ctx, gqlclient)
-	ingestVulnerabilityMetadatas(ctx, gqlclient)
+	bulkIngestVulnerabilityMetadata(ctx, gqlclient)
 	ingestPkgEqual(ctx, gqlclient)
 	ingestCertifyBad(ctx, gqlclient)
-	ingestCertifyBads(ctx, gqlclient)
+	bulkIngestCertifyBad(ctx, gqlclient)
 	ingestCertifyGood(ctx, gqlclient)
-	ingestCertifyGoods(ctx, gqlclient)
+	bulkIngestCertifyGood(ctx, gqlclient)
 	ingestHashEqual(ctx, gqlclient)
 	ingestHasSBOM(ctx, gqlclient)
 	ingestHasSourceAt(ctx, gqlclient)
 	ingestIsVulnerability(ctx, gqlclient)
 	ingestVEXStatement(ctx, gqlclient)
+	bulkIngestVEXStatement(ctx, gqlclient)
 	ingestReachabilityTestData(ctx, gqlclient)
 	time := time.Since(start)
 	logger.Infof("Ingesting test data into backend server took %v", time)
@@ -507,7 +508,7 @@ func ingestVulnerabilityMetadata(ctx context.Context, client graphql.Client) {
 	}
 }
 
-func ingestVulnerabilityMetadatas(ctx context.Context, client graphql.Client) {
+func bulkIngestVulnerabilityMetadata(ctx context.Context, client graphql.Client) {
 	logger := logging.FromContext(ctx)
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
 	ingestVulnerabilityMetadatas := []struct {
@@ -893,7 +894,7 @@ func ingestVulnerability(ctx context.Context, client graphql.Client) {
 	}
 }
 
-func ingestVulnerabilities(ctx context.Context, client graphql.Client) {
+func bulkIngestVulnerabilities(ctx context.Context, client graphql.Client) {
 	logger := logging.FromContext(ctx)
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
 	opensslNs := "openssl.org"
@@ -1423,7 +1424,7 @@ func ingestCertifyBad(ctx context.Context, client graphql.Client) {
 	}
 }
 
-func ingestCertifyBads(ctx context.Context, client graphql.Client) {
+func bulkIngestCertifyBad(ctx context.Context, client graphql.Client) {
 	logger := logging.FromContext(ctx)
 	opensslNs := "openssl.org"
 	opensslVersion := "3.0.3"
@@ -1747,7 +1748,7 @@ func ingestCertifyGood(ctx context.Context, client graphql.Client) {
 	}
 }
 
-func ingestCertifyGoods(ctx context.Context, client graphql.Client) {
+func bulkIngestCertifyGood(ctx context.Context, client graphql.Client) {
 	logger := logging.FromContext(ctx)
 	opensslNs := "openssl.org"
 	opensslVersion := "3.0.3"
@@ -2521,6 +2522,270 @@ func ingestVEXStatement(ctx context.Context, client graphql.Client) {
 			}
 			if _, err := model.CertifyVexArtifact(ctx, client, *ingest.artifact, *ingest.vuln, ingest.vexStatement); err != nil {
 				logger.Errorf("Error in ingesting: %v\n", err)
+			}
+
+		} else {
+			fmt.Printf("input missing for package or artifact")
+		}
+	}
+}
+
+func bulkIngestVEXStatement(ctx context.Context, client graphql.Client) {
+	logger := logging.FromContext(ctx)
+	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
+	opensslNs := "openssl.org"
+	opensslVersion := "3.0.3"
+	ingestCertifyVex := []struct {
+		name          string
+		pkgs          []model.PkgInputSpec
+		artifacts     []model.ArtifactInputSpec
+		vulns         []model.VulnerabilityInputSpec
+		vexStatements []model.VexStatementInputSpec
+	}{
+		{
+			name: "bulk ingest packages",
+			pkgs: []model.PkgInputSpec{
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+				{
+					Type:       "conan",
+					Namespace:  &opensslNs,
+					Name:       "openssl",
+					Version:    &opensslVersion,
+					Qualifiers: []model.PackageQualifierInputSpec{{Key: "user", Value: "bincrafters"}, {Key: "channel", Value: "stable"}},
+				},
+			},
+			vulns: []model.VulnerabilityInputSpec{
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2019-14750",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-h45f-rjvw-2rv2",
+				},
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2019-14750",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2019-13110",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-h45f-rjvw-2rv2",
+				},
+			},
+			vexStatements: []model.VexStatementInputSpec{
+				{
+					Status:           model.VexStatusFixed,
+					VexJustification: model.VexJustificationNotProvided,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusAffected,
+					VexJustification: model.VexJustificationNotProvided,
+					Statement:        "this package is vulnerable to this CVE",
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationComponentNotPresent,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusFixed,
+					VexJustification: model.VexJustificationNotProvided,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusAffected,
+					VexJustification: model.VexJustificationNotProvided,
+					Statement:        "this package is vulnerable to this CVE",
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationComponentNotPresent,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+			},
+		},
+		{
+			name: "bulk ingest artifacts",
+			artifacts: []model.ArtifactInputSpec{
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+				{
+					Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+					Algorithm: "sha256",
+				},
+			},
+			vulns: []model.VulnerabilityInputSpec{
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2018-15710",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2018-43610",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-hj5f-4gvw-4rv2",
+				},
+				{
+					Type:            "osv",
+					VulnerabilityID: "CVE-2018-15710",
+				},
+				{
+					Type:            "cve",
+					VulnerabilityID: "CVE-2018-43610",
+				},
+				{
+					Type:            "ghsa",
+					VulnerabilityID: "GHSA-hj5f-4gvw-4rv2",
+				},
+			},
+			vexStatements: []model.VexStatementInputSpec{
+				{
+					Status:           model.VexStatusUnderInvestigation,
+					VexJustification: model.VexJustificationNotProvided,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationNotProvided,
+					Statement:        "this artifact is not vulnerable to this CVE",
+					StatusNotes:      "status not affected because code not in execution path",
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationVulnerableCodeNotInExecutePath,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusUnderInvestigation,
+					VexJustification: model.VexJustificationNotProvided,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationNotProvided,
+					Statement:        "this artifact is not vulnerable to this CVE",
+					StatusNotes:      "status not affected because code not in execution path",
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+				{
+					Status:           model.VexStatusNotAffected,
+					VexJustification: model.VexJustificationVulnerableCodeNotInExecutePath,
+					KnownSince:       tm,
+					Origin:           "Demo ingestion",
+					Collector:        "Demo ingestion",
+				},
+			},
+		},
+	}
+	for _, ingest := range ingestCertifyVex {
+		if ingest.pkgs != nil {
+			if _, err := model.IngestPackages(ctx, client, ingest.pkgs); err != nil {
+				logger.Errorf("Error in ingesting packages: %v\n", err)
+			}
+			if _, err := model.IngestVulnerabilities(ctx, client, ingest.vulns); err != nil {
+				logger.Errorf("Error in ingesting vulnerabilities: %v\n", err)
+			}
+			if _, err := model.CertifyVexPkgs(ctx, client, ingest.pkgs, ingest.vulns, ingest.vexStatements); err != nil {
+				logger.Errorf("Error in ingesting CertifyVexPkgs: %v\n", err)
+			}
+
+		} else if ingest.artifacts != nil {
+			if _, err := model.IngestArtifacts(ctx, client, ingest.artifacts); err != nil {
+				logger.Errorf("Error in ingesting artifacts: %v\n", err)
+			}
+			if _, err := model.IngestVulnerabilities(ctx, client, ingest.vulns); err != nil {
+				logger.Errorf("Error in ingesting vulnerabilities: %v\n", err)
+			}
+			if _, err := model.CertifyVexArtifacts(ctx, client, ingest.artifacts, ingest.vulns, ingest.vexStatements); err != nil {
+				logger.Errorf("Error in ingesting CertifyVexArtifacts: %v\n", err)
 			}
 
 		} else {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -733,10 +733,6 @@ func getPreloadString(prefix, name string) string {
 
 // Retrieval read-only queries for evidence trees
 
-func (c *arangoClient) CertifyVEXStatement(ctx context.Context, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) ([]*model.CertifyVEXStatement, error) {
-	panic(fmt.Errorf("not implemented: CertifyVEXStatement - CertifyVEXStatement"))
-}
-
 func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
 	panic(fmt.Errorf("not implemented: HasSourceAt - HasSourceAt"))
 }
@@ -758,9 +754,6 @@ func (c *arangoClient) IngestVulnEqual(ctx context.Context, vulnerability model.
 }
 func (c *arangoClient) IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (*model.PkgEqual, error) {
 	panic(fmt.Errorf("not implemented: IngestPkgEqual - IngestPkgEqual"))
-}
-func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
-	panic(fmt.Errorf("not implemented: IngestVEXStatement - IngestVEXStatement"))
 }
 
 // Topological queries: queries where node connectivity matters more than node type

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -105,6 +105,13 @@ const (
 	hasSBOMArtEdgesStr string = "hasSBOMArtEdges"
 	hasSBOMsStr        string = "hasSBOMs"
 
+	// certifyVex collection
+
+	certifyVexPkgEdgesStr  string = "certifyVexPkgEdges"
+	certifyVexArtEdgesStr  string = "certifyVexArtEdges"
+	certifyVexVulnEdgesStr string = "certifyVexVulnEdges"
+	certifyVEXsStr         string = "certifyVEXs"
+
 	// certifyVuln collection
 	certifyVulnPkgEdgesStr string = "certifyVulnPkgEdges"
 	certifyVulnEdgesStr    string = "certifyVulnEdges"
@@ -269,12 +276,12 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		var isOccurrenceSubjectPkgEdges driver.EdgeDefinition
 		isOccurrenceSubjectPkgEdges.Collection = isOccurrenceSubjectPkgEdgesStr
 		isOccurrenceSubjectPkgEdges.From = []string{pkgVersionsStr}
-		isOccurrenceSubjectPkgEdges.To = []string{isDependenciesStr}
+		isOccurrenceSubjectPkgEdges.To = []string{isOccurrencesStr}
 
 		var isOccurrenceSubjectSrcEdges driver.EdgeDefinition
 		isOccurrenceSubjectSrcEdges.Collection = isOccurrenceSubjectSrcEdgesStr
 		isOccurrenceSubjectSrcEdges.From = []string{srcNamesStr}
-		isOccurrenceSubjectSrcEdges.To = []string{isDependenciesStr}
+		isOccurrenceSubjectSrcEdges.To = []string{isOccurrencesStr}
 
 		// setup hasSLSA collections
 		var hasSLSASubjectArtEdges driver.EdgeDefinition
@@ -306,13 +313,29 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		// setup hasSBOM collections
 		var hasSBOMPkgEdges driver.EdgeDefinition
 		hasSBOMPkgEdges.Collection = hasSBOMPkgEdgesStr
-		hasSBOMPkgEdges.From = []string{artifactsStr}
+		hasSBOMPkgEdges.From = []string{pkgVersionsStr}
 		hasSBOMPkgEdges.To = []string{hasSBOMsStr}
 
 		var hasSBOMArtEdges driver.EdgeDefinition
 		hasSBOMArtEdges.Collection = hasSBOMArtEdgesStr
 		hasSBOMArtEdges.From = []string{artifactsStr}
 		hasSBOMArtEdges.To = []string{hasSBOMsStr}
+
+		// setup certifyVex collections
+		var certifyVexPkgEdges driver.EdgeDefinition
+		certifyVexPkgEdges.Collection = certifyVexPkgEdgesStr
+		certifyVexPkgEdges.From = []string{pkgVersionsStr}
+		certifyVexPkgEdges.To = []string{certifyVEXsStr}
+
+		var certifyVexArtEdges driver.EdgeDefinition
+		certifyVexArtEdges.Collection = certifyVexArtEdgesStr
+		certifyVexArtEdges.From = []string{artifactsStr}
+		certifyVexArtEdges.To = []string{certifyVEXsStr}
+
+		var certifyVexVulnEdges driver.EdgeDefinition
+		certifyVexVulnEdges.Collection = certifyVexVulnEdgesStr
+		certifyVexVulnEdges.From = []string{certifyVEXsStr}
+		certifyVexVulnEdges.To = []string{vulnerabilitiesStr}
 
 		// setup certifyVuln collections
 		var certifyVulnPkgEdges driver.EdgeDefinition
@@ -381,7 +404,8 @@ func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			isOccurrenceArtEdges, isOccurrenceSubjectPkgEdges, isOccurrenceSubjectSrcEdges, hasSLSASubjectArtEdges,
 			hasSLSABuiltByEdges, hasSLSABuiltFromEdges, hashEqualArtEdges, hashEqualSubjectArtEdges, hasSBOMPkgEdges,
 			hasSBOMArtEdges, certifyVulnPkgEdges, certifyVulnEdges, certifyScorecardSrcEdges, certifyBadPkgVersionEdges, certifyBadPkgNameEdges,
-			certifyBadArtEdges, certifyBadSrcEdges, certifyGoodPkgVersionEdges, certifyGoodPkgNameEdges, certifyGoodArtEdges, certifyGoodSrcEdges}
+			certifyBadArtEdges, certifyBadSrcEdges, certifyGoodPkgVersionEdges, certifyGoodPkgNameEdges, certifyGoodArtEdges, certifyGoodSrcEdges,
+			certifyVexPkgEdges, certifyVexArtEdges, certifyVexVulnEdges}
 
 		// create a graph
 		graph, err = db.CreateGraphV2(ctx, "guac", &options)

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -938,8 +938,10 @@ func getCertifyBadFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mode
 			certifyBad.Subject = pkg
 		} else if src != nil {
 			certifyBad.Subject = src
-		} else {
+		} else if createdValue.Artifact != nil {
 			certifyBad.Subject = createdValue.Artifact
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for certifyBad")
 		}
 		certifyBadList = append(certifyBadList, certifyBad)
 	}

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -169,7 +169,7 @@ func getSrcCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryB
 	}
 	defer cursor.Close()
 
-	return getSourceCertifyBad(ctx, cursor)
+	return getCertifyBadFromCursor(ctx, cursor)
 }
 
 func getArtCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyBad, error) {
@@ -194,7 +194,7 @@ func getArtCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryB
 	}
 	defer cursor.Close()
 
-	return getArtifactCertifyBad(ctx, cursor)
+	return getCertifyBadFromCursor(ctx, cursor)
 }
 
 func getPkgCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any, includeDepPkgVersion bool) ([]*model.CertifyBad, error) {
@@ -244,7 +244,7 @@ func getPkgCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryB
 	}
 	defer cursor.Close()
 
-	return getPkgCertifyBad(ctx, cursor)
+	return getCertifyBadFromCursor(ctx, cursor)
 }
 
 func setCertifyBadMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBadSpec *model.CertifyBadSpec, queryValues map[string]any) {
@@ -356,7 +356,7 @@ func (c *arangoClient) IngestCertifyBad(ctx context.Context, subject model.Packa
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getPkgCertifyBad(ctx, cursor)
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 			}
@@ -419,7 +419,7 @@ func (c *arangoClient) IngestCertifyBad(ctx context.Context, subject model.Packa
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getPkgCertifyBad(ctx, cursor)
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 			}
@@ -462,7 +462,7 @@ func (c *arangoClient) IngestCertifyBad(ctx context.Context, subject model.Packa
 			return nil, fmt.Errorf("failed to ingest artifact certifyBad: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getArtifactCertifyBad(ctx, cursor)
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 		}
@@ -529,7 +529,7 @@ func (c *arangoClient) IngestCertifyBad(ctx context.Context, subject model.Packa
 			return nil, fmt.Errorf("failed to ingest source certifyBad: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getSourceCertifyBad(ctx, cursor)
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 		}
@@ -644,7 +644,7 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getPkgCertifyBad(ctx, cursor)
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 			}
@@ -705,7 +705,7 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getPkgCertifyBad(ctx, cursor)
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 			}
@@ -779,7 +779,7 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 			return nil, fmt.Errorf("failed to ingest artifact certifyBad: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getArtifactCertifyBad(ctx, cursor)
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 		}
@@ -877,7 +877,7 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 			return nil, fmt.Errorf("failed to ingest source certifyBad: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getSourceCertifyBad(ctx, cursor)
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
 		}
@@ -889,50 +889,11 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 	}
 }
 
-func getPkgCertifyBad(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyBad, error) {
+func getCertifyBadFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyBad, error) {
 	type collectedData struct {
-		PkgVersion    *dbPkgVersion `json:"pkgVersion"`
-		CertifyBadID  string        `json:"certifyBad_id"`
-		Justification string        `json:"justification"`
-		Collector     string        `json:"collector"`
-		Origin        string        `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to package certifyBad from cursor: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var certifyBadList []*model.CertifyBad
-	for _, createdValue := range createdValues {
-		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
-			createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-
-		certifyBad := &model.CertifyBad{
-			ID:            createdValue.CertifyBadID,
-			Subject:       pkg,
-			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
-		}
-		certifyBadList = append(certifyBadList, certifyBad)
-	}
-	return certifyBadList, nil
-}
-
-func getArtifactCertifyBad(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyBad, error) {
-	type collectedData struct {
+		PkgVersion    *dbPkgVersion   `json:"pkgVersion"`
 		Artifact      *model.Artifact `json:"artifact"`
+		SrcName       *dbSrcName      `json:"srcName"`
 		CertifyBadID  string          `json:"certifyBad_id"`
 		Justification string          `json:"justification"`
 		Collector     string          `json:"collector"`
@@ -947,7 +908,7 @@ func getArtifactCertifyBad(ctx context.Context, cursor driver.Cursor) ([]*model.
 			if driver.IsNoMoreDocuments(err) {
 				break
 			} else {
-				return nil, fmt.Errorf("failed to artifact certifyBad from cursor: %w", err)
+				return nil, fmt.Errorf("failed to certifyBad from cursor: %w", err)
 			}
 		} else {
 			createdValues = append(createdValues, doc)
@@ -956,54 +917,29 @@ func getArtifactCertifyBad(ctx context.Context, cursor driver.Cursor) ([]*model.
 
 	var certifyBadList []*model.CertifyBad
 	for _, createdValue := range createdValues {
+		var pkg *model.Package = nil
+		var src *model.Source = nil
+		if createdValue.PkgVersion != nil {
+			pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+				createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		} else if createdValue.SrcName != nil {
+			src = generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+				createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
+		}
+
 		certifyBad := &model.CertifyBad{
 			ID:            createdValue.CertifyBadID,
-			Subject:       createdValue.Artifact,
 			Justification: createdValue.Justification,
 			Origin:        createdValue.Collector,
 			Collector:     createdValue.Origin,
 		}
-		certifyBadList = append(certifyBadList, certifyBad)
-	}
-	return certifyBadList, nil
-}
 
-func getSourceCertifyBad(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyBad, error) {
-	type collectedData struct {
-		SrcName       *dbSrcName `json:"srcName"`
-		CertifyBadID  string     `json:"certifyBad_id"`
-		Justification string     `json:"justification"`
-		Collector     string     `json:"collector"`
-		Origin        string     `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to source certifyBad from cursor: %w", err)
-			}
+		if pkg != nil {
+			certifyBad.Subject = pkg
+		} else if src != nil {
+			certifyBad.Subject = src
 		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var certifyBadList []*model.CertifyBad
-	for _, createdValue := range createdValues {
-
-		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
-			createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
-
-		certifyBad := &model.CertifyBad{
-			ID:            createdValue.CertifyBadID,
-			Subject:       src,
-			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			certifyBad.Subject = createdValue.Artifact
 		}
 		certifyBadList = append(certifyBadList, certifyBad)
 	}

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -936,8 +936,10 @@ func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 			certifyGood.Subject = pkg
 		} else if src != nil {
 			certifyGood.Subject = src
-		} else {
+		} else if createdValue.Artifact != nil {
 			certifyGood.Subject = createdValue.Artifact
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for certifyGood")
 		}
 		certifyGoodList = append(certifyGoodList, certifyGood)
 	}

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -168,7 +168,7 @@ func getSrcCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 	}
 	defer cursor.Close()
 
-	return getSourceCertifyGood(ctx, cursor)
+	return getCertifyGoodFromCursor(ctx, cursor)
 }
 
 func getArtCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.CertifyGood, error) {
@@ -193,7 +193,7 @@ func getArtCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 	}
 	defer cursor.Close()
 
-	return getArtifactCertifyGood(ctx, cursor)
+	return getCertifyGoodFromCursor(ctx, cursor)
 }
 
 func getPkgCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any, includeDepPkgVersion bool) ([]*model.CertifyGood, error) {
@@ -244,7 +244,7 @@ func getPkgCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 	}
 	defer cursor.Close()
 
-	return getPkgCertifyGood(ctx, cursor)
+	return getCertifyGoodFromCursor(ctx, cursor)
 }
 
 func setCertifyGoodMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyGoodSpec *model.CertifyGoodSpec, queryValues map[string]any) {
@@ -356,7 +356,7 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 			}
 			defer cursor.Close()
 
-			certifyGoodList, err := getPkgCertifyGood(ctx, cursor)
+			certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 			}
@@ -419,7 +419,7 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 			}
 			defer cursor.Close()
 
-			certifyGoodList, err := getPkgCertifyGood(ctx, cursor)
+			certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 			}
@@ -462,7 +462,7 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 			return nil, fmt.Errorf("failed to ingest artifact certifyGood: %w", err)
 		}
 		defer cursor.Close()
-		certifyGoodList, err := getArtifactCertifyGood(ctx, cursor)
+		certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 		}
@@ -529,7 +529,7 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 			return nil, fmt.Errorf("failed to ingest source certifyGood: %w", err)
 		}
 		defer cursor.Close()
-		certifyGoodList, err := getSourceCertifyGood(ctx, cursor)
+		certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 		}
@@ -644,7 +644,7 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 			}
 			defer cursor.Close()
 
-			certifyGoodList, err := getPkgCertifyGood(ctx, cursor)
+			certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 			}
@@ -705,7 +705,7 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 			}
 			defer cursor.Close()
 
-			certifyGoodList, err := getPkgCertifyGood(ctx, cursor)
+			certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 			}
@@ -779,7 +779,7 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 			return nil, fmt.Errorf("failed to ingest artifact certifyGoods %w", err)
 		}
 		defer cursor.Close()
-		certifyGoodList, err := getArtifactCertifyGood(ctx, cursor)
+		certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 		}
@@ -877,7 +877,7 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 			return nil, fmt.Errorf("failed to ingest source certifyGoods: %w", err)
 		}
 		defer cursor.Close()
-		certifyGoodList, err := getSourceCertifyGood(ctx, cursor)
+		certifyGoodList, err := getCertifyGoodFromCursor(ctx, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get certifyGoods from arango cursor: %w", err)
 		}
@@ -889,13 +889,15 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 	}
 }
 
-func getPkgCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
+func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
 	type collectedData struct {
-		PkgVersion    *dbPkgVersion `json:"pkgVersion"`
-		CertifyGoodID string        `json:"certifyGood_id"`
-		Justification string        `json:"justification"`
-		Collector     string        `json:"collector"`
-		Origin        string        `json:"origin"`
+		PkgVersion    *dbPkgVersion   `json:"pkgVersion"`
+		Artifact      *model.Artifact `json:"artifact"`
+		SrcName       *dbSrcName      `json:"srcName"`
+		CertifyGoodID string          `json:"certifyGood_id"`
+		Justification string          `json:"justification"`
+		Collector     string          `json:"collector"`
+		Origin        string          `json:"origin"`
 	}
 
 	var createdValues []collectedData
@@ -915,95 +917,27 @@ func getPkgCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.Cert
 
 	var certifyGoodList []*model.CertifyGood
 	for _, createdValue := range createdValues {
-		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
-			createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-
+		var pkg *model.Package = nil
+		var src *model.Source = nil
+		if createdValue.PkgVersion != nil {
+			pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+				createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		} else if createdValue.SrcName != nil {
+			src = generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+				createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
+		}
 		certifyGood := &model.CertifyGood{
 			ID:            createdValue.CertifyGoodID,
-			Subject:       pkg,
 			Justification: createdValue.Justification,
 			Origin:        createdValue.Collector,
 			Collector:     createdValue.Origin,
 		}
-		certifyGoodList = append(certifyGoodList, certifyGood)
-	}
-	return certifyGoodList, nil
-}
-
-func getArtifactCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
-	type collectedData struct {
-		Artifact      *model.Artifact `json:"artifact"`
-		CertifyGoodID string          `json:"certifyGood_id"`
-		Justification string          `json:"justification"`
-		Collector     string          `json:"collector"`
-		Origin        string          `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to artifact certifyGood from cursor: %w", err)
-			}
+		if pkg != nil {
+			certifyGood.Subject = pkg
+		} else if src != nil {
+			certifyGood.Subject = src
 		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var certifyGoodList []*model.CertifyGood
-	for _, createdValue := range createdValues {
-		certifyGood := &model.CertifyGood{
-			ID:            createdValue.CertifyGoodID,
-			Subject:       createdValue.Artifact,
-			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
-		}
-		certifyGoodList = append(certifyGoodList, certifyGood)
-	}
-	return certifyGoodList, nil
-}
-
-func getSourceCertifyGood(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyGood, error) {
-	type collectedData struct {
-		SrcName       *dbSrcName `json:"srcName"`
-		CertifyGoodID string     `json:"certifyGood_id"`
-		Justification string     `json:"justification"`
-		Collector     string     `json:"collector"`
-		Origin        string     `json:"origin"`
-	}
-
-	var createdValues []collectedData
-	for {
-		var doc collectedData
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if err != nil {
-			if driver.IsNoMoreDocuments(err) {
-				break
-			} else {
-				return nil, fmt.Errorf("failed to source certifyGood from cursor: %w", err)
-			}
-		} else {
-			createdValues = append(createdValues, doc)
-		}
-	}
-
-	var certifyGoodList []*model.CertifyGood
-	for _, createdValue := range createdValues {
-
-		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
-			createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
-
-		certifyGood := &model.CertifyGood{
-			ID:            createdValue.CertifyGoodID,
-			Subject:       src,
-			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			certifyGood.Subject = createdValue.Artifact
 		}
 		certifyGoodList = append(certifyGoodList, certifyGood)
 	}

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -81,7 +81,7 @@ func (c *arangoClient) Scorecards(ctx context.Context, certifyScorecardSpec *mod
 	}
 	defer cursor.Close()
 
-	return getCertifyScorecard(ctx, cursor)
+	return getCertifyScorecardFromCursor(ctx, cursor)
 }
 
 func setCertifyScorecardMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyScorecardSpec *model.CertifyScorecardSpec, queryValues map[string]any) {
@@ -266,7 +266,7 @@ func (c *arangoClient) IngestScorecards(ctx context.Context, sources []*model.So
 		return nil, fmt.Errorf("failed to ingest scorecard: %w", err)
 	}
 	defer cursor.Close()
-	scorecardList, err := getCertifyScorecard(ctx, cursor)
+	scorecardList, err := getCertifyScorecardFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scorecard from arango cursor: %w", err)
 	}
@@ -338,7 +338,7 @@ func (c *arangoClient) IngestScorecard(ctx context.Context, source model.SourceI
 	}
 	defer cursor.Close()
 
-	scorecardList, err := getCertifyScorecard(ctx, cursor)
+	scorecardList, err := getCertifyScorecardFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scorecard from arango cursor: %w", err)
 	}
@@ -369,7 +369,7 @@ func getCollectedScorecardChecks(checksList []string) ([]*model.ScorecardCheck, 
 	return scorecardChecks, nil
 }
 
-func getCertifyScorecard(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyScorecard, error) {
+func getCertifyScorecardFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyScorecard, error) {
 	type collectedData struct {
 		SrcName          *dbSrcName `json:"srcName"`
 		ScorecardID      string     `json:"scorecard_id"`

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -14,3 +14,56 @@
 // limitations under the License.
 
 package arangodb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+const (
+	statusStr           string = "status"
+	vexJustificationStr string = "vexJustification"
+	statementStr        string = "statement"
+	statusNotesStr      string = "statusNotes"
+	knownSinceStr       string = "knownSince"
+)
+
+func (c *arangoClient) CertifyVEXStatement(ctx context.Context, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) ([]*model.CertifyVEXStatement, error) {
+	panic(fmt.Errorf("not implemented: CertifyVEXStatement - CertifyVEXStatement"))
+}
+
+func getVEXStatementQueryValues(pkg *model.PkgInputSpec, artifact *model.ArtifactInputSpec, vulnerability *model.VulnerabilityInputSpec, vexStatement *model.VexStatementInputSpec) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	if pkg != nil {
+		pkgId := guacPkgId(*pkg)
+		values["pkgVersionGuacKey"] = pkgId.VersionId
+	} else {
+		values["art_algorithm"] = strings.ToLower(artifact.Algorithm)
+		values["art_digest"] = strings.ToLower(artifact.Digest)
+	}
+	if vulnerability != nil {
+		vuln := guacVulnId(*vulnerability)
+		values["guacVulnKey"] = vuln.VulnerabilityID
+	}
+	values[statusStr] = vexStatement.Status
+	values[vexJustificationStr] = vexStatement.VexJustification
+	values[statementStr] = vexStatement.Statement
+	values[statusNotesStr] = vexStatement.StatusNotes
+	values[knownSinceStr] = vexStatement.KnownSince
+	values[origin] = vexStatement.Origin
+	values[collector] = vexStatement.Collector
+
+	return values
+}
+
+func (c *arangoClient) IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error) {
+	return []string{}, fmt.Errorf("not implemented - IngestVEXStatements")
+}
+
+func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
+	panic(fmt.Errorf("not implemented: IngestVEXStatement - IngestVEXStatement"))
+}

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -65,5 +67,239 @@ func (c *arangoClient) IngestVEXStatements(ctx context.Context, subjects model.P
 }
 
 func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
-	panic(fmt.Errorf("not implemented: IngestVEXStatement - IngestVEXStatement"))
+	if subject.Artifact != nil {
+		query := `
+		  LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
+
+		  LET firstVuln = FIRST(
+			FOR vVulnID in vulnerabilities
+			  FILTER vVulnID.guacKey == @guacVulnKey
+			FOR vType in vulnTypes
+			  FILTER vType._id == vVulnID._parent
+	
+			RETURN {
+			  "typeID": vType._id,
+			  "type": vType.type,
+			  "vuln_id": vVulnID._id,
+			  "vuln": vVulnID.vulnerabilityID,
+			  "vulnDoc": vVulnID
+			}
+		  )
+		  
+		  LET certifyVex = FIRST(
+			  UPSERT { artifactID:artifact._id, vulnerabilityID:firstVuln.vulnDoc._id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+				  INSERT {artifactID:artifact._id, vulnerabilityID:firstVuln.vulnDoc._id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+				  UPDATE {} IN certifyVEXs
+				  RETURN NEW
+		  )
+		  
+		  INSERT { _key: CONCAT("certifyVexArtEdges", artifact._key, certifyVex._key), _from: artifact._id, _to: certifyVex._id } INTO certifyVexArtEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("certifyVexVulnEdges", certifyVex._key, firstVuln.vulnDoc._key), _from: certifyVex._id, _to: firstVuln.vulnDoc._id } INTO certifyVexVulnEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'artifact': {
+				'id': artifact._id,
+				'algorithm': artifact.algorithm,
+				'digest': artifact.digest
+			},
+			'vulnerability': {
+				'type_id': firstVuln.typeID,
+				'type': firstVuln.type,
+				'vuln_id': firstVuln.vuln_id,
+				'vuln': firstVuln.vuln
+			},
+			'certifyVex': certifyVex._id,
+			'status': certifyVex.status,
+			'vexJustification': certifyVex.vexJustification,
+			'statement': certifyVex.statement,
+			'statusNotes': certifyVex.statusNotes,
+			'knownSince': certifyVex.knownSince,
+			'collector': certifyVex.collector,
+			'origin': certifyVex.origin  
+		  }`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getVEXStatementQueryValues(nil, subject.Artifact, &vulnerability, &vexStatement), "IngestVEXStatement - Artifact")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest VEX: %w", err)
+		}
+		defer cursor.Close()
+		vexList, err := getCertifyVex(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get VEX from arango cursor: %w", err)
+		}
+
+		if len(vexList) == 1 {
+			return vexList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of VEX ingested is greater than one")
+		}
+	} else {
+		query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == @pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		LET firstVuln = FIRST(
+			FOR vVulnID in vulnerabilities
+			  FILTER vVulnID.guacKey == @guacVulnKey
+			FOR vType in vulnTypes
+			  FILTER vType._id == vVulnID._parent
+	
+			RETURN {
+			  "typeID": vType._id,
+			  "type": vType.type,
+			  "vuln_id": vVulnID._id,
+			  "vuln": vVulnID.vulnerabilityID,
+			  "vulnDoc": vVulnID
+			}
+		  )
+		  
+		LET certifyVex = FIRST(
+			UPSERT { packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln.vulnDoc._id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+				INSERT {packageID:firstPkg.versionDoc._id, vulnerabilityID:firstVuln.vulnDoc._id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+				UPDATE {} IN certifyVEXs
+				RETURN NEW
+		)
+		
+		INSERT { _key: CONCAT("certifyVexPkgEdges", firstPkg.versionDoc._key, certifyVex._key), _from: firstPkg.versionDoc._id, _to: certifyVex._id } INTO certifyVexPkgEdges OPTIONS { overwriteMode: "ignore" }
+		INSERT { _key: CONCAT("certifyVexVulnEdges", certifyVex._key, firstVuln.vulnDoc._key), _from: certifyVex._id, _to: firstVuln.vulnDoc._id } INTO certifyVexVulnEdges OPTIONS { overwriteMode: "ignore" }
+		
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'vulnerability': {
+				'type_id': firstVuln.typeID,
+				'type': firstVuln.type,
+				'vuln_id': firstVuln.vuln_id,
+				'vuln': firstVuln.vuln
+			},
+			'certifyVex_id': certifyVex._id,
+			'status': certifyVex.status,
+			'vexJustification': certifyVex.vexJustification,
+			'statement': certifyVex.statement,
+			'statusNotes': certifyVex.statusNotes,
+			'knownSince': certifyVex.knownSince,
+			'collector': certifyVex.collector,
+			'origin': certifyVex.origin  
+		  }`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getVEXStatementQueryValues(subject.Package, nil, &vulnerability, &vexStatement), "IngestVEXStatement - Package")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ingest VEX: %w", err)
+		}
+		defer cursor.Close()
+
+		vexList, err := getCertifyVex(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get VEX from arango cursor: %w", err)
+		}
+
+		if len(vexList) == 1 {
+			return vexList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of VEX ingested is greater than one")
+		}
+	}
+}
+
+func getCertifyVex(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyVEXStatement, error) {
+	type collectedData struct {
+		PkgVersion       *dbPkgVersion   `json:"pkgVersion"`
+		Artifact         *model.Artifact `json:"artifact"`
+		Vulnerability    *dbVulnID       `json:"vulnerability"`
+		CertifyVexId     string          `json:"certifyVex_id"`
+		Status           string          `json:"status"`
+		VexJustification string          `json:"vexJustification"`
+		Statement        string          `json:"statement"`
+		StatusNotes      string          `json:"statusNotes"`
+		KnownSince       time.Time       `json:"knownSince"`
+		Collector        string          `json:"collector"`
+		Origin           string          `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to package Vex from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyVexList []*model.CertifyVEXStatement
+	for _, createdValue := range createdValues {
+		var pkg *model.Package = nil
+		if createdValue.PkgVersion != nil {
+			pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+				createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		}
+
+		vuln := &model.Vulnerability{
+			ID:   createdValue.Vulnerability.VulnID,
+			Type: createdValue.Vulnerability.VulnType,
+			VulnerabilityIDs: []*model.VulnerabilityID{
+				{
+					ID:              createdValue.Vulnerability.VulnID,
+					VulnerabilityID: createdValue.Vulnerability.Vuln,
+				},
+			},
+		}
+		certifyVex := &model.CertifyVEXStatement{
+			ID:               createdValue.CertifyVexId,
+			Vulnerability:    vuln,
+			Status:           model.VexStatus(createdValue.Status),
+			VexJustification: model.VexJustification(createdValue.VexJustification),
+			Statement:        createdValue.Statement,
+			StatusNotes:      createdValue.StatusNotes,
+			KnownSince:       createdValue.KnownSince,
+			Origin:           createdValue.Collector,
+			Collector:        createdValue.Origin,
+		}
+		if pkg != nil {
+			certifyVex.Subject = pkg
+		} else {
+			certifyVex.Subject = createdValue.Artifact
+		}
+
+		certifyVexList = append(certifyVexList, certifyVex)
+	}
+	return certifyVexList, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -714,8 +714,10 @@ func getCertifyVexFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mode
 		}
 		if pkg != nil {
 			certifyVex.Subject = pkg
-		} else {
+		} else if createdValue.Artifact != nil {
 			certifyVex.Subject = createdValue.Artifact
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for certifyVex")
 		}
 
 		certifyVexList = append(certifyVexList, certifyVex)

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -1,0 +1,16 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -97,7 +97,7 @@ func getPkgCertifyVulnForQuery(ctx context.Context, c *arangoClient, arangoQuery
 	}
 	defer cursor.Close()
 
-	return geCertifyVuln(ctx, cursor)
+	return geCertifyVulnFromCursor(ctx, cursor)
 }
 
 func setCertifyVulnMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyVulnSpec *model.CertifyVulnSpec, queryValues map[string]any) {
@@ -298,7 +298,7 @@ func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.Pkg
 	}
 	defer cursor.Close()
 
-	certifyVulnList, err := geCertifyVuln(ctx, cursor)
+	certifyVulnList, err := geCertifyVulnFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get certifyVulns from arango cursor: %w", err)
 	}
@@ -393,7 +393,7 @@ func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInput
 	}
 	defer cursor.Close()
 
-	certifyVulnList, err := geCertifyVuln(ctx, cursor)
+	certifyVulnList, err := geCertifyVulnFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get certifyVulns from arango cursor: %w", err)
 	}
@@ -405,7 +405,7 @@ func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.PkgInput
 	}
 }
 
-func geCertifyVuln(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyVuln, error) {
+func geCertifyVulnFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.CertifyVuln, error) {
 	type collectedData struct {
 		PkgVersion     *dbPkgVersion `json:"pkgVersion"`
 		Vulnerability  *dbVulnID     `json:"vulnerability"`

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -565,8 +565,10 @@ func getHasSBOMFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.H
 		}
 		if pkg != nil {
 			hasSBOM.Subject = pkg
-		} else {
+		} else if createdValue.Artifact != nil {
 			hasSBOM.Subject = createdValue.Artifact
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for hasSBOM")
 		}
 		hasSBOMList = append(hasSBOMList, hasSBOM)
 	}

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -378,7 +378,9 @@ func getHasSLSAFromCursor(c *arangoClient, ctx context.Context, cursor driver.Cu
 
 	var hasSLSAList []*model.HasSlsa
 	for _, createdValue := range createdValues {
-
+		if createdValue.BuiltBy == nil || createdValue.Subject == nil {
+			return nil, fmt.Errorf("failed to get subject or builtBy from cursor for hasSLSA")
+		}
 		var builtFromArtifacts []*model.Artifact
 		if val, ok := builtFromMap[artifactKey(createdValue.Subject.Algorithm, createdValue.Subject.Digest)]; ok {
 			builtFromArtifacts = val

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -73,7 +73,7 @@ func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASp
 	}
 	defer cursor.Close()
 
-	return getHasSLSA(c, ctx, cursor, map[string][]*model.Artifact{}, hasSLSASpec.BuiltFrom)
+	return getHasSLSAFromCursor(c, ctx, cursor, map[string][]*model.Artifact{}, hasSLSASpec.BuiltFrom)
 }
 
 func setHasSLSAMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSLSASpec *model.HasSLSASpec, queryValues map[string]any) {
@@ -269,7 +269,7 @@ func (c *arangoClient) IngestSLSAs(ctx context.Context, subjects []*model.Artifa
 		return nil, fmt.Errorf("failed to ingest hasSLSA: %w", err)
 	}
 	defer cursor.Close()
-	hasSLSAList, err := getHasSLSA(c, ctx, cursor, builtFromMap, nil)
+	hasSLSAList, err := getHasSLSAFromCursor(c, ctx, cursor, builtFromMap, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hasSLSA from arango cursor: %w", err)
 	}
@@ -328,7 +328,7 @@ func (c *arangoClient) IngestSLSA(ctx context.Context, subject model.ArtifactInp
 	}
 	defer cursor.Close()
 
-	hasSLSAList, err := getHasSLSA(c, ctx, cursor, map[string][]*model.Artifact{artifactKey(subject.Algorithm, subject.Digest): artifacts}, nil)
+	hasSLSAList, err := getHasSLSAFromCursor(c, ctx, cursor, map[string][]*model.Artifact{artifactKey(subject.Algorithm, subject.Digest): artifacts}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hasSLSA from arango cursor: %w", err)
 	}
@@ -346,7 +346,7 @@ func artifactKey(alg, dig string) string {
 	return strings.Join([]string{algorithm, digest}, ":")
 }
 
-func getHasSLSA(c *arangoClient, ctx context.Context, cursor driver.Cursor, builtFromMap map[string][]*model.Artifact, filterBuiltFrom []*model.ArtifactSpec) ([]*model.HasSlsa, error) {
+func getHasSLSAFromCursor(c *arangoClient, ctx context.Context, cursor driver.Cursor, builtFromMap map[string][]*model.Artifact, filterBuiltFrom []*model.ArtifactSpec) ([]*model.HasSlsa, error) {
 	type collectedData struct {
 		Subject       *model.Artifact `json:"subject"`
 		BuiltBy       *model.Builder  `json:"builtBy"`

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -131,7 +131,7 @@ func getHashEqualForQuery(ctx context.Context, c *arangoClient, arangoQueryBuild
 	}
 	defer cursor.Close()
 
-	return getHashEqual(ctx, cursor)
+	return getHashEqualFromCursor(ctx, cursor)
 }
 
 func setHashEqualMatchValues(arangoQueryBuilder *arangoQueryBuilder, hashEqualSpec *model.HashEqualSpec, queryValues map[string]any) {
@@ -239,7 +239,7 @@ func (c *arangoClient) IngestHashEquals(ctx context.Context, artifacts []*model.
 	}
 	defer cursor.Close()
 
-	return getHashEqual(ctx, cursor)
+	return getHashEqualFromCursor(ctx, cursor)
 }
 
 func (c *arangoClient) IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error) {
@@ -279,7 +279,7 @@ RETURN {
 	}
 	defer cursor.Close()
 
-	hashEqualList, err := getHashEqual(ctx, cursor)
+	hashEqualList, err := getHashEqualFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hashEqual from arango cursor: %w", err)
 	}
@@ -291,7 +291,7 @@ RETURN {
 	}
 }
 
-func getHashEqual(ctx context.Context, cursor driver.Cursor) ([]*model.HashEqual, error) {
+func getHashEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.HashEqual, error) {
 	type collectedData struct {
 		Artifact      *model.Artifact `json:"artifact"`
 		EqualArtifact *model.Artifact `json:"equalArtifact"`

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -179,7 +179,7 @@ func getDependencyForQuery(ctx context.Context, c *arangoClient, arangoQueryBuil
 	}
 	defer cursor.Close()
 
-	return getIsDependency(ctx, cursor)
+	return getIsDependencyFromCursor(ctx, cursor)
 }
 
 func setIsDependencyMatchValues(arangoQueryBuilder *arangoQueryBuilder, isDependencySpec *model.IsDependencySpec, queryValues map[string]any, queryDepPkgVersion bool) {
@@ -532,7 +532,7 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.Pkg
 	}
 	defer cursor.Close()
 
-	return getIsDependency(ctx, cursor)
+	return getIsDependencyFromCursor(ctx, cursor)
 }
 
 func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (*model.IsDependency, error) {
@@ -728,7 +728,7 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.PkgInputS
 	}
 	defer cursor.Close()
 
-	isDependencyList, err := getIsDependency(ctx, cursor)
+	isDependencyList, err := getIsDependencyFromCursor(ctx, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dependency from arango cursor: %w", err)
 	}
@@ -753,7 +753,7 @@ func convertDependencyTypeToEnum(status string) (model.DependencyType, error) {
 	return model.DependencyTypeUnknown, fmt.Errorf("failed to convert DependencyType to enum")
 }
 
-func getIsDependency(ctx context.Context, cursor driver.Cursor) ([]*model.IsDependency, error) {
+func getIsDependencyFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.IsDependency, error) {
 	type collectedData struct {
 		PkgVersion     *dbPkgVersion `json:"pkgVersion"`
 		DepPkg         *dbPkgVersion `json:"depPkg"`

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -634,6 +634,9 @@ func getIsOccurrenceFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mo
 
 	var isOccurrenceList []*model.IsOccurrence
 	for _, createdValue := range createdValues {
+		if createdValue.Artifact == nil {
+			return nil, fmt.Errorf("failed to get artifact from cursor for isOccurrence")
+		}
 		var pkg *model.Package = nil
 		var src *model.Source = nil
 		if createdValue.PkgVersion != nil {
@@ -652,8 +655,10 @@ func getIsOccurrenceFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mo
 		}
 		if pkg != nil {
 			isOccurrence.Subject = pkg
-		} else {
+		} else if src != nil {
 			isOccurrence.Subject = src
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for isOccurrence")
 		}
 		isOccurrenceList = append(isOccurrenceList, isOccurrence)
 	}

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -83,6 +83,7 @@ type Backend interface {
 	IngestSLSA(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error)
 	IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error)
+	IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error)
 	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (*model.CertifyVuln, error)
 	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error)
 	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error)

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -65,6 +65,30 @@ func (n *vexLink) BuildModelNode(c *demoClient) (model.Node, error) {
 
 // Ingest CertifyVex
 
+func (c *demoClient) IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error) {
+	var modelVexStatementIDs []string
+
+	for i := range vexStatements {
+		var certVex *model.CertifyVEXStatement
+		var err error
+		if len(subjects.Packages) > 0 {
+			subject := model.PackageOrArtifactInput{Package: subjects.Packages[i]}
+			certVex, err = c.IngestVEXStatement(ctx, subject, *vulnerabilities[i], *vexStatements[i])
+			if err != nil {
+				return nil, gqlerror.Errorf("IngestVEXStatement failed with err: %v", err)
+			}
+		} else {
+			subject := model.PackageOrArtifactInput{Artifact: subjects.Artifacts[i]}
+			certVex, err = c.IngestVEXStatement(ctx, subject, *vulnerabilities[i], *vexStatements[i])
+			if err != nil {
+				return nil, gqlerror.Errorf("IngestVEXStatement failed with err: %v", err)
+			}
+		}
+		modelVexStatementIDs = append(modelVexStatementIDs, certVex.ID)
+	}
+	return modelVexStatementIDs, nil
+}
+
 func (c *demoClient) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (*model.CertifyVEXStatement, error) {
 	return c.ingestVEXStatement(ctx, subject, vulnerability, vexStatement, true)
 }

--- a/pkg/assembler/backends/neo4j/certifyVEXStatement.go
+++ b/pkg/assembler/backends/neo4j/certifyVEXStatement.go
@@ -642,5 +642,8 @@ func (c *neo4jClient) IngestVEXStatement(ctx context.Context, subject model.Pack
 	// }
 	// panic(fmt.Errorf("not implemented: IngestVEXStatement - IngestVEXStatement"))
 	return nil, fmt.Errorf("not implemented - IngestVEXStatement")
+}
 
+func (c *neo4jClient) IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error) {
+	return []string{}, fmt.Errorf("not implemented - IngestVEXStatements")
 }

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5660,7 +5660,7 @@ func (v *CertifyVexArtifactResponse) GetIngestVEXStatement() string { return v.I
 
 // CertifyVexArtifactsResponse is returned by CertifyVexArtifacts on success.
 type CertifyVexArtifactsResponse struct {
-	// Bulk add VEX certifications for a package and vulnerability.
+	// Bulk add VEX certifications for a package and vulnerability. The returned array of IDs can be a an array of empty string.
 	IngestVEXStatements []string `json:"ingestVEXStatements"`
 }
 
@@ -5678,7 +5678,7 @@ func (v *CertifyVexPkgResponse) GetIngestVEXStatement() string { return v.Ingest
 
 // CertifyVexPkgsResponse is returned by CertifyVexPkgs on success.
 type CertifyVexPkgsResponse struct {
-	// Bulk add VEX certifications for a package and vulnerability.
+	// Bulk add VEX certifications for a package and vulnerability. The returned array of IDs can be a an array of empty string.
 	IngestVEXStatements []string `json:"ingestVEXStatements"`
 }
 

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5658,6 +5658,15 @@ type CertifyVexArtifactResponse struct {
 // GetIngestVEXStatement returns CertifyVexArtifactResponse.IngestVEXStatement, and is useful for accessing the field via an interface.
 func (v *CertifyVexArtifactResponse) GetIngestVEXStatement() string { return v.IngestVEXStatement }
 
+// CertifyVexArtifactsResponse is returned by CertifyVexArtifacts on success.
+type CertifyVexArtifactsResponse struct {
+	// Bulk add VEX certifications for a package and vulnerability.
+	IngestVEXStatements []string `json:"ingestVEXStatements"`
+}
+
+// GetIngestVEXStatements returns CertifyVexArtifactsResponse.IngestVEXStatements, and is useful for accessing the field via an interface.
+func (v *CertifyVexArtifactsResponse) GetIngestVEXStatements() []string { return v.IngestVEXStatements }
+
 // CertifyVexPkgResponse is returned by CertifyVexPkg on success.
 type CertifyVexPkgResponse struct {
 	// Adds a VEX certification for a package. The returned ID can be empty string.
@@ -5666,6 +5675,15 @@ type CertifyVexPkgResponse struct {
 
 // GetIngestVEXStatement returns CertifyVexPkgResponse.IngestVEXStatement, and is useful for accessing the field via an interface.
 func (v *CertifyVexPkgResponse) GetIngestVEXStatement() string { return v.IngestVEXStatement }
+
+// CertifyVexPkgsResponse is returned by CertifyVexPkgs on success.
+type CertifyVexPkgsResponse struct {
+	// Bulk add VEX certifications for a package and vulnerability.
+	IngestVEXStatements []string `json:"ingestVEXStatements"`
+}
+
+// GetIngestVEXStatements returns CertifyVexPkgsResponse.IngestVEXStatements, and is useful for accessing the field via an interface.
+func (v *CertifyVexPkgsResponse) GetIngestVEXStatements() []string { return v.IngestVEXStatements }
 
 // CertifyVulnPkgResponse is returned by CertifyVulnPkg on success.
 type CertifyVulnPkgResponse struct {
@@ -6447,7 +6465,7 @@ func (v *IngestBuilderResponse) GetIngestBuilder() string { return v.IngestBuild
 
 // IngestBuildersResponse is returned by IngestBuilders on success.
 type IngestBuildersResponse struct {
-	// Bulk ingests new builders and returns a list of them.
+	// Bulk ingests new builders and returns a list of them. The returned array of IDs can be a an array of empty string.
 	IngestBuilders []string `json:"ingestBuilders"`
 }
 
@@ -18610,6 +18628,26 @@ func (v *__CertifyVexArtifactInput) GetVulnerability() VulnerabilityInputSpec { 
 // GetVexStatement returns __CertifyVexArtifactInput.VexStatement, and is useful for accessing the field via an interface.
 func (v *__CertifyVexArtifactInput) GetVexStatement() VexStatementInputSpec { return v.VexStatement }
 
+// __CertifyVexArtifactsInput is used internally by genqlient
+type __CertifyVexArtifactsInput struct {
+	Artifacts       []ArtifactInputSpec      `json:"artifacts"`
+	Vulnerabilities []VulnerabilityInputSpec `json:"vulnerabilities"`
+	VexStatements   []VexStatementInputSpec  `json:"vexStatements"`
+}
+
+// GetArtifacts returns __CertifyVexArtifactsInput.Artifacts, and is useful for accessing the field via an interface.
+func (v *__CertifyVexArtifactsInput) GetArtifacts() []ArtifactInputSpec { return v.Artifacts }
+
+// GetVulnerabilities returns __CertifyVexArtifactsInput.Vulnerabilities, and is useful for accessing the field via an interface.
+func (v *__CertifyVexArtifactsInput) GetVulnerabilities() []VulnerabilityInputSpec {
+	return v.Vulnerabilities
+}
+
+// GetVexStatements returns __CertifyVexArtifactsInput.VexStatements, and is useful for accessing the field via an interface.
+func (v *__CertifyVexArtifactsInput) GetVexStatements() []VexStatementInputSpec {
+	return v.VexStatements
+}
+
 // __CertifyVexPkgInput is used internally by genqlient
 type __CertifyVexPkgInput struct {
 	Pkg           PkgInputSpec           `json:"pkg"`
@@ -18625,6 +18663,24 @@ func (v *__CertifyVexPkgInput) GetVulnerability() VulnerabilityInputSpec { retur
 
 // GetVexStatement returns __CertifyVexPkgInput.VexStatement, and is useful for accessing the field via an interface.
 func (v *__CertifyVexPkgInput) GetVexStatement() VexStatementInputSpec { return v.VexStatement }
+
+// __CertifyVexPkgsInput is used internally by genqlient
+type __CertifyVexPkgsInput struct {
+	Pkgs            []PkgInputSpec           `json:"pkgs"`
+	Vulnerabilities []VulnerabilityInputSpec `json:"vulnerabilities"`
+	VexStatements   []VexStatementInputSpec  `json:"vexStatements"`
+}
+
+// GetPkgs returns __CertifyVexPkgsInput.Pkgs, and is useful for accessing the field via an interface.
+func (v *__CertifyVexPkgsInput) GetPkgs() []PkgInputSpec { return v.Pkgs }
+
+// GetVulnerabilities returns __CertifyVexPkgsInput.Vulnerabilities, and is useful for accessing the field via an interface.
+func (v *__CertifyVexPkgsInput) GetVulnerabilities() []VulnerabilityInputSpec {
+	return v.Vulnerabilities
+}
+
+// GetVexStatements returns __CertifyVexPkgsInput.VexStatements, and is useful for accessing the field via an interface.
+func (v *__CertifyVexPkgsInput) GetVexStatements() []VexStatementInputSpec { return v.VexStatements }
 
 // __CertifyVulnPkgInput is used internally by genqlient
 type __CertifyVulnPkgInput struct {
@@ -19914,6 +19970,43 @@ func CertifyVexArtifact(
 	return &data, err
 }
 
+// The query or mutation executed by CertifyVexArtifacts.
+const CertifyVexArtifacts_Operation = `
+mutation CertifyVexArtifacts ($artifacts: [ArtifactInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $vexStatements: [VexStatementInputSpec!]!) {
+	ingestVEXStatements(subjects: {artifacts:$artifacts}, vulnerabilities: $vulnerabilities, vexStatements: $vexStatements)
+}
+`
+
+func CertifyVexArtifacts(
+	ctx context.Context,
+	client graphql.Client,
+	artifacts []ArtifactInputSpec,
+	vulnerabilities []VulnerabilityInputSpec,
+	vexStatements []VexStatementInputSpec,
+) (*CertifyVexArtifactsResponse, error) {
+	req := &graphql.Request{
+		OpName: "CertifyVexArtifacts",
+		Query:  CertifyVexArtifacts_Operation,
+		Variables: &__CertifyVexArtifactsInput{
+			Artifacts:       artifacts,
+			Vulnerabilities: vulnerabilities,
+			VexStatements:   vexStatements,
+		},
+	}
+	var err error
+
+	var data CertifyVexArtifactsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by CertifyVexPkg.
 const CertifyVexPkg_Operation = `
 mutation CertifyVexPkg ($pkg: PkgInputSpec!, $vulnerability: VulnerabilityInputSpec!, $vexStatement: VexStatementInputSpec!) {
@@ -19940,6 +20033,43 @@ func CertifyVexPkg(
 	var err error
 
 	var data CertifyVexPkgResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by CertifyVexPkgs.
+const CertifyVexPkgs_Operation = `
+mutation CertifyVexPkgs ($pkgs: [PkgInputSpec!]!, $vulnerabilities: [VulnerabilityInputSpec!]!, $vexStatements: [VexStatementInputSpec!]!) {
+	ingestVEXStatements(subjects: {packages:$pkgs}, vulnerabilities: $vulnerabilities, vexStatements: $vexStatements)
+}
+`
+
+func CertifyVexPkgs(
+	ctx context.Context,
+	client graphql.Client,
+	pkgs []PkgInputSpec,
+	vulnerabilities []VulnerabilityInputSpec,
+	vexStatements []VexStatementInputSpec,
+) (*CertifyVexPkgsResponse, error) {
+	req := &graphql.Request{
+		OpName: "CertifyVexPkgs",
+		Query:  CertifyVexPkgs_Operation,
+		Variables: &__CertifyVexPkgsInput{
+			Pkgs:            pkgs,
+			Vulnerabilities: vulnerabilities,
+			VexStatements:   vexStatements,
+		},
+	}
+	var err error
+
+	var data CertifyVexPkgsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/operations/certifyVEXStatement.graphql
+++ b/pkg/assembler/clients/operations/certifyVEXStatement.graphql
@@ -40,3 +40,31 @@ mutation CertifyVexArtifact(
     vexStatement: $vexStatement
   )
 }
+
+
+# Defines the GraphQL operations to bulk ingest VEX statements into GUAC
+
+mutation CertifyVexPkgs(
+  $pkgs: [PkgInputSpec!]!, 
+  $vulnerabilities: [VulnerabilityInputSpec!]!, 
+  $vexStatements: [VexStatementInputSpec!]!
+) {
+  ingestVEXStatements(
+    subjects: {
+      packages: $pkgs}, 
+      vulnerabilities: 
+      $vulnerabilities, 
+      vexStatements: $vexStatements)
+}
+
+mutation CertifyVexArtifacts(
+  $artifacts: [ArtifactInputSpec!]!, 
+  $vulnerabilities: [VulnerabilityInputSpec!]!, 
+  $vexStatements: [VexStatementInputSpec!]!
+  ) {
+  ingestVEXStatements(
+    subjects: {artifacts: $artifacts}, 
+    vulnerabilities: $vulnerabilities, 
+    vexStatements: $vexStatements)
+}
+

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -30,6 +30,7 @@ type MutationResolver interface {
 	IngestScorecard(ctx context.Context, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) (string, error)
 	IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]string, error)
 	IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) (string, error)
+	IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error)
 	IngestCertifyVuln(ctx context.Context, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) (string, error)
 	IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]string, error)
 	IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (string, error)
@@ -974,6 +975,39 @@ func (ec *executionContext) field_Mutation_ingestVEXStatement_args(ctx context.C
 		}
 	}
 	args["vexStatement"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestVEXStatements_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.PackageOrArtifactInputs
+	if tmp, ok := rawArgs["subjects"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subjects"))
+		arg0, err = ec.unmarshalNPackageOrArtifactInputs2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactInputs(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["subjects"] = arg0
+	var arg1 []*model.VulnerabilityInputSpec
+	if tmp, ok := rawArgs["vulnerabilities"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilities"))
+		arg1, err = ec.unmarshalNVulnerabilityInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["vulnerabilities"] = arg1
+	var arg2 []*model.VexStatementInputSpec
+	if tmp, ok := rawArgs["vexStatements"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vexStatements"))
+		arg2, err = ec.unmarshalNVexStatementInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatementInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["vexStatements"] = arg2
 	return args, nil
 }
 
@@ -2268,6 +2302,61 @@ func (ec *executionContext) fieldContext_Mutation_ingestVEXStatement(ctx context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestVEXStatement_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestVEXStatements(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestVEXStatements(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestVEXStatements(rctx, fc.Args["subjects"].(model.PackageOrArtifactInputs), fc.Args["vulnerabilities"].([]*model.VulnerabilityInputSpec), fc.Args["vexStatements"].([]*model.VexStatementInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestVEXStatements(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestVEXStatements_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -5710,6 +5799,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "ingestVEXStatement":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestVEXStatement(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ingestVEXStatements":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestVEXStatements(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -1002,6 +1002,28 @@ func (ec *executionContext) unmarshalNVexStatementInputSpec2githubᚗcomᚋguacs
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNVexStatementInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatementInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.VexStatementInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.VexStatementInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNVexStatementInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatementInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNVexStatementInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatementInputSpec(ctx context.Context, v interface{}) (*model.VexStatementInputSpec, error) {
+	res, err := ec.unmarshalInputVexStatementInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNVexStatus2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatus(ctx context.Context, v interface{}) (model.VexStatus, error) {
 	var res model.VexStatus
 	err := res.UnmarshalGQL(v)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -190,6 +190,7 @@ type ComplexityRoot struct {
 		IngestSource                 func(childComplexity int, source model.SourceInputSpec) int
 		IngestSources                func(childComplexity int, sources []*model.SourceInputSpec) int
 		IngestVEXStatement           func(childComplexity int, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) int
+		IngestVEXStatements          func(childComplexity int, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) int
 		IngestVulnEqual              func(childComplexity int, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) int
 		IngestVulnerabilities        func(childComplexity int, vulns []*model.VulnerabilityInputSpec) int
 		IngestVulnerability          func(childComplexity int, vuln model.VulnerabilityInputSpec) int
@@ -1291,6 +1292,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestVEXStatement(childComplexity, args["subject"].(model.PackageOrArtifactInput), args["vulnerability"].(model.VulnerabilityInputSpec), args["vexStatement"].(model.VexStatementInputSpec)), true
+
+	case "Mutation.ingestVEXStatements":
+		if e.complexity.Mutation.IngestVEXStatements == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestVEXStatements_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestVEXStatements(childComplexity, args["subjects"].(model.PackageOrArtifactInputs), args["vulnerabilities"].([]*model.VulnerabilityInputSpec), args["vexStatements"].([]*model.VexStatementInputSpec)), true
 
 	case "Mutation.ingestVulnEqual":
 		if e.complexity.Mutation.IngestVulnEqual == nil {
@@ -3029,6 +3042,12 @@ extend type Mutation {
     vulnerability: VulnerabilityInputSpec!
     vexStatement: VexStatementInputSpec!
   ): ID!
+  "Bulk add VEX certifications for a package and vulnerability."
+  ingestVEXStatements(
+    subjects: PackageOrArtifactInputs!, 
+    vulnerabilities: [VulnerabilityInputSpec!]!, 
+    vexStatements: [VexStatementInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/certifyVuln.graphql", Input: `#

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3042,7 +3042,7 @@ extend type Mutation {
     vulnerability: VulnerabilityInputSpec!
     vexStatement: VexStatementInputSpec!
   ): ID!
-  "Bulk add VEX certifications for a package and vulnerability."
+  "Bulk add VEX certifications for a package and vulnerability. The returned array of IDs can be a an array of empty string."
   ingestVEXStatements(
     subjects: PackageOrArtifactInputs!, 
     vulnerabilities: [VulnerabilityInputSpec!]!, 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -2529,7 +2529,7 @@ extend type Query {
 extend type Mutation {
   "Ingests a new builder and returns it. The returned ID can be empty string."
   ingestBuilder(builder: BuilderInputSpec): ID!
-  "Bulk ingests new builders and returns a list of them."
+  "Bulk ingests new builders and returns a list of them. The returned array of IDs can be a an array of empty string."
   ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},

--- a/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
@@ -6,6 +6,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -25,6 +26,11 @@ func (r *mutationResolver) IngestVEXStatement(ctx context.Context, subject model
 		return "", err
 	}
 	return ingestedVEXStatement.ID, err
+}
+
+// IngestVEXStatements is the resolver for the ingestVEXStatements field.
+func (r *mutationResolver) IngestVEXStatements(ctx context.Context, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestVEXStatements - ingestVEXStatements"))
 }
 
 // CertifyVEXStatement is the resolver for the CertifyVEXStatement field.

--- a/pkg/assembler/graphql/schema/builder.graphql
+++ b/pkg/assembler/graphql/schema/builder.graphql
@@ -46,6 +46,6 @@ extend type Query {
 extend type Mutation {
   "Ingests a new builder and returns it. The returned ID can be empty string."
   ingestBuilder(builder: BuilderInputSpec): ID!
-  "Bulk ingests new builders and returns a list of them."
+  "Bulk ingests new builders and returns a list of them. The returned array of IDs can be a an array of empty string."
   ingestBuilders(builders: [BuilderInputSpec!]!): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -141,7 +141,7 @@ extend type Mutation {
     vulnerability: VulnerabilityInputSpec!
     vexStatement: VexStatementInputSpec!
   ): ID!
-  "Bulk add VEX certifications for a package and vulnerability."
+  "Bulk add VEX certifications for a package and vulnerability. The returned array of IDs can be a an array of empty string."
   ingestVEXStatements(
     subjects: PackageOrArtifactInputs!, 
     vulnerabilities: [VulnerabilityInputSpec!]!, 

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -141,4 +141,10 @@ extend type Mutation {
     vulnerability: VulnerabilityInputSpec!
     vexStatement: VexStatementInputSpec!
   ): ID!
+  "Bulk add VEX certifications for a package and vulnerability."
+  ingestVEXStatements(
+    subjects: PackageOrArtifactInputs!, 
+    vulnerabilities: [VulnerabilityInputSpec!]!, 
+    vexStatements: [VexStatementInputSpec!]!
+  ): [ID!]!
 }


### PR DESCRIPTION
# Description of the PR

- update vex schema for bulk ingestion
- update inmem with bulk ingestion implementation with unit tests
- arango implementation for vex ingestion, bulk ingestion and query
- remove reused code
- fix a couple of typos in backend
- update bulk assembler to use new bulk ingestion for vex

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
