### PR TITLE
Included docstrings for parser_csaf

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -91,6 +91,11 @@ func (c *csafParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStri
 	return nil, fmt.Errorf("not yet implemented")
 }
 
+// findPurl searches the given CSAF product tree recursively to find the
+// purl for the specified product reference.
+//
+// It recursively calls itself on each child branch of the tree in a
+// depth first search manner if the nodes name isn't equal to product_ref.
 func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string) *string {
 	if tree.Name == product_ref {
 		purl := tree.Product.IdentificationHelper["purl"]
@@ -107,10 +112,26 @@ func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string) 
 	return nil
 }
 
+// findProductRef searches for a product reference string for the given product ID
+// by recursively traversing the CSAF product tree.
+//
+// It calls findProductRefSearch to perform the recursive search, passing along
+// the context, product tree, product ID to find, and an empty visited map to
+// track searched nodes.
+//
+// findProductRefSearch was seperated from findProductRef so that the code can use
+// a visited map and avoid infinite recursion.
 func findProductRef(ctx context.Context, tree csaf.ProductBranch, product_id string) *string {
 	return findProductRefSearch(ctx, tree, product_id, make(map[visitedProductRef]bool))
 }
 
+// findProductRefSearch recursively searches the product tree for a product
+// reference matching the given product ID.
+//
+// It tracks visited nodes in the tree to avoid infinite recursion.
+//
+// If the product ID is found in a relationship, it returns the associated
+// product reference string.
 func findProductRefSearch(ctx context.Context, tree csaf.ProductBranch, product_id string, visited map[visitedProductRef]bool) *string {
 	if visited[visitedProductRef{tree.Product.Name, tree.Product.ID, tree.Name, tree.Category}] {
 		return nil
@@ -132,6 +153,13 @@ func findProductRefSearch(ctx context.Context, tree csaf.ProductBranch, product_
 	return nil
 }
 
+// findActionStatement searches the given Vulnerability tree to find the action statement
+// for the product with the given product_id.
+//
+// It iterates through the Remediations in the tree and checks if the ProductIDs slice
+// contains the product_id. If found, it returns a pointer to the Details string for that
+// Remediation.
+// If no matching Remediation is found, it returns nil.
 func findActionStatement(tree *csaf.Vulnerability, product_id string) *string {
 	for _, r := range tree.Remediations {
 		for _, p := range r.ProductIDs {
@@ -143,6 +171,13 @@ func findActionStatement(tree *csaf.Vulnerability, product_id string) *string {
 	return nil
 }
 
+// findImpactStatement searches the given Vulnerability tree to find the impact statement
+// for the product with the given product_id.
+//
+// It iterates through the Threats in the tree and looks for one with Category "impact".
+// It then checks if the ProductIDs slice contains the product_id.
+// If found, it returns a pointer to the Details string for that Threat.
+// If no matching Threat is found, it returns nil.
 func findImpactStatement(tree *csaf.Vulnerability, product_id string) *string {
 	for _, t := range tree.Threats {
 		if t.Category == "impact" {
@@ -156,6 +191,17 @@ func findImpactStatement(tree *csaf.Vulnerability, product_id string) *string {
 	return nil
 }
 
+// findPkgSpec finds the package specification for the product with the
+// given ID in the CSAF document.
+//
+// It first calls findProductRef to get the product reference string for
+// the ID. If not found, returns an error.
+//
+// It then calls findPurl to get the purl for that product reference.
+// If not found, returns an error.
+//
+// Finally, it calls helpers.PurlToPkg to convert the purl to a package
+// spec to return.
 func (c *csafParser) findPkgSpec(ctx context.Context, product_id string) (*generated.PkgInputSpec, error) {
 	pref := findProductRef(ctx, c.csaf.ProductTree, product_id)
 	if pref == nil {
@@ -170,6 +216,12 @@ func (c *csafParser) findPkgSpec(ctx context.Context, product_id string) (*gener
 	return helpers.PurlToPkg(*purl)
 }
 
+// generateVexIngest generates a VEX ingest object from a CSAF vulnerability and other input data.
+//
+// The function maps CSAF data into a VEX ingest object for adding to the vulnerability graph.
+// It sets the VEX statement fields like justification, status and text.
+// It finds the package for the product ID to add to ingest.
+// Returns nil if the package cannot be found.
 func (c *csafParser) generateVexIngest(ctx context.Context, vulnInput *generated.VulnerabilityInputSpec, csafVuln *csaf.Vulnerability, status string, product_id string) *assembler.VexIngest {
 	logger := logging.FromContext(ctx)
 	vi := &assembler.VexIngest{}
@@ -221,43 +273,42 @@ func (c *csafParser) generateVexIngest(ctx context.Context, vulnInput *generated
 	return vi
 }
 
+// GetPredicates generates the VEX and CertifyVuln predicates for the CSAF document.
+//
+// It returns a pointer to an assembler.IngestPredicates struct containing the
+// generated VEX and CertifyVuln predicates.
 func (c *csafParser) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
 	rv := &assembler.IngestPredicates{}
 	var vis []assembler.VexIngest
 	var cvs []assembler.CertifyVulnIngest
 
-	if len(c.csaf.Vulnerabilities) > 0 {
+	for _, v := range c.csaf.Vulnerabilities {
+		vuln, err := helpers.CreateVulnInput(v.CVE)
+		if err != nil {
+			return nil
+		}
 
-		for _, v := range c.csaf.Vulnerabilities {
-			vuln, err := helpers.CreateVulnInput(v.CVE)
-			if err != nil {
-				return nil
-			}
-
-			statuses := []string{"fixed", "known_not_affected", "known_affected", "first_affected", "first_fixed", "last_affected", "recommended", "under_investigation"}
-			for _, status := range statuses {
-				products := v.ProductStatus[status]
-				if len(products) > 0 {
-					for _, product := range products {
-						vi := c.generateVexIngest(ctx, vuln, &v, status, product)
-						if vi == nil {
-							continue
-						}
-
-						if status == "known_affected" || status == "under_investigation" {
-							vulnData := generated.ScanMetadataInput{
-								TimeScanned: c.csaf.Document.Tracking.CurrentReleaseDate,
-							}
-							cv := assembler.CertifyVulnIngest{
-								Pkg:           vi.Pkg,
-								Vulnerability: vuln,
-								VulnData:      &vulnData,
-							}
-							cvs = append(cvs, cv)
-						}
-						vis = append(vis, *vi)
-					}
+		statuses := []string{"fixed", "known_not_affected", "known_affected", "first_affected", "first_fixed", "last_affected", "recommended", "under_investigation"}
+		for _, status := range statuses {
+			products := v.ProductStatus[status]
+			for _, product := range products {
+				vi := c.generateVexIngest(ctx, vuln, &v, status, product)
+				if vi == nil {
+					continue
 				}
+
+				if status == "known_affected" || status == "under_investigation" {
+					vulnData := generated.ScanMetadataInput{
+						TimeScanned: c.csaf.Document.Tracking.CurrentReleaseDate,
+					}
+					cv := assembler.CertifyVulnIngest{
+						Pkg:           vi.Pkg,
+						Vulnerability: vuln,
+						VulnData:      &vulnData,
+					}
+					cvs = append(cvs, cv)
+				}
+				vis = append(vis, *vi)
 			}
 		}
 	}


### PR DESCRIPTION
# Description of the PR

I am in the process of implementing OpenVEX (Going to create an issue for that). To do this, I am trying to understand CSAF. 

When trying to understand `parser_csaf`, I started including docstrings for myself, but then realized that it could also be helpful for anyone else trying to understand `parser_casf`.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
