### PR TITLE
Fixed a Potential Stack Overflow Error in findPurl 2

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -92,13 +92,21 @@ func (c *csafParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStri
 }
 
 func findPurl(ctx context.Context, tree csaf.ProductBranch, product_ref string) *string {
+	return findPurlSearch(ctx, tree, product_ref, make(map[string]bool))
+}
+
+func findPurlSearch(ctx context.Context, tree csaf.ProductBranch, product_ref string, visited map[string]bool) *string {
+	if visited[tree.Name] {
+		return nil
+	}
+	visited[tree.Name] = true
 	if tree.Name == product_ref {
 		purl := tree.Product.IdentificationHelper["purl"]
 		return &purl
 	}
 
 	for _, b := range tree.Branches {
-		purl := findPurl(ctx, b, product_ref)
+		purl := findPurlSearch(ctx, b, product_ref, visited)
 		if purl != nil {
 			return purl
 		}


### PR DESCRIPTION
# Description of the PR

* Fixed the potential stack overflow error for the function `findPurl` in `pkg/ingestor/parser/csaf/parser_csaf.go`
* Included unit tests for `findPurl`
* This PR is pretty much the same as #1143, but the conflicts in that PR were crazy so I created this PR.
# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
