### PR TITLE
Tag ent tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,27 +68,12 @@ jobs:
         run: go mod download
       - name: Run integration tests
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             ENT_TEST_DATABASE_URL: 'postgresql://guac:guac@localhost/guac?sslmode=disable'
         run: make integration-test
-        
+
   test-unit:
     runs-on: ubuntu-latest
     name: CI for unit tests
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: guac
-          POSTGRES_PASSWORD: guac
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # tag=v3
@@ -103,8 +88,6 @@ jobs:
       - name: Setup the project
         run: go mod download
       - name: Run tests
-        env:
-          ENT_TEST_DATABASE_URL: 'postgresql://guac:guac@localhost/guac?sslmode=disable'
         run: make test
 
   static-analysis:

--- a/pkg/assembler/backends/ent/backend/artifact_test.go
+++ b/pkg/assembler/backends/ent/backend/artifact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/artifact_test.go
+++ b/pkg/assembler/backends/ent/backend/artifact_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/certify_test.go
+++ b/pkg/assembler/backends/ent/backend/certify_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/certify_test.go
+++ b/pkg/assembler/backends/ent/backend/certify_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/dependency_test.go
+++ b/pkg/assembler/backends/ent/backend/dependency_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/dependency_test.go
+++ b/pkg/assembler/backends/ent/backend/dependency_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 // func (s *Suite) TestIsDependency() {

--- a/pkg/assembler/backends/ent/backend/hashequal_test.go
+++ b/pkg/assembler/backends/ent/backend/hashequal_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/hashequal_test.go
+++ b/pkg/assembler/backends/ent/backend/hashequal_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/helpers_test.go
+++ b/pkg/assembler/backends/ent/backend/helpers_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/helpers_test.go
+++ b/pkg/assembler/backends/ent/backend/helpers_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/package_test.go
+++ b/pkg/assembler/backends/ent/backend/package_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/package_test.go
+++ b/pkg/assembler/backends/ent/backend/package_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/pkgequal_test.go
+++ b/pkg/assembler/backends/ent/backend/pkgequal_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/pkgequal_test.go
+++ b/pkg/assembler/backends/ent/backend/pkgequal_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/scorecard_test.go
+++ b/pkg/assembler/backends/ent/backend/scorecard_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/scorecard_test.go
+++ b/pkg/assembler/backends/ent/backend/scorecard_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/search_test.go
+++ b/pkg/assembler/backends/ent/backend/search_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/search_test.go
+++ b/pkg/assembler/backends/ent/backend/search_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/slsa_test.go
+++ b/pkg/assembler/backends/ent/backend/slsa_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/slsa_test.go
+++ b/pkg/assembler/backends/ent/backend/slsa_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/software_test.go
+++ b/pkg/assembler/backends/ent/backend/software_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 // Usually this would be part of ent, but the import cycle doesn't allow for it.

--- a/pkg/assembler/backends/ent/backend/software_test.go
+++ b/pkg/assembler/backends/ent/backend/software_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/source_test.go
+++ b/pkg/assembler/backends/ent/backend/source_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 import (

--- a/pkg/assembler/backends/ent/backend/source_test.go
+++ b/pkg/assembler/backends/ent/backend/source_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/vex_test.go
+++ b/pkg/assembler/backends/ent/backend/vex_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 // func (s *Suite) TestVEX() {

--- a/pkg/assembler/backends/ent/backend/vex_test.go
+++ b/pkg/assembler/backends/ent/backend/vex_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/vulnerability_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integrationEnt
+//go:build integration
 
 package backend
 

--- a/pkg/assembler/backends/ent/backend/vulnerability_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integrationEnt
+
 package backend
 
 //var c1 = &model.VulnerabilityInputSpec{


### PR DESCRIPTION
Put ent tests behind tag integrationEnt until we have infra to bring up a postgres instance in our integration tests.