### PR TITLE
Remove 32-bit arm build as ent does not support it.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,12 +71,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guaccsub
     id: guaccsub
     binary: guaccsub-{{ .Os }}-{{ .Arch }}
@@ -87,12 +84,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacgql
     id: guacgql
     binary: guacgql-{{ .Os }}-{{ .Arch }}
@@ -103,12 +97,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacingest
     id: guacingest
     binary: guacingest-{{ .Os }}-{{ .Arch }}
@@ -119,12 +110,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacone
     id: guacone
     binary: guacone-{{ .Os }}-{{ .Arch }}
@@ -135,12 +123,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
 
 universal_binaries:
   - replace: true


### PR DESCRIPTION
https://github.com/ent/ent/issues/3125

Ent doesn't support 32 bit builds, so remove from goreleaser config.