### PR TITLE
Add 'integration' tag to golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,8 @@ run:
     - ".*\\.pb\\.go$"
     - "pkg/assembler/generated/.*"
     - "resolvers/schema\\.resolvers\\.go"
+  build-tags:
+    - integration
 linters:
   enable:
     - forcetypeassert


### PR DESCRIPTION
# Description of the PR

Added `integration` custom tag to `.golangci.yaml` configuration to solve CI `Lint` failure on `main` branch (ref. https://github.com/guacsec/guac/actions/runs/6021675765/job/16334972954):

```sh
golangci-lint run
pkg/assembler/backends/ent/backend/query_helpers.go:37:6: func `pkgTreeFromVersion` is unused (unused)
func pkgTreeFromVersion(ctx context.Context, pv *ent.PackageVersion) (*ent.PackageType, error) {
     ^
pkg/assembler/backends/ent/backend/query_helpers.go:72:6: func `buildPackageTreeQuery` is unused (unused)
func buildPackageTreeQuery(q *ent.PackageTypeQuery, ns, packageName string, pv *ent.PackageVersion) {
     ^
```

since methods are used from https://github.com/guacsec/guac/blob/1e83043cb83a7c11f61731d9fdee7882298b0125/pkg/assembler/backends/ent/backend/package_test.go#L124 which has the `//go:build integration` tag

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
