### PR TITLE
IngestVEXStatement resolver: fix `err` management

### DIFF
--- a/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers.go
@@ -21,7 +21,7 @@ func (r *mutationResolver) IngestVEXStatement(ctx context.Context, subject model
 	ingestedVEXStatement, err := r.Backend.IngestVEXStatement(ctx, subject,
 		model.VulnerabilityInputSpec{Type: strings.ToLower(vulnerability.Type), VulnerabilityID: strings.ToLower(vulnerability.VulnerabilityID)},
 		vexStatement)
-	if err == nil {
+	if err != nil {
 		return "", err
 	}
 	return ingestedVEXStatement.ID, err


### PR DESCRIPTION
# Description of the PR

Fix `err` management after having called the backend

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
