### PR TITLE
Move validation checks into resolvers

### DIFF
--- a/internal/testing/testdata/models.go
+++ b/internal/testing/testdata/models.go
@@ -116,7 +116,62 @@ var P2out = &model.Package{
 	}},
 }
 
+var P4 = &model.PkgInputSpec{
+	Type:      "conan",
+	Namespace: ptrfrom.String("openssl.org"),
+	Name:      "openssl",
+	Version:   ptrfrom.String("3.0.3"),
+}
+
 var CB1out = &model.CertifyBad{
 	Subject:       S2out,
 	Justification: "test justification",
 }
+
+var CG1out = &model.CertifyGood{
+	Subject:       P1out,
+	Justification: "test justification one",
+}
+
+var SC1out = &model.CertifyScorecard{
+	Source: S1out,
+	Scorecard: &model.Scorecard{
+		Checks: []*model.ScorecardCheck{},
+		Origin: "test origin",
+	},
+}
+
+var V1 = &model.VulnerabilityInputSpec{
+	Type:            "OSV",
+	VulnerabilityID: "CVE-2014-8140",
+}
+
+var VEX1out = &model.CertifyVEXStatement{
+	ID: "1",
+}
+
+var C1 = &model.VulnerabilityInputSpec{
+	Type:            "cve",
+	VulnerabilityID: "CVE-2019-13110",
+}
+var C1out = &model.VulnerabilityID{
+	VulnerabilityID: "cve-2019-13110",
+}
+
+var C2 = &model.VulnerabilityInputSpec{
+	Type:            "cve",
+	VulnerabilityID: "CVE-2014-8139",
+}
+var C2out = &model.VulnerabilityID{
+	VulnerabilityID: "cve-2014-8139",
+}
+
+var B1 = &model.BuilderInputSpec{
+	URI: "asdf",
+}
+
+var O1 = &model.VulnerabilityInputSpec{
+	Type:            "OSV",
+	VulnerabilityID: "CVE-2014-8140",
+}
+var MAll = model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions}

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -173,10 +173,6 @@ func getScorecardValues(src *model.SourceInputSpec, scorecard *model.ScorecardIn
 // Ingest Scorecards
 
 func (c *arangoClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
-	if len(sources) != len(scorecards) {
-		return nil, fmt.Errorf("uneven source and scorecards for ingestion")
-	}
-
 	var listOfValues []map[string]any
 
 	for i := range sources {

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -174,14 +174,6 @@ func getCertifyVulnQueryValues(pkg *model.PkgInputSpec, vulnerability *model.Vul
 }
 
 func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
-	// TODO (pxp928): move checks to resolver so all backends don't have to implement
-	if len(pkgs) != len(vulnerabilities) {
-		return nil, fmt.Errorf("uneven packages and vulnerabilities for ingestion")
-	}
-	if len(pkgs) != len(certifyVulns) {
-		return nil, fmt.Errorf("uneven packages and certifyVuln for ingestion")
-	}
-
 	var listOfValues []map[string]any
 
 	for i := range certifyVulns {

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -207,10 +207,6 @@ func getHasSBOMQueryValues(pkg *model.PkgInputSpec, artifact *model.ArtifactInpu
 
 func (c *arangoClient) IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error) {
 	if len(subjects.Packages) > 0 {
-		if len(subjects.Packages) != len(hasSBOMs) {
-			return nil, fmt.Errorf("uneven packages and hasSBOMs for ingestion")
-		}
-
 		var listOfValues []map[string]any
 
 		for i := range subjects.Packages {
@@ -314,10 +310,6 @@ func (c *arangoClient) IngestHasSBOMs(ctx context.Context, subjects model.Packag
 		return hasSBOMList, nil
 
 	} else if len(subjects.Artifacts) > 0 {
-
-		if len(subjects.Artifacts) != len(hasSBOMs) {
-			return nil, fmt.Errorf("uneven artifacts and hasSBOMs for ingestion")
-		}
 
 		var listOfValues []map[string]any
 

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -179,16 +179,6 @@ func getSLSAValues(subject model.ArtifactInputSpec, builtFrom []*model.Artifact,
 }
 
 func (c *arangoClient) IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error) {
-	if len(subjects) != len(slsaList) {
-		return nil, fmt.Errorf("uneven subjects and slsa attestation for ingestion")
-	}
-	if len(subjects) != len(builtFromList) {
-		return nil, fmt.Errorf("uneven subjects and built from artifact list for ingestion")
-	}
-	if len(subjects) != len(builtByList) {
-		return nil, fmt.Errorf("uneven subjects and built by for ingestion")
-	}
-
 	builtFromMap := map[string][]*model.Artifact{}
 	var listOfValues []map[string]any
 

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -26,9 +26,6 @@ import (
 )
 
 func (c *arangoClient) HashEqual(ctx context.Context, hashEqualSpec *model.HashEqualSpec) ([]*model.HashEqual, error) {
-	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
-		return nil, fmt.Errorf("cannot specify more than 2 artifacts in HashEquals")
-	}
 	values := map[string]any{}
 	if hashEqualSpec.Artifacts != nil {
 		if len(hashEqualSpec.Artifacts) == 1 {
@@ -167,12 +164,6 @@ func getHashEqualQueryValues(artifact *model.ArtifactInputSpec, equalArtifact *m
 }
 
 func (c *arangoClient) IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]*model.HashEqual, error) {
-	if len(artifacts) != len(otherArtifacts) {
-		return nil, fmt.Errorf("uneven artifacts and other artifacts for ingestion")
-	} else if len(artifacts) != len(hashEquals) {
-		return nil, fmt.Errorf("uneven artifacts and hashEquals for ingestion")
-	}
-
 	var listOfValues []map[string]any
 
 	for i := range artifacts {

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -304,11 +304,6 @@ func getDependencyQueryValues(pkg *model.PkgInputSpec, depPkg *model.PkgInputSpe
 
 func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
 	// TODO(LUMJJB): handle pkgmatchtype
-	if len(pkgs) != len(depPkgs) {
-		return nil, fmt.Errorf("uneven packages and dependent packages for ingestion")
-	} else if len(pkgs) != len(dependencies) {
-		return nil, fmt.Errorf("uneven packages and isDependency for ingestion")
-	}
 
 	var listOfValues []map[string]any
 

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -225,12 +225,6 @@ func getOccurrenceQueryValues(pkg *model.PkgInputSpec, src *model.SourceInputSpe
 
 func (c *arangoClient) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
 	if len(subjects.Packages) > 0 {
-		if len(subjects.Packages) != len(artifacts) {
-			return nil, fmt.Errorf("uneven packages and artifacts for ingestion")
-		} else if len(subjects.Packages) != len(occurrences) {
-			return nil, fmt.Errorf("uneven packages and occurrence for ingestion")
-		}
-
 		var listOfValues []map[string]any
 
 		for i := range subjects.Packages {
@@ -337,12 +331,6 @@ func (c *arangoClient) IngestOccurrences(ctx context.Context, subjects model.Pac
 		return isOccurrenceList, nil
 
 	} else if len(subjects.Sources) > 0 {
-		if len(subjects.Sources) != len(artifacts) {
-			return nil, fmt.Errorf("uneven sources and artifacts for ingestion")
-		} else if len(subjects.Sources) != len(occurrences) {
-			return nil, fmt.Errorf("uneven sources and occurrence for ingestion")
-		}
-
 		var listOfValues []map[string]any
 
 		for i := range subjects.Sources {

--- a/pkg/assembler/backends/ent/backend/dependency.go
+++ b/pkg/assembler/backends/ent/backend/dependency.go
@@ -61,13 +61,6 @@ func (b *EntBackend) IsDependency(ctx context.Context, spec *model.IsDependencyS
 }
 
 func (b *EntBackend) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
-	if len(pkgs) != len(depPkgs) {
-		return nil, Errorf("uneven packages and dependent packages for ingestion")
-	}
-	if len(pkgs) != len(dependencies) {
-		return nil, Errorf("uneven packages and dependencies nodes for ingestion")
-	}
-
 	// TODO: This looks like a good candidate for using BulkCreate()
 
 	var modelIsDependencies []*model.IsDependency

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -25,21 +25,12 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcename"
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func (b *EntBackend) IsOccurrence(ctx context.Context, query *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error) {
-	funcName := "IsOccurrence"
-	if query != nil {
-		if err := helper.ValidatePackageOrSourceQueryFilter(query.Subject); err != nil {
-			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
-		}
-	} else {
-		return nil, nil
-	}
 
 	predicates := []predicate.Occurrence{
 		optionalPredicate(query.ID, IDEQ),
@@ -118,9 +109,6 @@ func (b *EntBackend) IngestOccurrence(ctx context.Context,
 	spec model.IsOccurrenceInputSpec,
 ) (*model.IsOccurrence, error) {
 	funcName := "IngestOccurrence"
-	if err := helper.ValidatePackageOrSourceInput(&subject, "IngestOccurrence"); err != nil {
-		return nil, gqlerror.Errorf("%v :: %s", funcName, err)
-	}
 
 	recordID, err := WithinTX(ctx, b.client, func(ctx context.Context) (*int, error) {
 		tx := ent.TxFromContext(ctx)

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -503,46 +503,6 @@ func (s *Suite) TestOccurrence() {
 			},
 		},
 		{
-			Name:  "Ingest without package",
-			InPkg: []*model.PkgInputSpec{},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					PkgSrc: model.PackageOrSourceInput{
-						Package: p1,
-					},
-					Artifact: a1,
-					Occurrence: &model.IsOccurrenceInputSpec{
-						Justification: "justification",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
-			Name:  "Query error",
-			InPkg: []*model.PkgInputSpec{p1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					PkgSrc: model.PackageOrSourceInput{
-						Package: p1,
-					},
-					Artifact: a1,
-					Occurrence: &model.IsOccurrenceInputSpec{
-						Justification: "justification",
-					},
-				},
-			},
-			Query: &model.IsOccurrenceSpec{
-				Subject: &model.PackageOrSourceSpec{
-					Package: &model.PkgSpec{},
-					Source:  &model.SourceSpec{},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InPkg: []*model.PkgInputSpec{p1},
 			InArt: []*model.ArtifactInputSpec{a1},

--- a/pkg/assembler/backends/ent/backend/sbom.go
+++ b/pkg/assembler/backends/ent/backend/sbom.go
@@ -23,7 +23,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/billofmaterials"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 )
@@ -70,9 +69,6 @@ func (b *EntBackend) HasSBOM(ctx context.Context, spec *model.HasSBOMSpec) ([]*m
 
 func (b *EntBackend) IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, spec model.HasSBOMInputSpec) (*model.HasSbom, error) {
 	funcName := "IngestHasSbom"
-	if err := helper.ValidatePackageOrArtifactInput(&subject, "IngestHasSbom"); err != nil {
-		return nil, Errorf("%v ::  %s", funcName, err)
-	}
 
 	sbomId, err := WithinTX(ctx, b.client, func(ctx context.Context) (*int, error) {
 		client := ent.TxFromContext(ctx)

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -422,23 +422,6 @@ func (s *Suite) Test_HasSBOM() {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Ingest without two subjects",
-			InPkg: []*model.PkgInputSpec{p1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					Sub: model.PackageOrArtifactInput{
-						Package:  p1,
-						Artifact: a1,
-					},
-					Spec: &model.HasSBOMInputSpec{
-						DownloadLocation: "location one",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InPkg: []*model.PkgInputSpec{p1},
 			Calls: []call{

--- a/pkg/assembler/backends/ent/backend/slsa.go
+++ b/pkg/assembler/backends/ent/backend/slsa.go
@@ -68,10 +68,6 @@ func (b *EntBackend) HasSlsa(ctx context.Context, spec *model.HasSLSASpec) ([]*m
 }
 
 func (b *EntBackend) IngestSLSA(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (*model.HasSlsa, error) {
-	if len(builtFrom) < 1 {
-		return nil, fmt.Errorf("must have at least 1 builtFrom")
-	}
-
 	att, err := WithinTX(ctx, b.client, func(ctx context.Context) (*ent.SLSAAttestation, error) {
 		return upsertSLSA(ctx, ent.TxFromContext(ctx), subject, builtFrom, builtBy, slsa)
 	})

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -130,12 +130,6 @@ func upsertHasSourceAt(ctx context.Context, client *ent.Tx, pkg model.PkgInputSp
 }
 
 func (b *EntBackend) Sources(ctx context.Context, filter *model.SourceSpec) ([]*model.Source, error) {
-	if filter != nil && filter.Commit != nil && filter.Tag != nil {
-		if *filter.Commit != "" && *filter.Tag != "" {
-			return nil, Errorf("Passing both commit and tag selectors is an error")
-		}
-	}
-
 	records, err := b.client.SourceName.Query().
 		Where(sourceQuery(filter)).
 		Limit(MaxPageSize).

--- a/pkg/assembler/backends/inmem/certifyGood.go
+++ b/pkg/assembler/backends/inmem/certifyGood.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -60,29 +59,6 @@ func (n *goodLink) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest CertifyGood
 
 func (c *demoClient) IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]*model.CertifyGood, error) {
-	valuesDefined := 0
-	if len(subjects.Packages) > 0 {
-		if len(subjects.Packages) != len(certifyGoods) {
-			return nil, gqlerror.Errorf("uneven packages and certifyGoods for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if len(subjects.Artifacts) > 0 {
-		if len(subjects.Artifacts) != len(certifyGoods) {
-			return nil, gqlerror.Errorf("uneven artifacts and certifyGoods for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if len(subjects.Sources) > 0 {
-		if len(subjects.Sources) != len(certifyGoods) {
-			return nil, gqlerror.Errorf("uneven sources and certifyGoods for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if valuesDefined != 1 {
-		return nil, gqlerror.Errorf("must specify at most packages, artifacts or sources for %v", "IngestCertifyGoods")
-	}
-
 	var modelCertifyGoods []*model.CertifyGood
 
 	for i := range certifyGoods {
@@ -117,9 +93,6 @@ func (c *demoClient) IngestCertifyGood(ctx context.Context, subject model.Packag
 }
 func (c *demoClient) ingestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec, readOnly bool) (*model.CertifyGood, error) {
 	funcName := "IngestCertifyGood"
-	if err := helper.ValidatePackageSourceOrArtifactInput(&subject, "good subject"); err != nil {
-		return nil, err
-	}
 
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
@@ -235,11 +208,6 @@ func (c *demoClient) ingestCertifyGood(ctx context.Context, subject model.Packag
 // Query CertifyGood
 func (c *demoClient) CertifyGood(ctx context.Context, filter *model.CertifyGoodSpec) ([]*model.CertifyGood, error) {
 	funcName := "CertifyGood"
-	if filter != nil {
-		if err := helper.ValidatePackageSourceOrArtifactQueryFilter(filter.Subject); err != nil {
-			return nil, err
-		}
-	}
 
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/assembler/backends/inmem/certifyGood_test.go
+++ b/pkg/assembler/backends/inmem/certifyGood_test.go
@@ -478,48 +478,6 @@ func TestCertifyGood(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Ingest with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source:   s1,
-						Artifact: a1,
-					},
-					CG: &model.CertifyGoodInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
-			Name:  "Query with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source: s1,
-					},
-					CG: &model.CertifyGoodInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			Query: &model.CertifyGoodSpec{
-				Subject: &model.PackageSourceOrArtifactSpec{
-					Package: &model.PkgSpec{
-						Version: ptrfrom.String("2.11.1"),
-					},
-					Artifact: &model.ArtifactSpec{
-						Algorithm: ptrfrom.String("asdf"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query good ID",
 			InSrc: []*model.SourceInputSpec{s1},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/certifyScorecard.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard.go
@@ -56,9 +56,6 @@ func (n *scorecardLink) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest Scorecards
 
 func (c *demoClient) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]*model.CertifyScorecard, error) {
-	if len(sources) != len(scorecards) {
-		return nil, gqlerror.Errorf("uneven source and scorecards for ingestion")
-	}
 	var modelCertifyScorecards []*model.CertifyScorecard
 	for i := range scorecards {
 		scorecard, err := c.IngestScorecard(ctx, *sources[i], *scorecards[i])

--- a/pkg/assembler/backends/inmem/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement_test.go
@@ -729,54 +729,6 @@ func TestVEX(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:   "Ingest double sub",
-			InPkg:  []*model.PkgInputSpec{p1},
-			InArt:  []*model.ArtifactInputSpec{a1},
-			InVuln: []*model.VulnerabilityInputSpec{o1},
-			Calls: []call{
-				{
-					Sub: model.PackageOrArtifactInput{
-						Package:  p1,
-						Artifact: a1,
-					},
-					Vuln: o1,
-					In: &model.VexStatementInputSpec{
-						VexJustification: "test justification",
-						KnownSince:       time.Unix(1e9, 0),
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
-			Name:   "Query double sub",
-			InPkg:  []*model.PkgInputSpec{p1},
-			InVuln: []*model.VulnerabilityInputSpec{o1},
-			Calls: []call{
-				{
-					Sub: model.PackageOrArtifactInput{
-						Package: p1,
-					},
-					Vuln: o1,
-					In: &model.VexStatementInputSpec{
-						VexJustification: "test justification",
-						KnownSince:       time.Unix(1e9, 0),
-					},
-				},
-			},
-			Query: &model.CertifyVEXStatementSpec{
-				Subject: &model.PackageOrArtifactSpec{
-					Package: &model.PkgSpec{
-						Version: ptrfrom.String(""),
-					},
-					Artifact: &model.ArtifactSpec{
-						Algorithm: ptrfrom.String("sha256"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:   "Query bad id",
 			InPkg:  []*model.PkgInputSpec{p1},
 			InVuln: []*model.VulnerabilityInputSpec{o1},

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -61,13 +61,6 @@ func (n *certifyVulnerabilityLink) BuildModelNode(c *demoClient) (model.Node, er
 
 // Ingest CertifyVuln
 func (c *demoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]*model.CertifyVuln, error) {
-	// TODO (pxp928): move checks to resolver so all backends don't have to implement
-	if len(pkgs) != len(vulnerabilities) {
-		return nil, gqlerror.Errorf("uneven packages and vulnerabilities for ingestion")
-	}
-	if len(pkgs) != len(certifyVulns) {
-		return nil, gqlerror.Errorf("uneven packages and certifyVuln for ingestion")
-	}
 	var modelCertifyVulnList []*model.CertifyVuln
 	for i := range certifyVulns {
 		certifyVuln, err := c.IngestCertifyVuln(ctx, *pkgs[i], *vulnerabilities[i], *certifyVulns[i])

--- a/pkg/assembler/backends/inmem/certifyVuln_test.go
+++ b/pkg/assembler/backends/inmem/certifyVuln_test.go
@@ -1058,32 +1058,6 @@ func TestIngestCertifyVulns(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name:  "Ingest without vuln",
-			InPkg: []*model.PkgInputSpec{p2},
-			Calls: []call{
-				{
-					Pkgs:         []*model.PkgInputSpec{p2},
-					Vulns:        []*model.VulnerabilityInputSpec{},
-					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
-				},
-			},
-			Query:        &model.CertifyVulnSpec{},
-			ExpIngestErr: true,
-		},
-		{
-			Name:  "Ingest missing pkg",
-			InPkg: []*model.PkgInputSpec{},
-			Calls: []call{
-				{
-					Pkgs:         []*model.PkgInputSpec{},
-					Vulns:        []*model.VulnerabilityInputSpec{},
-					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
-				},
-			},
-			Query:        &model.CertifyVulnSpec{},
-			ExpIngestErr: true,
-		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
 		return strings.Compare(".ID", p[len(p)-1].String()) == 0

--- a/pkg/assembler/backends/inmem/hasMetadata.go
+++ b/pkg/assembler/backends/inmem/hasMetadata.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -68,9 +67,6 @@ func (c *demoClient) IngestHasMetadata(ctx context.Context, subject model.Packag
 
 func (c *demoClient) ingestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec, readOnly bool) (*model.HasMetadata, error) {
 	funcName := "IngestHasMetadata"
-	if err := helper.ValidatePackageSourceOrArtifactInput(&subject, "HasMetadata subject"); err != nil {
-		return nil, err
-	}
 
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
@@ -191,11 +187,6 @@ func (c *demoClient) ingestHasMetadata(ctx context.Context, subject model.Packag
 // Query HasMetadata
 func (c *demoClient) HasMetadata(ctx context.Context, filter *model.HasMetadataSpec) ([]*model.HasMetadata, error) {
 	funcName := "HasMetadata"
-	if filter != nil {
-		if err := helper.ValidatePackageSourceOrArtifactQueryFilter(filter.Subject); err != nil {
-			return nil, err
-		}
-	}
 
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/assembler/backends/inmem/hasMetadata_test.go
+++ b/pkg/assembler/backends/inmem/hasMetadata_test.go
@@ -600,48 +600,6 @@ func TestHasMetadata(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Ingest with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source:   s1,
-						Artifact: a1,
-					},
-					HM: &model.HasMetadataInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
-			Name:  "Query with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source: s1,
-					},
-					HM: &model.HasMetadataInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			Query: &model.HasMetadataSpec{
-				Subject: &model.PackageSourceOrArtifactSpec{
-					Package: &model.PkgSpec{
-						Version: ptrfrom.String("2.11.1"),
-					},
-					Artifact: &model.ArtifactSpec{
-						Algorithm: ptrfrom.String("asdf"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query good ID",
 			InSrc: []*model.SourceInputSpec{s1},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -58,23 +57,6 @@ func (n *hasSBOMStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest HasSBOM
 
 func (c *demoClient) IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error) {
-	valuesDefined := 0
-	if len(subjects.Packages) > 0 {
-		if len(subjects.Packages) != len(hasSBOMs) {
-			return nil, gqlerror.Errorf("uneven packages and hasSBOMs for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if len(subjects.Artifacts) > 0 {
-		if len(subjects.Artifacts) != len(hasSBOMs) {
-			return nil, gqlerror.Errorf("uneven artifact and hasSBOMs for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if valuesDefined != 1 {
-		return nil, gqlerror.Errorf("must specify at most packages or artifacts for %v", "IngestHasSBOMs")
-	}
-
 	var modelHasSboms []*model.HasSbom
 
 	for i := range hasSBOMs {
@@ -104,9 +86,6 @@ func (c *demoClient) IngestHasSbom(ctx context.Context, subject model.PackageOrA
 
 func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, input model.HasSBOMInputSpec, readOnly bool) (*model.HasSbom, error) {
 	funcName := "IngestHasSbom"
-	if err := helper.ValidatePackageOrArtifactInput(&subject, "IngestHasSbom"); err != nil {
-		return nil, gqlerror.Errorf("%v ::  %s", funcName, err)
-	}
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
 
@@ -215,12 +194,6 @@ func (c *demoClient) convHasSBOM(in *hasSBOMStruct) (*model.HasSbom, error) {
 
 func (c *demoClient) HasSBOM(ctx context.Context, filter *model.HasSBOMSpec) ([]*model.HasSbom, error) {
 	funcName := "HasSBOM"
-	if filter != nil {
-		if err := helper.ValidatePackageOrArtifactQueryFilter(filter.Subject); err != nil {
-			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
-		}
-	}
-
 	c.m.RLock()
 	defer c.m.RUnlock()
 

--- a/pkg/assembler/backends/inmem/hasSBOM_test.go
+++ b/pkg/assembler/backends/inmem/hasSBOM_test.go
@@ -423,23 +423,6 @@ func TestHasSBOM(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Ingest without two subjects",
-			InPkg: []*model.PkgInputSpec{p1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					Sub: model.PackageOrArtifactInput{
-						Package:  p1,
-						Artifact: a1,
-					},
-					HS: &model.HasSBOMInputSpec{
-						DownloadLocation: "location one",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InPkg: []*model.PkgInputSpec{p1},
 			Calls: []call{
@@ -530,7 +513,7 @@ func TestHasSBOM(t *testing.T) {
 	}
 }
 
-func TestIngestHasSBOM(t *testing.T) {
+func TestIngestHasSBOMs(t *testing.T) {
 	type call struct {
 		Sub model.PackageOrArtifactInputs
 		HS  []*model.HasSBOMInputSpec

--- a/pkg/assembler/backends/inmem/hasSLSA.go
+++ b/pkg/assembler/backends/inmem/hasSLSA.go
@@ -159,15 +159,6 @@ func matchSLSAPreds(haves []*model.SLSAPredicate, wants []*model.SLSAPredicateSp
 // Ingest HasSlsa
 
 func (c *demoClient) IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]*model.HasSlsa, error) {
-	if len(subjects) != len(slsaList) {
-		return nil, gqlerror.Errorf("uneven subjects and slsa attestation for ingestion")
-	}
-	if len(subjects) != len(builtFromList) {
-		return nil, gqlerror.Errorf("uneven subjects and built from artifact list for ingestion")
-	}
-	if len(subjects) != len(builtByList) {
-		return nil, gqlerror.Errorf("uneven subjects and built by for ingestion")
-	}
 	var modelHasSLSAList []*model.HasSlsa
 	for i := range subjects {
 		hasSLSA, err := c.IngestSLSA(ctx, *subjects[i], builtFromList[i], *builtByList[i], *slsaList[i])
@@ -190,9 +181,6 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 	builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec, readOnly bool) (
 	*model.HasSlsa, error) {
 
-	if len(builtFrom) < 1 {
-		return nil, gqlerror.Errorf("IngestSLSA :: Must have at least 1 builtFrom")
-	}
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
 

--- a/pkg/assembler/backends/inmem/hasSLSA_test.go
+++ b/pkg/assembler/backends/inmem/hasSLSA_test.go
@@ -715,22 +715,6 @@ func TestIngestHasSLSAs(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name:  "Ingest no Materials 1",
-			InArt: []*model.ArtifactInputSpec{a1},
-			InBld: []*model.BuilderInputSpec{b1},
-			Calls: []call{
-				{
-					Sub: []*model.ArtifactInputSpec{a1},
-					BF:  [][]*model.ArtifactInputSpec{[]*model.ArtifactInputSpec{}},
-					BB:  []*model.BuilderInputSpec{b1},
-					SLSA: []*model.SLSAInputSpec{
-						{},
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
 		return strings.Compare(".ID", p[len(p)-1].String()) == 0

--- a/pkg/assembler/backends/inmem/hashEqual.go
+++ b/pkg/assembler/backends/inmem/hashEqual.go
@@ -75,13 +75,6 @@ func (n *hashEqualStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest HashEqual
 
 func (c *demoClient) IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]*model.HashEqual, error) {
-	if len(artifacts) != len(otherArtifacts) {
-		return nil, gqlerror.Errorf("uneven artifacts and other artifacts for ingestion")
-	}
-	if len(artifacts) != len(hashEquals) {
-		return nil, gqlerror.Errorf("uneven artifacts and hashEquals nodes for ingestion")
-	}
-
 	var modelHashEquals []*model.HashEqual
 	for i := range hashEquals {
 		hashEqual, err := c.IngestHashEqual(ctx, *artifacts[i], *otherArtifacts[i], *hashEquals[i])
@@ -201,10 +194,6 @@ func (c *demoClient) matchArtifacts(filter []*model.ArtifactSpec, value []uint32
 
 func (c *demoClient) HashEqual(ctx context.Context, filter *model.HashEqualSpec) ([]*model.HashEqual, error) {
 	funcName := "HashEqual"
-	if len(filter.Artifacts) > 2 {
-		return nil, gqlerror.Errorf(
-			"%v :: Provided spec has too many Artifacts", funcName)
-	}
 	c.m.RLock()
 	defer c.m.RUnlock()
 	if filter.ID != nil {

--- a/pkg/assembler/backends/inmem/hashEqual_test.go
+++ b/pkg/assembler/backends/inmem/hashEqual_test.go
@@ -384,41 +384,6 @@ func TestHashEqual(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Query three",
-			InArt: []*model.ArtifactInputSpec{a1, a2, a3},
-			Calls: []call{
-				{
-					A1: a1,
-					A2: a2,
-					HE: &model.HashEqualInputSpec{},
-				},
-				{
-					A1: a2,
-					A2: a3,
-					HE: &model.HashEqualInputSpec{},
-				},
-				{
-					A1: a1,
-					A2: a3,
-					HE: &model.HashEqualInputSpec{},
-				},
-			},
-			Query: &model.HashEqualSpec{
-				Artifacts: []*model.ArtifactSpec{
-					{
-						Algorithm: ptrfrom.String("gitHash"),
-					},
-					{
-						Digest: ptrfrom.String("6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"),
-					},
-					{
-						Digest: ptrfrom.String("asdf"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InArt: []*model.ArtifactInputSpec{a1, a2, a3},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -54,12 +54,6 @@ func (n *isDependencyLink) BuildModelNode(c *demoClient) (model.Node, error) {
 
 func (c *demoClient) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]*model.IsDependency, error) {
 	// TODO(LUMJJB): match flags
-	if len(pkgs) != len(depPkgs) {
-		return nil, gqlerror.Errorf("uneven packages and dependent packages for ingestion")
-	}
-	if len(pkgs) != len(dependencies) {
-		return nil, gqlerror.Errorf("uneven packages and dependencies nodes for ingestion")
-	}
 
 	var modelIsDependencies []*model.IsDependency
 	for i := range dependencies {

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -99,29 +98,6 @@ func (n *isOccurrenceStruct) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest IngestOccurrences
 
 func (c *demoClient) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
-	valuesDefined := 0
-	if len(subjects.Packages) > 0 {
-		if len(subjects.Packages) != len(artifacts) {
-			return nil, gqlerror.Errorf("uneven packages and artifacts for ingestion")
-		}
-		if len(subjects.Packages) != len(occurrences) {
-			return nil, gqlerror.Errorf("uneven packages and occurrence for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if len(subjects.Sources) > 0 {
-		if len(subjects.Sources) != len(artifacts) {
-			return nil, gqlerror.Errorf("uneven Sources and artifacts for ingestion")
-		}
-		if len(subjects.Sources) != len(occurrences) {
-			return nil, gqlerror.Errorf("uneven Sources and occurrence for ingestion")
-		}
-		valuesDefined = valuesDefined + 1
-	}
-	if valuesDefined != 1 {
-		return nil, gqlerror.Errorf("must specify at most packages or sources for %v", "IngestOccurrences")
-	}
-
 	var modelIsOccurrences []*model.IsOccurrence
 
 	for i := range occurrences {
@@ -153,9 +129,6 @@ func (c *demoClient) IngestOccurrence(ctx context.Context, subject model.Package
 
 func (c *demoClient) ingestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec, readOnly bool) (*model.IsOccurrence, error) {
 	funcName := "IngestOccurrence"
-	if err := helper.ValidatePackageOrSourceInput(&subject, "IngestOccurrence"); err != nil {
-		return nil, gqlerror.Errorf("%v ::  %s", funcName, err)
-	}
 
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
@@ -288,11 +261,6 @@ func (c *demoClient) artifactMatch(aID uint32, artifactSpec *model.ArtifactSpec)
 
 func (c *demoClient) IsOccurrence(ctx context.Context, filter *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error) {
 	funcName := "IsOccurrence"
-	if filter != nil {
-		if err := helper.ValidatePackageOrSourceQueryFilter(filter.Subject); err != nil {
-			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
-		}
-	}
 
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/assembler/backends/inmem/isOccurrence_test.go
+++ b/pkg/assembler/backends/inmem/isOccurrence_test.go
@@ -510,29 +510,6 @@ func TestOccurrence(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Query error",
-			InPkg: []*model.PkgInputSpec{p1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				call{
-					PkgSrc: model.PackageOrSourceInput{
-						Package: p1,
-					},
-					Artifact: a1,
-					Occurrence: &model.IsOccurrenceInputSpec{
-						Justification: "justification",
-					},
-				},
-			},
-			Query: &model.IsOccurrenceSpec{
-				Subject: &model.PackageOrSourceSpec{
-					Package: &model.PkgSpec{},
-					Source:  &model.SourceSpec{},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InPkg: []*model.PkgInputSpec{p1},
 			InArt: []*model.ArtifactInputSpec{a1},

--- a/pkg/assembler/backends/inmem/path.go
+++ b/pkg/assembler/backends/inmem/path.go
@@ -39,10 +39,6 @@ func processUsingOnly(usingOnly []model.Edge) edgeMap {
 }
 
 func (c *demoClient) Path(ctx context.Context, source string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error) {
-	if maxPathLength <= 0 {
-		return nil, gqlerror.Errorf("maxPathLength argument must be positive, got %d", maxPathLength)
-	}
-
 	sourceID, err := strconv.ParseUint(source, 10, 32)
 	if err != nil {
 		return nil, err

--- a/pkg/assembler/backends/inmem/pkgEqual.go
+++ b/pkg/assembler/backends/inmem/pkgEqual.go
@@ -196,9 +196,6 @@ func (c *demoClient) ingestPkgEqual(ctx context.Context, pkg model.PkgInputSpec,
 
 func (c *demoClient) PkgEqual(ctx context.Context, filter *model.PkgEqualSpec) ([]*model.PkgEqual, error) {
 	funcName := "PkgEqual"
-	if filter != nil && len(filter.Packages) > 2 {
-		return nil, gqlerror.Errorf("%v :: too many packages in query, max 2, got: %v", funcName, len(filter.Packages))
-	}
 	c.m.RLock()
 	defer c.m.RUnlock()
 	if filter.ID != nil {

--- a/pkg/assembler/backends/inmem/pkgEqual_test.go
+++ b/pkg/assembler/backends/inmem/pkgEqual_test.go
@@ -384,41 +384,6 @@ func TestPkgEqual(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Query three",
-			InPkg: []*model.PkgInputSpec{p1, p2, p3},
-			Calls: []call{
-				{
-					P1: p1,
-					P2: p2,
-					HE: &model.PkgEqualInputSpec{},
-				},
-				{
-					P1: p2,
-					P2: p3,
-					HE: &model.PkgEqualInputSpec{},
-				},
-				{
-					P1: p1,
-					P2: p3,
-					HE: &model.PkgEqualInputSpec{},
-				},
-			},
-			Query: &model.PkgEqualSpec{
-				Packages: []*model.PkgSpec{
-					{
-						Name: ptrfrom.String("somename"),
-					},
-					{
-						Version: ptrfrom.String("1.2.3"),
-					},
-					{
-						Type: ptrfrom.String("asdf"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query bad ID",
 			InPkg: []*model.PkgInputSpec{p1, p2, p3},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/pointOfContact.go
+++ b/pkg/assembler/backends/inmem/pointOfContact.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -68,9 +67,6 @@ func (c *demoClient) IngestPointOfContact(ctx context.Context, subject model.Pac
 
 func (c *demoClient) ingestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, pointOfContact model.PointOfContactInputSpec, readOnly bool) (*model.PointOfContact, error) {
 	funcName := "IngestPointOfContact"
-	if err := helper.ValidatePackageSourceOrArtifactInput(&subject, "PointOfContact subject"); err != nil {
-		return nil, err
-	}
 
 	lock(&c.m, readOnly)
 	defer unlock(&c.m, readOnly)
@@ -191,11 +187,6 @@ func (c *demoClient) ingestPointOfContact(ctx context.Context, subject model.Pac
 // Query PointOfContact
 func (c *demoClient) PointOfContact(ctx context.Context, filter *model.PointOfContactSpec) ([]*model.PointOfContact, error) {
 	funcName := "PointOfContact"
-	if filter != nil {
-		if err := helper.ValidatePackageSourceOrArtifactQueryFilter(filter.Subject); err != nil {
-			return nil, err
-		}
-	}
 
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/assembler/backends/inmem/pointOfContact_test.go
+++ b/pkg/assembler/backends/inmem/pointOfContact_test.go
@@ -600,48 +600,6 @@ func TestPointOfContact(t *testing.T) {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Ingest with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			InArt: []*model.ArtifactInputSpec{a1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source:   s1,
-						Artifact: a1,
-					},
-					HM: &model.PointOfContactInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			ExpIngestErr: true,
-		},
-		{
-			Name:  "Query with two subjects",
-			InSrc: []*model.SourceInputSpec{s1},
-			Calls: []call{
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Source: s1,
-					},
-					HM: &model.PointOfContactInputSpec{
-						Justification: "test justification",
-					},
-				},
-			},
-			Query: &model.PointOfContactSpec{
-				Subject: &model.PackageSourceOrArtifactSpec{
-					Package: &model.PkgSpec{
-						Version: ptrfrom.String("2.11.1"),
-					},
-					Artifact: &model.ArtifactSpec{
-						Algorithm: ptrfrom.String("asdf"),
-					},
-				},
-			},
-			ExpQueryErr: true,
-		},
-		{
 			Name:  "Query good ID",
 			InSrc: []*model.SourceInputSpec{s1},
 			Calls: []call{

--- a/pkg/assembler/backends/inmem/src.go
+++ b/pkg/assembler/backends/inmem/src.go
@@ -263,11 +263,6 @@ func duplicateSrcName(names srcNameList, input model.SourceInputSpec) (bool, *sr
 func (c *demoClient) Sources(ctx context.Context, filter *model.SourceSpec) ([]*model.Source, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
-	if filter != nil && filter.Commit != nil && filter.Tag != nil {
-		if *filter.Commit != "" && *filter.Tag != "" {
-			return nil, gqlerror.Errorf("Passing both commit and tag selectors is an error")
-		}
-	}
 	if filter != nil && filter.ID != nil {
 		id, err := strconv.ParseUint(*filter.ID, 10, 32)
 		if err != nil {

--- a/pkg/assembler/backends/inmem/vulnEqual.go
+++ b/pkg/assembler/backends/inmem/vulnEqual.go
@@ -131,9 +131,6 @@ func (c *demoClient) convVulnEqual(in *vulnerabilityEqualLink) (*model.VulnEqual
 // Query IsVulnerability
 func (c *demoClient) VulnEqual(ctx context.Context, filter *model.VulnEqualSpec) ([]*model.VulnEqual, error) {
 	funcName := "VulnEqual"
-	if filter != nil && len(filter.Vulnerabilities) > 2 {
-		return nil, gqlerror.Errorf("%v :: too many vulnerabilities in query, max 2, got: %v", funcName, len(filter.Vulnerabilities))
-	}
 	c.m.RLock()
 	defer c.m.RUnlock()
 	if filter.ID != nil {

--- a/pkg/assembler/backends/inmem/vulnEqual_test.go
+++ b/pkg/assembler/backends/inmem/vulnEqual_test.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func TestVulEqual(t *testing.T) {
+func TestVulnEqual(t *testing.T) {
 	type call struct {
 		Vuln      *model.VulnerabilityInputSpec
 		OtherVuln *model.VulnerabilityInputSpec

--- a/pkg/assembler/backends/inmem/vulnMetadata.go
+++ b/pkg/assembler/backends/inmem/vulnMetadata.go
@@ -53,10 +53,6 @@ func (n *vulnerabilityMetadataLink) BuildModelNode(c *demoClient) (model.Node, e
 
 // Ingest VulnerabilityMetadata
 func (c *demoClient) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
-	// TODO (pxp928): move checks to resolver so all backends don't have to implement
-	if len(vulnerabilities) != len(vulnerabilityMetadatas) {
-		return nil, gqlerror.Errorf("uneven vulnerabilities and vulnerabilityMetadatas for ingestion")
-	}
 	var modelVulnMetadataIDList []string
 	for i := range vulnerabilityMetadatas {
 		vulnMetadata, err := c.IngestVulnerabilityMetadata(ctx, *vulnerabilities[i], *vulnerabilityMetadatas[i])

--- a/pkg/assembler/backends/neo4j/certifyGood.go
+++ b/pkg/assembler/backends/neo4j/certifyGood.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/dbtype"
@@ -33,13 +32,7 @@ func (c *neo4jClient) CertifyGood(ctx context.Context, certifyGoodSpec *model.Ce
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	// TODO: Fix validation
 	queryAll := true
-	// queryAll, err := helper.ValidatePackageSourceOrArtifactQueryInput(certifyGoodSpec.Subject)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	aggregateCertifyGood := []*model.CertifyGood{}
 
 	if queryAll || (certifyGoodSpec.Subject != nil && certifyGoodSpec.Subject.Package != nil) {
@@ -265,11 +258,6 @@ func generateModelCertifyGood(subject model.PackageSourceOrArtifact, justificati
 // ingest certifyGood
 
 func (c *neo4jClient) IngestCertifyGood(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyGood model.CertifyGoodInputSpec) (*model.CertifyGood, error) {
-
-	err := helper.ValidatePackageSourceOrArtifactInput(&subject, "IngestCertifyGood")
-	if err != nil {
-		return nil, err
-	}
 	panic(fmt.Errorf("not implemented: IngestCertifyGood - IngestCertifyGood"))
 }
 

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -33,13 +33,7 @@ const (
 // TODO: noe4j backend does not match the schema. This needs updating before use!
 func (c *neo4jClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpec) ([]*model.HasSbom, error) {
 
-	// TODO: Fix validation
 	queryAll := true
-	// queryAll, err := helper.ValidatePackageOrSourceQueryInput(hasSBOMSpec.Subject)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 

--- a/pkg/assembler/backends/neo4j/hashEqual.go
+++ b/pkg/assembler/backends/neo4j/hashEqual.go
@@ -28,10 +28,6 @@ import (
 
 func (c *neo4jClient) HashEqual(ctx context.Context, hashEqualSpec *model.HashEqualSpec) ([]*model.HashEqual, error) {
 
-	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
-		return nil, gqlerror.Errorf("cannot specify more than 2 artifacts in HashEquals")
-	}
-
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 

--- a/pkg/assembler/backends/neo4j/isOccurrence.go
+++ b/pkg/assembler/backends/neo4j/isOccurrence.go
@@ -34,13 +34,7 @@ func (c *neo4jClient) IsOccurrence(ctx context.Context, isOccurrenceSpec *model.
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	// TODO: Fix validation
 	queryAll := true
-	// queryAll, err := helper.ValidatePackageOrSourceQueryInput(isOccurrenceSpec.Subject)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	aggregateIsOccurrence := []*model.IsOccurrence{}
 
 	if queryAll || (isOccurrenceSpec.Subject != nil && isOccurrenceSpec.Subject.Package != nil) {
@@ -217,11 +211,6 @@ func (c *neo4jClient) IngestOccurrence(ctx context.Context, subject model.Packag
 
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
-
-	err := helper.ValidatePackageOrSourceInput(&subject, "IngestOccurrence")
-	if err != nil {
-		return nil, err
-	}
 
 	var sb strings.Builder
 	var firstMatch bool = true

--- a/pkg/assembler/backends/neo4j/pkgEqual.go
+++ b/pkg/assembler/backends/neo4j/pkgEqual.go
@@ -30,10 +30,6 @@ import (
 
 func (c *neo4jClient) PkgEqual(ctx context.Context, pkgEqualSpec *model.PkgEqualSpec) ([]*model.PkgEqual, error) {
 
-	if pkgEqualSpec.Packages != nil && len(pkgEqualSpec.Packages) > 2 {
-		return nil, gqlerror.Errorf("cannot specify more than 2 packages in PkgEqual")
-	}
-
 	session := c.driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 

--- a/pkg/assembler/graphql/resolvers/certifyGood.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/certifyGood.resolvers_test.go
@@ -1,0 +1,277 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestCertifyGood(t *testing.T) {
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match model.MatchFlags
+		CG    *model.CertifyGoodInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two subjects",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source:   testdata.S1,
+						Artifact: testdata.A1,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestCertifyGood(ctx, o.Sub, &o.Match, *o.CG).
+					Return(testdata.CG1out, nil).
+					Times(times)
+				_, err := r.Mutation().IngestCertifyGood(ctx, o.Sub, o.Match, *o.CG)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIngestCertifyGoods(t *testing.T) {
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInputs
+		Match model.MatchFlags
+		CG    []*model.CertifyGoodInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two packages and one CertifyGood",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					Match: model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with two sources and one CertifyGood",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1, testdata.S2},
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with two artifacts and one CertifyGood",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with one package, one source, one artifact and one CertifyGood",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages:  []*model.PkgInputSpec{testdata.P1},
+						Sources:   []*model.SourceInputSpec{testdata.S1},
+						Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath All Version",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+					},
+					Match: model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestCertifyGoods(ctx, o.Sub, &o.Match, o.CG).
+					Return([]*model.CertifyGood{testdata.CG1out}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestCertifyGoods(ctx, o.Sub, o.Match, o.CG)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestCertifyGood(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.CertifyGoodSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with two subjects",
+			Query: &model.CertifyGoodSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.CertifyGoodSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				CertifyGood(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().CertifyGood(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers.go
@@ -6,6 +6,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -21,8 +22,12 @@ func (r *mutationResolver) IngestScorecard(ctx context.Context, source model.Sou
 
 // IngestScorecards is the resolver for the ingestScorecards field.
 func (r *mutationResolver) IngestScorecards(ctx context.Context, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) ([]string, error) {
-	ingestedScorecards, err := r.Backend.IngestScorecards(ctx, sources, scorecards)
+	funcName := "IngestScorecards"
 	ingestedScorecardsIDS := []string{}
+	if len(sources) != len(scorecards) {
+		return ingestedScorecardsIDS, fmt.Errorf("%v :: uneven source and scorecards for ingestion", funcName)
+	}
+	ingestedScorecards, err := r.Backend.IngestScorecards(ctx, sources, scorecards)
 	if err == nil {
 		for _, scorecard := range ingestedScorecards {
 			ingestedScorecardsIDS = append(ingestedScorecardsIDS, scorecard.ID)

--- a/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/certifyScorecard.resolvers_test.go
@@ -1,0 +1,96 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestScorecards(t *testing.T) {
+	type call struct {
+		Src []*model.SourceInputSpec
+		SC  []*model.ScorecardInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two sources and one Scorecard",
+			Calls: []call{
+				{
+					Src: []*model.SourceInputSpec{testdata.S1, testdata.S2},
+					SC: []*model.ScorecardInputSpec{
+						{
+							Origin:    "test origin",
+							Collector: "test collector",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Src: []*model.SourceInputSpec{testdata.S1},
+					SC: []*model.ScorecardInputSpec{
+						{
+							Origin:    "test origin",
+							Collector: "test collector",
+						},
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestScorecards(ctx, o.Src, o.SC).
+					Return([]*model.CertifyScorecard{testdata.SC1out}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestScorecards(ctx, o.Src, o.SC)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/certifyVEXStatement.resolvers_test.go
@@ -1,0 +1,219 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestVEXStatement(t *testing.T) {
+	type call struct {
+		Sub  model.PackageOrArtifactInput
+		Vuln *model.VulnerabilityInputSpec
+		In   *model.VexStatementInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest double sub",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package:  testdata.P1,
+						Artifact: testdata.A1,
+					},
+					Vuln: testdata.V1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest status-not_affected justification-not_provided statement-empty",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.V1,
+					In: &model.VexStatementInputSpec{
+						Status:           model.VexStatusNotAffected,
+						VexJustification: model.VexJustificationNotProvided,
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest status-affected justification-not_provided statement-empty",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.V1,
+					In: &model.VexStatementInputSpec{
+						Status:           model.VexStatusAffected,
+						VexJustification: model.VexJustificationNotProvided,
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest vulnerability NoVuln",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: &model.VulnerabilityInputSpec{
+						Type: "NoVuln",
+					},
+					In: &model.VexStatementInputSpec{
+						Status:           model.VexStatusAffected,
+						VexJustification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.V1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestVEXStatement(ctx, o.Sub, gomock.Any(), *o.In).
+					Return(testdata.VEX1out, nil).
+					Times(times)
+				_, err := r.Mutation().IngestVEXStatement(ctx, o.Sub, *o.Vuln, *o.In)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestCertifyVEXStatement(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.CertifyVEXStatementSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query double sub",
+			Query: &model.CertifyVEXStatementSpec{
+				Subject: &model.PackageOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String(""),
+					},
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha256"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.CertifyVEXStatementSpec{
+				Subject: &model.PackageOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha256"),
+					},
+				},
+			},
+			ExpQueryErr: false,
+		},
+		{
+			Name: "Happy path with Vulnerability",
+			Query: &model.CertifyVEXStatementSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type:            ptrfrom.String("CVE"),
+					VulnerabilityID: ptrfrom.String("CVE-2014-8140"),
+				},
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				CertifyVEXStatement(ctx, gomock.Any()).
+				Times(times)
+			_, err := r.Query().CertifyVEXStatement(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -26,6 +26,15 @@ func (r *mutationResolver) IngestCertifyVuln(ctx context.Context, pkg model.PkgI
 
 // IngestCertifyVulns is the resolver for the ingestCertifyVulns field.
 func (r *mutationResolver) IngestCertifyVulns(ctx context.Context, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) ([]string, error) {
+	funcName := "IngestCertifyVulns"
+	ingestedCertifyVulnsIDS := []string{}
+	if len(pkgs) != len(vulnerabilities) {
+		return ingestedCertifyVulnsIDS, gqlerror.Errorf("%v :: uneven packages and vulnerabilities for ingestion", funcName)
+	}
+	if len(pkgs) != len(certifyVulns) {
+		return ingestedCertifyVulnsIDS, gqlerror.Errorf("%v :: uneven packages and certifyVuln for ingestion", funcName)
+	}
+
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 	var lowercaseVulnInputList []*model.VulnerabilityInputSpec
 	for _, v := range vulnerabilities {
@@ -36,7 +45,6 @@ func (r *mutationResolver) IngestCertifyVulns(ctx context.Context, pkgs []*model
 		lowercaseVulnInputList = append(lowercaseVulnInputList, &lowercaseVulnInput)
 	}
 	ingestedCertifyVulns, err := r.Backend.IngestCertifyVulns(ctx, pkgs, lowercaseVulnInputList, certifyVulns)
-	ingestedCertifyVulnsIDS := []string{}
 	if err == nil {
 		for _, certifyVuln := range ingestedCertifyVulns {
 			ingestedCertifyVulnsIDS = append(ingestedCertifyVulnsIDS, certifyVuln.ID)

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers_test.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+var t1, _ = time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")
+
+func TestIngestCertifyVulns(t *testing.T) {
+	type call struct {
+		Pkgs         []*model.PkgInputSpec
+		Vulns        []*model.VulnerabilityInputSpec
+		CertifyVulns []*model.ScanMetadataInput
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest without vuln",
+			Calls: []call{
+				{
+					Pkgs:         []*model.PkgInputSpec{testdata.P2},
+					Vulns:        []*model.VulnerabilityInputSpec{},
+					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest missing pkg",
+			Calls: []call{
+				{
+					Pkgs:         []*model.PkgInputSpec{},
+					Vulns:        []*model.VulnerabilityInputSpec{},
+					CertifyVulns: []*model.ScanMetadataInput{&model.ScanMetadataInput{}},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Pkgs:  []*model.PkgInputSpec{testdata.P2, testdata.P1},
+					Vulns: []*model.VulnerabilityInputSpec{testdata.C1, testdata.C2},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    t1,
+						},
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestCertifyVulns(ctx, o.Pkgs, gomock.Any(), o.CertifyVulns).
+					//Return([]*model.CertifyScorecard{testdata.SC1out}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestCertifyVulns(ctx, o.Pkgs, o.Vulns, o.CertifyVulns)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/contact.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/contact.resolvers.go
@@ -7,11 +7,17 @@ package resolvers
 import (
 	"context"
 
+	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestPointOfContact is the resolver for the ingestPointOfContact field.
 func (r *mutationResolver) IngestPointOfContact(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) (string, error) {
+	funcName := "IngestPointOfContact"
+	if err := helper.ValidatePackageSourceOrArtifactInput(&subject, funcName); err != nil {
+		return "", gqlerror.Errorf("%v :: %s", funcName, err)
+	}
 	ingestedPOC, err := r.Backend.IngestPointOfContact(ctx, subject, &pkgMatchType, pointOfContact)
 	if err != nil {
 		return "", err
@@ -21,5 +27,8 @@ func (r *mutationResolver) IngestPointOfContact(ctx context.Context, subject mod
 
 // PointOfContact is the resolver for the PointOfContact field.
 func (r *queryResolver) PointOfContact(ctx context.Context, pointOfContactSpec model.PointOfContactSpec) ([]*model.PointOfContact, error) {
+	if err := helper.ValidatePackageSourceOrArtifactQueryFilter(pointOfContactSpec.Subject); err != nil {
+		return nil, gqlerror.Errorf("PointOfContact :: %s", err)
+	}
 	return r.Backend.PointOfContact(ctx, &pointOfContactSpec)
 }

--- a/pkg/assembler/graphql/resolvers/contact.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/contact.resolvers_test.go
@@ -1,0 +1,154 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestPointOfContact(t *testing.T) {
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match model.MatchFlags
+		HM    *model.PointOfContactInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two subjects",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source:   testdata.S1,
+						Artifact: testdata.A1,
+					},
+					HM: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestPointOfContact(ctx, o.Sub, &o.Match, *o.HM).
+					Return(&model.PointOfContact{ID: "a"}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestPointOfContact(ctx, o.Sub, o.Match, *o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestPointOfContact(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.PointOfContactSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with two subjects",
+			Query: &model.PointOfContactSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.PointOfContactSpec{
+				Email:         ptrfrom.String("a@b.com"),
+				Info:          ptrfrom.String("info1"),
+				Since:         ptrfrom.Time(time.Unix(1e9, 0)),
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				PointOfContact(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().PointOfContact(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/hasSBOM.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/hasSBOM.resolvers_test.go
@@ -1,0 +1,252 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestHasSbom(t *testing.T) {
+	type call struct {
+		Sub model.PackageOrArtifactInput
+		HS  *model.HasSBOMInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two subjects",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package:  testdata.P1,
+						Artifact: testdata.A1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						DownloadLocation: "location one",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						URI: "test uri",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestHasSbom(ctx, o.Sub, *o.HS).
+					Return(&model.HasSbom{ID: "a"}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestHasSbom(ctx, o.Sub, *o.HS)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIngestHasSBOMs(t *testing.T) {
+	type call struct {
+		Sub model.PackageOrArtifactInputs
+		HS  []*model.HasSBOMInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two packages and one HasSbom",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							URI: "test uri",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with two artifacts and one HasSbom",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							URI: "test uri",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with one package, one artifact and one HasSbom",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Packages:  []*model.PkgInputSpec{testdata.P1},
+						Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							URI: "test uri",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath",
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							URI: "test uri",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestHasSBOMs(ctx, o.Sub, o.HS).
+					Return([]*model.HasSbom{{ID: "a"}}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestHasSBOMs(ctx, o.Sub, o.HS)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestHasSbom(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.HasSBOMSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with two subjects",
+			Query: &model.HasSBOMSpec{
+				Subject: &model.PackageOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.HasSBOMSpec{
+				URI: ptrfrom.String("test uri"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				HasSBOM(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().HasSbom(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/hasSLSA.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/hasSLSA.resolvers_test.go
@@ -1,0 +1,198 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestHasSLSA(t *testing.T) {
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Sub  *model.ArtifactInputSpec
+		BF   []*model.ArtifactInputSpec
+		BB   *model.BuilderInputSpec
+		SLSA *model.SLSAInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with no builtFrom",
+			Calls: []call{
+				{
+					Sub: testdata.A1,
+					BF:  []*model.ArtifactInputSpec{},
+					BB:  testdata.B1,
+					SLSA: &model.SLSAInputSpec{
+						StartedOn: &testTime,
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: testdata.A1,
+					BF:  []*model.ArtifactInputSpec{testdata.A2},
+					BB:  testdata.B1,
+					SLSA: &model.SLSAInputSpec{
+						BuildType: "test type",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestSLSA(ctx, *o.Sub, o.BF, *o.BB, *o.SLSA).
+					Return(&model.HasSlsa{ID: "a"}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestSlsa(ctx, *o.Sub, o.BF, *o.BB, *o.SLSA)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIngestHasSLSAs(t *testing.T) {
+	type call struct {
+		Sub  []*model.ArtifactInputSpec
+		BF   [][]*model.ArtifactInputSpec
+		BB   []*model.BuilderInputSpec
+		SLSA []*model.SLSAInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest without slsaList",
+			Calls: []call{
+				{
+					Sub:  []*model.ArtifactInputSpec{testdata.A1},
+					BF:   [][]*model.ArtifactInputSpec{{testdata.A2}},
+					BB:   []*model.BuilderInputSpec{testdata.B1},
+					SLSA: []*model.SLSAInputSpec{},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest without builtFrom",
+			Calls: []call{
+				{
+					Sub: []*model.ArtifactInputSpec{testdata.A1},
+					BF:  [][]*model.ArtifactInputSpec{},
+					BB:  []*model.BuilderInputSpec{testdata.B1},
+					SLSA: []*model.SLSAInputSpec{
+						{
+							BuildType: "test type",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest without builtByList",
+			Calls: []call{
+				{
+					Sub: []*model.ArtifactInputSpec{testdata.A1},
+					BF:  [][]*model.ArtifactInputSpec{{testdata.A2}},
+					BB:  []*model.BuilderInputSpec{},
+					SLSA: []*model.SLSAInputSpec{
+						{
+							BuildType: "test type",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath",
+			Calls: []call{
+				{
+					Sub: []*model.ArtifactInputSpec{testdata.A1},
+					BF:  [][]*model.ArtifactInputSpec{{testdata.A2}},
+					BB:  []*model.BuilderInputSpec{testdata.B1},
+					SLSA: []*model.SLSAInputSpec{
+						{
+							BuildType: "test type",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestSLSAs(ctx, o.Sub, o.BF, o.BB, o.SLSA).
+					Return([]*model.HasSlsa{{ID: "a"}}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestSLSAs(ctx, o.Sub, o.BF, o.BB, o.SLSA)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestHashEqual is the resolver for the ingestHashEqual field.
@@ -21,8 +22,15 @@ func (r *mutationResolver) IngestHashEqual(ctx context.Context, artifact model.A
 
 // IngestHashEquals is the resolver for the ingestHashEquals field.
 func (r *mutationResolver) IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]string, error) {
-	ingestedHashEquals, err := r.Backend.IngestHashEquals(ctx, artifacts, otherArtifacts, hashEquals)
+	funcName := "IngestHashEquals"
 	ingestedHashEqualsIDS := []string{}
+	if len(artifacts) != len(otherArtifacts) {
+		return ingestedHashEqualsIDS, gqlerror.Errorf("%v :: uneven artifacts and other artifacts for ingestion", funcName)
+	} else if len(artifacts) != len(hashEquals) {
+		return ingestedHashEqualsIDS, gqlerror.Errorf("%v :: uneven artifacts and hashEquals for ingestion", funcName)
+	}
+
+	ingestedHashEquals, err := r.Backend.IngestHashEquals(ctx, artifacts, otherArtifacts, hashEquals)
 	if err == nil {
 		for _, hashEqual := range ingestedHashEquals {
 			ingestedHashEqualsIDS = append(ingestedHashEqualsIDS, hashEqual.ID)
@@ -33,5 +41,8 @@ func (r *mutationResolver) IngestHashEquals(ctx context.Context, artifacts []*mo
 
 // HashEqual is the resolver for the HashEqual field.
 func (r *queryResolver) HashEqual(ctx context.Context, hashEqualSpec model.HashEqualSpec) ([]*model.HashEqual, error) {
+	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
+		return nil, gqlerror.Errorf("HashEqual :: Provided spec has too many Artifacts")
+	}
 	return r.Backend.HashEqual(ctx, &hashEqualSpec)
 }

--- a/pkg/assembler/graphql/resolvers/hashEqual.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/hashEqual.resolvers_test.go
@@ -1,0 +1,172 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestHashEquals(t *testing.T) {
+	type call struct {
+		A1 []*model.ArtifactInputSpec
+		A2 []*model.ArtifactInputSpec
+		HE []*model.HashEqualInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with different number of artifacts",
+			Calls: []call{
+				{
+					A1: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					A2: []*model.ArtifactInputSpec{testdata.A2},
+					HE: []*model.HashEqualInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with different number of HashEqual",
+			Calls: []call{
+				{
+					A1: []*model.ArtifactInputSpec{testdata.A1},
+					A2: []*model.ArtifactInputSpec{testdata.A2},
+					HE: []*model.HashEqualInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "another justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath",
+			Calls: []call{
+				{
+					A1: []*model.ArtifactInputSpec{testdata.A1},
+					A2: []*model.ArtifactInputSpec{testdata.A2},
+					HE: []*model.HashEqualInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestHashEquals(ctx, o.A1, o.A2, o.HE).
+					Return([]*model.HashEqual{{ID: "a"}}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestHashEquals(ctx, o.A1, o.A2, o.HE)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestHashEqual(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.HashEqualSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query three",
+			Query: &model.HashEqualSpec{
+				Artifacts: []*model.ArtifactSpec{
+					{
+						Algorithm: ptrfrom.String("gitHash"),
+					},
+					{
+						Digest: ptrfrom.String("6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"),
+					},
+					{
+						Digest: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.HashEqualSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				HashEqual(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().HashEqual(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestDependency is the resolver for the ingestDependency field.
@@ -21,8 +22,16 @@ func (r *mutationResolver) IngestDependency(ctx context.Context, pkg model.PkgIn
 
 // IngestDependencies is the resolver for the ingestDependencies field.
 func (r *mutationResolver) IngestDependencies(ctx context.Context, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) ([]string, error) {
-	ingestedDependencies, err := r.Backend.IngestDependencies(ctx, pkgs, depPkgs, depPkgMatchType, dependencies)
+	funcName := "IngestDependencies"
 	ingestedDependenciesIDS := []string{}
+	if len(pkgs) != len(depPkgs) {
+		return ingestedDependenciesIDS, gqlerror.Errorf("%v :: uneven packages and dependent packages for ingestion", funcName)
+	}
+	if len(pkgs) != len(dependencies) {
+		return ingestedDependenciesIDS, gqlerror.Errorf("%v :: uneven packages and dependencies nodes for ingestion", funcName)
+	}
+
+	ingestedDependencies, err := r.Backend.IngestDependencies(ctx, pkgs, depPkgs, depPkgMatchType, dependencies)
 	if err == nil {
 		for _, dependency := range ingestedDependencies {
 			ingestedDependenciesIDS = append(ingestedDependenciesIDS, dependency.ID)

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers_test.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestDependencies(t *testing.T) {
+	type call struct {
+		P1s []*model.PkgInputSpec
+		P2s []*model.PkgInputSpec
+		MF  model.MatchFlags
+		IDs []*model.IsDependencyInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest two packages and one dependent package",
+			Calls: []call{
+				{
+					P1s: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					P2s: []*model.PkgInputSpec{testdata.P4},
+					MF:  testdata.MAll,
+					IDs: []*model.IsDependencyInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest one package and two dependency notes",
+			Calls: []call{
+				{
+					P1s: []*model.PkgInputSpec{testdata.P1},
+					P2s: []*model.PkgInputSpec{testdata.P4},
+					MF:  testdata.MAll,
+					IDs: []*model.IsDependencyInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath",
+			Calls: []call{{
+				P1s: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+				P2s: []*model.PkgInputSpec{testdata.P2, testdata.P4},
+				MF:  testdata.MAll,
+				IDs: []*model.IsDependencyInputSpec{
+					{
+						Justification: "test justification",
+					},
+					{
+						Justification: "test justification",
+					},
+				},
+			}},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestDependencies(ctx, o.P1s, o.P2s, o.MF, o.IDs).
+					Return([]*model.IsDependency{{ID: "a"}}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestDependencies(ctx, o.P1s, o.P2s, o.MF, o.IDs)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/isOccurrence.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/isOccurrence.resolvers_test.go
@@ -1,0 +1,316 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestOccurrence(t *testing.T) {
+	type call struct {
+		PkgSrc     model.PackageOrSourceInput
+		Artifact   *model.ArtifactInputSpec
+		Occurrence *model.IsOccurrenceInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with one package and one source",
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+						Source:  testdata.S1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestOccurrence(ctx, o.PkgSrc, *o.Artifact, *o.Occurrence).
+					Return(&model.IsOccurrence{ID: "1"}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestOccurrence(ctx, o.PkgSrc, *o.Artifact, *o.Occurrence)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIngestOccurrences(t *testing.T) {
+	type call struct {
+		PkgSrcs     model.PackageOrSourceInputs
+		Artifacts   []*model.ArtifactInputSpec
+		Occurrences []*model.IsOccurrenceInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two packages and one artifact",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with two packages, two artifacts and one occurrence",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with one source and two artifacts",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with one source, one artifact and two occurrence",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "another justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with both packages and sources",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+						Sources:  []*model.SourceInputSpec{testdata.S1},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath - packages",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					Occurrences: []*model.IsOccurrenceInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "HappyPath - sources",
+			Calls: []call{
+				{
+					PkgSrcs: model.PackageOrSourceInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1},
+					},
+					Artifacts: []*model.ArtifactInputSpec{testdata.A1},
+					Occurrences: []*model.IsOccurrenceInputSpec{{
+						Justification: "test justification",
+					}},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestOccurrences(ctx, o.PkgSrcs, o.Artifacts, o.Occurrences).
+					Return([]*model.IsOccurrence{{ID: "d"}}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestOccurrences(ctx, o.PkgSrcs, o.Artifacts, o.Occurrences)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIsOccurrence(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.IsOccurrenceSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query error",
+			Query: &model.IsOccurrenceSpec{
+				Subject: &model.PackageOrSourceSpec{
+					Package: &model.PkgSpec{},
+					Source:  &model.SourceSpec{},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.IsOccurrenceSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				IsOccurrence(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().IsOccurrence(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/metadata.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/metadata.resolvers.go
@@ -7,11 +7,18 @@ package resolvers
 import (
 	"context"
 
+	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestHasMetadata is the resolver for the ingestHasMetadata field.
 func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (string, error) {
+	funcName := "IngestHasMetadata"
+	if err := helper.ValidatePackageSourceOrArtifactInput(&subject, funcName); err != nil {
+		return "", gqlerror.Errorf("%v ::  %s", funcName, err)
+	}
+
 	ingestedHasMetadata, err := r.Backend.IngestHasMetadata(ctx, subject, &pkgMatchType, hasMetadata)
 	if err != nil {
 		return "", err
@@ -21,5 +28,8 @@ func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.
 
 // HasMetadata is the resolver for the HasMetadata field.
 func (r *queryResolver) HasMetadata(ctx context.Context, hasMetadataSpec model.HasMetadataSpec) ([]*model.HasMetadata, error) {
+	if err := helper.ValidatePackageSourceOrArtifactQueryFilter(hasMetadataSpec.Subject); err != nil {
+		return nil, gqlerror.Errorf("HasMetadata ::  %s", err)
+	}
 	return r.Backend.HasMetadata(ctx, &hasMetadataSpec)
 }

--- a/pkg/assembler/graphql/resolvers/metadata.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/metadata.resolvers_test.go
@@ -1,0 +1,160 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestIngestMetadata(t *testing.T) {
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		HM    *model.HasMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two subjects",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source:   testdata.S1,
+						Artifact: testdata.A1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Timestamp:     time.Unix(1e9, 0),
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestHasMetadata(ctx, o.Sub, o.Match, *o.HM).
+					Return(&model.HasMetadata{ID: "a"}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestHasMetadata(ctx, o.Sub, *o.Match, *o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.HasMetadataSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with two subjects",
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.HasMetadataSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				HasMetadata(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().HasMetadata(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/path.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/path.resolvers.go
@@ -8,10 +8,15 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Path is the resolver for the path field.
 func (r *queryResolver) Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error) {
+	if maxPathLength <= 0 {
+		return nil, gqlerror.Errorf("Path :: maxPathLength argument must be positive, got %d", maxPathLength)
+	}
+
 	return r.Backend.Path(ctx, subject, target, maxPathLength, usingOnly)
 }
 

--- a/pkg/assembler/graphql/resolvers/path.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/path.resolvers_test.go
@@ -1,0 +1,90 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestPath(t *testing.T) {
+	type call struct {
+		subject       string
+		target        string
+		maxPathLength int
+		usingOnly     []model.Edge
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with negative maxPathLength",
+			Calls: []call{
+				{
+					maxPathLength: -1,
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					subject:       "a",
+					target:        "b",
+					maxPathLength: 10,
+					usingOnly: []model.Edge{
+						model.EdgeArtifactCertifyBad,
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					Path(ctx, o.subject, o.target, o.maxPathLength, o.usingOnly).
+					Return([]model.Node{}, nil).
+					Times(times)
+				_, err := r.Query().Path(ctx, o.subject, o.target, o.maxPathLength, o.usingOnly)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/pkgEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/pkgEqual.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestPkgEqual is the resolver for the ingestPkgEqual field.
@@ -21,5 +22,8 @@ func (r *mutationResolver) IngestPkgEqual(ctx context.Context, pkg model.PkgInpu
 
 // PkgEqual is the resolver for the PkgEqual field.
 func (r *queryResolver) PkgEqual(ctx context.Context, pkgEqualSpec model.PkgEqualSpec) ([]*model.PkgEqual, error) {
+	if len(pkgEqualSpec.Packages) > 2 {
+		return nil, gqlerror.Errorf("PkgEqual :: too many packages in query, max 2, got: %v", len(pkgEqualSpec.Packages))
+	}
 	return r.Backend.PkgEqual(ctx, &pkgEqualSpec)
 }

--- a/pkg/assembler/graphql/resolvers/pkgEqual.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/pkgEqual.resolvers_test.go
@@ -1,0 +1,83 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestPkgEqual(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.PkgEqualSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query three",
+			Query: &model.PkgEqualSpec{
+				Packages: []*model.PkgSpec{
+					{
+						Name: ptrfrom.String("somename"),
+					},
+					{
+						Version: ptrfrom.String("1.2.3"),
+					},
+					{
+						Type: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.PkgEqualSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				PkgEqual(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().PkgEqual(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestSource is the resolver for the ingestSource field.
@@ -33,5 +34,11 @@ func (r *mutationResolver) IngestSources(ctx context.Context, sources []*model.S
 
 // Sources is the resolver for the sources field.
 func (r *queryResolver) Sources(ctx context.Context, sourceSpec model.SourceSpec) ([]*model.Source, error) {
+	if sourceSpec.Commit != nil && sourceSpec.Tag != nil {
+		if *sourceSpec.Commit != "" && *sourceSpec.Tag != "" {
+			return nil, gqlerror.Errorf("Sources :: Passing both commit and tag selectors is an error")
+		}
+	}
+
 	return r.Backend.Sources(ctx, &sourceSpec)
 }

--- a/pkg/assembler/graphql/resolvers/source.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers_test.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestSources(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.SourceSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with both commit and tag",
+			Query: &model.SourceSpec{
+				Tag:    ptrfrom.String("tag"),
+				Commit: ptrfrom.String("commit"),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.SourceSpec{
+				Name: ptrfrom.String("myrepo"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				Sources(ctx, test.Query).
+				Times(times)
+			_, err := r.Query().Sources(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
@@ -30,7 +30,7 @@ func (r *queryResolver) VulnEqual(ctx context.Context, vulnEqualSpec model.VulnE
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 
 	if vulnEqualSpec.Vulnerabilities != nil && len(vulnEqualSpec.Vulnerabilities) > 2 {
-		return nil, gqlerror.Errorf("cannot specify more than 2 vulnerabilities in VulnEqual")
+		return nil, gqlerror.Errorf("VulnEqual :: cannot specify more than 2 vulnerabilities in VulnEqual")
 	}
 
 	if len(vulnEqualSpec.Vulnerabilities) > 0 {

--- a/pkg/assembler/graphql/resolvers/vulnEqual.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/vulnEqual.resolvers_test.go
@@ -1,0 +1,101 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestVulnEqual(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.VulnEqualSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with three vulnerabilities",
+			Query: &model.VulnEqualSpec{
+				Vulnerabilities: []*model.VulnerabilitySpec{
+					{
+						VulnerabilityID: ptrfrom.String("CVE-2022-26499"),
+					},
+					{
+						VulnerabilityID: ptrfrom.String("CVE-2021-26499"),
+					},
+					{
+						VulnerabilityID: ptrfrom.String("CVE-2020-26499"),
+					},
+				},
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path with vulnerabilities",
+			Query: &model.VulnEqualSpec{
+				Vulnerabilities: []*model.VulnerabilitySpec{
+					{
+						Type:            ptrfrom.String("cve"),
+						VulnerabilityID: ptrfrom.String("CVE-2022-26499"),
+					},
+					{
+						Type:            ptrfrom.String("osv"),
+						VulnerabilityID: ptrfrom.String("CVE-2021-26499"),
+					},
+				},
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.VulnEqualSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				VulnEqual(ctx, gomock.Any()).
+				Times(times)
+			_, err := r.Query().VulnEqual(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers_test.go
@@ -1,0 +1,275 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+var greater = model.ComparatorGreater
+
+func TestIngestVulnerabilityMetadata(t *testing.T) {
+	type call struct {
+		Vuln         *model.VulnerabilityInputSpec
+		VulnMetadata *model.VulnerabilityMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with type novuln",
+			Calls: []call{
+				{
+					Vuln: &model.VulnerabilityInputSpec{
+						Type: "novuln",
+					},
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+						ScoreValue: 7.9,
+						Timestamp:  t1,
+						Collector:  "test collector",
+						Origin:     "test origin",
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Happy path",
+			Calls: []call{
+				{
+					Vuln: testdata.O1,
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+						ScoreValue: 7.9,
+						Timestamp:  t1,
+						Collector:  "test collector",
+						Origin:     "test origin",
+					},
+				},
+			},
+			ExpIngestErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestVulnerabilityMetadata(ctx, gomock.Any(), *o.VulnMetadata).
+					Return("xyz", nil).
+					Times(times)
+				_, err := r.Mutation().IngestVulnerabilityMetadata(ctx, *o.Vuln, *o.VulnMetadata)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestIngestVulnerabilityMetadatas(t *testing.T) {
+	type call struct {
+		Vulns         []*model.VulnerabilityInputSpec
+		VulnMetadatas []*model.VulnerabilityMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		Calls        []call
+		ExpIngestErr bool
+	}{
+		{
+			Name: "Ingest with two vulnerabilities and one vulnerabilityMetadata",
+			Calls: []call{
+				{
+					Vulns: []*model.VulnerabilityInputSpec{testdata.C1, testdata.C2},
+					VulnMetadatas: []*model.VulnerabilityMetadataInputSpec{
+						{
+							ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+							ScoreValue: 7.9,
+							Timestamp:  t1,
+							Collector:  "test collector",
+							Origin:     "test origin",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "Ingest with vulnerability type novuln",
+			Calls: []call{
+				{
+					Vulns: []*model.VulnerabilityInputSpec{
+						{
+							Type: "novuln",
+						},
+					},
+					VulnMetadatas: []*model.VulnerabilityMetadataInputSpec{
+						{
+							ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+							ScoreValue: 7.9,
+							Timestamp:  t1,
+							Collector:  "test collector",
+							Origin:     "test origin",
+						},
+					},
+				},
+			},
+			ExpIngestErr: true,
+		},
+		{
+			Name: "HappyPath",
+			Calls: []call{
+				{
+					Vulns: []*model.VulnerabilityInputSpec{testdata.C1, testdata.C2},
+					VulnMetadatas: []*model.VulnerabilityMetadataInputSpec{
+						{
+							ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+							ScoreValue: 7.9,
+							Timestamp:  t1,
+							Collector:  "test collector",
+							Origin:     "test origin",
+						},
+						{
+							ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+							ScoreValue: 8.9,
+							Timestamp:  t1,
+							Collector:  "test collector",
+							Origin:     "test origin",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			for _, o := range test.Calls {
+				times := 1
+				if test.ExpIngestErr {
+					times = 0
+				}
+				b.
+					EXPECT().
+					IngestVulnerabilityMetadatas(ctx, gomock.Any(), o.VulnMetadatas).
+					Return([]string{}, nil).
+					Times(times)
+				_, err := r.Mutation().IngestVulnerabilityMetadatas(ctx, o.Vulns, o.VulnMetadatas)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestVulnerabilityMetadata(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.VulnerabilityMetadataSpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with Comparator but without ScoreValue",
+			Query: &model.VulnerabilityMetadataSpec{
+				Comparator: &greater,
+				Collector:  ptrfrom.String("test collector"),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Query with type Novuln and NoVuln false",
+			Query: &model.VulnerabilityMetadataSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type:   ptrfrom.String("Novuln"),
+					NoVuln: ptrfrom.Bool(false),
+				},
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path - Vulnerability",
+			Query: &model.VulnerabilityMetadataSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					VulnerabilityID: ptrfrom.String("GHSA-h45f-rjvw-2rv2"),
+					Type:            ptrfrom.String("GHSA"),
+				},
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpQueryErr: false,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.VulnerabilityMetadataSpec{
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				VulnerabilityMetadata(ctx, gomock.Any()).
+				Times(times)
+			_, err := r.Query().VulnerabilityMetadata(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
@@ -58,10 +59,9 @@ func (r *queryResolver) Vulnerabilities(ctx context.Context, vulnSpec model.Vuln
 		vulnIDLowerCase = &lower
 	}
 
-	if vulnSpec.NoVuln != nil && !*vulnSpec.NoVuln {
-		if vulnSpec.Type != nil && *typeLowerCase == "novuln" {
-			return []*model.Vulnerability{}, gqlerror.Errorf("novuln boolean set to false, cannot specify vulnerability type to be novuln")
-		}
+	err := helper.ValidateVulnerabilitySpec(vulnSpec)
+	if err != nil {
+		return []*model.Vulnerability{}, gqlerror.Errorf("IngestVulnerabilityMetadata ::  %s", err)
 	}
 
 	return r.Backend.Vulnerabilities(ctx, &model.VulnerabilitySpec{ID: vulnSpec.ID, Type: typeLowerCase,

--- a/pkg/assembler/graphql/resolvers/vulnerability.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/vulnerability.resolvers_test.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/guacsec/guac/internal/testing/mocks"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func TestVulnerabilities(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Query       *model.VulnerabilitySpec
+		ExpQueryErr bool
+	}{
+		{
+			Name: "Query with type Novuln and NoVuln false",
+			Query: &model.VulnerabilitySpec{
+				Type:   ptrfrom.String("Novuln"),
+				NoVuln: ptrfrom.Bool(false),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name: "Happy path",
+			Query: &model.VulnerabilitySpec{
+				VulnerabilityID: ptrfrom.String("CVE-2014-8140"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b := mocks.NewMockBackend(ctrl)
+			r := resolvers.Resolver{Backend: b}
+			times := 1
+			if test.ExpQueryErr {
+				times = 0
+			}
+			b.
+				EXPECT().
+				Vulnerabilities(ctx, gomock.Any()).
+				Times(times)
+			_, err := r.Query().Vulnerabilities(ctx, *test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of the PR

Following the "template" changes discussed and approved in https://github.com/guacsec/guac/pull/1185, this PR moves all the existing validations checks into their resolvers, together with tests.

Fixes #1179 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
