### PR TITLE
Add support for sending encoded documents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,6 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/letsencrypt/boulder v0.0.0-20221109233200-85aa52084eaf // indirect
 	github.com/logrusorgru/aurora/v3 v3.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -193,6 +192,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jedib0t/go-pretty/v6 v6.4.7
 	github.com/jeremywohl/flatten v1.0.1
+	github.com/klauspost/compress v1.16.7
 	github.com/lib/pq v1.10.9
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -138,7 +138,7 @@ func processHelper(ctx context.Context, doc *processor.Document) (*processor.Doc
 }
 
 func processDocument(ctx context.Context, i *processor.Document) ([]*processor.Document, error) {
-	if err := decodeDocument(i); err != nil {
+	if err := decodeDocument(ctx, i); err != nil {
 		return nil, err
 	}
 
@@ -210,7 +210,7 @@ func unpackDocument(i *processor.Document) ([]*processor.Document, error) {
 	return p.Unpack(i) // nolint:wrapcheck
 }
 
-func decodeDocument(i *processor.Document) error {
+func decodeDocument(ctx context.Context, i *processor.Document) error {
 	var reader io.Reader
 	switch i.Encoding {
 	case processor.EncodingBzip2:
@@ -219,14 +219,16 @@ func decodeDocument(i *processor.Document) error {
 	case processor.EncodingUnknown:
 	}
 	if reader != nil {
-		if err := decompressDocument(i, reader); err != nil {
+		if err := decompressDocument(ctx, i, reader); err != nil {
 			return fmt.Errorf("unable to decode document: %w", err)
 		}
 	}
 	return nil
 }
 
-func decompressDocument(i *processor.Document, reader io.Reader) error {
+func decompressDocument(ctx context.Context, i *processor.Document, reader io.Reader) error {
+	logger := logging.FromContext(ctx)
+	logger.Infof("Decoding document:  %v", i.Encoding)
 	uncompressed, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("unable to decompress document: %w", err)

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -34,6 +34,7 @@ type Document struct {
 	Blob              []byte
 	Type              DocumentType
 	Format            FormatType
+	Encoding          EncodingType
 	SourceInformation SourceInformation
 }
 
@@ -76,6 +77,13 @@ const (
 	FormatJSONLines FormatType = "JSON_LINES"
 	FormatXML       FormatType = "XML"
 	FormatUnknown   FormatType = "UNKNOWN"
+)
+
+type EncodingType string
+
+const (
+	EncodingBzip2   EncodingType = "BZIP2"
+	EncodingUnknown EncodingType = "UNKNOWN"
 )
 
 // SourceInformation provides additional information about where the document comes from

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -83,6 +83,7 @@ type EncodingType string
 
 const (
 	EncodingBzip2   EncodingType = "BZIP2"
+	EncodingZstd    EncodingType = "ZSTD"
 	EncodingUnknown EncodingType = "UNKNOWN"
 )
 


### PR DESCRIPTION
# Description of the PR

This PR builds on top of #1195 and adds support for sending encoded/compressed documents. It expands `Document` struct with `Encoding` filed.

```
type Document struct {
	Blob              []byte
	Type              DocumentType
	Format            FormatType
	Encoding          EncodingType
	SourceInformation SourceInformation
}
```

which can indicate if content was encoded. At the moment only `bz2` is supported and tested, but the code can be easily expanded to add more popular codecs, gzip, zstd, ...

I've tested these changes by ingesting a large sbom of 230MB (compressed 17MB) and it works fine. Ingestion takes 90sec which is something we can take a look next.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
