### PR TITLE
Disable ent on 32 bit

### DIFF
--- a/cmd/guacgql/cmd/ent.go
+++ b/cmd/guacgql/cmd/ent.go
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(386 || arm || mips)
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	entbackend "github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
+)
+
+func init() {
+	if getBackend == nil {
+		getBackend = make(map[string]backendFunc)
+	}
+	getBackend[ent] = getEnt
+}
+
+func getEnt(ctx context.Context) (backends.Backend, error) {
+	client, err := entbackend.SetupBackend(ctx, entbackend.BackendOptions{
+		DriverName:  flags.dbDriver,
+		Address:     flags.dbAddress,
+		Debug:       flags.dbDebug,
+		AutoMigrate: flags.dbMigrate,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entbackend.GetBackend(client)
+}

--- a/cmd/guacgql/cmd/ent.go
+++ b/cmd/guacgql/cmd/ent.go
@@ -18,29 +18,22 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	entbackend "github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
 )
 
 func init() {
-	if getBackend == nil {
-		getBackend = make(map[string]backendFunc)
+	if getOpts == nil {
+		getOpts = make(map[string]optsFunc)
 	}
-	getBackend[ent] = getEnt
+	getOpts[ent] = getEnt
 }
 
-func getEnt(ctx context.Context) (backends.Backend, error) {
-	client, err := entbackend.SetupBackend(ctx, entbackend.BackendOptions{
+func getEnt() backends.BackendArgs {
+	return &entbackend.BackendOptions{
 		DriverName:  flags.dbDriver,
 		Address:     flags.dbAddress,
 		Debug:       flags.dbDebug,
 		AutoMigrate: flags.dbMigrate,
-	})
-	if err != nil {
-		return nil, err
 	}
-
-	return entbackend.GetBackend(client)
 }

--- a/cmd/guacgql/cmd/server.go
+++ b/cmd/guacgql/cmd/server.go
@@ -185,9 +185,10 @@ func generateNeptuneToken(neptuneURL string, region string) (string, error) {
 	return string(password), nil
 }
 
-// This method returns the AWS signer to be used for signing the request to be sent to Neptune Cluster.
-// It checks for the presence of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN in the environment.
-// If not found, it creates a new session and gets the credentials from the session.
+// This method returns the AWS signer to be used for signing the request to be
+// sent to Neptune Cluster.  It checks for the presence of AWS_ACCESS_KEY_ID,
+// AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN in the environment.  If not
+// found, it creates a new session and gets the credentials from the session.
 func getAWSRequestSigner() (*v4.Signer, error) {
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
@@ -230,14 +231,16 @@ func getInMem(ctx context.Context) (backends.Backend, error) {
 }
 
 func getNeptune(ctx context.Context) (backends.Backend, error) {
-	// TODO: rename the neo4j config to something more generic since it would be used by Neptune as well.
-	neptuneRequestURL := fmt.Sprintf("https://%s:%d/opencypher", flags.neptuneEndpoint, flags.neptunePort)
-	neptuneToken, err := generateNeptuneToken(neptuneRequestURL, flags.neptuneRegion)
+	neptuneRequestURL := fmt.Sprintf("https://%s:%d/opencypher",
+		flags.neptuneEndpoint, flags.neptunePort)
+	neptuneToken, err := generateNeptuneToken(neptuneRequestURL,
+		flags.neptuneRegion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create password for neptune: %w", err)
 	}
 
-	neptuneDBAddr := fmt.Sprintf("bolt+s://%s:%d/opencypher", flags.neptuneEndpoint, flags.neptunePort)
+	neptuneDBAddr := fmt.Sprintf("bolt+s://%s:%d/opencypher",
+		flags.neptuneEndpoint, flags.neptunePort)
 	args := &neo4j.Neo4jConfig{
 		User:   flags.neptuneUser,
 		Pass:   neptuneToken,

--- a/cmd/guacgql/cmd/server.go
+++ b/cmd/guacgql/cmd/server.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,43 +27,40 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/debug"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/backends/arangodb"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/inmem"
 	"github.com/guacsec/guac/pkg/assembler/backends/neo4j"
+	"github.com/guacsec/guac/pkg/assembler/backends/neptune"
 	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
 	"github.com/guacsec/guac/pkg/logging"
 )
 
 const (
-	arango             = "arango"
-	neo4js             = "neo4j"
-	inmems             = "inmem"
-	ent                = "ent"
-	neptune            = "neptune"
-	neptuneServiceName = "neptune-db"
+	arango   = "arango"
+	neo4js   = "neo4j"
+	inmems   = "inmem"
+	ent      = "ent"
+	neptunes = "neptune"
 )
 
-type backendFunc func(context.Context) (backends.Backend, error)
+type optsFunc func() backends.BackendArgs
 
-var getBackend map[string]backendFunc
+var getOpts map[string]optsFunc
 
 func init() {
-	if getBackend == nil {
-		getBackend = make(map[string]backendFunc)
+	if getOpts == nil {
+		getOpts = make(map[string]optsFunc)
 	}
-	getBackend[arango] = getArango
-	getBackend[neo4js] = getNeo4j
-	getBackend[inmems] = getInMem
-	getBackend[neptune] = getNeptune
+	getOpts[arango] = getArango
+	getOpts[neo4js] = getNeo4j
+	getOpts[inmems] = getInMem
+	getOpts[neptunes] = getNeptune
 }
 
 func startServer(cmd *cobra.Command) {
@@ -127,7 +123,10 @@ func startServer(cmd *cobra.Command) {
 }
 
 func validateFlags() error {
-	if !slices.Contains(maps.Keys(getBackend), flags.backend) {
+	if !slices.Contains(maps.Keys(getOpts), flags.backend) {
+		return fmt.Errorf("invalid graphql backend specified: %v", flags.backend)
+	}
+	if !slices.Contains(backends.List(), flags.backend) {
 		return fmt.Errorf("invalid graphql backend specified: %v", flags.backend)
 	}
 	return nil
@@ -136,7 +135,7 @@ func validateFlags() error {
 func getGraphqlServer(ctx context.Context) (*handler.Server, error) {
 	var topResolver resolvers.Resolver
 
-	backend, err := getBackend[flags.backend](ctx)
+	backend, err := backends.Get(flags.backend, ctx, getOpts[flags.backend]())
 	if err != nil {
 		return nil, fmt.Errorf("Error creating %v backend: %w", flags.backend, err)
 	}
@@ -153,99 +152,33 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprint(w, "Server is healthy")
 }
 
-// generateNeptuneToken generates a token for neptune using the AWS SDK.
-func generateNeptuneToken(neptuneURL string, region string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, neptuneURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("error creating http request for neptune: %w", err)
-	}
-
-	signer, err := getAWSRequestSigner()
-	if err != nil {
-		return "", fmt.Errorf("error creating AWS request signer: %w", err)
-	}
-
-	if _, err := signer.Sign(req, nil, neptuneServiceName, region, time.Now()); err != nil {
-		return "", fmt.Errorf("error signing neptune request: %w", err)
-	}
-
-	headers := []string{"Authorization", "X-Amz-Date", "X-Amz-Security-Token"}
-	hdrMap := make(map[string]string)
-	for _, h := range headers {
-		hdrMap[h] = req.Header.Get(h)
-	}
-
-	hdrMap["Host"] = req.Host
-	hdrMap["HttpMethod"] = req.Method
-	password, err := json.Marshal(hdrMap)
-	if err != nil {
-		return "", fmt.Errorf("error marshalling header map: %w", err)
-	}
-
-	return string(password), nil
-}
-
-// This method returns the AWS signer to be used for signing the request to be
-// sent to Neptune Cluster.  It checks for the presence of AWS_ACCESS_KEY_ID,
-// AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN in the environment.  If not
-// found, it creates a new session and gets the credentials from the session.
-func getAWSRequestSigner() (*v4.Signer, error) {
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
-
-	if accessKeyID != "" && secretAccessKey != "" && sessionToken != "" {
-		return v4.NewSigner(credentials.NewEnvCredentials()), nil
-	}
-
-	sess, err := session.NewSession()
-	if err != nil {
-		return nil, err
-	}
-
-	return v4.NewSigner(sess.Config.Credentials), nil
-}
-
-func getArango(ctx context.Context) (backends.Backend, error) {
-	args := &arangodb.ArangoConfig{
+func getArango() backends.BackendArgs {
+	return &arangodb.ArangoConfig{
 		User:   flags.arangoUser,
 		Pass:   flags.arangoPass,
 		DBAddr: flags.arangoAddr,
 	}
-	return arangodb.GetBackend(ctx, args)
 }
 
-func getNeo4j(ctx context.Context) (backends.Backend, error) {
-	args := &neo4j.Neo4jConfig{
+func getNeo4j() backends.BackendArgs {
+	return &neo4j.Neo4jConfig{
 		User:   flags.nUser,
 		Pass:   flags.nPass,
 		Realm:  flags.nRealm,
 		DBAddr: flags.nAddr,
 	}
-	return neo4j.GetBackend(args)
 }
 
-func getInMem(ctx context.Context) (backends.Backend, error) {
-	args := &inmem.DemoCredentials{}
-	return inmem.GetBackend(args)
+func getInMem() backends.BackendArgs {
+	return nil
 }
 
-func getNeptune(ctx context.Context) (backends.Backend, error) {
-	neptuneRequestURL := fmt.Sprintf("https://%s:%d/opencypher",
-		flags.neptuneEndpoint, flags.neptunePort)
-	neptuneToken, err := generateNeptuneToken(neptuneRequestURL,
-		flags.neptuneRegion)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create password for neptune: %w", err)
+func getNeptune() backends.BackendArgs {
+	return &neptune.NeptuneConfig{
+		Endpoint: flags.neptuneEndpoint,
+		Port:     flags.neptunePort,
+		Region:   flags.neptuneRegion,
+		User:     flags.neptuneUser,
+		Realm:    flags.neptuneRealm,
 	}
-
-	neptuneDBAddr := fmt.Sprintf("bolt+s://%s:%d/opencypher",
-		flags.neptuneEndpoint, flags.neptunePort)
-	args := &neo4j.Neo4jConfig{
-		User:   flags.neptuneUser,
-		Pass:   neptuneToken,
-		DBAddr: neptuneDBAddr,
-		Realm:  flags.neptuneRealm,
-	}
-	return neo4j.GetBackend(args)
 }

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -130,7 +130,7 @@ func Test_IngestArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	c, err := GetBackend(ctx, arangArg)
+	c, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -189,7 +189,7 @@ func Test_IngestArtifact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	c, err := GetBackend(ctx, arangArg)
+	c, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -257,7 +257,7 @@ func Test_Artifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	c, err := GetBackend(ctx, arangArg)
+	c, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -161,6 +161,10 @@ type arangoClient struct {
 	graph  driver.Graph
 }
 
+func init() {
+	backends.Register("arango", getBackend)
+}
+
 func arangoDBConnect(address, user, password string) (driver.Client, error) {
 	conn, err := arangodbdriverhttp.NewConnection(arangodbdriverhttp.ConnectionConfig{
 		Endpoints: []string{address},
@@ -208,7 +212,7 @@ func deleteDatabase(ctx context.Context, args backends.BackendArgs) error {
 	return nil
 }
 
-func GetBackend(ctx context.Context, args backends.BackendArgs) (backends.Backend, error) {
+func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backend, error) {
 	config, ok := args.(*ArangoConfig)
 	if !ok {
 		return nil, fmt.Errorf("failed to assert arango config from backend args")

--- a/pkg/assembler/backends/arangodb/builder_test.go
+++ b/pkg/assembler/backends/arangodb/builder_test.go
@@ -70,7 +70,7 @@ func Test_IngestBuilder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	c, err := GetBackend(ctx, arangArg)
+	c, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -127,7 +127,7 @@ func Test_IngestBuilders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	c, err := GetBackend(ctx, arangArg)
+	c, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -226,7 +226,7 @@ func Test_Builders(t *testing.T) {
 	}, cmp.Ignore())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := GetBackend(ctx, arangArg)
+			c, err := getBackend(ctx, arangArg)
 			if err != nil {
 				t.Fatalf("error creating arango backend: %v", err)
 			}

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -35,7 +35,7 @@ func TestCertifyBad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -565,7 +565,7 @@ func TestIngestCertifyBads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -952,7 +952,7 @@ func TestIngestCertifyBads(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -35,7 +35,7 @@ func TestCertifyGood(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -562,7 +562,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -949,7 +949,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/certifyScorecard_test.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard_test.go
@@ -36,7 +36,7 @@ func TestCertifyScorecard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -523,7 +523,7 @@ func TestIngestScorecards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -791,7 +791,7 @@ func TestIngestScorecards(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
@@ -36,7 +36,7 @@ func TestVEX(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -754,7 +754,7 @@ func TestVEXBulkIngest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -1215,7 +1215,7 @@ func TestVEXBulkIngest(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/certifyVuln_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln_test.go
@@ -47,7 +47,7 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -930,7 +930,7 @@ func TestIngestCertifyVulns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -1438,7 +1438,7 @@ func TestIngestCertifyVulns(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/hasMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata_test.go
@@ -615,7 +615,7 @@ package arangodb
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}
@@ -744,7 +744,7 @@ package arangodb
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/hasSBOM_test.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM_test.go
@@ -35,7 +35,7 @@ func TestHasSBOM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestIngestHasSBOM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -782,7 +782,7 @@ func TestIngestHasSBOM(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/hasSLSA_test.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA_test.go
@@ -36,7 +36,7 @@ func TestHasSLSA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestIngestHasSLSAs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -793,7 +793,7 @@ func TestIngestHasSLSAs(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/hashEqual_test.go
+++ b/pkg/assembler/backends/arangodb/hashEqual_test.go
@@ -36,7 +36,7 @@ func TestHashEqual(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -494,7 +494,7 @@ func TestIngestHashEquals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -860,7 +860,7 @@ func TestIngestHashEquals(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/isDependency_test.go
+++ b/pkg/assembler/backends/arangodb/isDependency_test.go
@@ -40,7 +40,7 @@ func TestIsDependency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -815,7 +815,7 @@ func TestIsDependencies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -986,7 +986,7 @@ func TestIsDependencies(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/isOccurrence_test.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence_test.go
@@ -58,7 +58,7 @@ func TestOccurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestIngestOccurrences(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -634,7 +634,7 @@ func TestIngestOccurrences(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/pkg_test.go
+++ b/pkg/assembler/backends/arangodb/pkg_test.go
@@ -299,7 +299,7 @@ func Test_Packages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -422,7 +422,7 @@ func Test_PackageTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -532,7 +532,7 @@ func Test_PackagesNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -646,7 +646,7 @@ func Test_PackagesName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -782,7 +782,7 @@ func Test_IngestPackages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/pointOfContact_test.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact_test.go
@@ -615,7 +615,7 @@ package arangodb
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}
@@ -744,7 +744,7 @@ package arangodb
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/search_test.go
+++ b/pkg/assembler/backends/arangodb/search_test.go
@@ -35,7 +35,7 @@ func Test_arangoClient_FindSoftware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/src_test.go
+++ b/pkg/assembler/backends/arangodb/src_test.go
@@ -40,7 +40,7 @@ func Test_IngestSources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -80,7 +80,7 @@ func Test_Sources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -164,7 +164,7 @@ func Test_SourceTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -263,7 +263,7 @@ func Test_SourceNamespaces(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/vulnMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata_test.go
@@ -46,7 +46,7 @@ func TestIngestVulnMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -1004,7 +1004,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -1362,7 +1362,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.GetBackend(nil)
+// 			b, err := inmem.getBackend(nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -40,7 +40,7 @@ func TestVulnerability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestVulnerabilityType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
@@ -409,7 +409,7 @@ func TestIngestVulnerabilities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
-	b, err := GetBackend(ctx, arangArg)
+	b, err := getBackend(ctx, arangArg)
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}

--- a/pkg/assembler/backends/ent/backend/migrations.go
+++ b/pkg/assembler/backends/ent/backend/migrations.go
@@ -36,7 +36,7 @@ type BackendOptions struct {
 }
 
 // SetupBackend sets up the ent backend, preparing the database and returning a client
-func SetupBackend(ctx context.Context, options BackendOptions) (*ent.Client, error) {
+func SetupBackend(ctx context.Context, options *BackendOptions) (*ent.Client, error) {
 	logger := logging.FromContext(ctx)
 
 	driver := dialect.Postgres

--- a/pkg/assembler/backends/ent/backend/register.go
+++ b/pkg/assembler/backends/ent/backend/register.go
@@ -13,25 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+//go:build !(386 || arm || mips)
 
-import (
-	"context"
+package backend
 
-	"entgo.io/ent/dialect"
-	"github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
-)
+import "github.com/guacsec/guac/pkg/assembler/backends"
 
-func main() {
-	ctx := context.Background()
-
-	_, err := backend.SetupBackend(ctx, &backend.BackendOptions{
-		AutoMigrate: true,
-		DriverName:  dialect.Postgres,
-		Address:     "postgres://localhost:5432/guac?sslmode=disable",
-	})
-
-	if err != nil {
-		panic(err)
-	}
+func init() {
+	backends.Register("ent", getBackend)
 }

--- a/pkg/assembler/backends/inmem/backend.go
+++ b/pkg/assembler/backends/inmem/backend.go
@@ -16,6 +16,7 @@
 package inmem
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -28,7 +29,9 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-type DemoCredentials struct{}
+func init() {
+	backends.Register("inmem", getBackend)
+}
 
 // node is the common interface of all backend nodes.
 type node interface {
@@ -102,7 +105,7 @@ type demoClient struct {
 	vulnerabilityMetadatas vulnerabilityMetadataList
 }
 
-func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
+func getBackend(_ context.Context, _ backends.BackendArgs) (backends.Backend, error) {
 	client := &demoClient{
 		artifacts:       artMap{},
 		builders:        builderMap{},

--- a/pkg/assembler/backends/inmem/certifyBad_test.go
+++ b/pkg/assembler/backends/inmem/certifyBad_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -502,7 +502,7 @@ func TestCertifyBad(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -790,7 +790,7 @@ func TestIngestCertifyBads(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -919,7 +919,7 @@ func TestCertifyBadNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/certifyGood_test.go
+++ b/pkg/assembler/backends/inmem/certifyGood_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -502,7 +502,7 @@ func TestCertifyGood(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -790,7 +790,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -919,7 +919,7 @@ func TestCertifyGoodNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/certifyLegal_test.go
+++ b/pkg/assembler/backends/inmem/certifyLegal_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -485,7 +485,7 @@ func TestLegal(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -585,7 +585,7 @@ func TestLegals(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -704,7 +704,7 @@ func TestLegalNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/certifyScorecard_test.go
+++ b/pkg/assembler/backends/inmem/certifyScorecard_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -409,7 +409,7 @@ func TestCertifyScorecard(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -591,7 +591,7 @@ func TestIngestScorecards(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -686,7 +686,7 @@ func TestCertifyScorecardNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -660,7 +660,7 @@ func TestVEX(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1024,7 +1024,7 @@ func TestVEXBulkIngest(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1137,7 +1137,7 @@ func TestVEXNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/certifyVuln_test.go
+++ b/pkg/assembler/backends/inmem/certifyVuln_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -600,7 +600,7 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1065,7 +1065,7 @@ func TestIngestCertifyVulns(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1184,7 +1184,7 @@ func TestCertifyVulnNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/hasMetadata_test.go
+++ b/pkg/assembler/backends/inmem/hasMetadata_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -624,7 +624,7 @@ func TestHasMetadata(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -753,7 +753,7 @@ func TestHasMetadataNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/hasSBOM_test.go
+++ b/pkg/assembler/backends/inmem/hasSBOM_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -476,7 +476,7 @@ func TestHasSBOM(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -702,7 +702,7 @@ func TestIngestHasSBOMs(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -802,7 +802,7 @@ func TestHasSBOMNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/hasSLSA_test.go
+++ b/pkg/assembler/backends/inmem/hasSLSA_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -497,7 +497,7 @@ func TestHasSLSA(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -722,7 +722,7 @@ func TestIngestHasSLSAs(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -830,7 +830,7 @@ func TestHasSLSANeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/hasSourceAt_test.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -501,7 +501,7 @@ func TestHasSourceAt(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -610,7 +610,7 @@ func TestHasSourceAtNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/hashEqual_test.go
+++ b/pkg/assembler/backends/inmem/hashEqual_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -415,7 +415,7 @@ func TestHashEqual(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -684,7 +684,7 @@ func TestIngestHashEquals(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -784,7 +784,7 @@ func TestHashEqualNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/isDependency_test.go
+++ b/pkg/assembler/backends/inmem/isDependency_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -564,7 +564,7 @@ func TestIsDependency(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -654,7 +654,7 @@ func TestIsDependencies(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -745,7 +745,7 @@ func TestIsDependencyNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/isOccurrence_test.go
+++ b/pkg/assembler/backends/inmem/isOccurrence_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -536,7 +536,7 @@ func TestOccurrence(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -650,7 +650,7 @@ func TestIngestOccurrences(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -759,7 +759,7 @@ func TestOccurrenceNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/license_test.go
+++ b/pkg/assembler/backends/inmem/license_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -151,7 +151,7 @@ func TestLicense(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -201,7 +201,7 @@ func TestIngestLicenses(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/pkgEqual_test.go
+++ b/pkg/assembler/backends/inmem/pkgEqual_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -415,7 +415,7 @@ func TestPkgEqual(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -515,7 +515,7 @@ func TestPkgEqualNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/pointOfContact_test.go
+++ b/pkg/assembler/backends/inmem/pointOfContact_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -624,7 +624,7 @@ func TestPointOfContact(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -753,7 +753,7 @@ func TestPointOfContactNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/vulnEqual_test.go
+++ b/pkg/assembler/backends/inmem/vulnEqual_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -438,7 +438,7 @@ func TestVulnEqual(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -531,7 +531,7 @@ func TestVulnerabilityEqualNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/vulnMetadata_test.go
+++ b/pkg/assembler/backends/inmem/vulnMetadata_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -787,7 +787,7 @@ func TestIngestVulnMetadata(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1085,7 +1085,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -1184,7 +1184,7 @@ func TestVulnMetadataNeighbors(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/inmem/vulnerability_test.go
+++ b/pkg/assembler/backends/inmem/vulnerability_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"golang.org/x/exp/slices"
 )
@@ -288,7 +288,7 @@ func TestVulnerability(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
@@ -345,7 +345,7 @@ func TestIngestVulnerabilities(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			b, err := inmem.GetBackend(nil)
+			b, err := backends.Get("inmem", nil, nil)
 			if err != nil {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}

--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -51,8 +51,15 @@ type neo4jClient struct {
 	driver neo4j.Driver
 }
 
-func GetBackend(args backends.BackendArgs) (backends.Backend, error) {
-	config := args.(*Neo4jConfig)
+func init() {
+	backends.Register("neo4j", getBackend)
+}
+
+func getBackend(_ context.Context, args backends.BackendArgs) (backends.Backend, error) {
+	config, ok := args.(*Neo4jConfig)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert neo4j config from backend args")
+	}
 	token := neo4j.BasicAuth(config.User, config.Pass, config.Realm)
 	driver, err := neo4j.NewDriver(config.DBAddr, token)
 	if err != nil {

--- a/pkg/assembler/backends/neptune/neptune.go
+++ b/pkg/assembler/backends/neptune/neptune.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neptune
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	"github.com/guacsec/guac/pkg/assembler/backends/neo4j"
+)
+
+const neptuneServiceName = "neptune-db"
+
+func init() {
+	backends.Register("neptune", getBackend)
+}
+
+type NeptuneConfig struct {
+	Endpoint string
+	Port     int
+	Region   string
+	User     string
+	Realm    string
+}
+
+func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backend, error) {
+	config, ok := args.(*NeptuneConfig)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert neptune config from backend args")
+	}
+	neptuneRequestURL := fmt.Sprintf("https://%s:%d/opencypher",
+		config.Endpoint, config.Port)
+	neptuneToken, err := generateNeptuneToken(neptuneRequestURL,
+		config.Region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create password for neptune: %w", err)
+	}
+
+	neptuneDBAddr := fmt.Sprintf("bolt+s://%s:%d/opencypher",
+		config.Endpoint, config.Port)
+	nargs := &neo4j.Neo4jConfig{
+		User:   config.User,
+		Pass:   neptuneToken,
+		DBAddr: neptuneDBAddr,
+		Realm:  config.Realm,
+	}
+	return backends.Get("neo4j", ctx, nargs)
+}
+
+// generateNeptuneToken generates a token for neptune using the AWS SDK.
+func generateNeptuneToken(neptuneURL string, region string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, neptuneURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("error creating http request for neptune: %w", err)
+	}
+
+	signer, err := getAWSRequestSigner()
+	if err != nil {
+		return "", fmt.Errorf("error creating AWS request signer: %w", err)
+	}
+
+	if _, err := signer.Sign(req, nil, neptuneServiceName, region, time.Now()); err != nil {
+		return "", fmt.Errorf("error signing neptune request: %w", err)
+	}
+
+	headers := []string{"Authorization", "X-Amz-Date", "X-Amz-Security-Token"}
+	hdrMap := make(map[string]string)
+	for _, h := range headers {
+		hdrMap[h] = req.Header.Get(h)
+	}
+
+	hdrMap["Host"] = req.Host
+	hdrMap["HttpMethod"] = req.Method
+	password, err := json.Marshal(hdrMap)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling header map: %w", err)
+	}
+
+	return string(password), nil
+}
+
+// This method returns the AWS signer to be used for signing the request to be
+// sent to Neptune Cluster.  It checks for the presence of AWS_ACCESS_KEY_ID,
+// AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN in the environment.  If not
+// found, it creates a new session and gets the credentials from the session.
+func getAWSRequestSigner() (*v4.Signer, error) {
+	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+
+	if accessKeyID != "" && secretAccessKey != "" && sessionToken != "" {
+		return v4.NewSigner(credentials.NewEnvCredentials()), nil
+	}
+
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return v4.NewSigner(sess.Config.Credentials), nil
+}

--- a/pkg/assembler/backends/register.go
+++ b/pkg/assembler/backends/register.go
@@ -13,25 +13,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package backends
 
 import (
 	"context"
 
-	"entgo.io/ent/dialect"
-	"github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
+	"golang.org/x/exp/maps"
 )
 
-func main() {
-	ctx := context.Background()
+type GBFunc func(context.Context, BackendArgs) (Backend, error)
 
-	_, err := backend.SetupBackend(ctx, &backend.BackendOptions{
-		AutoMigrate: true,
-		DriverName:  dialect.Postgres,
-		Address:     "postgres://localhost:5432/guac?sslmode=disable",
-	})
+var getBackend map[string]GBFunc
 
-	if err != nil {
-		panic(err)
-	}
+func init() {
+	getBackend = make(map[string]GBFunc)
+}
+
+func Register(name string, gb GBFunc) {
+	getBackend[name] = gb
+}
+
+func Get(name string, ctx context.Context, args BackendArgs) (Backend, error) {
+	return getBackend[name](ctx, args)
+}
+
+func List() []string {
+	return maps.Keys(getBackend)
 }

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler"
-	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/inmem"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
@@ -1699,8 +1700,7 @@ func startTestServer() (*http.Server, error) {
 
 func getGraphqlTestServer() (*handler.Server, error) {
 	var topResolver resolvers.Resolver
-	args := inmem.DemoCredentials{}
-	backend, err := inmem.GetBackend(&args)
+	backend, err := backends.Get("inmem", nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating inmem backend: %w", err)
 	}


### PR DESCRIPTION
# Description of the PR

Disable ent on 32 bit

supersedes #1201

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
