### PR TITLE
update SPDX parser to skip empty and 0 hashes

### DIFF
--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -157,6 +157,9 @@ func (s *spdxParser) getFiles() error {
 
 		// if checksums exists create an artifact for each of them
 		for _, checksum := range file.Checksums {
+			if isEmptyChecksum(checksum.Value) {
+				continue
+			}
 			// for each file create a package for each of them so they can be referenced as a dependency
 			purl := asmhelpers.GuacFilePurl(strings.ToLower(string(checksum.Algorithm)), checksum.Value, &file.FileName)
 			pkg, err := asmhelpers.PurlToPkg(purl)
@@ -169,6 +172,7 @@ func (s *spdxParser) getFiles() error {
 				Algorithm: strings.ToLower(string(checksum.Algorithm)),
 				Digest:    checksum.Value,
 			}
+
 			s.fileArtifacts[string(file.FileSPDXIdentifier)] = append(s.fileArtifacts[string(file.FileSPDXIdentifier)], artifact)
 		}
 	}
@@ -323,4 +327,16 @@ func getJustification(r *spdx.Relationship) string {
 		s += fmt.Sprintf("with comment: %s", r.RelationshipComment)
 	}
 	return s
+}
+
+func isEmptyChecksum(v string) bool {
+	return map[string]bool{
+		// all 0 hash
+		"0000000000000000000000000000000000000000":                         true,
+		"0000000000000000000000000000000000000000000000000000000000000000": true,
+		// sha1 empty file
+		"da39a3ee5e6b4b0d3255bfef95601890afd80709": true,
+		// sha256 empty file
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": true,
+	}[v]
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -338,5 +338,9 @@ func isEmptyChecksum(v string) bool {
 		"da39a3ee5e6b4b0d3255bfef95601890afd80709": true,
 		// sha256 empty file
 		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": true,
+		// sha512 empty file
+		"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e": true,
+		// TODO: add the same for other SPDX hash algorithms available
+		// ref: https://github.com/guacsec/guac/issues/1229
 	}[v]
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -468,6 +468,21 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
+				  "fileName": "file2",
+				  "SPDXID": "SPDXRef-dde3c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA512",
+					  "checksumValue": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				},
+				{
 				  "fileName": "include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -261,7 +261,7 @@ func Test_spdxParser(t *testing.T) {
 			"documentDescribes": [
 				"SPDXRef-6dcd47a4-bfcb-47d7-8ee4-60b6dc4861a8"
 			],
-			"name":"sbom-sha256:a743268cd3c56f921f3fb706cc0425c8ab78119fd433e38bb7c5dcd5635b0d10",
+			"name":"test-sbom",
 			"packages":[
 				{
 					"SPDXID": "SPDXRef-8c5bc68a-d747-48de-b737-bc9703c330e7",
@@ -324,6 +324,200 @@ func Test_spdxParser(t *testing.T) {
 				},
 				HasSBOM: []assembler.HasSBOMIngest{
 					{Pkg: pUrlToPkgDiscardError("pkg:oci/redhat/ubi9-container@sha256:4227a4b5013999a412196237c62e40d778d09cdc751720a66ff3701fbe5a4a9d?repository_url=registry.redhat.io/ubi9&tag=9.1.0-1750")},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SPDX with files that have 0000 hash file representation",
+			additionalOpts: []cmp.Option{
+				cmpopts.IgnoreFields(assembler.HasSBOMIngest{},
+					"HasSBOM")},
+			doc: &processor.Document{
+				Blob: []byte(`
+		{
+			"SPDXID":"SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.2",
+			"name":"testsbom",
+			"files":[
+				{
+				  "fileName": "file1",
+				  "SPDXID": "SPDXRef-3431c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA1",
+					  "checksumValue": "0000000000000000000000000000000000000000"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				},
+				{
+				  "fileName": "file2",
+				  "SPDXID": "SPDXRef-def1c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA256",
+					  "checksumValue": "0000000000000000000000000000000000000000000000000000000000000000"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				},
+				{
+				  "fileName": "include-file",
+				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA1",
+					  "checksumValue": "ba1c68d88439599dcca7594d610030a19eda4f63"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				}
+
+			]
+		}
+	`),
+				Format: processor.FormatJSON,
+				Type:   processor.DocumentSPDX,
+				SourceInformation: processor.SourceInformation{
+					Collector: "TestCollector",
+					Source:    "TestSource",
+				},
+			},
+			wantPredicates: &assembler.IngestPredicates{
+				IsDependency: []assembler.IsDependencyIngest{
+					{
+						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
+						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
+						IsDependency: &generated.IsDependencyInputSpec{
+							DependencyType: generated.DependencyTypeUnknown,
+							Justification:  "top-level package GUAC heuristic connecting to each file/package",
+						},
+					},
+				},
+				IsOccurrence: []assembler.IsOccurrenceIngest{
+
+					{
+						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						Artifact: &generated.ArtifactInputSpec{
+							Algorithm: "sha1",
+							Digest:    "ba1c68d88439599dcca7594d610030a19eda4f63",
+						},
+						IsOccurrence: &generated.IsOccurrenceInputSpec{Justification: "spdx file with checksum"},
+					},
+				},
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: pUrlToPkgDiscardError("pkg:guac/spdx/testsbom")},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "SPDX with files that have empty file hash representation",
+			additionalOpts: []cmp.Option{
+				cmpopts.IgnoreFields(assembler.HasSBOMIngest{},
+					"HasSBOM")},
+			doc: &processor.Document{
+				Blob: []byte(`
+		{
+			"SPDXID":"SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.2",
+			"name":"testsbom",
+			"files":[
+				{
+				  "fileName": "file1",
+				  "SPDXID": "SPDXRef-3431c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA1",
+					  "checksumValue": "0000000000000000000000000000000000000000"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				},
+				{
+				  "fileName": "file2",
+				  "SPDXID": "SPDXRef-def1c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA256",
+					  "checksumValue": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				},
+				{
+				  "fileName": "include-file",
+				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
+				  "fileTypes": [
+					"TEXT"
+				  ],
+				  "checksums": [
+					{
+					  "algorithm": "SHA1",
+					  "checksumValue": "ba1c68d88439599dcca7594d610030a19eda4f63"
+					}
+				  ],
+				  "licenseConcluded": "NOASSERTION",
+				  "copyrightText": ""
+				}
+
+			]
+		}
+	`),
+				Format: processor.FormatJSON,
+				Type:   processor.DocumentSPDX,
+				SourceInformation: processor.SourceInformation{
+					Collector: "TestCollector",
+					Source:    "TestSource",
+				},
+			},
+			wantPredicates: &assembler.IngestPredicates{
+				IsDependency: []assembler.IsDependencyIngest{
+					{
+						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
+						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
+						IsDependency: &generated.IsDependencyInputSpec{
+							DependencyType: generated.DependencyTypeUnknown,
+							Justification:  "top-level package GUAC heuristic connecting to each file/package",
+						},
+					},
+				},
+				IsOccurrence: []assembler.IsOccurrenceIngest{
+
+					{
+						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						Artifact: &generated.ArtifactInputSpec{
+							Algorithm: "sha1",
+							Digest:    "ba1c68d88439599dcca7594d610030a19eda4f63",
+						},
+						IsOccurrence: &generated.IsOccurrenceInputSpec{Justification: "spdx file with checksum"},
+					},
+				},
+				HasSBOM: []assembler.HasSBOMIngest{
+					{Pkg: pUrlToPkgDiscardError("pkg:guac/spdx/testsbom")},
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
# Description of the PR

When ingesting SBOMs, i noticed that the ingestion was slow (and was waiting on `IsOccurrences`). Experimented removing the hashes with all 0s in the digest field results in much faster times.

It looks like many of these files have this 0 hash and thus creates a node with very large number of edges out of it. 

This PR modifies the SPDX parser such that it ignores the hashes of all 0s (which Syft uses to represent symlinks), and empty file hashes.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
