### PR TITLE
fix: increase gprc max message size

### DIFF
--- a/pkg/collectsub/server/server.go
+++ b/pkg/collectsub/server/server.go
@@ -56,12 +56,13 @@ func NewServer(port int) (*server, error) {
 
 func (s *server) AddCollectEntries(ctx context.Context, in *pb.AddCollectEntriesRequest) (*pb.AddCollectEntriesResponse, error) {
 	logger := ctxzap.Extract(ctx).Sugar()
-	logger.Infof("AddCollectEntries called with entries: %v", in.Entries)
+	logger.Debugf("AddCollectEntries called with entries: %v", in.Entries)
 
 	err := s.Db.AddCollectEntries(ctx, in.Entries)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add entry to db: %w", err)
 	}
+	logger.Infof("AddCollectEntries added %d entries", len(in.Entries))
 
 	return &pb.AddCollectEntriesResponse{
 		Success: true,
@@ -70,7 +71,7 @@ func (s *server) AddCollectEntries(ctx context.Context, in *pb.AddCollectEntries
 
 func (s *server) GetCollectEntries(ctx context.Context, in *pb.GetCollectEntriesRequest) (*pb.GetCollectEntriesResponse, error) {
 	logger := ctxzap.Extract(ctx).Sugar()
-	logger.Infof("GetCollectEntries called with filters: %v", in.Filters)
+	logger.Debugf("GetCollectEntries called with filters: %v", in.Filters)
 
 	ret, err := s.Db.GetCollectEntries(ctx, in.Filters, in.SinceTime)
 	if err != nil {
@@ -126,6 +127,7 @@ func (s *server) Serve(ctx context.Context) error {
 				grpc_zap.UnaryServerInterceptor(logger.Desugar()),
 				contextToZapFieldsUnaryServerInterceptor(),
 			)),
+		grpc.MaxRecvMsgSize(16777216),
 	}
 	gs := grpc.NewServer(opts...)
 


### PR DESCRIPTION
# Description of the PR

Another issue while trying to ingest large SBOM is that a collector-sub message can get larger than default 4MB. I made a quick fix to increase it to 16MB which double than what I saw in largest SBOMs so far. If you think we can also make it configurable?

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
