### PR TITLE
Ent - CertifyVuln: fixed noVuln management

### DIFF
--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -307,17 +307,6 @@ var (
 				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_vulnerability_id_package_id",
 				Unique:  true,
 				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[8], CertifyVulnsColumns[9]},
-				Annotation: &entsql.IndexAnnotation{
-					Where: "vulnerability_id IS NOT NULL",
-				},
-			},
-			{
-				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_package_id",
-				Unique:  true,
-				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[9]},
-				Annotation: &entsql.IndexAnnotation{
-					Where: "vulnerability_id IS NULL",
-				},
 			},
 		},
 	}

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -17,7 +17,6 @@ package schema
 
 import (
 	"entgo.io/ent"
-	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -54,7 +53,6 @@ func (CertifyVuln) Edges() []ent.Edge {
 // Indexes of the Vulnerability.
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector").Edges("vulnerability", "package").Unique().Annotations(entsql.IndexWhere("vulnerability_id IS NOT NULL")),
-		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector").Edges("package").Unique().Annotations(entsql.IndexWhere("vulnerability_id IS NULL")),
+		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector").Edges("vulnerability", "package").Unique(),
 	}
 }


### PR DESCRIPTION
# Description of the PR
Running `guacone certifier osv` I've spotted an issue with guac running on ent backend in the `NoVuln` vulnerability management based on the `vulnerability_id` being always available (also for NoVuln` vulnerability)

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
