### PR TITLE
inmem - PkgEqual: Subpath query filtering

### DIFF
--- a/pkg/assembler/backends/inmem/certifyLegal.go
+++ b/pkg/assembler/backends/inmem/certifyLegal.go
@@ -317,14 +317,14 @@ func (c *demoClient) CertifyLegal(ctx context.Context, filter *model.CertifyLega
 
 	var search []uint32
 	foundOne := false
-	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Subject.Package)
+	if filter != nil && filter.Subject != nil && filter.Subject.Package != nil {
+		pkgs, err := c.findPackageVersion(filter.Subject.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = append(search, exactPackage.certifyLegals...)
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.certifyLegals...)
 		}
 	}
 	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Source != nil {

--- a/pkg/assembler/backends/inmem/certifyVEXStatement.go
+++ b/pkg/assembler/backends/inmem/certifyVEXStatement.go
@@ -254,13 +254,13 @@ func (c *demoClient) CertifyVEXStatement(ctx context.Context, filter *model.Cert
 		}
 	}
 	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Subject.Package)
+		pkgs, err := c.findPackageVersion(filter.Subject.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = append(search, exactPackage.vexLinks...)
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.vexLinks...)
 		}
 	}
 	if !foundOne && filter != nil && filter.Vulnerability != nil {

--- a/pkg/assembler/backends/inmem/certifyVuln.go
+++ b/pkg/assembler/backends/inmem/certifyVuln.go
@@ -197,13 +197,13 @@ func (c *demoClient) CertifyVuln(ctx context.Context, filter *model.CertifyVulnS
 	var search []uint32
 	foundOne := false
 	if filter != nil && filter.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Package)
+		pkgs, err := c.findPackageVersion(filter.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = append(search, exactPackage.certifyVulnLinks...)
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.certifyVulnLinks...)
 		}
 	}
 	if !foundOne && filter != nil && filter.Vulnerability != nil &&

--- a/pkg/assembler/backends/inmem/hasSBOM.go
+++ b/pkg/assembler/backends/inmem/hasSBOM.go
@@ -219,13 +219,13 @@ func (c *demoClient) HasSBOM(ctx context.Context, filter *model.HasSBOMSpec) ([]
 	var search []uint32
 	foundOne := false
 	if filter != nil && filter.Subject != nil && filter.Subject.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Subject.Package)
+		pkgs, err := c.findPackageVersion(filter.Subject.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = exactPackage.hasSBOMs
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.hasSBOMs...)
 		}
 	}
 	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Artifact != nil {

--- a/pkg/assembler/backends/inmem/isDependency.go
+++ b/pkg/assembler/backends/inmem/isDependency.go
@@ -183,38 +183,34 @@ func (c *demoClient) IsDependency(ctx context.Context, filter *model.IsDependenc
 	var search []uint32
 	foundOne := false
 	if filter != nil && filter.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Package)
+		pkgs, err := c.findPackageVersion(filter.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = append(search, exactPackage.isDependencyLinks...)
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.isDependencyLinks...)
 		}
 	}
 	if !foundOne && filter != nil && filter.DependentPackage != nil {
-		var exactPackageLinks []uint32
 		if filter.DependentPackage.Version == nil {
 			exactPackage, err := c.exactPackageName(filter.DependentPackage)
 			if err != nil {
 				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 			}
 			if exactPackage != nil {
-				exactPackageLinks = exactPackage.isDependencyLinks
+				search = append(search, exactPackage.isDependencyLinks...)
+				foundOne = true
 			}
 		} else {
-			exactPackage, err := c.exactPackageVersion(filter.Package)
+			pkgs, err := c.findPackageVersion(filter.Package)
 			if err != nil {
 				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 			}
-			if exactPackage != nil {
-				exactPackageLinks = exactPackage.isDependencyLinks
+			foundOne = len(pkgs) > 0
+			for _, pkg := range pkgs {
+				search = append(search, pkg.isDependencyLinks...)
 			}
-		}
-
-		if exactPackageLinks != nil {
-			search = append(search, exactPackageLinks...)
-			foundOne = true
 		}
 	}
 

--- a/pkg/assembler/backends/inmem/isOccurrence.go
+++ b/pkg/assembler/backends/inmem/isOccurrence.go
@@ -297,13 +297,13 @@ func (c *demoClient) IsOccurrence(ctx context.Context, filter *model.IsOccurrenc
 		}
 	}
 	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Package != nil {
-		exactPackage, err := c.exactPackageVersion(filter.Subject.Package)
+		pkgs, err := c.findPackageVersion(filter.Subject.Package)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
-		if exactPackage != nil {
-			search = append(search, exactPackage.occurrences...)
-			foundOne = true
+		foundOne = len(pkgs) > 0
+		for _, pkg := range pkgs {
+			search = append(search, pkg.occurrences...)
 		}
 	}
 	if !foundOne && filter != nil && filter.Subject != nil && filter.Subject.Source != nil {

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -743,21 +743,6 @@ func noMatchQualifiers(filter *model.PkgSpec, v map[string]string) bool {
 	return false
 }
 
-func (c *demoClient) exactPackageVersion(filter *model.PkgSpec) (*pkgVersionNode, error) {
-	pkgs, err := c.findPackageVersion(filter)
-	if err != nil {
-		return nil, gqlerror.Errorf("No package version matches spec %v", err)
-	}
-	switch len(pkgs) {
-	case 0:
-		return nil, nil
-	case 1:
-		return pkgs[0], nil
-	default:
-		return nil, gqlerror.Errorf("More than one package version matches spec")
-	}
-}
-
 func (c *demoClient) findPackageVersion(filter *model.PkgSpec) ([]*pkgVersionNode, error) {
 	if filter == nil {
 		return nil, nil
@@ -790,7 +775,6 @@ func (c *demoClient) findPackageVersion(filter *model.PkgSpec) ([]*pkgVersionNod
 		}
 		for _, v := range nm.versions {
 			if *filter.Version != v.version ||
-				//filter.Subpath == nil ||
 				noMatch(filter.Subpath, v.subpath) ||
 				noMatchQualifiers(filter, v.qualifiers) {
 				continue

--- a/pkg/assembler/backends/inmem/pkg.go
+++ b/pkg/assembler/backends/inmem/pkg.go
@@ -774,6 +774,7 @@ func (c *demoClient) exactPackageVersion(filter *model.PkgSpec) (*pkgVersionNode
 		}
 		for _, v := range nm.versions {
 			if *filter.Version != v.version ||
+				filter.Subpath == nil ||
 				noMatchInput(filter.Subpath, v.subpath) ||
 				noMatchQualifiers(filter, v.qualifiers) {
 				continue

--- a/pkg/assembler/backends/inmem/pkgEqual.go
+++ b/pkg/assembler/backends/inmem/pkgEqual.go
@@ -165,23 +165,18 @@ func (c *demoClient) PkgEqual(ctx context.Context, filter *model.PkgEqualSpec) (
 	}
 
 	var search []uint32
-	foundOne := false
 	for _, p := range filter.Packages {
-		if !foundOne {
-			exactPackage, err := c.exactPackageVersion(p)
-			if err != nil {
-				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
-			}
-			if exactPackage != nil {
-				search = append(search, exactPackage.pkgEquals...)
-				foundOne = true
-				break
-			}
+		pkgs, err := c.findPackageVersion(p)
+		if err != nil {
+			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+		}
+		for _, pkg := range pkgs {
+			search = append(search, pkg.pkgEquals...)
 		}
 	}
 
 	var out []*model.PkgEqual
-	if foundOne {
+	if len(search) > 0 {
 		for _, id := range search {
 			link, err := byID[*pkgEqualStruct](id, c)
 			if err != nil {

--- a/pkg/assembler/backends/inmem/pkgEqual_test.go
+++ b/pkg/assembler/backends/inmem/pkgEqual_test.go
@@ -231,6 +231,9 @@ func TestPkgEqual(t *testing.T) {
 				{
 					Packages: []*model.Package{p1out, p2out},
 				},
+				{
+					Packages: []*model.Package{p1out, p3out},
+				},
 			},
 		},
 		{
@@ -581,6 +584,10 @@ func TestIngestPkgEquals(t *testing.T) {
 			ExpHE: []*model.PkgEqual{
 				{
 					Packages:      []*model.Package{p1out, p2out},
+					Justification: "test justification",
+				},
+				{
+					Packages:      []*model.Package{p1out, p3out},
 					Justification: "test justification",
 				},
 			},


### PR DESCRIPTION
# Description of the PR

Draft PR to further discuss about https://github.com/guacsec/guac/pull/1243#discussion_r1320122295:

Added both `PkgEqual` instance to the expected outcomes for `Query on pkg algo and pkg` test based on the assumption that not having provided a `Subpath` value in the query `PkgEqualSpec` should not filter by `Subpath`.

The "reasonable" way I found to have it working has been adding the `filter.Subpath == nil` in the `exactPackageVersion` func rather than changing the `noMatchInput` because changing the latter made much more tests to fail even if this brings me the doubt that *maybe* the filtering could be broken somewhere else.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
