### PR TITLE
Feature/has metadata bulk ingestion and arango updates

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -605,7 +605,7 @@ func bulkIngestVulnerabilityMetadata(ctx context.Context, client graphql.Client)
 		if _, err := model.IngestVulnerabilities(ctx, client, ingest.vulns); err != nil {
 			logger.Errorf("Error in ingesting vulnerabilities: %v\n", err)
 		}
-		if _, err := model.VulnHasMetadatas(ctx, client, ingest.vulns, ingest.vulnerabilityMetadataList); err != nil {
+		if _, err := model.BulkVulnHasMetadata(ctx, client, ingest.vulns, ingest.vulnerabilityMetadataList); err != nil {
 			logger.Errorf("Error in ingesting VulnHasMetadatas: %v\n", err)
 		}
 	}

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -290,6 +290,21 @@ func (mr *MockBackendMockRecorder) IngestBuilders(ctx, builders interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestBuilders", reflect.TypeOf((*MockBackend)(nil).IngestBuilders), ctx, builders)
 }
 
+// IngestBulkVulnerabilityMetadata mocks base method.
+func (m *MockBackend) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IngestBulkVulnerabilityMetadata", ctx, vulnerabilities, vulnerabilityMetadataList)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IngestBulkVulnerabilityMetadata indicates an expected call of IngestBulkVulnerabilityMetadata.
+func (mr *MockBackendMockRecorder) IngestBulkVulnerabilityMetadata(ctx, vulnerabilities, vulnerabilityMetadataList interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestBulkVulnerabilityMetadata", reflect.TypeOf((*MockBackend)(nil).IngestBulkVulnerabilityMetadata), ctx, vulnerabilities, vulnerabilityMetadataList)
+}
+
 // IngestCertifyBad mocks base method.
 func (m *MockBackend) IngestCertifyBad(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, certifyBad model.CertifyBadInputSpec) (*model.CertifyBad, error) {
 	m.ctrl.T.Helper()
@@ -858,21 +873,6 @@ func (m *MockBackend) IngestVulnerabilityMetadata(ctx context.Context, vulnerabi
 func (mr *MockBackendMockRecorder) IngestVulnerabilityMetadata(ctx, vulnerability, vulnerabilityMetadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestVulnerabilityMetadata", reflect.TypeOf((*MockBackend)(nil).IngestVulnerabilityMetadata), ctx, vulnerability, vulnerabilityMetadata)
-}
-
-// IngestVulnerabilityMetadatas mocks base method.
-func (m *MockBackend) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IngestVulnerabilityMetadatas", ctx, vulnerabilities, vulnerabilityMetadatas)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IngestVulnerabilityMetadatas indicates an expected call of IngestVulnerabilityMetadatas.
-func (mr *MockBackendMockRecorder) IngestVulnerabilityMetadatas(ctx, vulnerabilities, vulnerabilityMetadatas interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestVulnerabilityMetadatas", reflect.TypeOf((*MockBackend)(nil).IngestVulnerabilityMetadatas), ctx, vulnerabilities, vulnerabilityMetadatas)
 }
 
 // IsDependency mocks base method.

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -290,6 +290,21 @@ func (mr *MockBackendMockRecorder) IngestBuilders(ctx, builders interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestBuilders", reflect.TypeOf((*MockBackend)(nil).IngestBuilders), ctx, builders)
 }
 
+// IngestBulkHasMetadata mocks base method.
+func (m *MockBackend) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IngestBulkHasMetadata", ctx, subjects, pkgMatchType, hasMetadataList)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IngestBulkHasMetadata indicates an expected call of IngestBulkHasMetadata.
+func (mr *MockBackendMockRecorder) IngestBulkHasMetadata(ctx, subjects, pkgMatchType, hasMetadataList interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestBulkHasMetadata", reflect.TypeOf((*MockBackend)(nil).IngestBulkHasMetadata), ctx, subjects, pkgMatchType, hasMetadataList)
+}
+
 // IngestBulkVulnerabilityMetadata mocks base method.
 func (m *MockBackend) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/assembler/assembler_test.go
+++ b/pkg/assembler/assembler_test.go
@@ -138,6 +138,13 @@ func TestIngestPredicates(t *testing.T) {
 					},
 				},
 				{
+					Src:      k8sSource,
+					Artifact: rootFileArtifact,
+					IsOccurrence: &generated.IsOccurrenceInputSpec{
+						Justification: "spdx file with checksum",
+					},
+				},
+				{
 					Pkg:      rootFilePack,
 					Artifact: rootFileArtifact,
 					IsOccurrence: &generated.IsOccurrenceInputSpec{
@@ -148,6 +155,15 @@ func TestIngestPredicates(t *testing.T) {
 			HasSBOM: []HasSBOMIngest{
 				{
 					Pkg: topLevelPack,
+					HasSBOM: &generated.HasSBOMInputSpec{
+						Uri:              "TestSource",
+						Algorithm:        "sha256",
+						Digest:           "8b5e8212cae084f92ff91f8625a50ea1070738cfc68ecca08bf04d64f64b9feb",
+						DownloadLocation: "TestSource",
+					},
+				},
+				{
+					Artifact: rootFileArtifact,
 					HasSBOM: &generated.HasSBOMInputSpec{
 						Uri:              "TestSource",
 						Algorithm:        "sha256",
@@ -381,6 +397,60 @@ func TestIngestPredicates(t *testing.T) {
 					},
 					VulnEqual: &generated.VulnEqualInputSpec{
 						Justification: "Decoded OSV data",
+					},
+				},
+			},
+			PointOfContact: []PointOfContactIngest{
+				{
+					Pkg: topLevelPack,
+					PkgMatchFlag: generated.MatchFlags{
+						Pkg: generated.PkgMatchTypeSpecificVersion,
+					},
+					//generated.PkgMatchTypeSpecificVersion,
+					PointOfContact: &generated.PointOfContactInputSpec{
+						Justification: "bad package",
+					},
+				},
+				{
+					Src: k8sSource,
+					PointOfContact: &generated.PointOfContactInputSpec{
+						Justification: "bad source",
+					},
+				},
+				{
+					Artifact: &generated.ArtifactInputSpec{
+						Algorithm: "sha256",
+						Digest:    "fe4fe40ac7250263c5dbe1cf3138912f3f416140aa248637a60d65fe22c47da4",
+					},
+					PointOfContact: &generated.PointOfContactInputSpec{
+						Justification: "bad artifact",
+					},
+				},
+			},
+			HasMetadata: []HasMetadataIngest{
+				{
+					Pkg: topLevelPack,
+					PkgMatchFlag: generated.MatchFlags{
+						Pkg: generated.PkgMatchTypeSpecificVersion,
+					},
+					//generated.PkgMatchTypeSpecificVersion,
+					HasMetadata: &generated.HasMetadataInputSpec{
+						Justification: "bad package",
+					},
+				},
+				{
+					Src: k8sSource,
+					HasMetadata: &generated.HasMetadataInputSpec{
+						Justification: "bad source",
+					},
+				},
+				{
+					Artifact: &generated.ArtifactInputSpec{
+						Algorithm: "sha256",
+						Digest:    "fe4fe40ac7250263c5dbe1cf3138912f3f416140aa248637a60d65fe22c47da4",
+					},
+					HasMetadata: &generated.HasMetadataInputSpec{
+						Justification: "bad artifact",
 					},
 				},
 			},

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -587,7 +587,7 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			return nil, fmt.Errorf("failed to generate index for isDependencies: %w", err)
 		}
 
-		if err := createIndexPerCollection(ctx, db, isOccurrencesStr, []string{"packageID", "artifactID", "justification"}, true, "byPkgIDArtIDJust"); err != nil {
+		if err := createIndexPerCollection(ctx, db, isOccurrencesStr, []string{"packageID", "artifactID", "justification", "origin"}, true, "byPkgIDArtIDOriginJust"); err != nil {
 			return nil, fmt.Errorf("failed to generate index for isOccurrences: %w", err)
 		}
 

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -99,6 +99,14 @@ const (
 	hashEqualSubjectArtEdgesStr string = "hashEqualSubjectArtEdges"
 	hashEqualsStr               string = "hashEquals"
 
+	// hasMetadata collection
+
+	hasMetadataPkgVersionEdgesStr string = "hasMetadataPkgVersionEdges"
+	hasMetadataPkgNameEdgesStr    string = "hasMetadataPkgNameEdges"
+	hasMetadataSrcEdgesStr        string = "hasMetadataSrcEdges"
+	hasMetadataArtEdgesStr        string = "hasMetadataArtEdges"
+	hasMetadataStr                string = "hasMetadataCollection"
+
 	// hasSBOM collection
 
 	hasSBOMPkgEdgesStr string = "hasSBOMPkgEdges"
@@ -120,7 +128,7 @@ const (
 	// vulnMetadata collection
 
 	vulnMetadataEdgesStr string = "vulnMetadataEdges"
-	vulnMetadatasStr     string = "vulnMetadatas"
+	vulnMetadataStr      string = "vulnMetadataCollection"
 
 	// vulnEquals collections
 
@@ -359,6 +367,27 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		hashEqualSubjectArtEdges.From = []string{artifactsStr}
 		hashEqualSubjectArtEdges.To = []string{hashEqualsStr}
 
+		// setup hasMetadata collections
+		var hasMetadataPkgVersionEdges driver.EdgeDefinition
+		hasMetadataPkgVersionEdges.Collection = hasMetadataPkgVersionEdgesStr
+		hasMetadataPkgVersionEdges.From = []string{pkgVersionsStr}
+		hasMetadataPkgVersionEdges.To = []string{hasMetadataStr}
+
+		var hasMetadataPkgNameEdges driver.EdgeDefinition
+		hasMetadataPkgNameEdges.Collection = hasMetadataPkgNameEdgesStr
+		hasMetadataPkgNameEdges.From = []string{pkgNamesStr}
+		hasMetadataPkgNameEdges.To = []string{hasMetadataStr}
+
+		var hasMetadataArtEdges driver.EdgeDefinition
+		hasMetadataArtEdges.Collection = hasMetadataArtEdgesStr
+		hasMetadataArtEdges.From = []string{artifactsStr}
+		hasMetadataArtEdges.To = []string{hasMetadataStr}
+
+		var hasMetadataSrcEdges driver.EdgeDefinition
+		hasMetadataSrcEdges.Collection = hasMetadataSrcEdgesStr
+		hasMetadataSrcEdges.From = []string{srcNamesStr}
+		hasMetadataSrcEdges.To = []string{hasMetadataStr}
+
 		// setup hasSBOM collections
 		var hasSBOMPkgEdges driver.EdgeDefinition
 		hasSBOMPkgEdges.Collection = hasSBOMPkgEdgesStr
@@ -401,7 +430,7 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		var vulnMetadataEdges driver.EdgeDefinition
 		vulnMetadataEdges.Collection = vulnMetadataEdgesStr
 		vulnMetadataEdges.From = []string{vulnerabilitiesStr}
-		vulnMetadataEdges.To = []string{vulnMetadatasStr}
+		vulnMetadataEdges.To = []string{vulnMetadataStr}
 
 		// setup vulnEqual collections
 		var vulnEqualVulnEdges driver.EdgeDefinition
@@ -482,7 +511,8 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			hasSBOMArtEdges, certifyVulnPkgEdges, certifyVulnEdges, certifyScorecardSrcEdges, certifyBadPkgVersionEdges, certifyBadPkgNameEdges,
 			certifyBadArtEdges, certifyBadSrcEdges, certifyGoodPkgVersionEdges, certifyGoodPkgNameEdges, certifyGoodArtEdges, certifyGoodSrcEdges,
 			certifyVexPkgEdges, certifyVexArtEdges, certifyVexVulnEdges, vulnMetadataEdges, vulnEqualVulnEdges, vulnEqualSubjectVulnEdges,
-			pkgEqualPkgEdges, pkgEqualSubjectPkgEdges}
+			pkgEqualPkgEdges, pkgEqualSubjectPkgEdges, hasMetadataPkgVersionEdges, hasMetadataPkgNameEdges,
+			hasMetadataArtEdges, hasMetadataSrcEdges}
 
 		// create a graph
 		graph, err = db.CreateGraphV2(ctx, "guac", &options)

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -22,10 +22,14 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
-	return nil, fmt.Errorf("not implemented: IngestHasMetadata")
-}
-
 func (c *arangoClient) HasMetadata(ctx context.Context, hasMetadataSpec *model.HasMetadataSpec) ([]*model.HasMetadata, error) {
 	return nil, fmt.Errorf("not implemented: HasMetadata")
+}
+
+func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
+}
+
+func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
+	return nil, fmt.Errorf("not implemented: IngestHasMetadata")
 }

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -17,33 +17,282 @@ package arangodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+const (
+	keyStr   string = "key"
+	valueStr string = "value"
+)
+
 func (c *arangoClient) HasMetadata(ctx context.Context, hasMetadataSpec *model.HasMetadataSpec) ([]*model.HasMetadata, error) {
-	return nil, fmt.Errorf("not implemented: HasMetadata")
+
+	var arangoQueryBuilder *arangoQueryBuilder
+	if hasMetadataSpec.Subject != nil {
+		var combinedHasMetadata []*model.HasMetadata
+		if hasMetadataSpec.Subject.Package != nil {
+			values := map[string]any{}
+			// pkgVersion hasMetadata
+			arangoQueryBuilder = setPkgVersionMatchValues(hasMetadataSpec.Subject.Package, values)
+			arangoQueryBuilder.forOutBound(hasMetadataPkgVersionEdgesStr, "hasMetadata", "pVersion")
+			setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+
+			pkgVersionHasMetadata, err := getPkgHasMetadataForQuery(ctx, c, arangoQueryBuilder, values, true)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package version hasMetadata with error: %w", err)
+			}
+
+			combinedHasMetadata = append(combinedHasMetadata, pkgVersionHasMetadata...)
+
+			if hasMetadataSpec.Subject.Package.ID == nil {
+				// pkgName hasMetadata
+				values = map[string]any{}
+				arangoQueryBuilder = setPkgNameMatchValues(hasMetadataSpec.Subject.Package, values)
+				arangoQueryBuilder.forOutBound(hasMetadataPkgNameEdgesStr, "hasMetadata", "pName")
+				setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+
+				pkgNameHasMetadata, err := getPkgHasMetadataForQuery(ctx, c, arangoQueryBuilder, values, false)
+				if err != nil {
+					return nil, fmt.Errorf("failed to retrieve package name hasMetadata with error: %w", err)
+				}
+
+				combinedHasMetadata = append(combinedHasMetadata, pkgNameHasMetadata...)
+			}
+		}
+		if hasMetadataSpec.Subject.Source != nil {
+			values := map[string]any{}
+			arangoQueryBuilder = setSrcMatchValues(hasMetadataSpec.Subject.Source, values)
+			arangoQueryBuilder.forOutBound(hasMetadataSrcEdgesStr, "hasMetadata", "sName")
+			setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+
+			srcHasMetadata, err := getSrcHasMetadataForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve source hasMetadata with error: %w", err)
+			}
+
+			combinedHasMetadata = append(combinedHasMetadata, srcHasMetadata...)
+		}
+		if hasMetadataSpec.Subject.Artifact != nil {
+			values := map[string]any{}
+			arangoQueryBuilder = setArtifactMatchValues(hasMetadataSpec.Subject.Artifact, values)
+			arangoQueryBuilder.forOutBound(hasMetadataArtEdgesStr, "hasMetadata", "art")
+			setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+
+			artHasMetadata, err := getArtHasMetadataForQuery(ctx, c, arangoQueryBuilder, values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve artifact hasMetadata with error: %w", err)
+			}
+
+			combinedHasMetadata = append(combinedHasMetadata, artHasMetadata...)
+		}
+		return combinedHasMetadata, nil
+	} else {
+		values := map[string]any{}
+		var combinedHasMetadata []*model.HasMetadata
+
+		// pkgVersion hasMetadata
+		arangoQueryBuilder = newForQuery(hasMetadataStr, "hasMetadata")
+		setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+		arangoQueryBuilder.forInBound(hasMetadataPkgVersionEdgesStr, "pVersion", "hasMetadata")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgVersionHasMetadata, err := getPkgHasMetadataForQuery(ctx, c, arangoQueryBuilder, values, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package version hasMetadata  with error: %w", err)
+		}
+		combinedHasMetadata = append(combinedHasMetadata, pkgVersionHasMetadata...)
+
+		// pkgName hasMetadata
+		values = map[string]any{}
+		arangoQueryBuilder = newForQuery(hasMetadataStr, "hasMetadata")
+		setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+		arangoQueryBuilder.forInBound(hasMetadataPkgNameEdgesStr, "pName", "hasMetadata")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgNameHasMetadata, err := getPkgHasMetadataForQuery(ctx, c, arangoQueryBuilder, values, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package name hasMetadata  with error: %w", err)
+		}
+		combinedHasMetadata = append(combinedHasMetadata, pkgNameHasMetadata...)
+
+		// get sources
+		values = map[string]any{}
+		arangoQueryBuilder = newForQuery(hasMetadataStr, "hasMetadata")
+		setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+		arangoQueryBuilder.forInBound(hasMetadataSrcEdgesStr, "sName", "hasMetadata")
+		arangoQueryBuilder.forInBound(srcHasNameStr, "sNs", "sName")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+
+		srcHasMetadata, err := getSrcHasMetadataForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve source hasMetadata with error: %w", err)
+		}
+		combinedHasMetadata = append(combinedHasMetadata, srcHasMetadata...)
+
+		// get artifacts
+		values = map[string]any{}
+		arangoQueryBuilder = newForQuery(hasMetadataStr, "hasMetadata")
+		setHasMetadataMatchValues(arangoQueryBuilder, hasMetadataSpec, values)
+		arangoQueryBuilder.forInBound(hasMetadataArtEdgesStr, "art", "hasMetadata")
+
+		artHasMetadata, err := getArtHasMetadataForQuery(ctx, c, arangoQueryBuilder, values)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve artifact hasMetadata with error: %w", err)
+		}
+		combinedHasMetadata = append(combinedHasMetadata, artHasMetadata...)
+
+		return combinedHasMetadata, nil
+	}
 }
 
-func setHasMetadataMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBadSpec *model.CertifyBadSpec, queryValues map[string]any) {
-	if certifyBadSpec.ID != nil {
-		arangoQueryBuilder.filter("certifyBad", "_id", "==", "@id")
-		queryValues["id"] = *certifyBadSpec.ID
+func getSrcHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.HasMetadata, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'srcName': {
+			'type_id': sType._id,
+			'type': sType.type,
+			'namespace_id': sNs._id,
+			'namespace': sNs.namespace,
+			'name_id': sName._id,
+			'name': sName.name,
+			'commit': sName.commit,
+			'tag': sName.tag
+		},
+		'hasMetadata_id': hasMetadata._id,
+		'key': hasMetadata.key,
+		'value': hasMetadata.value,
+		'timestamp': hasMetadata.timestamp,
+		'justification': hasMetadata.justification,
+		'collector': hasMetadata.collector,
+		'origin': hasMetadata.origin  
+	  }`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasMetadata")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for HasMetadata: %w", err)
 	}
-	if certifyBadSpec.Justification != nil {
-		arangoQueryBuilder.filter("certifyBad", justification, "==", "@"+justification)
-		queryValues[justification] = *certifyBadSpec.Justification
+	defer cursor.Close()
+
+	return getHasMetadataFromCursor(ctx, cursor)
+}
+
+func getArtHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any) ([]*model.HasMetadata, error) {
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		'artifact': {
+			'id': art._id,
+			'algorithm': art.algorithm,
+			'digest': art.digest
+		},
+		'hasMetadata_id': hasMetadata._id,
+		'key': hasMetadata.key,
+		'value': hasMetadata.value,
+		'timestamp': hasMetadata.timestamp,
+		'justification': hasMetadata.justification,
+		'collector': hasMetadata.collector,
+		'origin': hasMetadata.origin
+	  }`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasMetadata")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for HasMetadata: %w", err)
 	}
-	if certifyBadSpec.Origin != nil {
-		arangoQueryBuilder.filter("certifyBad", origin, "==", "@"+origin)
-		queryValues[origin] = *certifyBadSpec.Origin
+	defer cursor.Close()
+
+	return getHasMetadataFromCursor(ctx, cursor)
+}
+
+func getPkgHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any, includeDepPkgVersion bool) ([]*model.HasMetadata, error) {
+	if includeDepPkgVersion {
+		arangoQueryBuilder.query.WriteString("\n")
+		arangoQueryBuilder.query.WriteString(`RETURN {
+			'pkgVersion': {
+				'type_id': pType._id,
+				'type': pType.type,
+				'namespace_id': pNs._id,
+				'namespace': pNs.namespace,
+				'name_id': pName._id,
+				'name': pName.name,
+				'version_id': pVersion._id,
+				'version': pVersion.version,
+				'subpath': pVersion.subpath,
+				'qualifier_list': pVersion.qualifier_list
+			},
+			'hasMetadata_id': hasMetadata._id,
+			'key': hasMetadata.key,
+			'value': hasMetadata.value,
+			'timestamp': hasMetadata.timestamp,
+			'justification': hasMetadata.justification,
+			'collector': hasMetadata.collector,
+			'origin': hasMetadata.origin
+		  }`)
+	} else {
+		arangoQueryBuilder.query.WriteString("\n")
+		arangoQueryBuilder.query.WriteString(`RETURN {
+			'pkgVersion': {
+				'type_id': pType._id,
+				'type': pType.type,
+				'namespace_id': pNs._id,
+				'namespace': pNs.namespace,
+				'name_id': pName._id,
+				'name': pName.name
+			},
+			'hasMetadata_id': hasMetadata._id,
+			'key': hasMetadata.key,
+			'value': hasMetadata.value,
+			'timestamp': hasMetadata.timestamp,
+			'justification': hasMetadata.justification,
+			'collector': hasMetadata.collector,
+		'origin': hasMetadata.origin
+		  }`)
 	}
-	if certifyBadSpec.Collector != nil {
-		arangoQueryBuilder.filter("certifyBad", collector, "==", "@"+collector)
-		queryValues[collector] = *certifyBadSpec.Collector
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasMetadata")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for HasMetadata: %w", err)
+	}
+	defer cursor.Close()
+
+	return getHasMetadataFromCursor(ctx, cursor)
+}
+
+func setHasMetadataMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasMetadataSpec *model.HasMetadataSpec, queryValues map[string]any) {
+	if hasMetadataSpec.ID != nil {
+		arangoQueryBuilder.filter("hasMetadata", "_id", "==", "@id")
+		queryValues["id"] = *hasMetadataSpec.ID
+	}
+	if hasMetadataSpec.Key != nil {
+		arangoQueryBuilder.filter("hasMetadata", keyStr, "==", "@"+keyStr)
+		queryValues[keyStr] = *hasMetadataSpec.Key
+	}
+	if hasMetadataSpec.Value != nil {
+		arangoQueryBuilder.filter("hasMetadata", valueStr, "==", "@"+valueStr)
+		queryValues[valueStr] = *hasMetadataSpec.Value
+	}
+	if hasMetadataSpec.Since != nil {
+		arangoQueryBuilder.filter("hasMetadata", timeStampStr, ">=", "@"+timeStampStr)
+		queryValues[timeStampStr] = *hasMetadataSpec.Since
+	}
+	if hasMetadataSpec.Justification != nil {
+		arangoQueryBuilder.filter("hasMetadata", justification, "==", "@"+justification)
+		queryValues[justification] = *hasMetadataSpec.Justification
+	}
+	if hasMetadataSpec.Origin != nil {
+		arangoQueryBuilder.filter("hasMetadata", origin, "==", "@"+origin)
+		queryValues[origin] = *hasMetadataSpec.Origin
+	}
+	if hasMetadataSpec.Collector != nil {
+		arangoQueryBuilder.filter("hasMetadata", collector, "==", "@"+collector)
+		queryValues[collector] = *hasMetadataSpec.Collector
 	}
 }
 
@@ -65,9 +314,9 @@ func getHasMetadataQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Matc
 		values["srcNameGuacKey"] = source.NameId
 	}
 
-	values["key"] = hasMetadata.Key
-	values["value"] = hasMetadata.Value
-	values[timeStampStr] = hasMetadata.Justification
+	values[keyStr] = hasMetadata.Key
+	values[valueStr] = hasMetadata.Value
+	values[timeStampStr] = hasMetadata.Timestamp
 	values[justification] = hasMetadata.Justification
 	values[origin] = hasMetadata.Origin
 	values[collector] = hasMetadata.Collector
@@ -137,21 +386,21 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 			'origin': hasMetadata.origin  
 		  }`
 
-			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyBad), "IngestCertifyBad - PkgVersion")
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasMetadataQueryValues(subject.Package, pkgMatchType, nil, nil, &hasMetadata), "IngestHasMetadata - PkgVersion")
 			if err != nil {
-				return nil, fmt.Errorf("failed to ingest package certifyBad: %w", err)
+				return nil, fmt.Errorf("failed to ingest package hasMetadata: %w", err)
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+			hasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+				return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
 			}
 
-			if len(certifyBadList) == 1 {
-				return certifyBadList[0], nil
+			if len(hasMetadataList) == 1 {
+				return hasMetadataList[0], nil
 			} else {
-				return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+				return nil, fmt.Errorf("number of hasMetadata ingested is greater than one")
 			}
 		} else {
 			query := `
@@ -203,21 +452,21 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 				'origin': hasMetadata.origin  
 			  }`
 
-			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyBad), "IngestCertifyBad - PkgName")
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasMetadataQueryValues(subject.Package, pkgMatchType, nil, nil, &hasMetadata), "IngestHasMetadata - PkgName")
 			if err != nil {
-				return nil, fmt.Errorf("failed to ingest package certifyBad: %w", err)
+				return nil, fmt.Errorf("failed to ingest package hasMetadata: %w", err)
 			}
 			defer cursor.Close()
 
-			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+			hasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+				return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
 			}
 
-			if len(certifyBadList) == 1 {
-				return certifyBadList[0], nil
+			if len(hasMetadataList) == 1 {
+				return hasMetadataList[0], nil
 			} else {
-				return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+				return nil, fmt.Errorf("number of hasMetadata ingested is greater than one")
 			}
 		}
 
@@ -250,20 +499,20 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 		  'origin': hasMetadata.origin  
 		}`
 
-		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(nil, nil, subject.Artifact, nil, &certifyBad), "IngestCertifyBad - artifact")
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasMetadataQueryValues(nil, nil, subject.Artifact, nil, &hasMetadata), "IngestHasMetadata - artifact")
 		if err != nil {
-			return nil, fmt.Errorf("failed to ingest artifact certifyBad: %w", err)
+			return nil, fmt.Errorf("failed to ingest artifact hasMetadata: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+		hasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+			return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
 		}
 
-		if len(certifyBadList) == 1 {
-			return certifyBadList[0], nil
+		if len(hasMetadataList) == 1 {
+			return hasMetadataList[0], nil
 		} else {
-			return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+			return nil, fmt.Errorf("number of hasMetadata ingested is greater than one")
 		}
 
 	} else if subject.Source != nil {
@@ -320,29 +569,389 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 		  'origin': hasMetadata.origin  
 		}`
 
-		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(nil, nil, nil, subject.Source, &certifyBad), "IngestCertifyBad - source")
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasMetadataQueryValues(nil, nil, nil, subject.Source, &hasMetadata), "IngestHasMetadata - source")
 		if err != nil {
-			return nil, fmt.Errorf("failed to ingest source certifyBad: %w", err)
+			return nil, fmt.Errorf("failed to ingest source hasMetadata: %w", err)
 		}
 		defer cursor.Close()
-		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+		hasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+			return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
 		}
 
-		if len(certifyBadList) == 1 {
-			return certifyBadList[0], nil
+		if len(hasMetadataList) == 1 {
+			return hasMetadataList[0], nil
 		} else {
-			return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+			return nil, fmt.Errorf("number of hasMetadata ingested is greater than one")
 		}
 
 	} else {
-		return nil, fmt.Errorf("package, artifact, or source is specified for IngestCertifyBad")
+		return nil, fmt.Errorf("package, artifact, or source is specified for IngestHasMetadata")
 	}
 }
 
 func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
-	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
+	if len(subjects.Packages) > 0 {
+		var listOfValues []map[string]any
+
+		for i := range subjects.Packages {
+			listOfValues = append(listOfValues, getHasMetadataQueryValues(subjects.Packages[i], pkgMatchType, nil, nil, hasMetadataList[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+			query := `LET firstPkg = FIRST(
+				FOR pVersion in pkgVersions
+				  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+				FOR pName in pkgNames
+				  FILTER pName._id == pVersion._parent
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+		
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'version_id': pVersion._id,
+				  'version': pVersion.version,
+				  'subpath': pVersion.subpath,
+				  'qualifier_list': pVersion.qualifier_list,
+				  'versionDoc': pVersion
+				}
+			)
+			  
+			  LET hasMetadata = FIRST(
+				  UPSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  INSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  UPDATE {} IN hasMetadataCollection
+					  RETURN NEW
+			  )
+			  
+			  LET edgeCollection = (
+				INSERT {  _key: CONCAT("hasMetadataPkgVersionEdges", firstPkg.versionDoc._key, hasMetadata._key), _from: firstPkg.version_id, _to: hasMetadata._id } INTO hasMetadataPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+			  )
+			  
+			  RETURN {
+				'pkgVersion': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name,
+					'version_id': firstPkg.version_id,
+					'version': firstPkg.version,
+					'subpath': firstPkg.subpath,
+					'qualifier_list': firstPkg.qualifier_list
+				},
+				'hasMetadata_id': hasMetadata._id,
+				'key': hasMetadata.key,
+				'value': hasMetadata.value,
+				'timestamp': hasMetadata.timestamp,
+				'justification': hasMetadata.justification,
+				'collector': hasMetadata.collector,
+				'origin': hasMetadata.origin  
+			  }`
+
+			sb.WriteString(query)
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestBulkHasMetadata - PkgVersion")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package hasMetadata: %w", err)
+			}
+			defer cursor.Close()
+
+			ingestHasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
+			}
+
+			var hasMetadataIDList []string
+			for _, ingestedHasMetadata := range ingestHasMetadataList {
+				hasMetadataIDList = append(hasMetadataIDList, ingestedHasMetadata.ID)
+			}
+
+			return hasMetadataIDList, nil
+
+		} else {
+			query := `
+			LET firstPkg = FIRST(
+				FOR pName in pkgNames
+				  FILTER pName.guacKey == doc.pkgNameGuacKey
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+		
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'nameDoc': pName
+				}
+			)
+			  
+			  LET hasMetadata = FIRST(
+				  UPSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  INSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+					  UPDATE {} IN hasMetadataCollection
+					  RETURN NEW
+			  )
+			  
+			  LET edgeCollection = (
+				INSERT {  _key: CONCAT("hasMetadataPkgNameEdges", firstPkg.nameDoc._key, hasMetadata._key), _from: firstPkg.name_id, _to: hasMetadata._id } INTO hasMetadataPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+			  )
+			  
+			  RETURN {
+				'pkgVersion': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name
+				},
+				'hasMetadata_id': hasMetadata._id,
+			    'key': hasMetadata.key,
+			    'value': hasMetadata.value,
+			 	'timestamp': hasMetadata.timestamp,
+				'justification': hasMetadata.justification,
+				'collector': hasMetadata.collector,
+				'origin': hasMetadata.origin  
+			  }`
+
+			sb.WriteString(query)
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestBulkHasMetadata - PkgName")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package hasMetadata: %w", err)
+			}
+			defer cursor.Close()
+
+			ingestHasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
+			}
+
+			var hasMetadataIDList []string
+			for _, ingestedHasMetadata := range ingestHasMetadataList {
+				hasMetadataIDList = append(hasMetadataIDList, ingestedHasMetadata.ID)
+			}
+
+			return hasMetadataIDList, nil
+		}
+
+	} else if len(subjects.Artifacts) > 0 {
+		var listOfValues []map[string]any
+
+		for i := range subjects.Artifacts {
+			listOfValues = append(listOfValues, getHasMetadataQueryValues(nil, nil, subjects.Artifacts[i], nil, hasMetadataList[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
+		  
+		LET hasMetadata = FIRST(
+			UPSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				INSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				UPDATE {} IN hasMetadataCollection
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("hasMetadataArtEdges", artifact._key, hasMetadata._key), _from: artifact._id, _to: hasMetadata._id } INTO hasMetadataArtEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'artifact': {
+			  'id': artifact._id,
+			  'algorithm': artifact.algorithm,
+			  'digest': artifact.digest
+		  },
+		  'hasMetadata_id': hasMetadata._id,
+		  'key': hasMetadata.key,
+		  'value': hasMetadata.value,
+		  'timestamp': hasMetadata.timestamp,
+		  'justification': hasMetadata.justification,
+		  'collector': hasMetadata.collector,
+		  'origin': hasMetadata.origin  
+		}`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestBulkHasMetadata - artifact")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest artifact hasMetadata: %w", err)
+		}
+		defer cursor.Close()
+
+		ingestHasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
+		}
+
+		var hasMetadataIDList []string
+		for _, ingestedHasMetadata := range ingestHasMetadataList {
+			hasMetadataIDList = append(hasMetadataIDList, ingestedHasMetadata.ID)
+		}
+
+		return hasMetadataIDList, nil
+
+	} else if len(subjects.Sources) > 0 {
+		var listOfValues []map[string]any
+
+		for i := range subjects.Sources {
+			listOfValues = append(listOfValues, getHasMetadataQueryValues(nil, nil, nil, subjects.Sources[i], hasMetadataList[i]))
+		}
+
+		var documents []string
+		for _, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			documents = append(documents, string(bs))
+		}
+
+		queryValues := map[string]any{}
+		queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+		var sb strings.Builder
+
+		sb.WriteString("for doc in [")
+		for i, val := range listOfValues {
+			bs, _ := json.Marshal(val)
+			if i == len(listOfValues)-1 {
+				sb.WriteString(string(bs))
+			} else {
+				sb.WriteString(string(bs) + ",")
+			}
+		}
+		sb.WriteString("]")
+
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == doc.srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		LET hasMetadata = FIRST(
+			UPSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				INSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				UPDATE {} IN hasMetadataCollection
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("hasMetadataSrcEdges", firstSrc.nameDoc._key, hasMetadata._key), _from: firstSrc.name_id, _to: hasMetadata._id } INTO hasMetadataSrcEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'srcName': {
+			  'type_id': firstSrc.typeID,
+			  'type': firstSrc.type,
+			  'namespace_id': firstSrc.namespace_id,
+			  'namespace': firstSrc.namespace,
+			  'name_id': firstSrc.name_id,
+			  'name': firstSrc.name,
+			  'commit': firstSrc.commit,
+			  'tag': firstSrc.tag
+		  },
+		  'hasMetadata_id': hasMetadata._id,
+		  'key': hasMetadata.key,
+		  'value': hasMetadata.value,
+		  'timestamp': hasMetadata.timestamp,
+		  'justification': hasMetadata.justification,
+		  'collector': hasMetadata.collector,
+		  'origin': hasMetadata.origin  
+		}`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestBulkHasMetadata - source")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source hasMetadata: %w", err)
+		}
+		defer cursor.Close()
+
+		ingestHasMetadataList, err := getHasMetadataFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasMetadata from arango cursor: %w", err)
+		}
+
+		var hasMetadataIDList []string
+		for _, ingestedHasMetadata := range ingestHasMetadataList {
+			hasMetadataIDList = append(hasMetadataIDList, ingestedHasMetadata.ID)
+		}
+
+		return hasMetadataIDList, nil
+
+	} else {
+		return nil, fmt.Errorf("packages, artifacts, or sources not specified for IngestBulkHasMetadata")
+	}
 }
 
 func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.HasMetadata, error) {
@@ -350,7 +959,10 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 		PkgVersion    *dbPkgVersion   `json:"pkgVersion"`
 		Artifact      *model.Artifact `json:"artifact"`
 		SrcName       *dbSrcName      `json:"srcName"`
-		CertifyBadID  string          `json:"certifyBad_id"`
+		HasMetadataID string          `json:"hasMetadata_id"`
+		Key           string          `json:"key"`
+		Value         string          `json:"value"`
+		Timestamp     time.Time       `json:"timestamp"`
 		Justification string          `json:"justification"`
 		Collector     string          `json:"collector"`
 		Origin        string          `json:"origin"`
@@ -364,14 +976,14 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 			if driver.IsNoMoreDocuments(err) {
 				break
 			} else {
-				return nil, fmt.Errorf("failed to certifyBad from cursor: %w", err)
+				return nil, fmt.Errorf("failed to hasMetadata from cursor: %w", err)
 			}
 		} else {
 			createdValues = append(createdValues, doc)
 		}
 	}
 
-	var certifyBadList []*model.CertifyBad
+	var hasMetadataList []*model.HasMetadata
 	for _, createdValue := range createdValues {
 		var pkg *model.Package = nil
 		var src *model.Source = nil
@@ -383,23 +995,26 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 				createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
 		}
 
-		certifyBad := &model.CertifyBad{
-			ID:            createdValue.CertifyBadID,
+		hasMetadata := &model.HasMetadata{
+			ID:            createdValue.HasMetadataID,
+			Key:           createdValue.Key,
+			Value:         createdValue.Value,
+			Timestamp:     createdValue.Timestamp,
 			Justification: createdValue.Justification,
 			Origin:        createdValue.Collector,
 			Collector:     createdValue.Origin,
 		}
 
 		if pkg != nil {
-			certifyBad.Subject = pkg
+			hasMetadata.Subject = pkg
 		} else if src != nil {
-			certifyBad.Subject = src
+			hasMetadata.Subject = src
 		} else if createdValue.Artifact != nil {
-			certifyBad.Subject = createdValue.Artifact
+			hasMetadata.Subject = createdValue.Artifact
 		} else {
-			return nil, fmt.Errorf("failed to get subject from cursor for certifyBad")
+			return nil, fmt.Errorf("failed to get subject from cursor for hasMetadata")
 		}
-		certifyBadList = append(certifyBadList, certifyBad)
+		hasMetadataList = append(hasMetadataList, hasMetadata)
 	}
-	return certifyBadList, nil
+	return hasMetadataList, nil
 }

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -18,7 +18,9 @@ package arangodb
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -26,10 +28,378 @@ func (c *arangoClient) HasMetadata(ctx context.Context, hasMetadataSpec *model.H
 	return nil, fmt.Errorf("not implemented: HasMetadata")
 }
 
+func setHasMetadataMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBadSpec *model.CertifyBadSpec, queryValues map[string]any) {
+	if certifyBadSpec.ID != nil {
+		arangoQueryBuilder.filter("certifyBad", "_id", "==", "@id")
+		queryValues["id"] = *certifyBadSpec.ID
+	}
+	if certifyBadSpec.Justification != nil {
+		arangoQueryBuilder.filter("certifyBad", justification, "==", "@"+justification)
+		queryValues[justification] = *certifyBadSpec.Justification
+	}
+	if certifyBadSpec.Origin != nil {
+		arangoQueryBuilder.filter("certifyBad", origin, "==", "@"+origin)
+		queryValues[origin] = *certifyBadSpec.Origin
+	}
+	if certifyBadSpec.Collector != nil {
+		arangoQueryBuilder.filter("certifyBad", collector, "==", "@"+collector)
+		queryValues[collector] = *certifyBadSpec.Collector
+	}
+}
+
+func getHasMetadataQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.MatchFlags, artifact *model.ArtifactInputSpec, source *model.SourceInputSpec, hasMetadata *model.HasMetadataInputSpec) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	if pkg != nil {
+		pkgId := guacPkgId(*pkg)
+		if pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
+			values["pkgNameGuacKey"] = pkgId.NameId
+		} else {
+			values["pkgVersionGuacKey"] = pkgId.VersionId
+		}
+	} else if artifact != nil {
+		values["art_algorithm"] = strings.ToLower(artifact.Algorithm)
+		values["art_digest"] = strings.ToLower(artifact.Digest)
+	} else {
+		source := guacSrcId(*source)
+		values["srcNameGuacKey"] = source.NameId
+	}
+
+	values["key"] = hasMetadata.Key
+	values["value"] = hasMetadata.Value
+	values[timeStampStr] = hasMetadata.Justification
+	values[justification] = hasMetadata.Justification
+	values[origin] = hasMetadata.Origin
+	values[collector] = hasMetadata.Collector
+
+	return values
+}
+
+func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
+	if subject.Package != nil {
+		if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+			query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == @pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+		  
+		  LET hasMetadata = FIRST(
+			  UPSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				  INSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				  UPDATE {} IN hasMetadataCollection
+				  RETURN NEW
+		  )
+		  
+		  LET edgeCollection = (
+			INSERT {  _key: CONCAT("hasMetadataPkgVersionEdges", firstPkg.versionDoc._key, hasMetadata._key), _from: firstPkg.version_id, _to: hasMetadata._id } INTO hasMetadataPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+		  )
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'hasMetadata_id': hasMetadata._id,
+			'key': hasMetadata.key,
+			'value': hasMetadata.value,
+			'timestamp': hasMetadata.timestamp,
+			'justification': hasMetadata.justification,
+			'collector': hasMetadata.collector,
+			'origin': hasMetadata.origin  
+		  }`
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyBad), "IngestCertifyBad - PkgVersion")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyBad: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+			}
+
+			if len(certifyBadList) == 1 {
+				return certifyBadList[0], nil
+			} else {
+				return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+			}
+		} else {
+			query := `
+			LET firstPkg = FIRST(
+				FOR pName in pkgNames
+				  FILTER pName.guacKey == @pkgNameGuacKey
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+		
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'nameDoc': pName
+				}
+			)
+			  
+			  LET hasMetadata = FIRST(
+				  UPSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+					  INSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+					  UPDATE {} IN hasMetadataCollection
+					  RETURN NEW
+			  )
+			  
+			  LET edgeCollection = (
+				INSERT {  _key: CONCAT("hasMetadataPkgNameEdges", firstPkg.nameDoc._key, hasMetadata._key), _from: firstPkg.name_id, _to: hasMetadata._id } INTO hasMetadataPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+			  )
+			  
+			  RETURN {
+				'pkgVersion': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name
+				},
+				'hasMetadata_id': hasMetadata._id,
+			    'key': hasMetadata.key,
+			    'value': hasMetadata.value,
+			 	'timestamp': hasMetadata.timestamp,
+				'justification': hasMetadata.justification,
+				'collector': hasMetadata.collector,
+				'origin': hasMetadata.origin  
+			  }`
+
+			cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(subject.Package, pkgMatchType, nil, nil, &certifyBad), "IngestCertifyBad - PkgName")
+			if err != nil {
+				return nil, fmt.Errorf("failed to ingest package certifyBad: %w", err)
+			}
+			defer cursor.Close()
+
+			certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+			}
+
+			if len(certifyBadList) == 1 {
+				return certifyBadList[0], nil
+			} else {
+				return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+			}
+		}
+
+	} else if subject.Artifact != nil {
+		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
+		  
+		LET hasMetadata = FIRST(
+			UPSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				INSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				UPDATE {} IN hasMetadataCollection
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("hasMetadataArtEdges", artifact._key, hasMetadata._key), _from: artifact._id, _to: hasMetadata._id } INTO hasMetadataArtEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'artifact': {
+			  'id': artifact._id,
+			  'algorithm': artifact.algorithm,
+			  'digest': artifact.digest
+		  },
+		  'hasMetadata_id': hasMetadata._id,
+		  'key': hasMetadata.key,
+		  'value': hasMetadata.value,
+		  'timestamp': hasMetadata.timestamp,
+		  'justification': hasMetadata.justification,
+		  'collector': hasMetadata.collector,
+		  'origin': hasMetadata.origin  
+		}`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(nil, nil, subject.Artifact, nil, &certifyBad), "IngestCertifyBad - artifact")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest artifact certifyBad: %w", err)
+		}
+		defer cursor.Close()
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+		}
+
+		if len(certifyBadList) == 1 {
+			return certifyBadList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+		}
+
+	} else if subject.Source != nil {
+		query := `
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == @srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		LET hasMetadata = FIRST(
+			UPSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				INSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				UPDATE {} IN hasMetadataCollection
+				RETURN NEW
+		)
+		
+		LET edgeCollection = (
+		  INSERT {  _key: CONCAT("hasMetadataSrcEdges", firstSrc.nameDoc._key, hasMetadata._key), _from: firstSrc.name_id, _to: hasMetadata._id } INTO hasMetadataSrcEdges OPTIONS { overwriteMode: "ignore" }
+		)
+		
+		RETURN {
+		  'srcName': {
+			  'type_id': firstSrc.typeID,
+			  'type': firstSrc.type,
+			  'namespace_id': firstSrc.namespace_id,
+			  'namespace': firstSrc.namespace,
+			  'name_id': firstSrc.name_id,
+			  'name': firstSrc.name,
+			  'commit': firstSrc.commit,
+			  'tag': firstSrc.tag
+		  },
+		  'hasMetadata_id': hasMetadata._id,
+		  'key': hasMetadata.key,
+		  'value': hasMetadata.value,
+		  'timestamp': hasMetadata.timestamp,
+		  'justification': hasMetadata.justification,
+		  'collector': hasMetadata.collector,
+		  'origin': hasMetadata.origin  
+		}`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getCertifyBadQueryValues(nil, nil, nil, subject.Source, &certifyBad), "IngestCertifyBad - source")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest source certifyBad: %w", err)
+		}
+		defer cursor.Close()
+		certifyBadList, err := getCertifyBadFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certifyBads from arango cursor: %w", err)
+		}
+
+		if len(certifyBadList) == 1 {
+			return certifyBadList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of certifyBad ingested is greater than one")
+		}
+
+	} else {
+		return nil, fmt.Errorf("package, artifact, or source is specified for IngestCertifyBad")
+	}
+}
+
 func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
 	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
 }
 
-func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
-	return nil, fmt.Errorf("not implemented: IngestHasMetadata")
+func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.HasMetadata, error) {
+	type collectedData struct {
+		PkgVersion    *dbPkgVersion   `json:"pkgVersion"`
+		Artifact      *model.Artifact `json:"artifact"`
+		SrcName       *dbSrcName      `json:"srcName"`
+		CertifyBadID  string          `json:"certifyBad_id"`
+		Justification string          `json:"justification"`
+		Collector     string          `json:"collector"`
+		Origin        string          `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to certifyBad from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var certifyBadList []*model.CertifyBad
+	for _, createdValue := range createdValues {
+		var pkg *model.Package = nil
+		var src *model.Source = nil
+		if createdValue.PkgVersion != nil {
+			pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+				createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		} else if createdValue.SrcName != nil {
+			src = generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+				createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
+		}
+
+		certifyBad := &model.CertifyBad{
+			ID:            createdValue.CertifyBadID,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+
+		if pkg != nil {
+			certifyBad.Subject = pkg
+		} else if src != nil {
+			certifyBad.Subject = src
+		} else if createdValue.Artifact != nil {
+			certifyBad.Subject = createdValue.Artifact
+		} else {
+			return nil, fmt.Errorf("failed to get subject from cursor for certifyBad")
+		}
+		certifyBadList = append(certifyBadList, certifyBad)
+	}
+	return certifyBadList, nil
 }

--- a/pkg/assembler/backends/arangodb/hasMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata_test.go
@@ -13,649 +13,1133 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
-// TODO (pxp928): enable once implemented
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
 
-// func TestHasMetadata(t *testing.T) {
-// 	type call struct {
-// 		Sub   model.PackageSourceOrArtifactInput
-// 		Match *model.MatchFlags
-// 		HM    *model.HasMetadataInputSpec
-// 	}
-// 	tests := []struct {
-// 		Name         string
-// 		InPkg        []*model.PkgInputSpec
-// 		InSrc        []*model.SourceInputSpec
-// 		InArt        []*model.ArtifactInputSpec
-// 		Calls        []call
-// 		Query        *model.HasMetadataSpec
-// 		ExpHM        []*model.HasMetadata
-// 		ExpIngestErr bool
-// 		ExpQueryErr  bool
-// 	}{
-// 		{
-// 			Name:  "HappyPath",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Key:           "key1",
-// 						Value:         "value1",
-// 						Timestamp:     time.Unix(1e9, 0),
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Key:           ptrfrom.String("key1"),
-// 				Value:         ptrfrom.String("value1"),
-// 				Since:         ptrfrom.Time(time.Unix(1e9, 0)),
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1out,
-// 					Key:           "key1",
-// 					Value:         "value1",
-// 					Timestamp:     time.Unix(1e9, 0),
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "HappyPath check time since",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Key:           "key1",
-// 						Value:         "value1",
-// 						Timestamp:     time.Unix(1e9, 0),
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Key:           ptrfrom.String("key1"),
-// 				Value:         ptrfrom.String("value1"),
-// 				Since:         ptrfrom.Time(time.Unix(1e8, 0)),
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1out,
-// 					Key:           "key1",
-// 					Value:         "value1",
-// 					Timestamp:     time.Unix(1e9, 0),
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "UnhappyPath check time since",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Key:           "key1",
-// 						Value:         "value1",
-// 						Timestamp:     time.Unix(1e9, 0),
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Key:           ptrfrom.String("key1"),
-// 				Value:         ptrfrom.String("value1"),
-// 				Since:         ptrfrom.Time(time.Unix(1e10, 0)),
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: nil,
-// 		},
-// 		{
-// 			Name:  "HappyPath All Version",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeAllVersions,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1outName,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Ingest same twice",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Ingest two different keys",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Key:           "key1",
-// 						Value:         "value1",
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Key:           "key2",
-// 						Value:         "value2",
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1out,
-// 					Key:           "key1",
-// 					Value:         "value1",
-// 					Justification: "test justification",
-// 				},
-// 				{
-// 					Subject:       p1out,
-// 					Key:           "key2",
-// 					Value:         "value2",
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
+	"github.com/google/go-cmp/cmp"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
 
-// 		{
-// 			Name:  "Query on Justification",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification one",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Justification: ptrfrom.String("test justification one"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p1out,
-// 					Justification: "test justification one",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Package",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p2,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Subject: &model.PackageSourceOrArtifactSpec{
-// 					Package: &model.PkgSpec{
-// 						Version: ptrfrom.String("2.11.1"),
-// 					},
-// 				},
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p2out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Source",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1, s2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s2,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Subject: &model.PackageSourceOrArtifactSpec{
-// 					Source: &model.SourceSpec{
-// 						Name: ptrfrom.String("bobsrepo"),
-// 					},
-// 				},
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       s2out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Artifact",
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			InArt: []*model.ArtifactInputSpec{a1, a2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a2,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Subject: &model.PackageSourceOrArtifactSpec{
-// 					Artifact: &model.ArtifactSpec{
-// 						Algorithm: ptrfrom.String("sha1"),
-// 					},
-// 				},
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       a2out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query none",
-// 			InArt: []*model.ArtifactInputSpec{a1, a2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a2,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Subject: &model.PackageSourceOrArtifactSpec{
-// 					Artifact: &model.ArtifactSpec{
-// 						Algorithm: ptrfrom.String("asdf"),
-// 					},
-// 				},
-// 			},
-// 			ExpHM: nil,
-// 		},
-// 		{
-// 			Name:  "Query multiple",
-// 			InSrc: []*model.SourceInputSpec{s1, s2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s2,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       s1out,
-// 					Justification: "test justification",
-// 				},
-// 				{
-// 					Subject:       s2out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query Packages",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p2,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p2,
-// 					},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeAllVersions,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				Subject: &model.PackageSourceOrArtifactSpec{
-// 					Package: &model.PkgSpec{
-// 						Version: ptrfrom.String("2.11.1"),
-// 					},
-// 				},
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       p2out,
-// 					Justification: "test justification",
-// 				},
-// 				{
-// 					Subject:       p1outName,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query ID",
-// 			InArt: []*model.ArtifactInputSpec{a1, a2},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a2,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				ID: ptrfrom.String("3"),
-// 			},
-// 			ExpHM: []*model.HasMetadata{
-// 				{
-// 					Subject:       a1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name: "Ingest without subject",
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			ExpIngestErr: true,
-// 		},
-// 		{
-// 			Name:  "Query good ID",
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
-// 					},
-// 					HM: &model.HasMetadataInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasMetadataSpec{
-// 				ID: ptrfrom.String("asdf"),
-// 			},
-// 			ExpQueryErr: true,
-// 		},
-// 	}
-// 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-// 		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-// 	}, cmp.Ignore())
-// 	ctx := context.Background()
-// 	for _, test := range tests {
-// 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.getBackend(nil)
-// 			if err != nil {
-// 				t.Fatalf("Could not instantiate testing backend: %v", err)
-// 			}
-// 			for _, p := range test.InPkg {
-// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
-// 					t.Fatalf("Could not ingest package: %v", err)
-// 				}
-// 			}
-// 			for _, s := range test.InSrc {
-// 				if _, err := b.IngestSource(ctx, *s); err != nil {
-// 					t.Fatalf("Could not ingest source: %v", err)
-// 				}
-// 			}
-// 			for _, a := range test.InArt {
-// 				if _, err := b.IngestArtifact(ctx, a); err != nil {
-// 					t.Fatalf("Could not ingest artifact: %v", err)
-// 				}
-// 			}
-// 			for _, o := range test.Calls {
-// 				_, err := b.IngestHasMetadata(ctx, o.Sub, o.Match, *o.HM)
-// 				if (err != nil) != test.ExpIngestErr {
-// 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
-// 				}
-// 				if err != nil {
-// 					return
-// 				}
-// 			}
-// 			got, err := b.HasMetadata(ctx, test.Query)
-// 			if (err != nil) != test.ExpQueryErr {
-// 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
-// 			}
-// 			if err != nil {
-// 				return
-// 			}
-// 			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
-// 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
-// 			}
-// 		})
-// 	}
-// }
+func TestHasMetadata(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		HM    *model.HasMetadataInputSpec
+	}
+	tests := []struct {
+		Name          string
+		InPkg         []*model.PkgInputSpec
+		InSrc         []*model.SourceInputSpec
+		InArt         []*model.ArtifactInputSpec
+		Calls         []call
+		Query         *model.HasMetadataSpec
+		QueryID       bool
+		QueryPkgID    bool
+		QuerySourceID bool
+		QueryArtID    bool
+		ExpHM         []*model.HasMetadata
+		ExpIngestErr  bool
+		ExpQueryErr   bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Timestamp:     time.Unix(1e9, 0),
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Key:           ptrfrom.String("key1"),
+				Value:         ptrfrom.String("value1"),
+				Since:         ptrfrom.Time(time.Unix(1e9, 0)),
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Key:           "key1",
+					Value:         "value1",
+					Timestamp:     time.Unix(1e9, 0),
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath check time since",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Timestamp:     time.Unix(1e9, 0),
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Key:           ptrfrom.String("key1"),
+				Value:         ptrfrom.String("value1"),
+				Since:         ptrfrom.Time(time.Unix(1e8, 0)),
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Key:           "key1",
+					Value:         "value1",
+					Timestamp:     time.Unix(1e9, 0),
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "UnhappyPath check time since",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Timestamp:     time.Unix(1e9, 0),
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Key:           ptrfrom.String("key1"),
+				Value:         ptrfrom.String("value1"),
+				Since:         ptrfrom.Time(time.Unix(1e10, 0)),
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHM: nil,
+		},
+		{
+			Name:  "HappyPath All Version",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Key:           "key1",
+					Value:         "value1",
+					Timestamp:     time.Unix(1e9, 0),
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P1outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest same twice",
+			InPkg: []*model.PkgInputSpec{testdata.P3},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P3,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P3,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+						Subpath: ptrfrom.String("saved_model_cli.py"),
+					},
+				},
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P3out,
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P1outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest two different keys - query key",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key2",
+						Value:         "value2",
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Key: ptrfrom.String("key2"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Key:           "key2",
+					Value:         "value2",
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest two different keys - query value",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key2",
+						Value:         "value2",
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Value: ptrfrom.String("value1"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Key:           "key1",
+					Value:         "value1",
+					Timestamp:     time.Unix(1e9, 0),
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P1out,
+					Key:           "key1",
+					Value:         "value1",
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Justification",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification one",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification two",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification one"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Justification: "test justification one",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
+					},
+				},
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P4out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package version ID",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			QueryPkgID: true,
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P4out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.S2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source ID",
+			InPkg: []*model.PkgInputSpec{},
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			QuerySourceID: true,
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.S2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.A2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Artifact ID",
+			InSrc: []*model.SourceInputSpec{},
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			QueryArtID: true,
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.A2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query none",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("asdf"),
+					},
+				},
+			},
+			ExpHM: nil,
+		},
+		{
+			Name:  "Query multiple",
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Type: ptrfrom.String("git"),
+					},
+				}},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.S2out,
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query Packages",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2, testdata.P4},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P2,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Name:    ptrfrom.String("openssl"),
+						Version: ptrfrom.String("3.0.3"),
+					},
+				},
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P4out,
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P4outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			QueryID: true,
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.A2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestHasMetadata(ctx, o.Sub, o.Match, *o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if test.QueryID {
+					test.Query = &model.HasMetadataSpec{
+						ID: ptrfrom.String(found.ID),
+					}
+				}
+				if test.QueryPkgID {
+					if _, ok := found.Subject.(*model.Package); ok {
+						test.Query = &model.HasMetadataSpec{
+							Subject: &model.PackageSourceOrArtifactSpec{
+								Package: &model.PkgSpec{
+									ID: ptrfrom.String(found.Subject.(*model.Package).Namespaces[0].Names[0].Versions[0].ID),
+								},
+							},
+						}
+					}
+				}
+				if test.QuerySourceID {
+					if _, ok := found.Subject.(*model.Source); ok {
+						test.Query = &model.HasMetadataSpec{
+							Subject: &model.PackageSourceOrArtifactSpec{
+								Source: &model.SourceSpec{
+									ID: ptrfrom.String(found.Subject.(*model.Source).Namespaces[0].Names[0].ID),
+								},
+							},
+						}
+					}
+				}
+				if test.QueryArtID {
+					if _, ok := found.Subject.(*model.Artifact); ok {
+						test.Query = &model.HasMetadataSpec{
+							Subject: &model.PackageSourceOrArtifactSpec{
+								Artifact: &model.ArtifactSpec{
+									ID: ptrfrom.String(found.Subject.(*model.Artifact).ID),
+								},
+							},
+						}
+					}
+				}
+			}
+			got, err := b.HasMetadata(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIngestBulkHasMetadata(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInputs
+		Match *model.MatchFlags
+		HM    []*model.HasMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.HasMetadataSpec
+		ExpCB        []*model.HasMetadata
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath All Version",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.P1out,
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P1outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest same twice",
+			InPkg: []*model.PkgInputSpec{testdata.P3},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P3, testdata.P3},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.P3out,
+					Justification: "test justification",
+				},
+				{
+					Subject:       testdata.P1outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.P2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{testdata.S2, testdata.S2},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.S2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Artifacts: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{testdata.S1},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       testdata.A2out,
+					Justification: "test justification",
+				},
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.IngestBulkHasMetadata(ctx, o.Sub, o.Match, o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+			got, err := b.HasMetadata(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpCB, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TODO (pxp928): add tests back in when implemented
 
 // func TestHasMetadataNeighbors(t *testing.T) {
 // 	type call struct {
@@ -673,11 +1157,11 @@ package arangodb
 // 	}{
 // 		{
 // 			Name:  "HappyPath",
-// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InPkg: []*model.PkgInputSpec{testdata.P1},
 // 			Calls: []call{
 // 				{
 // 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
+// 						Package: testdata.P1,
 // 					},
 // 					Match: &model.MatchFlags{
 // 						Pkg: model.PkgMatchTypeSpecificVersion,
@@ -694,13 +1178,13 @@ package arangodb
 // 		},
 // 		{
 // 			Name:  "Pkg Name Src and Artifact",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			InArt: []*model.ArtifactInputSpec{a1},
+// 			InPkg: []*model.PkgInputSpec{testdata.P1},
+// 			InSrc: []*model.SourceInputSpec{testdata.S1},
+// 			InArt: []*model.ArtifactInputSpec{testdata.A1},
 // 			Calls: []call{
 // 				{
 // 					Sub: model.PackageSourceOrArtifactInput{
-// 						Package: p1,
+// 						Package: testdata.P1,
 // 					},
 // 					Match: &model.MatchFlags{
 // 						Pkg: model.PkgMatchTypeAllVersions,
@@ -711,7 +1195,7 @@ package arangodb
 // 				},
 // 				{
 // 					Sub: model.PackageSourceOrArtifactInput{
-// 						Source: s1,
+// 						Source: testdata.S1,
 // 					},
 // 					HM: &model.HasMetadataInputSpec{
 // 						Justification: "test justification",
@@ -719,7 +1203,7 @@ package arangodb
 // 				},
 // 				{
 // 					Sub: model.PackageSourceOrArtifactInput{
-// 						Artifact: a1,
+// 						Artifact: testdata.A1,
 // 					},
 // 					HM: &model.HasMetadataInputSpec{
 // 						Justification: "test justification",
@@ -744,7 +1228,7 @@ package arangodb
 // 	ctx := context.Background()
 // 	for _, test := range tests {
 // 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := inmem.getBackend(nil)
+// 			b, err := backends.Get("inmem", nil, nil)
 // 			if err != nil {
 // 				t.Fatalf("Could not instantiate testing backend: %v", err)
 // 			}

--- a/pkg/assembler/backends/arangodb/hasMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (
@@ -861,7 +863,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 		InArt        []*model.ArtifactInputSpec
 		Calls        []call
 		Query        *model.HasMetadataSpec
-		ExpCB        []*model.HasMetadata
+		ExpHM        []*model.HasMetadata
 		ExpIngestErr bool
 		ExpQueryErr  bool
 	}{
@@ -886,7 +888,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Justification: ptrfrom.String("test justification"),
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification",
@@ -914,7 +916,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Justification: ptrfrom.String("test justification"),
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification",
@@ -947,9 +949,14 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 				},
 			},
 			Query: &model.HasMetadataSpec{
-				Justification: ptrfrom.String("test justification"),
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+						Subpath: ptrfrom.String("saved_model_cli.py"),
+					},
+				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       testdata.P3out,
 					Justification: "test justification",
@@ -962,12 +969,12 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 		},
 		{
 			Name:  "Query on Package",
-			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			Calls: []call{
 				{
 					Sub: model.PackageSourceOrArtifactInputs{
-						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+						Packages: []*model.PkgInputSpec{testdata.P1, testdata.P4},
 					},
 					Match: &model.MatchFlags{
 						Pkg: model.PkgMatchTypeSpecificVersion,
@@ -995,13 +1002,15 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Subject: &model.PackageSourceOrArtifactSpec{
 					Package: &model.PkgSpec{
-						Version: ptrfrom.String("2.11.1"),
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
-					Subject:       testdata.P2out,
+					Subject:       testdata.P4out,
 					Justification: "test justification",
 				},
 			},
@@ -1045,7 +1054,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       testdata.S2out,
 					Justification: "test justification",
@@ -1088,7 +1097,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       testdata.A2out,
 					Justification: "test justification",
@@ -1132,7 +1141,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpCB, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -213,11 +213,11 @@ func (c *arangoClient) IngestVulnerabilityMetadata(ctx context.Context, vulnerab
 	}
 }
 
-func (c *arangoClient) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
+func (c *arangoClient) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
 	var listOfValues []map[string]any
 
-	for i := range vulnerabilityMetadatas {
-		listOfValues = append(listOfValues, getVulnMetadataQueryValues(vulnerabilities[i], *vulnerabilityMetadatas[i]))
+	for i := range vulnerabilityMetadataList {
+		listOfValues = append(listOfValues, getVulnMetadataQueryValues(vulnerabilities[i], *vulnerabilityMetadataList[i]))
 	}
 
 	var documents []string

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -47,7 +47,7 @@ func (c *arangoClient) VulnerabilityMetadata(ctx context.Context, vulnerabilityM
 
 	} else {
 		values := map[string]any{}
-		arangoQueryBuilder = newForQuery(vulnMetadatasStr, "vulnMetadata")
+		arangoQueryBuilder = newForQuery(vulnMetadataStr, "vulnMetadata")
 		err := setVulnMetadataMatchValues(arangoQueryBuilder, vulnerabilityMetadataSpec, values)
 		if err != nil {
 			return nil, fmt.Errorf("setting match values for vuln metadata resulted in error: %w", err)
@@ -174,7 +174,7 @@ func (c *arangoClient) IngestVulnerabilityMetadata(ctx context.Context, vulnerab
 	  LET vulnMetadata = FIRST(
 		  UPSERT { vulnerabilityID:firstVuln.vulnDoc._id, scoreType:@scoreType, scoreValue:@scoreValue, timestamp:@timestamp, collector:@collector, origin:@origin } 
 			  INSERT { vulnerabilityID:firstVuln.vulnDoc._id, scoreType:@scoreType, scoreValue:@scoreValue, timestamp:@timestamp, collector:@collector, origin:@origin } 
-			  UPDATE {} IN vulnMetadatas
+			  UPDATE {} IN vulnMetadataCollection
 			  RETURN NEW
 	  )
 				  
@@ -261,7 +261,7 @@ func (c *arangoClient) IngestBulkVulnerabilityMetadata(ctx context.Context, vuln
 	  LET vulnMetadata = FIRST(
 		  UPSERT { vulnerabilityID:firstVuln.vulnDoc._id, scoreType:doc.scoreType, scoreValue:doc.scoreValue, timestamp:doc.timestamp, collector:doc.collector, origin:doc.origin } 
 			  INSERT { vulnerabilityID:firstVuln.vulnDoc._id, scoreType:doc.scoreType, scoreValue:doc.scoreValue, timestamp:doc.timestamp, collector:doc.collector, origin:doc.origin } 
-			  UPDATE {} IN vulnMetadatas
+			  UPDATE {} IN vulnMetadataCollection
 			  RETURN NEW
 	  )
 				  

--- a/pkg/assembler/backends/arangodb/vulnMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata_test.go
@@ -1311,7 +1311,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 				t.Fatalf("Could not ingest vulnerabilities: %a", err)
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestVulnerabilityMetadatas(ctx, o.Vulns, o.VulnMetadatas)
+				_, err := b.IngestBulkVulnerabilityMetadata(ctx, o.Vulns, o.VulnMetadatas)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -81,6 +81,7 @@ type Backend interface {
 	IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error)
 	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error)
 	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error)
+	IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error)
 	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error)
 	IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]*model.HashEqual, error)
 	IngestOccurrence(ctx context.Context, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) (*model.IsOccurrence, error)

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -97,7 +97,7 @@ type Backend interface {
 	IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (*model.VulnEqual, error)
 	IngestVulnEquals(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, otherVulnerabilities []*model.VulnerabilityInputSpec, vulnEquals []*model.VulnEqualInputSpec) ([]string, error)
 	IngestVulnerabilityMetadata(ctx context.Context, vulnerability model.VulnerabilityInputSpec, vulnerabilityMetadata model.VulnerabilityMetadataInputSpec) (string, error)
-	IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error)
+	IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error)
 
 	// Topological queries: queries where node connectivity matters more than node type
 	Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error)

--- a/pkg/assembler/backends/inmem/hasMetadata.go
+++ b/pkg/assembler/backends/inmem/hasMetadata.go
@@ -17,6 +17,7 @@ package inmem
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -61,6 +62,11 @@ func (n *hasMetadataLink) BuildModelNode(c *demoClient) (model.Node, error) {
 }
 
 // Ingest HasMetadata
+
+func (c *demoClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
+}
+
 func (c *demoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {
 	return c.ingestHasMetadata(ctx, subject, pkgMatchType, hasMetadata, true)
 }

--- a/pkg/assembler/backends/inmem/hasMetadata.go
+++ b/pkg/assembler/backends/inmem/hasMetadata.go
@@ -17,7 +17,6 @@ package inmem
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -64,7 +63,33 @@ func (n *hasMetadataLink) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest HasMetadata
 
 func (c *demoClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
-	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
+	var modelHasMetadataIDs []string
+
+	for i := range hasMetadataList {
+		var hasMetadata *model.HasMetadata
+		var err error
+		if len(subjects.Packages) > 0 {
+			subject := model.PackageSourceOrArtifactInput{Package: subjects.Packages[i]}
+			hasMetadata, err = c.IngestHasMetadata(ctx, subject, pkgMatchType, *hasMetadataList[i])
+			if err != nil {
+				return nil, gqlerror.Errorf("IngestHasMetadata failed with err: %v", err)
+			}
+		} else if len(subjects.Sources) > 0 {
+			subject := model.PackageSourceOrArtifactInput{Source: subjects.Sources[i]}
+			hasMetadata, err = c.IngestHasMetadata(ctx, subject, pkgMatchType, *hasMetadataList[i])
+			if err != nil {
+				return nil, gqlerror.Errorf("IngestHasMetadata failed with err: %v", err)
+			}
+		} else {
+			subject := model.PackageSourceOrArtifactInput{Artifact: subjects.Artifacts[i]}
+			hasMetadata, err = c.IngestHasMetadata(ctx, subject, pkgMatchType, *hasMetadataList[i])
+			if err != nil {
+				return nil, gqlerror.Errorf("IngestHasMetadata failed with err: %v", err)
+			}
+		}
+		modelHasMetadataIDs = append(modelHasMetadataIDs, hasMetadata.ID)
+	}
+	return modelHasMetadataIDs, nil
 }
 
 func (c *demoClient) IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error) {

--- a/pkg/assembler/backends/inmem/hasMetadata_test.go
+++ b/pkg/assembler/backends/inmem/hasMetadata_test.go
@@ -666,6 +666,294 @@ func TestHasMetadata(t *testing.T) {
 	}
 }
 
+func TestIngestBulkHasMetadata(t *testing.T) {
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInputs
+		Match *model.MatchFlags
+		HM    []*model.HasMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.HasMetadataSpec
+		ExpCB        []*model.HasMetadata
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       p1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath All Version",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				call{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       p1outName,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest same twice",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1, p1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       p1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{p1, p2},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1, p2},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{s1},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       p2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1, s2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{s2, s2},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       s2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InSrc: []*model.SourceInputSpec{s1},
+			InArt: []*model.ArtifactInputSpec{a1, a2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Artifacts: []*model.ArtifactInputSpec{a1, a2},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{s1},
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpCB: []*model.HasMetadata{
+				{
+					Subject:       a2out,
+					Justification: "test justification",
+				},
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := backends.Get("inmem", nil, nil)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.IngestBulkHasMetadata(ctx, o.Sub, o.Match, o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+			got, err := b.HasMetadata(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpCB, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestHasMetadataNeighbors(t *testing.T) {
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput

--- a/pkg/assembler/backends/inmem/hasMetadata_test.go
+++ b/pkg/assembler/backends/inmem/hasMetadata_test.go
@@ -679,7 +679,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 		InArt        []*model.ArtifactInputSpec
 		Calls        []call
 		Query        *model.HasMetadataSpec
-		ExpCB        []*model.HasMetadata
+		ExpHM        []*model.HasMetadata
 		ExpIngestErr bool
 		ExpQueryErr  bool
 	}{
@@ -704,7 +704,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Justification: ptrfrom.String("test justification"),
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       p1out,
 					Justification: "test justification",
@@ -715,7 +715,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Name:  "HappyPath All Version",
 			InPkg: []*model.PkgInputSpec{p1},
 			Calls: []call{
-				call{
+				{
 					Sub: model.PackageSourceOrArtifactInputs{
 						Packages: []*model.PkgInputSpec{p1},
 					},
@@ -732,7 +732,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Justification: ptrfrom.String("test justification"),
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       p1outName,
 					Justification: "test justification",
@@ -763,7 +763,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				Justification: ptrfrom.String("test justification"),
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       p1out,
 					Justification: "test justification",
@@ -809,7 +809,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       p2out,
 					Justification: "test justification",
@@ -855,7 +855,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       s2out,
 					Justification: "test justification",
@@ -898,7 +898,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 					},
 				},
 			},
-			ExpCB: []*model.HasMetadata{
+			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       a2out,
 					Justification: "test justification",
@@ -947,7 +947,7 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpCB, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/inmem/vulnMetadata.go
+++ b/pkg/assembler/backends/inmem/vulnMetadata.go
@@ -52,10 +52,10 @@ func (n *vulnerabilityMetadataLink) BuildModelNode(c *demoClient) (model.Node, e
 }
 
 // Ingest VulnerabilityMetadata
-func (c *demoClient) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
+func (c *demoClient) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
 	var modelVulnMetadataIDList []string
-	for i := range vulnerabilityMetadatas {
-		vulnMetadata, err := c.IngestVulnerabilityMetadata(ctx, *vulnerabilities[i], *vulnerabilityMetadatas[i])
+	for i := range vulnerabilityMetadataList {
+		vulnMetadata, err := c.IngestVulnerabilityMetadata(ctx, *vulnerabilities[i], *vulnerabilityMetadataList[i])
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestVulnerabilityMetadata failed with err: %v", err)
 		}

--- a/pkg/assembler/backends/inmem/vulnMetadata_test.go
+++ b/pkg/assembler/backends/inmem/vulnMetadata_test.go
@@ -1094,7 +1094,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 				t.Fatalf("Could not ingest vulnerabilities: %a", err)
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestVulnerabilityMetadatas(ctx, o.Vulns, o.VulnMetadatas)
+				_, err := b.IngestBulkVulnerabilityMetadata(ctx, o.Vulns, o.VulnMetadatas)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}

--- a/pkg/assembler/backends/neo4j/hasMetadata.go
+++ b/pkg/assembler/backends/neo4j/hasMetadata.go
@@ -29,3 +29,7 @@ func (c *neo4jClient) IngestHasMetadata(ctx context.Context, subject model.Packa
 func (c *neo4jClient) HasMetadata(ctx context.Context, hasMetadataSpec *model.HasMetadataSpec) ([]*model.HasMetadata, error) {
 	return nil, fmt.Errorf("not implemented: HasMetadata")
 }
+
+func (c *neo4jClient) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: IngestBulkHasMetadata")
+}

--- a/pkg/assembler/backends/neo4j/vulnMetadata.go
+++ b/pkg/assembler/backends/neo4j/vulnMetadata.go
@@ -26,8 +26,8 @@ func (c *neo4jClient) IngestVulnerabilityMetadata(ctx context.Context, vulnerabi
 	return "", fmt.Errorf("not implemented - IngestVulnerabilityMetadata")
 }
 
-func (c *neo4jClient) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
-	return []string{""}, fmt.Errorf("not implemented - IngestVulnerabilityMetadata")
+func (c *neo4jClient) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
+	return []string{""}, fmt.Errorf("not implemented - IngestBulkVulnerabilityMetadata")
 }
 
 func (c *neo4jClient) VulnerabilityMetadata(ctx context.Context, vulnerabilityMetadataSpec *model.VulnerabilityMetadataSpec) ([]*model.VulnerabilityMetadata, error) {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -7244,6 +7244,17 @@ type HasMetadataArtifactResponse struct {
 // GetIngestHasMetadata returns HasMetadataArtifactResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
 func (v *HasMetadataArtifactResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
 
+// HasMetadataArtifactsResponse is returned by HasMetadataArtifacts on success.
+type HasMetadataArtifactsResponse struct {
+	// Adds bulk metadata about a package, source or artifact. The returned array of IDs can be a an array of empty string.
+	IngestBulkHasMetadata []string `json:"ingestBulkHasMetadata"`
+}
+
+// GetIngestBulkHasMetadata returns HasMetadataArtifactsResponse.IngestBulkHasMetadata, and is useful for accessing the field via an interface.
+func (v *HasMetadataArtifactsResponse) GetIngestBulkHasMetadata() []string {
+	return v.IngestBulkHasMetadata
+}
+
 // HasMetadataInputSpec represents the mutation input to ingest a CertifyGood evidence.
 type HasMetadataInputSpec struct {
 	Key           string    `json:"key"`
@@ -7281,6 +7292,15 @@ type HasMetadataPkgResponse struct {
 // GetIngestHasMetadata returns HasMetadataPkgResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
 func (v *HasMetadataPkgResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
 
+// HasMetadataPkgsResponse is returned by HasMetadataPkgs on success.
+type HasMetadataPkgsResponse struct {
+	// Adds bulk metadata about a package, source or artifact. The returned array of IDs can be a an array of empty string.
+	IngestBulkHasMetadata []string `json:"ingestBulkHasMetadata"`
+}
+
+// GetIngestBulkHasMetadata returns HasMetadataPkgsResponse.IngestBulkHasMetadata, and is useful for accessing the field via an interface.
+func (v *HasMetadataPkgsResponse) GetIngestBulkHasMetadata() []string { return v.IngestBulkHasMetadata }
+
 // HasMetadataSrcResponse is returned by HasMetadataSrc on success.
 type HasMetadataSrcResponse struct {
 	// Adds metadata about a package, source or artifact. The returned ID can be empty string.
@@ -7289,6 +7309,15 @@ type HasMetadataSrcResponse struct {
 
 // GetIngestHasMetadata returns HasMetadataSrcResponse.IngestHasMetadata, and is useful for accessing the field via an interface.
 func (v *HasMetadataSrcResponse) GetIngestHasMetadata() string { return v.IngestHasMetadata }
+
+// HasMetadataSrcsResponse is returned by HasMetadataSrcs on success.
+type HasMetadataSrcsResponse struct {
+	// Adds bulk metadata about a package, source or artifact. The returned array of IDs can be a an array of empty string.
+	IngestBulkHasMetadata []string `json:"ingestBulkHasMetadata"`
+}
+
+// GetIngestBulkHasMetadata returns HasMetadataSrcsResponse.IngestBulkHasMetadata, and is useful for accessing the field via an interface.
+func (v *HasMetadataSrcsResponse) GetIngestBulkHasMetadata() []string { return v.IngestBulkHasMetadata }
 
 // HasSBOMArtifactResponse is returned by HasSBOMArtifact on success.
 type HasSBOMArtifactResponse struct {
@@ -21185,6 +21214,20 @@ func (v *__HasMetadataArtifactInput) GetArtifact() ArtifactInputSpec { return v.
 // GetHasMetadata returns __HasMetadataArtifactInput.HasMetadata, and is useful for accessing the field via an interface.
 func (v *__HasMetadataArtifactInput) GetHasMetadata() HasMetadataInputSpec { return v.HasMetadata }
 
+// __HasMetadataArtifactsInput is used internally by genqlient
+type __HasMetadataArtifactsInput struct {
+	Artifacts       []ArtifactInputSpec    `json:"artifacts"`
+	HasMetadataList []HasMetadataInputSpec `json:"hasMetadataList"`
+}
+
+// GetArtifacts returns __HasMetadataArtifactsInput.Artifacts, and is useful for accessing the field via an interface.
+func (v *__HasMetadataArtifactsInput) GetArtifacts() []ArtifactInputSpec { return v.Artifacts }
+
+// GetHasMetadataList returns __HasMetadataArtifactsInput.HasMetadataList, and is useful for accessing the field via an interface.
+func (v *__HasMetadataArtifactsInput) GetHasMetadataList() []HasMetadataInputSpec {
+	return v.HasMetadataList
+}
+
 // __HasMetadataPkgInput is used internally by genqlient
 type __HasMetadataPkgInput struct {
 	Pkg          PkgInputSpec         `json:"pkg"`
@@ -21201,6 +21244,24 @@ func (v *__HasMetadataPkgInput) GetPkgMatchType() MatchFlags { return v.PkgMatch
 // GetHasMetadata returns __HasMetadataPkgInput.HasMetadata, and is useful for accessing the field via an interface.
 func (v *__HasMetadataPkgInput) GetHasMetadata() HasMetadataInputSpec { return v.HasMetadata }
 
+// __HasMetadataPkgsInput is used internally by genqlient
+type __HasMetadataPkgsInput struct {
+	Pkgs            []PkgInputSpec         `json:"pkgs"`
+	PkgMatchType    MatchFlags             `json:"pkgMatchType"`
+	HasMetadataList []HasMetadataInputSpec `json:"hasMetadataList"`
+}
+
+// GetPkgs returns __HasMetadataPkgsInput.Pkgs, and is useful for accessing the field via an interface.
+func (v *__HasMetadataPkgsInput) GetPkgs() []PkgInputSpec { return v.Pkgs }
+
+// GetPkgMatchType returns __HasMetadataPkgsInput.PkgMatchType, and is useful for accessing the field via an interface.
+func (v *__HasMetadataPkgsInput) GetPkgMatchType() MatchFlags { return v.PkgMatchType }
+
+// GetHasMetadataList returns __HasMetadataPkgsInput.HasMetadataList, and is useful for accessing the field via an interface.
+func (v *__HasMetadataPkgsInput) GetHasMetadataList() []HasMetadataInputSpec {
+	return v.HasMetadataList
+}
+
 // __HasMetadataSrcInput is used internally by genqlient
 type __HasMetadataSrcInput struct {
 	Source      SourceInputSpec      `json:"source"`
@@ -21212,6 +21273,20 @@ func (v *__HasMetadataSrcInput) GetSource() SourceInputSpec { return v.Source }
 
 // GetHasMetadata returns __HasMetadataSrcInput.HasMetadata, and is useful for accessing the field via an interface.
 func (v *__HasMetadataSrcInput) GetHasMetadata() HasMetadataInputSpec { return v.HasMetadata }
+
+// __HasMetadataSrcsInput is used internally by genqlient
+type __HasMetadataSrcsInput struct {
+	Sources         []SourceInputSpec      `json:"sources"`
+	HasMetadataList []HasMetadataInputSpec `json:"hasMetadataList"`
+}
+
+// GetSources returns __HasMetadataSrcsInput.Sources, and is useful for accessing the field via an interface.
+func (v *__HasMetadataSrcsInput) GetSources() []SourceInputSpec { return v.Sources }
+
+// GetHasMetadataList returns __HasMetadataSrcsInput.HasMetadataList, and is useful for accessing the field via an interface.
+func (v *__HasMetadataSrcsInput) GetHasMetadataList() []HasMetadataInputSpec {
+	return v.HasMetadataList
+}
 
 // __HasSBOMArtifactInput is used internally by genqlient
 type __HasSBOMArtifactInput struct {
@@ -23059,6 +23134,41 @@ func HasMetadataArtifact(
 	return &data, err
 }
 
+// The query or mutation executed by HasMetadataArtifacts.
+const HasMetadataArtifacts_Operation = `
+mutation HasMetadataArtifacts ($artifacts: [ArtifactInputSpec!]!, $hasMetadataList: [HasMetadataInputSpec!]!) {
+	ingestBulkHasMetadata(subjects: {artifacts:$artifacts}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadataList: $hasMetadataList)
+}
+`
+
+func HasMetadataArtifacts(
+	ctx context.Context,
+	client graphql.Client,
+	artifacts []ArtifactInputSpec,
+	hasMetadataList []HasMetadataInputSpec,
+) (*HasMetadataArtifactsResponse, error) {
+	req := &graphql.Request{
+		OpName: "HasMetadataArtifacts",
+		Query:  HasMetadataArtifacts_Operation,
+		Variables: &__HasMetadataArtifactsInput{
+			Artifacts:       artifacts,
+			HasMetadataList: hasMetadataList,
+		},
+	}
+	var err error
+
+	var data HasMetadataArtifactsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by HasMetadataPkg.
 const HasMetadataPkg_Operation = `
 mutation HasMetadataPkg ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $hasMetadata: HasMetadataInputSpec!) {
@@ -23096,6 +23206,43 @@ func HasMetadataPkg(
 	return &data, err
 }
 
+// The query or mutation executed by HasMetadataPkgs.
+const HasMetadataPkgs_Operation = `
+mutation HasMetadataPkgs ($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $hasMetadataList: [HasMetadataInputSpec!]!) {
+	ingestBulkHasMetadata(subjects: {packages:$pkgs}, pkgMatchType: $pkgMatchType, hasMetadataList: $hasMetadataList)
+}
+`
+
+func HasMetadataPkgs(
+	ctx context.Context,
+	client graphql.Client,
+	pkgs []PkgInputSpec,
+	pkgMatchType MatchFlags,
+	hasMetadataList []HasMetadataInputSpec,
+) (*HasMetadataPkgsResponse, error) {
+	req := &graphql.Request{
+		OpName: "HasMetadataPkgs",
+		Query:  HasMetadataPkgs_Operation,
+		Variables: &__HasMetadataPkgsInput{
+			Pkgs:            pkgs,
+			PkgMatchType:    pkgMatchType,
+			HasMetadataList: hasMetadataList,
+		},
+	}
+	var err error
+
+	var data HasMetadataPkgsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by HasMetadataSrc.
 const HasMetadataSrc_Operation = `
 mutation HasMetadataSrc ($source: SourceInputSpec!, $hasMetadata: HasMetadataInputSpec!) {
@@ -23120,6 +23267,41 @@ func HasMetadataSrc(
 	var err error
 
 	var data HasMetadataSrcResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by HasMetadataSrcs.
+const HasMetadataSrcs_Operation = `
+mutation HasMetadataSrcs ($sources: [SourceInputSpec!]!, $hasMetadataList: [HasMetadataInputSpec!]!) {
+	ingestBulkHasMetadata(subjects: {sources:$sources}, pkgMatchType: {pkg:ALL_VERSIONS}, hasMetadataList: $hasMetadataList)
+}
+`
+
+func HasMetadataSrcs(
+	ctx context.Context,
+	client graphql.Client,
+	sources []SourceInputSpec,
+	hasMetadataList []HasMetadataInputSpec,
+) (*HasMetadataSrcsResponse, error) {
+	req := &graphql.Request{
+		OpName: "HasMetadataSrcs",
+		Query:  HasMetadataSrcs_Operation,
+		Variables: &__HasMetadataSrcsInput{
+			Sources:         sources,
+			HasMetadataList: hasMetadataList,
+		},
+	}
+	var err error
+
+	var data HasMetadataSrcsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -6028,6 +6028,17 @@ type BuilderInputSpec struct {
 // GetUri returns BuilderInputSpec.Uri, and is useful for accessing the field via an interface.
 func (v *BuilderInputSpec) GetUri() string { return v.Uri }
 
+// BulkVulnHasMetadataResponse is returned by BulkVulnHasMetadata on success.
+type BulkVulnHasMetadataResponse struct {
+	// Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string.
+	IngestBulkVulnerabilityMetadata []string `json:"ingestBulkVulnerabilityMetadata"`
+}
+
+// GetIngestBulkVulnerabilityMetadata returns BulkVulnHasMetadataResponse.IngestBulkVulnerabilityMetadata, and is useful for accessing the field via an interface.
+func (v *BulkVulnHasMetadataResponse) GetIngestBulkVulnerabilityMetadata() []string {
+	return v.IngestBulkVulnerabilityMetadata
+}
+
 // CertifyBadArtifactResponse is returned by CertifyBadArtifact on success.
 type CertifyBadArtifactResponse struct {
 	// Adds a certification that a package, source or artifact is considered bad. The returned ID can be empty string.
@@ -20543,17 +20554,6 @@ func (v *VulnHasMetadataResponse) GetIngestVulnerabilityMetadata() string {
 	return v.IngestVulnerabilityMetadata
 }
 
-// VulnHasMetadatasResponse is returned by VulnHasMetadatas on success.
-type VulnHasMetadatasResponse struct {
-	// Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string.
-	IngestVulnerabilityMetadatas []string `json:"ingestVulnerabilityMetadatas"`
-}
-
-// GetIngestVulnerabilityMetadatas returns VulnHasMetadatasResponse.IngestVulnerabilityMetadatas, and is useful for accessing the field via an interface.
-func (v *VulnHasMetadatasResponse) GetIngestVulnerabilityMetadatas() []string {
-	return v.IngestVulnerabilityMetadatas
-}
-
 // VulnerabilitiesResponse is returned by Vulnerabilities on success.
 type VulnerabilitiesResponse struct {
 	// Returns all vulnerabilities matching a filter.
@@ -20752,6 +20752,22 @@ type __ArtifactsInput struct {
 
 // GetFilter returns __ArtifactsInput.Filter, and is useful for accessing the field via an interface.
 func (v *__ArtifactsInput) GetFilter() ArtifactSpec { return v.Filter }
+
+// __BulkVulnHasMetadataInput is used internally by genqlient
+type __BulkVulnHasMetadataInput struct {
+	Vulnerabilities           []VulnerabilityInputSpec         `json:"vulnerabilities"`
+	VulnerabilityMetadataList []VulnerabilityMetadataInputSpec `json:"vulnerabilityMetadataList"`
+}
+
+// GetVulnerabilities returns __BulkVulnHasMetadataInput.Vulnerabilities, and is useful for accessing the field via an interface.
+func (v *__BulkVulnHasMetadataInput) GetVulnerabilities() []VulnerabilityInputSpec {
+	return v.Vulnerabilities
+}
+
+// GetVulnerabilityMetadataList returns __BulkVulnHasMetadataInput.VulnerabilityMetadataList, and is useful for accessing the field via an interface.
+func (v *__BulkVulnHasMetadataInput) GetVulnerabilityMetadataList() []VulnerabilityMetadataInputSpec {
+	return v.VulnerabilityMetadataList
+}
 
 // __CertifyBadArtifactInput is used internally by genqlient
 type __CertifyBadArtifactInput struct {
@@ -21771,22 +21787,6 @@ func (v *__VulnHasMetadataInput) GetVulnMetadata() VulnerabilityMetadataInputSpe
 	return v.VulnMetadata
 }
 
-// __VulnHasMetadatasInput is used internally by genqlient
-type __VulnHasMetadatasInput struct {
-	Vulnerabilities []VulnerabilityInputSpec         `json:"vulnerabilities"`
-	VulnMetadatas   []VulnerabilityMetadataInputSpec `json:"vulnMetadatas"`
-}
-
-// GetVulnerabilities returns __VulnHasMetadatasInput.Vulnerabilities, and is useful for accessing the field via an interface.
-func (v *__VulnHasMetadatasInput) GetVulnerabilities() []VulnerabilityInputSpec {
-	return v.Vulnerabilities
-}
-
-// GetVulnMetadatas returns __VulnHasMetadatasInput.VulnMetadatas, and is useful for accessing the field via an interface.
-func (v *__VulnHasMetadatasInput) GetVulnMetadatas() []VulnerabilityMetadataInputSpec {
-	return v.VulnMetadatas
-}
-
 // __VulnerabilitiesInput is used internally by genqlient
 type __VulnerabilitiesInput struct {
 	Filter VulnerabilitySpec `json:"filter"`
@@ -21824,6 +21824,41 @@ func Artifacts(
 	var err error
 
 	var data ArtifactsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by BulkVulnHasMetadata.
+const BulkVulnHasMetadata_Operation = `
+mutation BulkVulnHasMetadata ($vulnerabilities: [VulnerabilityInputSpec!]!, $vulnerabilityMetadataList: [VulnerabilityMetadataInputSpec!]!) {
+	ingestBulkVulnerabilityMetadata(vulnerabilities: $vulnerabilities, vulnerabilityMetadataList: $vulnerabilityMetadataList)
+}
+`
+
+func BulkVulnHasMetadata(
+	ctx context.Context,
+	client graphql.Client,
+	vulnerabilities []VulnerabilityInputSpec,
+	vulnerabilityMetadataList []VulnerabilityMetadataInputSpec,
+) (*BulkVulnHasMetadataResponse, error) {
+	req := &graphql.Request{
+		OpName: "BulkVulnHasMetadata",
+		Query:  BulkVulnHasMetadata_Operation,
+		Variables: &__BulkVulnHasMetadataInput{
+			Vulnerabilities:           vulnerabilities,
+			VulnerabilityMetadataList: vulnerabilityMetadataList,
+		},
+	}
+	var err error
+
+	var data BulkVulnHasMetadataResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(
@@ -26483,41 +26518,6 @@ func VulnHasMetadata(
 	var err error
 
 	var data VulnHasMetadataResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
-// The query or mutation executed by VulnHasMetadatas.
-const VulnHasMetadatas_Operation = `
-mutation VulnHasMetadatas ($vulnerabilities: [VulnerabilityInputSpec!]!, $vulnMetadatas: [VulnerabilityMetadataInputSpec!]!) {
-	ingestVulnerabilityMetadatas(vulnerabilities: $vulnerabilities, vulnerabilityMetadatas: $vulnMetadatas)
-}
-`
-
-func VulnHasMetadatas(
-	ctx context.Context,
-	client graphql.Client,
-	vulnerabilities []VulnerabilityInputSpec,
-	vulnMetadatas []VulnerabilityMetadataInputSpec,
-) (*VulnHasMetadatasResponse, error) {
-	req := &graphql.Request{
-		OpName: "VulnHasMetadatas",
-		Query:  VulnHasMetadatas_Operation,
-		Variables: &__VulnHasMetadatasInput{
-			Vulnerabilities: vulnerabilities,
-			VulnMetadatas:   vulnMetadatas,
-		},
-	}
-	var err error
-
-	var data VulnHasMetadatasResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -289,7 +289,7 @@ func ingestVulnMetadatas(ctx context.Context, client graphql.Client, vm []assemb
 		vulnMetadataList = append(vulnMetadataList, *ingest.VulnMetadata)
 	}
 	if len(vm) > 0 {
-		_, err := model.VulnHasMetadatas(ctx, client, vulnerabilities, vulnMetadataList)
+		_, err := model.BulkVulnHasMetadata(ctx, client, vulnerabilities, vulnMetadataList)
 		if err != nil {
 			return fmt.Errorf("VulnHasMetadatas failed with error: %w", err)
 		}

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -150,12 +150,17 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 			}
 
 			// TODO: add bulk ingestion for PointOfContact
-			logger.Infof("assembling PointOfContact: %v", len(p.CertifyGood))
+			logger.Infof("assembling PointOfContact: %v", len(p.PointOfContact))
 			for _, poc := range p.PointOfContact {
 				if err := ingestPointOfContact(ctx, gqlclient, poc); err != nil {
 					return fmt.Errorf("ingestPointOfContact failed with error: %w", err)
 
 				}
+			}
+
+			logger.Infof("assembling HasMetadata: %v", len(p.HasMetadata))
+			if err := ingestBulkHasMetadata(ctx, gqlclient, p.HasMetadata); err != nil {
+				return fmt.Errorf("ingestBulkHasMetadata failed with error: %w", err)
 			}
 
 			logger.Infof("assembling HasSBOM: %v", len(p.HasSBOM))
@@ -458,6 +463,62 @@ func ingestHasSBOMs(ctx context.Context, client graphql.Client, v []assembler.Ha
 		_, err := model.HasSBOMPkgs(ctx, client, pkgs, pkgSBOMs)
 		if err != nil {
 			return fmt.Errorf("hasSBOMPkgs failed with error: %w", err)
+		}
+	}
+	return nil
+}
+
+func ingestBulkHasMetadata(ctx context.Context, client graphql.Client, v []assembler.HasMetadataIngest) error {
+	var pkgVersions []model.PkgInputSpec
+	var pkgNames []model.PkgInputSpec
+	var sources []model.SourceInputSpec
+	var artifacts []model.ArtifactInputSpec
+	var pkgVersionHasMetadata []model.HasMetadataInputSpec
+	var pkgNameHasMetadata []model.HasMetadataInputSpec
+	var srcHasMetadata []model.HasMetadataInputSpec
+	var artHasMetadata []model.HasMetadataInputSpec
+	for _, ingest := range v {
+		if err := validatePackageSourceOrArtifactInput(ingest.Pkg, ingest.Src, ingest.Artifact, "ingestBulkHasMetadata"); err != nil {
+			return fmt.Errorf("input validation failed for ingestBulkHasMetadata: %w", err)
+		}
+		if ingest.Pkg != nil {
+			if ingest.PkgMatchFlag.Pkg == model.PkgMatchTypeSpecificVersion {
+				pkgVersions = append(pkgVersions, *ingest.Pkg)
+				pkgVersionHasMetadata = append(pkgVersionHasMetadata, *ingest.HasMetadata)
+			} else {
+				pkgNames = append(pkgNames, *ingest.Pkg)
+				pkgNameHasMetadata = append(pkgNameHasMetadata, *ingest.HasMetadata)
+			}
+		} else if ingest.Src != nil {
+			sources = append(sources, *ingest.Src)
+			srcHasMetadata = append(srcHasMetadata, *ingest.HasMetadata)
+		} else {
+			artifacts = append(artifacts, *ingest.Artifact)
+			artHasMetadata = append(artHasMetadata, *ingest.HasMetadata)
+		}
+	}
+	if len(pkgVersions) > 0 {
+		_, err := model.HasMetadataPkgs(ctx, client, pkgVersions, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion}, pkgVersionHasMetadata)
+		if err != nil {
+			return fmt.Errorf("HasMetadataPkgs - specific version failed with error: %w", err)
+		}
+	}
+	if len(pkgNames) > 0 {
+		_, err := model.HasMetadataPkgs(ctx, client, pkgNames, model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions}, pkgNameHasMetadata)
+		if err != nil {
+			return fmt.Errorf("HasMetadataPkgs - all versions failed with error: %w", err)
+		}
+	}
+	if len(sources) > 0 {
+		_, err := model.HasMetadataSrcs(ctx, client, sources, srcHasMetadata)
+		if err != nil {
+			return fmt.Errorf("HasMetadataSrcs failed with error: %w", err)
+		}
+	}
+	if len(artifacts) > 0 {
+		_, err := model.HasMetadataArtifacts(ctx, client, artifacts, artHasMetadata)
+		if err != nil {
+			return fmt.Errorf("HasMetadataArtifacts failed with error: %w", err)
 		}
 	}
 	return nil

--- a/pkg/assembler/clients/operations/metadata.graphql
+++ b/pkg/assembler/clients/operations/metadata.graphql
@@ -50,3 +50,40 @@ mutation HasMetadataArtifact(
     hasMetadata: $hasMetadata
   )
 }
+
+
+# Defines the GraphQL operations to bulk ingest a HasMetadata into GUAC
+
+mutation HasMetadataPkgs(
+  $pkgs: [PkgInputSpec!]!
+  $pkgMatchType: MatchFlags!
+  $hasMetadataList: [HasMetadataInputSpec!]!
+) {
+  ingestBulkHasMetadata(
+    subjects: { packages: $pkgs }
+    pkgMatchType: $pkgMatchType
+    hasMetadataList: $hasMetadataList
+  )
+}
+
+mutation HasMetadataSrcs(
+  $sources: [SourceInputSpec!]!
+  $hasMetadataList: [HasMetadataInputSpec!]!
+) {
+  ingestBulkHasMetadata(
+    subjects: { sources: $sources }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    hasMetadataList: $hasMetadataList
+  )
+}
+
+mutation HasMetadataArtifacts(
+  $artifacts: [ArtifactInputSpec!]!
+  $hasMetadataList: [HasMetadataInputSpec!]!
+) {
+  ingestBulkHasMetadata(
+    subjects: { artifacts: $artifacts }
+    pkgMatchType: { pkg: ALL_VERSIONS }
+    hasMetadataList: $hasMetadataList
+  )
+}

--- a/pkg/assembler/clients/operations/vulnMetadata.graphql
+++ b/pkg/assembler/clients/operations/vulnMetadata.graphql
@@ -29,12 +29,12 @@ mutation VulnHasMetadata(
 
 # Defines the GraphQL operations to bulk ingest metadata for a vulnerability into GUAC
 
-mutation VulnHasMetadatas(
+mutation BulkVulnHasMetadata(
   $vulnerabilities: [VulnerabilityInputSpec!]!, 
-  $vulnMetadatas: [VulnerabilityMetadataInputSpec!]!
+  $vulnerabilityMetadataList: [VulnerabilityMetadataInputSpec!]!
   ) {
-  ingestVulnerabilityMetadatas(
+  ingestBulkVulnerabilityMetadata(
     vulnerabilities: $vulnerabilities, 
-    vulnerabilityMetadatas: $vulnMetadatas
+    vulnerabilityMetadataList: $vulnerabilityMetadataList
   )
 }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -50,6 +50,7 @@ type MutationResolver interface {
 	IngestLicense(ctx context.Context, license *model.LicenseInputSpec) (string, error)
 	IngestLicenses(ctx context.Context, licenses []*model.LicenseInputSpec) ([]string, error)
 	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (string, error)
+	IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error)
 	IngestPackage(ctx context.Context, pkg model.PkgInputSpec) (string, error)
 	IngestPackages(ctx context.Context, pkgs []*model.PkgInputSpec) ([]string, error)
 	IngestPkgEqual(ctx context.Context, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) (string, error)
@@ -59,7 +60,7 @@ type MutationResolver interface {
 	IngestVulnEqual(ctx context.Context, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) (string, error)
 	IngestVulnEquals(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, otherVulnerabilities []*model.VulnerabilityInputSpec, vulnEquals []*model.VulnEqualInputSpec) ([]string, error)
 	IngestVulnerabilityMetadata(ctx context.Context, vulnerability model.VulnerabilityInputSpec, vulnerabilityMetadata model.VulnerabilityMetadataInputSpec) (string, error)
-	IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error)
+	IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error)
 	IngestVulnerability(ctx context.Context, vuln model.VulnerabilityInputSpec) (string, error)
 	IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]string, error)
 }
@@ -155,6 +156,63 @@ func (ec *executionContext) field_Mutation_ingestBuilders_args(ctx context.Conte
 		}
 	}
 	args["builders"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestBulkHasMetadata_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.PackageSourceOrArtifactInputs
+	if tmp, ok := rawArgs["subjects"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subjects"))
+		arg0, err = ec.unmarshalNPackageSourceOrArtifactInputs2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageSourceOrArtifactInputs(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["subjects"] = arg0
+	var arg1 model.MatchFlags
+	if tmp, ok := rawArgs["pkgMatchType"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgMatchType"))
+		arg1, err = ec.unmarshalNMatchFlags2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐMatchFlags(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkgMatchType"] = arg1
+	var arg2 []*model.HasMetadataInputSpec
+	if tmp, ok := rawArgs["hasMetadataList"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hasMetadataList"))
+		arg2, err = ec.unmarshalNHasMetadataInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["hasMetadataList"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestBulkVulnerabilityMetadata_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.VulnerabilityInputSpec
+	if tmp, ok := rawArgs["vulnerabilities"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilities"))
+		arg0, err = ec.unmarshalNVulnerabilityInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["vulnerabilities"] = arg0
+	var arg1 []*model.VulnerabilityMetadataInputSpec
+	if tmp, ok := rawArgs["vulnerabilityMetadataList"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilityMetadataList"))
+		arg1, err = ec.unmarshalNVulnerabilityMetadataInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityMetadataInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["vulnerabilityMetadataList"] = arg1
 	return args, nil
 }
 
@@ -1268,30 +1326,6 @@ func (ec *executionContext) field_Mutation_ingestVulnerabilityMetadata_args(ctx 
 		}
 	}
 	args["vulnerabilityMetadata"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_ingestVulnerabilityMetadatas_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 []*model.VulnerabilityInputSpec
-	if tmp, ok := rawArgs["vulnerabilities"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilities"))
-		arg0, err = ec.unmarshalNVulnerabilityInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityInputSpecᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["vulnerabilities"] = arg0
-	var arg1 []*model.VulnerabilityMetadataInputSpec
-	if tmp, ok := rawArgs["vulnerabilityMetadatas"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("vulnerabilityMetadatas"))
-		arg1, err = ec.unmarshalNVulnerabilityMetadataInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVulnerabilityMetadataInputSpecᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["vulnerabilityMetadatas"] = arg1
 	return args, nil
 }
 
@@ -3626,6 +3660,61 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasMetadata(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_ingestBulkHasMetadata(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestBulkHasMetadata(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestBulkHasMetadata(rctx, fc.Args["subjects"].(model.PackageSourceOrArtifactInputs), fc.Args["pkgMatchType"].(model.MatchFlags), fc.Args["hasMetadataList"].([]*model.HasMetadataInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestBulkHasMetadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestBulkHasMetadata_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_ingestPackage(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_ingestPackage(ctx, field)
 	if err != nil {
@@ -4121,8 +4210,8 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnerabilityMetadata(ct
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_ingestVulnerabilityMetadatas(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_ingestVulnerabilityMetadatas(ctx, field)
+func (ec *executionContext) _Mutation_ingestBulkVulnerabilityMetadata(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestBulkVulnerabilityMetadata(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4135,7 +4224,7 @@ func (ec *executionContext) _Mutation_ingestVulnerabilityMetadatas(ctx context.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().IngestVulnerabilityMetadatas(rctx, fc.Args["vulnerabilities"].([]*model.VulnerabilityInputSpec), fc.Args["vulnerabilityMetadatas"].([]*model.VulnerabilityMetadataInputSpec))
+		return ec.resolvers.Mutation().IngestBulkVulnerabilityMetadata(rctx, fc.Args["vulnerabilities"].([]*model.VulnerabilityInputSpec), fc.Args["vulnerabilityMetadataList"].([]*model.VulnerabilityMetadataInputSpec))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4152,7 +4241,7 @@ func (ec *executionContext) _Mutation_ingestVulnerabilityMetadatas(ctx context.C
 	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_ingestVulnerabilityMetadatas(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_ingestBulkVulnerabilityMetadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -4169,7 +4258,7 @@ func (ec *executionContext) fieldContext_Mutation_ingestVulnerabilityMetadatas(c
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_ingestVulnerabilityMetadatas_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_ingestBulkVulnerabilityMetadata_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6635,6 +6724,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "ingestBulkHasMetadata":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestBulkHasMetadata(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "ingestPackage":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestPackage(ctx, field)
@@ -6698,9 +6794,9 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "ingestVulnerabilityMetadatas":
+		case "ingestBulkVulnerabilityMetadata":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_ingestVulnerabilityMetadatas(ctx, field)
+				return ec._Mutation_ingestBulkVulnerabilityMetadata(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/metadata.generated.go
+++ b/pkg/assembler/graphql/generated/metadata.generated.go
@@ -696,6 +696,28 @@ func (ec *executionContext) unmarshalNHasMetadataInputSpec2githubᚗcomᚋguacse
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNHasMetadataInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.HasMetadataInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.HasMetadataInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNHasMetadataInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNHasMetadataInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataInputSpec(ctx context.Context, v interface{}) (*model.HasMetadataInputSpec, error) {
+	res, err := ec.unmarshalInputHasMetadataInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNHasMetadataSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasMetadataSpec(ctx context.Context, v interface{}) (model.HasMetadataSpec, error) {
 	res, err := ec.unmarshalInputHasMetadataSpec(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -180,49 +180,50 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		IngestArtifact               func(childComplexity int, artifact *model.ArtifactInputSpec) int
-		IngestArtifacts              func(childComplexity int, artifacts []*model.ArtifactInputSpec) int
-		IngestBuilder                func(childComplexity int, builder *model.BuilderInputSpec) int
-		IngestBuilders               func(childComplexity int, builders []*model.BuilderInputSpec) int
-		IngestCertifyBad             func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) int
-		IngestCertifyBads            func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) int
-		IngestCertifyGood            func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) int
-		IngestCertifyGoods           func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) int
-		IngestCertifyLegal           func(childComplexity int, subject model.PackageOrSourceInput, declaredLicenses []*model.LicenseInputSpec, discoveredLicenses []*model.LicenseInputSpec, certifyLegal model.CertifyLegalInputSpec) int
-		IngestCertifyLegals          func(childComplexity int, subjects model.PackageOrSourceInputs, declaredLicensesList [][]*model.LicenseInputSpec, discoveredLicensesList [][]*model.LicenseInputSpec, certifyLegals []*model.CertifyLegalInputSpec) int
-		IngestCertifyVuln            func(childComplexity int, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) int
-		IngestCertifyVulns           func(childComplexity int, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) int
-		IngestDependencies           func(childComplexity int, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) int
-		IngestDependency             func(childComplexity int, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) int
-		IngestHasMetadata            func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) int
-		IngestHasSBOMs               func(childComplexity int, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) int
-		IngestHasSbom                func(childComplexity int, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) int
-		IngestHasSourceAt            func(childComplexity int, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) int
-		IngestHashEqual              func(childComplexity int, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) int
-		IngestHashEquals             func(childComplexity int, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) int
-		IngestLicense                func(childComplexity int, license *model.LicenseInputSpec) int
-		IngestLicenses               func(childComplexity int, licenses []*model.LicenseInputSpec) int
-		IngestOccurrence             func(childComplexity int, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) int
-		IngestOccurrences            func(childComplexity int, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) int
-		IngestPackage                func(childComplexity int, pkg model.PkgInputSpec) int
-		IngestPackages               func(childComplexity int, pkgs []*model.PkgInputSpec) int
-		IngestPkgEqual               func(childComplexity int, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) int
-		IngestPkgEquals              func(childComplexity int, pkgs []*model.PkgInputSpec, otherPackages []*model.PkgInputSpec, pkgEquals []*model.PkgEqualInputSpec) int
-		IngestPointOfContact         func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) int
-		IngestSLSAs                  func(childComplexity int, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) int
-		IngestScorecard              func(childComplexity int, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) int
-		IngestScorecards             func(childComplexity int, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) int
-		IngestSlsa                   func(childComplexity int, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) int
-		IngestSource                 func(childComplexity int, source model.SourceInputSpec) int
-		IngestSources                func(childComplexity int, sources []*model.SourceInputSpec) int
-		IngestVEXStatement           func(childComplexity int, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) int
-		IngestVEXStatements          func(childComplexity int, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) int
-		IngestVulnEqual              func(childComplexity int, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) int
-		IngestVulnEquals             func(childComplexity int, vulnerabilities []*model.VulnerabilityInputSpec, otherVulnerabilities []*model.VulnerabilityInputSpec, vulnEquals []*model.VulnEqualInputSpec) int
-		IngestVulnerabilities        func(childComplexity int, vulns []*model.VulnerabilityInputSpec) int
-		IngestVulnerability          func(childComplexity int, vuln model.VulnerabilityInputSpec) int
-		IngestVulnerabilityMetadata  func(childComplexity int, vulnerability model.VulnerabilityInputSpec, vulnerabilityMetadata model.VulnerabilityMetadataInputSpec) int
-		IngestVulnerabilityMetadatas func(childComplexity int, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) int
+		IngestArtifact                  func(childComplexity int, artifact *model.ArtifactInputSpec) int
+		IngestArtifacts                 func(childComplexity int, artifacts []*model.ArtifactInputSpec) int
+		IngestBuilder                   func(childComplexity int, builder *model.BuilderInputSpec) int
+		IngestBuilders                  func(childComplexity int, builders []*model.BuilderInputSpec) int
+		IngestBulkHasMetadata           func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) int
+		IngestBulkVulnerabilityMetadata func(childComplexity int, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) int
+		IngestCertifyBad                func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyBad model.CertifyBadInputSpec) int
+		IngestCertifyBads               func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) int
+		IngestCertifyGood               func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, certifyGood model.CertifyGoodInputSpec) int
+		IngestCertifyGoods              func(childComplexity int, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) int
+		IngestCertifyLegal              func(childComplexity int, subject model.PackageOrSourceInput, declaredLicenses []*model.LicenseInputSpec, discoveredLicenses []*model.LicenseInputSpec, certifyLegal model.CertifyLegalInputSpec) int
+		IngestCertifyLegals             func(childComplexity int, subjects model.PackageOrSourceInputs, declaredLicensesList [][]*model.LicenseInputSpec, discoveredLicensesList [][]*model.LicenseInputSpec, certifyLegals []*model.CertifyLegalInputSpec) int
+		IngestCertifyVuln               func(childComplexity int, pkg model.PkgInputSpec, vulnerability model.VulnerabilityInputSpec, certifyVuln model.ScanMetadataInput) int
+		IngestCertifyVulns              func(childComplexity int, pkgs []*model.PkgInputSpec, vulnerabilities []*model.VulnerabilityInputSpec, certifyVulns []*model.ScanMetadataInput) int
+		IngestDependencies              func(childComplexity int, pkgs []*model.PkgInputSpec, depPkgs []*model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependencies []*model.IsDependencyInputSpec) int
+		IngestDependency                func(childComplexity int, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) int
+		IngestHasMetadata               func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, hasMetadata model.HasMetadataInputSpec) int
+		IngestHasSBOMs                  func(childComplexity int, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) int
+		IngestHasSbom                   func(childComplexity int, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) int
+		IngestHasSourceAt               func(childComplexity int, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) int
+		IngestHashEqual                 func(childComplexity int, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) int
+		IngestHashEquals                func(childComplexity int, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) int
+		IngestLicense                   func(childComplexity int, license *model.LicenseInputSpec) int
+		IngestLicenses                  func(childComplexity int, licenses []*model.LicenseInputSpec) int
+		IngestOccurrence                func(childComplexity int, subject model.PackageOrSourceInput, artifact model.ArtifactInputSpec, occurrence model.IsOccurrenceInputSpec) int
+		IngestOccurrences               func(childComplexity int, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) int
+		IngestPackage                   func(childComplexity int, pkg model.PkgInputSpec) int
+		IngestPackages                  func(childComplexity int, pkgs []*model.PkgInputSpec) int
+		IngestPkgEqual                  func(childComplexity int, pkg model.PkgInputSpec, otherPackage model.PkgInputSpec, pkgEqual model.PkgEqualInputSpec) int
+		IngestPkgEquals                 func(childComplexity int, pkgs []*model.PkgInputSpec, otherPackages []*model.PkgInputSpec, pkgEquals []*model.PkgEqualInputSpec) int
+		IngestPointOfContact            func(childComplexity int, subject model.PackageSourceOrArtifactInput, pkgMatchType model.MatchFlags, pointOfContact model.PointOfContactInputSpec) int
+		IngestSLSAs                     func(childComplexity int, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) int
+		IngestScorecard                 func(childComplexity int, source model.SourceInputSpec, scorecard model.ScorecardInputSpec) int
+		IngestScorecards                func(childComplexity int, sources []*model.SourceInputSpec, scorecards []*model.ScorecardInputSpec) int
+		IngestSlsa                      func(childComplexity int, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) int
+		IngestSource                    func(childComplexity int, source model.SourceInputSpec) int
+		IngestSources                   func(childComplexity int, sources []*model.SourceInputSpec) int
+		IngestVEXStatement              func(childComplexity int, subject model.PackageOrArtifactInput, vulnerability model.VulnerabilityInputSpec, vexStatement model.VexStatementInputSpec) int
+		IngestVEXStatements             func(childComplexity int, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.VulnerabilityInputSpec, vexStatements []*model.VexStatementInputSpec) int
+		IngestVulnEqual                 func(childComplexity int, vulnerability model.VulnerabilityInputSpec, otherVulnerability model.VulnerabilityInputSpec, vulnEqual model.VulnEqualInputSpec) int
+		IngestVulnEquals                func(childComplexity int, vulnerabilities []*model.VulnerabilityInputSpec, otherVulnerabilities []*model.VulnerabilityInputSpec, vulnEquals []*model.VulnEqualInputSpec) int
+		IngestVulnerabilities           func(childComplexity int, vulns []*model.VulnerabilityInputSpec) int
+		IngestVulnerability             func(childComplexity int, vuln model.VulnerabilityInputSpec) int
+		IngestVulnerabilityMetadata     func(childComplexity int, vulnerability model.VulnerabilityInputSpec, vulnerabilityMetadata model.VulnerabilityMetadataInputSpec) int
 	}
 
 	Package struct {
@@ -1103,6 +1104,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.IngestBuilders(childComplexity, args["builders"].([]*model.BuilderInputSpec)), true
 
+	case "Mutation.ingestBulkHasMetadata":
+		if e.complexity.Mutation.IngestBulkHasMetadata == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestBulkHasMetadata_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestBulkHasMetadata(childComplexity, args["subjects"].(model.PackageSourceOrArtifactInputs), args["pkgMatchType"].(model.MatchFlags), args["hasMetadataList"].([]*model.HasMetadataInputSpec)), true
+
+	case "Mutation.ingestBulkVulnerabilityMetadata":
+		if e.complexity.Mutation.IngestBulkVulnerabilityMetadata == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestBulkVulnerabilityMetadata_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestBulkVulnerabilityMetadata(childComplexity, args["vulnerabilities"].([]*model.VulnerabilityInputSpec), args["vulnerabilityMetadataList"].([]*model.VulnerabilityMetadataInputSpec)), true
+
 	case "Mutation.ingestCertifyBad":
 		if e.complexity.Mutation.IngestCertifyBad == nil {
 			break
@@ -1558,18 +1583,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestVulnerabilityMetadata(childComplexity, args["vulnerability"].(model.VulnerabilityInputSpec), args["vulnerabilityMetadata"].(model.VulnerabilityMetadataInputSpec)), true
-
-	case "Mutation.ingestVulnerabilityMetadatas":
-		if e.complexity.Mutation.IngestVulnerabilityMetadatas == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_ingestVulnerabilityMetadatas_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.IngestVulnerabilityMetadatas(childComplexity, args["vulnerabilities"].([]*model.VulnerabilityInputSpec), args["vulnerabilityMetadatas"].([]*model.VulnerabilityMetadataInputSpec)), true
 
 	case "Package.id":
 		if e.complexity.Package.ID == nil {
@@ -4370,6 +4383,12 @@ extend type Mutation {
     pkgMatchType: MatchFlags!
     hasMetadata: HasMetadataInputSpec!
   ): ID!
+  "Adds bulk metadata about a package, source or artifact. The returned array of IDs can be a an array of empty string."
+  ingestBulkHasMetadata(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    hasMetadataList: [HasMetadataInputSpec!]!
+  ): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/package.graphql", Input: `#
@@ -5156,7 +5175,7 @@ extend type Mutation {
   "Adds metadata about a vulnerability. The returned ID can be empty string."
   ingestVulnerabilityMetadata(vulnerability: VulnerabilityInputSpec!, vulnerabilityMetadata: VulnerabilityMetadataInputSpec!): ID!
   "Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string."
-  ingestVulnerabilityMetadatas(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadatas: [VulnerabilityMetadataInputSpec!]!): [ID!]!
+  ingestBulkVulnerabilityMetadata(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadataList: [VulnerabilityMetadataInputSpec!]!): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/vulnerability.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/metadata.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/metadata.resolvers.go
@@ -6,7 +6,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -29,7 +28,30 @@ func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.
 
 // IngestBulkHasMetadata is the resolver for the ingestBulkHasMetadata field.
 func (r *mutationResolver) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
-	panic(fmt.Errorf("not implemented: IngestBulkHasMetadata - ingestBulkHasMetadata"))
+	funcName := "IngestBulkHasMetadata"
+	valuesDefined := 0
+	if len(subjects.Packages) > 0 {
+		if len(subjects.Packages) != len(hasMetadataList) {
+			return []string{}, gqlerror.Errorf("%v :: uneven packages and hasMetadata for ingestion", funcName)
+		}
+		valuesDefined = valuesDefined + 1
+	}
+	if len(subjects.Artifacts) > 0 {
+		if len(subjects.Artifacts) != len(hasMetadataList) {
+			return []string{}, gqlerror.Errorf("%v :: uneven artifacts and hasMetadata for ingestion", funcName)
+		}
+		valuesDefined = valuesDefined + 1
+	}
+	if len(subjects.Sources) > 0 {
+		if len(subjects.Sources) != len(hasMetadataList) {
+			return []string{}, gqlerror.Errorf("%v :: uneven sources and hasMetadata for ingestion", funcName)
+		}
+		valuesDefined = valuesDefined + 1
+	}
+	if valuesDefined != 1 {
+		return []string{}, gqlerror.Errorf("%v :: must specify at most packages, artifacts or sources", funcName)
+	}
+	return r.Backend.IngestBulkHasMetadata(ctx, subjects, &pkgMatchType, hasMetadataList)
 }
 
 // HasMetadata is the resolver for the HasMetadata field.

--- a/pkg/assembler/graphql/resolvers/metadata.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/metadata.resolvers.go
@@ -6,6 +6,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -24,6 +25,11 @@ func (r *mutationResolver) IngestHasMetadata(ctx context.Context, subject model.
 		return "", err
 	}
 	return ingestedHasMetadata.ID, err
+}
+
+// IngestBulkHasMetadata is the resolver for the ingestBulkHasMetadata field.
+func (r *mutationResolver) IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestBulkHasMetadata - ingestBulkHasMetadata"))
 }
 
 // HasMetadata is the resolver for the HasMetadata field.

--- a/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers.go
@@ -31,11 +31,11 @@ func (r *mutationResolver) IngestVulnerabilityMetadata(ctx context.Context, vuln
 		model.VulnerabilityInputSpec{Type: strings.ToLower(vulnerability.Type), VulnerabilityID: strings.ToLower(vulnerability.VulnerabilityID)}, vulnerabilityMetadata)
 }
 
-// IngestVulnerabilityMetadatas is the resolver for the ingestVulnerabilityMetadatas field.
-func (r *mutationResolver) IngestVulnerabilityMetadatas(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadatas []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
+// IngestBulkVulnerabilityMetadata is the resolver for the ingestBulkVulnerabilityMetadata field.
+func (r *mutationResolver) IngestBulkVulnerabilityMetadata(ctx context.Context, vulnerabilities []*model.VulnerabilityInputSpec, vulnerabilityMetadataList []*model.VulnerabilityMetadataInputSpec) ([]string, error) {
 	funcName := "IngestVulnerabilityMetadatas"
-	if len(vulnerabilities) != len(vulnerabilityMetadatas) {
-		return []string{}, gqlerror.Errorf("%v :: uneven vulnerabilities and vulnerabilityMetadatas for ingestion", funcName)
+	if len(vulnerabilities) != len(vulnerabilityMetadataList) {
+		return []string{}, gqlerror.Errorf("%v :: uneven vulnerabilities and vulnerabilityMetadata for ingestion", funcName)
 	}
 
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
@@ -58,7 +58,7 @@ func (r *mutationResolver) IngestVulnerabilityMetadatas(ctx context.Context, vul
 		}
 		lowercaseVulnInputList = append(lowercaseVulnInputList, &lowercaseVulnInput)
 	}
-	return r.Backend.IngestVulnerabilityMetadatas(ctx, lowercaseVulnInputList, vulnerabilityMetadatas)
+	return r.Backend.IngestBulkVulnerabilityMetadata(ctx, lowercaseVulnInputList, vulnerabilityMetadataList)
 }
 
 // VulnerabilityMetadata is the resolver for the vulnerabilityMetadata field.

--- a/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/vulnMetadata.resolvers_test.go
@@ -230,10 +230,10 @@ func TestIngestVulnerabilityMetadatas(t *testing.T) {
 				}
 				b.
 					EXPECT().
-					IngestVulnerabilityMetadatas(ctx, gomock.Any(), o.VulnMetadatas).
+					IngestBulkVulnerabilityMetadata(ctx, gomock.Any(), o.VulnMetadatas).
 					Return([]string{}, nil).
 					Times(times)
-				_, err := r.Mutation().IngestVulnerabilityMetadatas(ctx, o.Vulns, o.VulnMetadatas)
+				_, err := r.Mutation().IngestBulkVulnerabilityMetadata(ctx, o.Vulns, o.VulnMetadatas)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -92,4 +92,10 @@ extend type Mutation {
     pkgMatchType: MatchFlags!
     hasMetadata: HasMetadataInputSpec!
   ): ID!
+  "Adds bulk metadata about a package, source or artifact. The returned array of IDs can be a an array of empty string."
+  ingestBulkHasMetadata(
+    subjects: PackageSourceOrArtifactInputs!
+    pkgMatchType: MatchFlags!
+    hasMetadataList: [HasMetadataInputSpec!]!
+  ): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/vulnMetadata.graphql
+++ b/pkg/assembler/graphql/schema/vulnMetadata.graphql
@@ -111,5 +111,5 @@ extend type Mutation {
   "Adds metadata about a vulnerability. The returned ID can be empty string."
   ingestVulnerabilityMetadata(vulnerability: VulnerabilityInputSpec!, vulnerabilityMetadata: VulnerabilityMetadataInputSpec!): ID!
   "Bulk add certifications that vulnerability has a specific score. The returned array of IDs can be a an array of empty string."
-  ingestVulnerabilityMetadatas(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadatas: [VulnerabilityMetadataInputSpec!]!): [ID!]!
+  ingestBulkVulnerabilityMetadata(vulnerabilities: [VulnerabilityInputSpec!]!, vulnerabilityMetadataList: [VulnerabilityMetadataInputSpec!]!): [ID!]!
 }


### PR DESCRIPTION
# Description of the PR

- bulk ingestion for `hasMetadata`
- change `vulnMetadata` to match `hasMetadata` bulk collection name
- update assembler with missing `hasMetadata` ingestion (including bulk)
- update resolver checks for `hasMetadata` and add missing unit tests
- update inmem backend with unit tests
- update arango backend with unit tests

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
