### PR TITLE
Fixed CSAF GetIdentifiers

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -88,7 +88,7 @@ func (c *csafParser) GetIdentities(ctx context.Context) []common.TrustInformatio
 }
 
 func (c *csafParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	return c.identifierStrings, nil
 }
 
 // findPurl searches the given CSAF product tree recursively to find the

--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -253,6 +253,7 @@ func (c *csafParser) generateVexIngest(ctx context.Context, vulnInput *generated
 
 	vi.VexData = &vd
 	vi.Vulnerability = vulnInput
+	c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, product_id)
 
 	pkg, err := c.findPkgSpec(ctx, product_id)
 	if err != nil {

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -231,7 +231,6 @@ func Test_csafParser_GetIdentifiers(t *testing.T) {
 	type fields struct {
 		doc               *processor.Document
 		identifierStrings *common.IdentifierStrings
-		csaf              *csaf.CSAF
 	}
 	test := struct {
 		name    string

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
+
 	"github.com/openvex/go-vex/pkg/csaf"
 
 	"github.com/google/go-cmp/cmp"
@@ -222,5 +224,43 @@ func Test_findPurl(t *testing.T) {
 				t.Errorf("findPurl() = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func Test_csafParser_GetIdentifiers(t *testing.T) {
+	type fields struct {
+		doc               *processor.Document
+		identifierStrings *common.IdentifierStrings
+		csaf              *csaf.CSAF
+	}
+	type args struct {
+		ctx context.Context
+	}
+	test := struct {
+		name    string
+		fields  fields
+		args    args
+		want    *common.IdentifierStrings
+		wantErr bool
+	}{
+		name: "default test",
+		fields: fields{
+			identifierStrings: &common.IdentifierStrings{},
+		},
+		want: &common.IdentifierStrings{},
+	}
+
+	c := &csafParser{
+		doc:               test.fields.doc,
+		identifierStrings: test.fields.identifierStrings,
+		csaf:              test.fields.csaf,
+	}
+	got, err := c.GetIdentifiers(test.args.ctx)
+	if (err != nil) != test.wantErr {
+		t.Errorf("GetIdentifiers() error = %v, wantErr %v", err, test.wantErr)
+		return
+	}
+	if !reflect.DeepEqual(got, test.want) {
+		t.Errorf("GetIdentifiers() got = %v, want %v", got, test.want)
 	}
 }

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -233,34 +233,84 @@ func Test_csafParser_GetIdentifiers(t *testing.T) {
 		identifierStrings *common.IdentifierStrings
 		csaf              *csaf.CSAF
 	}
-	type args struct {
-		ctx context.Context
-	}
 	test := struct {
 		name    string
 		fields  fields
-		args    args
+		ctx     context.Context
 		want    *common.IdentifierStrings
 		wantErr bool
 	}{
 		name: "default test",
 		fields: fields{
+			doc: &processor.Document{
+				Blob:   testdata.CsafExampleRedHat,
+				Format: processor.FormatJSON,
+				Type:   processor.DocumentCsaf,
+				SourceInformation: processor.SourceInformation{
+					Collector: "TestCollector",
+					Source:    "TestSource",
+				},
+			},
 			identifierStrings: &common.IdentifierStrings{},
 		},
-		want: &common.IdentifierStrings{},
+		ctx: context.Background(),
+		want: &common.IdentifierStrings{
+			PurlStrings: []string{
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-8.el8_6.src",
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-debuginfo-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-debuginfo-1:1.1.1k-8.el8_6.i686",
+				"BaseOS-8.6.0.Z.EUS:openssl-debuginfo-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-debuginfo-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-debuginfo-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-debugsource-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-debugsource-1:1.1.1k-8.el8_6.i686",
+				"BaseOS-8.6.0.Z.EUS:openssl-debugsource-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-debugsource-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-debugsource-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-devel-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-devel-1:1.1.1k-8.el8_6.i686",
+				"BaseOS-8.6.0.Z.EUS:openssl-devel-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-devel-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-devel-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-1:1.1.1k-8.el8_6.i686",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-debuginfo-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-debuginfo-1:1.1.1k-8.el8_6.i686",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-debuginfo-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-debuginfo-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-libs-debuginfo-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-perl-1:1.1.1k-8.el8_6.aarch64",
+				"BaseOS-8.6.0.Z.EUS:openssl-perl-1:1.1.1k-8.el8_6.ppc64le",
+				"BaseOS-8.6.0.Z.EUS:openssl-perl-1:1.1.1k-8.el8_6.s390x",
+				"BaseOS-8.6.0.Z.EUS:openssl-perl-1:1.1.1k-8.el8_6.x86_64",
+				"BaseOS-8.6.0.Z.EUS:openssl-1:1.1.1k-7.el8_6.x86_64",
+			},
+		},
 	}
 
-	c := &csafParser{
-		doc:               test.fields.doc,
-		identifierStrings: test.fields.identifierStrings,
-		csaf:              test.fields.csaf,
+	c := NewCsafParser()
+
+	err := c.Parse(test.ctx, test.fields.doc)
+	if err != nil {
+		t.Errorf("Parse() error = %v", err)
+		return
 	}
-	got, err := c.GetIdentifiers(test.args.ctx)
+
+	_ = c.GetPredicates(test.ctx)
+
+	got, err := c.GetIdentifiers(test.ctx)
 	if (err != nil) != test.wantErr {
 		t.Errorf("GetIdentifiers() error = %v, wantErr %v", err, test.wantErr)
 		return
 	}
-	if !reflect.DeepEqual(got, test.want) {
-		t.Errorf("GetIdentifiers() got = %v, want %v", got, test.want)
+	if d := cmp.Diff(test.want, got, testdata.IngestPredicatesCmpOpts...); len(d) != 0 {
+		t.Errorf("csaf.GetPredicate mismatch values (+got, -expected): %s", d)
 	}
 }


### PR DESCRIPTION
# Description of the PR

* Got the CSAF parser to return `c.identifierStrings`
* Included tests
* https://github.com/guacsec/guac/pull/1241#discussion_r1323140736

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
