### PR TITLE
guacone - managing totalSuccess

### DIFF
--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -145,6 +145,7 @@ var filesCmd = &cobra.Command{
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)
 			}
+			totalSuccess += 1
 			return nil
 		}
 

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -36,7 +36,7 @@ popd
 echo @@@@ Starting up guac server in background
 go run "${GUAC_DIR}/cmd/guacgql" &
 
-sleep 5
+sleep 15
 
 echo @@@@ Ingesting guac-data into server
 go run "${GUAC_DIR}/cmd/guacone" collect files "${GUAC_DIR}/guac-data/docs/"

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -36,6 +36,8 @@ popd
 echo @@@@ Starting up guac server in background
 go run "${GUAC_DIR}/cmd/guacgql" &
 
+sleep 3
+
 echo @@@@ Ingesting guac-data into server
 go run "${GUAC_DIR}/cmd/guacone" collect files "${GUAC_DIR}/guac-data/docs/"
 

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -36,7 +36,7 @@ popd
 echo @@@@ Starting up guac server in background
 go run "${GUAC_DIR}/cmd/guacgql" &
 
-sleep 3
+sleep 5
 
 echo @@@@ Ingesting guac-data into server
 go run "${GUAC_DIR}/cmd/guacone" collect files "${GUAC_DIR}/guac-data/docs/"


### PR DESCRIPTION
# Description of the PR

Running tests locally, I figured out that `guacone collect files` prints `completed ingesting 0 documents of 1` so I've fixed the total number of successfully ingested file.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
