### PR TITLE
add nightly release

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,0 +1,90 @@
+#
+# Copyright 2022 The GUAC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow requires a GitHub Personal Access Token named PAT_NIGHTLY_RELEASE
+# to work. The token must have read/write permissions on Contents.
+# This is becuase the inbuilt GITHUB_TOKEN will not create a new workflow run -
+# see https://docs.github.com/en/actions/using-workflows/triggering-a-workflow
+
+name: Nightly Release
+
+on:
+  workflow_dispatch: # testing only, trigger manually to test it works
+  schedule:
+    - cron: '44 4 * * *'   #UTC
+
+env:
+  NIGHTLY_RELEASE_TAG: v0-nightly   #goreleaser enforces semver on tags
+  # Note that the container tag (per .goreleaser-nightly.yaml) 
+  # is simply 'nightly' without semver prefix
+
+jobs:
+  refresh-nightly-tag:
+    runs-on: ubuntu-latest
+    name: trigger nightly build 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # tag=v3
+
+      - name: refresh nightly tag
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          github-token: ${{ secrets.PAT_NIGHTLY_RELEASE }}   # must use PAT here or the release workflow won't be triggered
+          script: |
+
+            const { owner, repo } = context.repo
+
+            try { 
+              console.log('Deleting release')
+              const { data: { id } } = await github.rest.repos.getReleaseByTag({ 
+                owner, 
+                repo, 
+                tag: "${{ env.NIGHTLY_RELEASE_TAG }}"
+              })
+              const result = await github.rest.repos.deleteRelease({ 
+                owner, 
+                repo, 
+                release_id: id 
+              })
+              console.log(result)
+            } catch (error) { 
+              // ignore error in case release doesn't exist
+              console.log(error)
+            }
+
+            try { 
+              console.log('Deleting tag')
+              const result = github.rest.git.deleteRef({
+                owner: owner,
+                repo: repo,
+                ref: "tags/${{ env.NIGHTLY_RELEASE_TAG }}"
+              })
+              console.log(result)
+            } catch (error) {
+              // ignore error in case tag doesn't exist
+              console.log(error)
+            }
+ 
+            // sleep to make sure the delete ops above are propagated in github
+            await new Promise(r => setTimeout(r, 3000));
+        
+            console.log('Creating tag to trigger build')
+            const result = github.rest.git.createRef({
+              owner: owner,
+              repo: repo,
+              ref: "refs/tags/${{ env.NIGHTLY_RELEASE_TAG }}",
+              sha: context.sha
+            })
+            console.log(result)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,8 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # use .goreleaser-nightly.yaml for nightly build; otherwise use the default
+          args: ${{ contains( github.ref, 'nightly' ) && 'release --clean -f .goreleaser-nightly.yaml' || 'release --clean' }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_CONTEXT: default

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -1,0 +1,227 @@
+# GoReleaser config for Nightly Release
+# This is replicated from .goreleaser.yaml with specific release parameters
+# (at the bottom of the file) for night release.
+
+---
+project_name: guac
+
+env:
+  - CGO_ENABLED=0
+  - PKG=github.com/guacsec/guac/pkg/version
+
+dockers:
+  # see details at https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
+    dockerfile: dockerfiles/Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"
+    dockerfile: dockerfiles/Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
+
+docker_manifests:
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:nightly"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "--a"
+      - "git_sha={{.FullCommit}}"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}@${digest}"
+      - "--yes"
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - main: ./cmd/guaccollect
+    id: guaccollect
+    binary: guaccollect-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      # See https://goreleaser.com/customization/templates/#common-fields for field definitions
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    # goos: [ 'darwin', 'linux', 'windows' ] - default
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+  - main: ./cmd/guaccsub
+    id: guaccsub
+    binary: guaccsub-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+  - main: ./cmd/guacgql
+    id: guacgql
+    binary: guacgql-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+  - main: ./cmd/guacingest
+    id: guacingest
+    binary: guacingest-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+  - main: ./cmd/guacone
+    id: guacone
+    binary: guacone-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+
+universal_binaries:
+  - replace: true
+    name_template: guacone
+    id: guacone
+    ids:
+      - guacone
+  - replace: true
+    name_template: guacingest
+    id: guacingest
+    ids:
+      - guacingest
+  - replace: true
+    name_template: guaccsub
+    id: guaccsub
+    ids:
+      - guaccsub
+  - replace: true
+    name_template: guaccollect
+    id: guaccollect
+    ids:
+      - guaccollect
+  - replace: true
+    name_template: guacgql
+    id: guacgql
+    ids:
+      - guacgql
+
+sboms:
+  - id: bins
+    artifacts: binary
+    documents:
+      - "${artifact}.spdx.sbom.json"
+
+signs:
+  - id: guac-cosign-keyless
+    artifacts: checksum
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: cosign
+    args:
+      - "sign-blob"
+      - "--yes"
+      - "--output-signature"
+      - "${artifact}-keyless.sig"
+      - "--output-certificate"
+      - "${artifact}-keyless.pem"
+      - "${artifact}"
+    output: true
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+# Anything above this line should be identical to .goreleaser.yaml 
+# EXCEPT - dockers.docker_manifests.name_template
+# The following are specifically for nightly build
+# Without Goreleaser Pro, we have to replicate this config file for different builds
+release:
+  prerelease: true
+  mode: replace
+  make_latest: false
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
# Description of the PR

This PR adds nightly build/release support includes bins and container images.

A scheduled workflow is added to trigger existing release workflow with specific goreleaser config for nightly.
Note that a GitHub Personal Access Token named PAT_NIGHTLY_RELEASE, set up as a secret, with read/write permission on Contents is required.

Bins are released under the v0-nightly tag/version due to goreleaser's enforcement on tag value.
Container image is released under the nightly tag.

fix #941

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
