### PR TITLE
add NoVuln node to ingestion when a package isn't affected

### DIFF
--- a/internal/testing/testdata/exampledata/rhsa-csaf.json
+++ b/internal/testing/testdata/exampledata/rhsa-csaf.json
@@ -120,7 +120,10 @@
                 "name": "openssl-1:1.1.1k-8.el8_6.aarch64",
                 "product": {
                   "name": "openssl-1:1.1.1k-8.el8_6.aarch64",
-                  "product_id": "openssl-1:1.1.1k-8.el8_6.aarch64"
+                  "product_id": "openssl-1:1.1.1k-8.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/openssl@1.1.1k-8.el8_6?arch=aarch64&epoch=1"
+                  }
                 }
               },
               {

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2228,6 +2228,29 @@ var (
 				Type:       "rpm",
 				Namespace:  strP("redhat"),
 				Name:       "openssl",
+				Version:    strP("1.1.1k-8.el8_6"),
+				Qualifiers: []model.PackageQualifierInputSpec{{Key: "arch", Value: "aarch64"}, {Key: "epoch", Value: "1"}},
+				Subpath:    strP(""),
+			},
+			Vulnerability: &model.VulnerabilityInputSpec{Type: "cve", VulnerabilityID: "cve-2023-0286"},
+			VexData: &model.VexStatementInputSpec{
+				Status:           generated.VexStatusFixed,
+				VexJustification: generated.VexJustificationNotProvided,
+				Statement: `For details on how to apply this update, which includes the changes described in this advisory, refer to:
+
+https://access.redhat.com/articles/11258
+
+For the update to take effect, all services linked to the OpenSSL library must be restarted, or the system rebooted.`,
+
+				KnownSince: parseRfc3339("2023-03-23T11:14:00Z"),
+				Origin:     "RHSA-2023:1441",
+			},
+		},
+		{
+			Pkg: &model.PkgInputSpec{
+				Type:       "rpm",
+				Namespace:  strP("redhat"),
+				Name:       "openssl",
 				Version:    strP("1.1.1k-7.el8_6"),
 				Qualifiers: []model.PackageQualifierInputSpec{{Key: "arch", Value: "x86_64"}, {Key: "epoch", Value: "1"}},
 				Subpath:    strP(""),
@@ -2248,6 +2271,23 @@ For the update to take effect, all services linked to the OpenSSL library must b
 		},
 	}
 	CsafCertifyVulnIngest = []assembler.CertifyVulnIngest{
+		{
+			Pkg: &model.PkgInputSpec{
+				Type:      "rpm",
+				Namespace: strP("redhat"),
+				Name:      "openssl",
+				Version:   strP("1.1.1k-8.el8_6"),
+				Qualifiers: []model.PackageQualifierInputSpec{
+					{Key: "arch", Value: "aarch64"},
+					{Key: "epoch", Value: "1"},
+				},
+				Subpath: strP(""),
+			},
+			Vulnerability: &model.VulnerabilityInputSpec{Type: "NoVuln", VulnerabilityID: ""},
+			VulnData: &model.ScanMetadataInput{
+				TimeScanned: parseRfc3339("2023-03-23T11:14:00Z"),
+			},
+		},
 		{
 			Pkg: &model.PkgInputSpec{
 				Type:      "rpm",

--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -301,6 +301,19 @@ func (c *csafParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 						VulnData:      &vulnData,
 					}
 					cvs = append(cvs, cv)
+				} else if status == "known_not_affected" || status == "fixed" {
+					vulnData := generated.ScanMetadataInput{
+						TimeScanned: c.csaf.Document.Tracking.CurrentReleaseDate,
+					}
+					noVuln := generated.VulnerabilityInputSpec{
+						Type: "NoVuln",
+					}
+					cv := assembler.CertifyVulnIngest{
+						Pkg:           vi.Pkg,
+						Vulnerability: &noVuln,
+						VulnData:      &vulnData,
+					}
+					cvs = append(cvs, cv)
 				}
 				vis = append(vis, *vi)
 			}


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
When ingesting VEX documents add NoVuln node if package is not affected

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #1015 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
