### PR TITLE
Log and continue on ingest errors with bulk assemler.

### DIFF
--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -38,7 +38,7 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				collectedPackages = append(collectedPackages, *v)
 			}
 			if err := ingestPackages(ctx, gqlclient, collectedPackages); err != nil {
-				return fmt.Errorf("ingestPackages failed with error: %w", err)
+				logger.Errorf("ingestPackages failed with error: %v", err)
 			}
 
 			sources := p.GetSources(ctx)
@@ -50,7 +50,7 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				collectedSources = append(collectedSources, *v)
 			}
 			if err := ingestSources(ctx, gqlclient, collectedSources); err != nil {
-				return fmt.Errorf("ingestSources failed with error: %w", err)
+				logger.Errorf("ingestSources failed with error: %v", err)
 			}
 
 			artifacts := p.GetArtifacts(ctx)
@@ -61,13 +61,13 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				collectedArtifacts = append(collectedArtifacts, *v)
 			}
 			if err := ingestArtifacts(ctx, gqlclient, collectedArtifacts); err != nil {
-				return fmt.Errorf("ingestArtifacts failed with error: %w", err)
+				logger.Errorf("ingestArtifacts failed with error: %v", err)
 			}
 
 			materials := p.GetMaterials(ctx)
 			logger.Infof("assembling Materials (Artifact): %v", len(materials))
 			if err := ingestArtifacts(ctx, gqlclient, materials); err != nil {
-				return fmt.Errorf("ingestArtifacts failed with error: %w", err)
+				logger.Errorf("ingestArtifacts failed with error: %v", err)
 			}
 
 			builders := p.GetBuilders(ctx)
@@ -78,7 +78,7 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				collectedBuilders = append(collectedBuilders, *v)
 			}
 			if err := ingestBuilders(ctx, gqlclient, collectedBuilders); err != nil {
-				return fmt.Errorf("ingestBuilders failed with error: %w", err)
+				logger.Errorf("ingestBuilders failed with error: %v", err)
 			}
 
 			vulns := p.GetVulnerabilities(ctx)
@@ -89,48 +89,48 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 				collectedVulns = append(collectedVulns, *v)
 			}
 			if err := ingestVulnerabilities(ctx, gqlclient, collectedVulns); err != nil {
-				return fmt.Errorf("ingestVulnerabilities failed with error: %w", err)
+				logger.Errorf("ingestVulnerabilities failed with error: %v", err)
 			}
 
 			licenses := p.GetLicenses(ctx)
 			logger.Infof("assembling Licenses: %v", len(licenses))
 			if err := ingestLicenses(ctx, gqlclient, licenses); err != nil {
-				return fmt.Errorf("ingestLicenses failed with error: %w", err)
+				logger.Errorf("ingestLicenses failed with error: %v", err)
 			}
 
 			logger.Infof("assembling CertifyScorecard: %v", len(p.CertifyScorecard))
 			if err := ingestCertifyScorecards(ctx, gqlclient, p.CertifyScorecard); err != nil {
-				return fmt.Errorf("ingestCertifyScorecards failed with error: %w", err)
+				logger.Errorf("ingestCertifyScorecards failed with error: %v", err)
 			}
 
 			logger.Infof("assembling IsDependency: %v", len(p.IsDependency))
 			if err := ingestIsDependencies(ctx, gqlclient, p.IsDependency); err != nil {
-				return fmt.Errorf("ingestIsDependencies failed with error: %w", err)
+				logger.Errorf("ingestIsDependencies failed with error: %v", err)
 			}
 
 			logger.Infof("assembling IsOccurrence: %v", len(p.IsOccurrence))
 			if err := ingestIsOccurrences(ctx, gqlclient, p.IsOccurrence); err != nil {
-				return fmt.Errorf("ingestIsOccurrences failed with error: %w", err)
+				logger.Errorf("ingestIsOccurrences failed with error: %v", err)
 			}
 
 			logger.Infof("assembling HasSLSA: %v", len(p.HasSlsa))
 			if err := ingestHasSLSAs(ctx, gqlclient, p.HasSlsa); err != nil {
-				return fmt.Errorf("ingestHasSLSAs failed with error: %w", err)
+				logger.Errorf("ingestHasSLSAs failed with error: %v", err)
 			}
 
 			logger.Infof("assembling CertifyVuln: %v", len(p.CertifyVuln))
 			if err := ingestCertifyVulns(ctx, gqlclient, p.CertifyVuln); err != nil {
-				return fmt.Errorf("ingestCertifyVulns failed with error: %w", err)
+				logger.Errorf("ingestCertifyVulns failed with error: %v", err)
 			}
 
 			logger.Infof("assembling VulnMetadata: %v", len(p.VulnMetadata))
 			if err := ingestVulnMetadatas(ctx, gqlclient, p.VulnMetadata); err != nil {
-				return fmt.Errorf("ingestVulnMetadatas failed with error: %w", err)
+				logger.Errorf("ingestVulnMetadatas failed with error: %v", err)
 			}
 
 			logger.Infof("assembling VulnEqual: %v", len(p.VulnEqual))
 			if err := ingestVulnEquals(ctx, gqlclient, p.VulnEqual); err != nil {
-				return fmt.Errorf("ingestVulnEquals failed with error: %w", err)
+				logger.Errorf("ingestVulnEquals failed with error: %v", err)
 
 			}
 
@@ -138,56 +138,56 @@ func GetBulkAssembler(ctx context.Context, gqlclient graphql.Client) func([]asse
 			logger.Infof("assembling HasSourceAt: %v", len(p.HasSourceAt))
 			for _, hsa := range p.HasSourceAt {
 				if err := hasSourceAt(ctx, gqlclient, hsa); err != nil {
-					return fmt.Errorf("hasSourceAt failed with error: %w", err)
+					logger.Errorf("hasSourceAt failed with error: %v", err)
 
 				}
 			}
 
 			logger.Infof("assembling CertifyBad: %v", len(p.CertifyBad))
 			if err := ingestCertifyBads(ctx, gqlclient, p.CertifyBad); err != nil {
-				return fmt.Errorf("ingestCertifyBads failed with error: %w", err)
+				logger.Errorf("ingestCertifyBads failed with error: %v", err)
 
 			}
 
 			logger.Infof("assembling CertifyGood: %v", len(p.CertifyGood))
 			if err := ingestCertifyGoods(ctx, gqlclient, p.CertifyGood); err != nil {
-				return fmt.Errorf("ingestCertifyGoods failed with error: %w", err)
+				logger.Errorf("ingestCertifyGoods failed with error: %v", err)
 
 			}
 
 			logger.Infof("assembling PointOfContact: %v", len(p.PointOfContact))
 			if err := ingestPointOfContacts(ctx, gqlclient, p.PointOfContact); err != nil {
-				return fmt.Errorf("ingestPointOfContacts failed with error: %w", err)
+				logger.Errorf("ingestPointOfContacts failed with error: %v", err)
 			}
 
 			logger.Infof("assembling HasMetadata: %v", len(p.HasMetadata))
 			if err := ingestBulkHasMetadata(ctx, gqlclient, p.HasMetadata); err != nil {
-				return fmt.Errorf("ingestBulkHasMetadata failed with error: %w", err)
+				logger.Errorf("ingestBulkHasMetadata failed with error: %v", err)
 			}
 
 			logger.Infof("assembling HasSBOM: %v", len(p.HasSBOM))
 			if err := ingestHasSBOMs(ctx, gqlclient, p.HasSBOM); err != nil {
-				return fmt.Errorf("ingestHasSBOMs failed with error: %w", err)
+				logger.Errorf("ingestHasSBOMs failed with error: %v", err)
 			}
 
 			logger.Infof("assembling VEX : %v", len(p.Vex))
 			if err := ingestVEXs(ctx, gqlclient, p.Vex); err != nil {
-				return fmt.Errorf("ingestVEXs failed with error: %w", err)
+				logger.Errorf("ingestVEXs failed with error: %v", err)
 			}
 
 			logger.Infof("assembling HashEqual : %v", len(p.HashEqual))
 			if err := ingestHashEquals(ctx, gqlclient, p.HashEqual); err != nil {
-				return fmt.Errorf("ingestHashEquals failed with error: %w", err)
+				logger.Errorf("ingestHashEquals failed with error: %v", err)
 			}
 
 			logger.Infof("assembling PkgEqual : %v", len(p.PkgEqual))
 			if err := ingestPkgEquals(ctx, gqlclient, p.PkgEqual); err != nil {
-				return fmt.Errorf("ingestPkgEquals failed with error: %w", err)
+				logger.Errorf("ingestPkgEquals failed with error: %v", err)
 			}
 
 			logger.Infof("assembling CertifyLegal : %v", len(p.CertifyLegal))
 			if err := ingestCertifyLegals(ctx, gqlclient, p.CertifyLegal); err != nil {
-				return fmt.Errorf("ingestCertifyLegals failed with error: %w", err)
+				logger.Errorf("ingestCertifyLegals failed with error: %v", err)
 			}
 		}
 		return nil


### PR DESCRIPTION
When ingesting, continue on error. Currently the incomplete backends panic when calling mutations that are not implemented yet. We still want `guacone collect files` to ingest all the nouns/verbs that are implemented. This is a short term fix, as we want to differentiate between actual errors and not-implemented apis in the future.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
