### PR TITLE
Add OCI registry collector

### DIFF
--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -38,6 +39,12 @@ import (
 type ociOptions struct {
 	graphqlEndpoint   string
 	dataSource        datasource.CollectSource
+	csubClientOptions client.CsubClientOptions
+}
+
+type ociRegistryOptions struct {
+	graphqlEndpoint   string
+	registry          string
 	csubClientOptions client.CsubClientOptions
 }
 
@@ -112,7 +119,79 @@ var ociCmd = &cobra.Command{
 	},
 }
 
+var ociRegistryCmd = &cobra.Command{
+	Use:   "registry [flags] registry",
+	Short: "takes an OCI registry with catalog capability and downloads sbom and attestation stored in OCI to add to GUAC graph",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateOCIRegistryFlags(
+			viper.GetString("gql-addr"),
+			viper.GetString("csub-addr"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
+			args)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		// Register collector
+		ociRegistryCollector := oci.NewOCIRegistryCollector(ctx, opts.registry, false, 30*time.Second)
+		err = collector.RegisterDocumentCollector(ociRegistryCollector, oci.OCIRegistryCollector)
+		if err != nil {
+			logger.Errorf("unable to register oci collector: %v", err)
+		}
+
+		// initialize collectsub client
+		csubClient, err := csub_client.NewClient(opts.csubClientOptions)
+		if err != nil {
+			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
+			csubClient = nil
+		} else {
+			defer csubClient.Close()
+		}
+
+		totalNum := 0
+		gotErr := false
+		// Set emit function to go through the entire pipeline
+		emit := func(d *processor.Document) error {
+			totalNum += 1
+			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+
+			if err != nil {
+				gotErr = true
+				return fmt.Errorf("unable to ingest document: %w", err)
+			}
+			return nil
+		}
+
+		// Collect
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("collector ended gracefully")
+				return true
+			}
+			logger.Errorf("collector ended with error: %v", err)
+			return false
+		}
+		if err := collector.Collect(ctx, emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		if gotErr {
+			logger.Fatalf("completed ingestion with errors")
+		} else {
+			logger.Infof("completed ingesting %v documents", totalNum)
+		}
+	},
+}
+
 func validateOCIFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, args []string) (ociOptions, error) {
+
 	var opts ociOptions
 	opts.graphqlEndpoint = gqlEndpoint
 
@@ -145,6 +224,32 @@ func validateOCIFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTls
 	return opts, nil
 }
 
+// TODO(ridwanhoq): refactor common logic with validateOCIFlags
+func validateOCIRegistryFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, args []string) (ociRegistryOptions, error) {
+	var opts ociRegistryOptions
+	opts.graphqlEndpoint = gqlEndpoint
+	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	if err != nil {
+		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+	}
+	opts.csubClientOptions = csubOpts
+
+	// else direct CLI call, no polling
+	if len(args) != 1 {
+		return opts, fmt.Errorf("expected exactly one argument for registry, got %v", len(args))
+	}
+
+	registry := args[0]
+	// validate that the supplied registry is a valid hostname
+	_, err = net.LookupHost(registry)
+	if err != nil {
+		return opts, fmt.Errorf("%s is not a valid hostname: %w", registry, err)
+	}
+	opts.registry = registry
+	return opts, nil
+}
+
 func init() {
 	collectCmd.AddCommand(ociCmd)
+	collectCmd.AddCommand(ociRegistryCmd)
 }

--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -518,3 +518,11 @@ func hasNoDigest(r ref.Ref) bool {
 func hasNoIdentifier(r ref.Ref) bool {
 	return hasNoTag(r) && hasNoDigest(r)
 }
+
+func getRegClientOptions() []regclient.Opt {
+	rcOpts := []regclient.Opt{}
+	rcOpts = append(rcOpts, regclient.WithDockerCreds())
+	rcOpts = append(rcOpts, regclient.WithDockerCerts())
+	rcOpts = append(rcOpts, regclient.WithUserAgent(version.UserAgent))
+	return rcOpts
+}

--- a/pkg/handler/collector/oci/oci_registry.go
+++ b/pkg/handler/collector/oci/oci_registry.go
@@ -1,0 +1,99 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/pkg/errors"
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/ref"
+)
+
+const (
+	OCIRegistryCollector = "OCIRegistryCollector"
+)
+
+type ociRegistryCollector struct {
+	collectDataSource datasource.CollectSource
+	checkedDigest     map[string][]string
+	registry          string
+	poll              bool
+	interval          time.Duration
+}
+
+func NewOCIRegistryCollector(ctx context.Context, registry string, poll bool, interval time.Duration) *ociRegistryCollector {
+	return &ociRegistryCollector{
+		checkedDigest: map[string][]string{},
+		registry:      registry,
+		poll:          poll,
+		interval:      interval,
+	}
+}
+
+func (o *ociRegistryCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	r, err := ref.New(o.registry)
+	if err != nil {
+		return fmt.Errorf("failed to parse ref %s: %v", r, err)
+	}
+
+	rcOpts := getRegClientOptions()
+	rc := regclient.New(rcOpts...)
+	defer rc.Close(ctx, r)
+
+	rl, err := rc.RepoList(ctx, o.registry)
+	if err != nil && errors.Is(err, types.ErrNotImplemented) {
+		return fmt.Errorf("registry %s does not support underlying _catalog API: %w", o.registry, err)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to list repositories in registry %s: %w", o.registry, err)
+	}
+	if len(rl.Repositories) == 0 {
+		return fmt.Errorf("no repositories found in registry %s", o.registry)
+	}
+
+	sources := []datasource.Source{}
+	for _, repo := range rl.Repositories {
+
+		sources = append(sources, datasource.Source{
+			Value: o.registry + "/" + repo,
+		})
+	}
+	o.collectDataSource, err = inmemsource.NewInmemDataSources(&datasource.DataSources{
+		OciDataSources: sources,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create datasource: %w", err)
+	}
+	ociCollector := NewOCICollector(ctx, o.collectDataSource, o.poll, o.interval)
+	err = ociCollector.RetrieveArtifacts(ctx, docChannel)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve artifacts from OCI collector: %w", err)
+	}
+	o.checkedDigest = ociCollector.checkedDigest
+	return nil
+}
+
+// Type is the collector type of the collector
+func (o *ociRegistryCollector) Type() string {
+	return OCIRegistryCollector
+}


### PR DESCRIPTION
# Description of the PR

Support collecting all OCI artifacts in an OCI registry that has the `/v2/_catalog` endpoint enabled.

TODO:
- [ ] Add unit tests
- [ ] Should we be duplicating the logic in both `guacone` and `guaccollect`?
- [ ] Should we be doing the collection in parallel? Huge registries will take a long time?
- [ ] How can we ensure that we don't collect something that hasn't been collected before? IE, if I run a collection twice against a registry, can we ensure that we don't collect everything all over again?

Fixes #298 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
