### PR TITLE
Feature/ hasSourceAt bulk inmem and arango implementation 

### DIFF
--- a/cmd/guacgql/cmd/ingest.go
+++ b/cmd/guacgql/cmd/ingest.go
@@ -2156,7 +2156,7 @@ func ingestHasSourceAt(ctx context.Context, client graphql.Client) {
 		if _, err := model.IngestSource(ctx, client, ingest.source); err != nil {
 			logger.Errorf("Error in ingesting source: %v\n", err)
 		}
-		if _, err := model.HasSourceAt(ctx, client, ingest.pkg, ingest.pkgMatchType, ingest.source, ingest.hasSourceAt); err != nil {
+		if _, err := model.IngestHasSourceAt(ctx, client, ingest.pkg, ingest.pkgMatchType, ingest.source, ingest.hasSourceAt); err != nil {
 			logger.Errorf("Error in ingesting: %v\n", err)
 		}
 	}
@@ -2921,7 +2921,7 @@ func ingestReachabilityTestData(ctx context.Context, client graphql.Client) {
 		if _, err := model.IsOccurrencePkg(ctx, client, ingest.depPkgWithVersion, ingest.art, ingest.occurrence); err != nil {
 			logger.Errorf("Error in ingesting: %v\n", err)
 		}
-		if _, err := model.HasSourceAt(ctx, client, ingest.depPkgWithVersion, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion}, ingest.source, ingest.hasSourceAt); err != nil {
+		if _, err := model.IngestHasSourceAt(ctx, client, ingest.depPkgWithVersion, model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion}, ingest.source, ingest.hasSourceAt); err != nil {
 			logger.Errorf("Error in ingesting: %v\n", err)
 		}
 		if _, err := model.IsOccurrenceSrc(ctx, client, ingest.source, ingest.sourceArt, ingest.sourceOccurrence); err != nil {

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -530,6 +530,21 @@ func (mr *MockBackendMockRecorder) IngestHasSourceAt(ctx, pkg, pkgMatchType, sou
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestHasSourceAt", reflect.TypeOf((*MockBackend)(nil).IngestHasSourceAt), ctx, pkg, pkgMatchType, source, hasSourceAt)
 }
 
+// IngestHasSourceAts mocks base method.
+func (m *MockBackend) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IngestHasSourceAts", ctx, pkgs, pkgMatchType, sources, hasSourceAts)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IngestHasSourceAts indicates an expected call of IngestHasSourceAts.
+func (mr *MockBackendMockRecorder) IngestHasSourceAts(ctx, pkgs, pkgMatchType, sources, hasSourceAts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestHasSourceAts", reflect.TypeOf((*MockBackend)(nil).IngestHasSourceAts), ctx, pkgs, pkgMatchType, sources, hasSourceAts)
+}
+
 // IngestHashEqual mocks base method.
 func (m *MockBackend) IngestHashEqual(ctx context.Context, artifact, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error) {
 	m.ctrl.T.Helper()

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -121,6 +121,13 @@ const (
 	hasSBOMArtEdgesStr string = "hasSBOMArtEdges"
 	hasSBOMsStr        string = "hasSBOMs"
 
+	// hasSourceAt collection
+
+	hasSourceAtPkgVersionEdgesStr string = "hasSourceAtPkgVersionEdges"
+	hasSourceAtPkgNameEdgesStr    string = "hasSourceAtPkgNameEdges"
+	hasSourceAtEdgesStr           string = "hasSourceAtEdges"
+	hasSourceAtsStr               string = "hasSourceAts"
+
 	// certifyVex collection
 
 	certifyVexPkgEdgesStr  string = "certifyVexPkgEdges"
@@ -129,6 +136,7 @@ const (
 	certifyVEXsStr         string = "certifyVEXs"
 
 	// certifyVuln collection
+
 	certifyVulnPkgEdgesStr string = "certifyVulnPkgEdges"
 	certifyVulnEdgesStr    string = "certifyVulnEdges"
 	certifyVulnsStr        string = "certifyVulns"
@@ -428,6 +436,22 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 		hasSBOMArtEdges.From = []string{artifactsStr}
 		hasSBOMArtEdges.To = []string{hasSBOMsStr}
 
+		// setup hasSourceAt collections
+		var hasSourceAtPkgVersionEdges driver.EdgeDefinition
+		hasSourceAtPkgVersionEdges.Collection = hasSourceAtPkgVersionEdgesStr
+		hasSourceAtPkgVersionEdges.From = []string{pkgVersionsStr}
+		hasSourceAtPkgVersionEdges.To = []string{hasSourceAtsStr}
+
+		var hasSourceAtPkgNameEdges driver.EdgeDefinition
+		hasSourceAtPkgNameEdges.Collection = hasSourceAtPkgNameEdgesStr
+		hasSourceAtPkgNameEdges.From = []string{pkgNamesStr}
+		hasSourceAtPkgNameEdges.To = []string{hasSourceAtsStr}
+
+		var hasSourceAtEdges driver.EdgeDefinition
+		hasSourceAtEdges.Collection = hasSourceAtEdgesStr
+		hasSourceAtEdges.From = []string{hasSourceAtsStr}
+		hasSourceAtEdges.To = []string{srcNamesStr}
+
 		// setup certifyVex collections
 		var certifyVexPkgEdges driver.EdgeDefinition
 		certifyVexPkgEdges.Collection = certifyVexPkgEdgesStr
@@ -542,7 +566,7 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			certifyVexPkgEdges, certifyVexArtEdges, certifyVexVulnEdges, vulnMetadataEdges, vulnEqualVulnEdges, vulnEqualSubjectVulnEdges,
 			pkgEqualPkgEdges, pkgEqualSubjectPkgEdges, hasMetadataPkgVersionEdges, hasMetadataPkgNameEdges,
 			hasMetadataArtEdges, hasMetadataSrcEdges, pointOfContactPkgVersionEdges, pointOfContactPkgNameEdges,
-			pointOfContactArtEdges, pointOfContactSrcEdges}
+			pointOfContactArtEdges, pointOfContactSrcEdges, hasSourceAtEdges, hasSourceAtPkgVersionEdges, hasSourceAtPkgNameEdges}
 
 		// create a graph
 		graph, err = db.CreateGraphV2(ctx, "guac", &options)

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -888,18 +888,6 @@ func getPreloadString(prefix, name string) string {
 	return name
 }
 
-// Retrieval read-only queries for evidence trees
-
-func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
-	panic(fmt.Errorf("not implemented: HasSourceAt - HasSourceAt"))
-}
-
-// Mutations for evidence trees (read-write queries, assume software trees ingested)
-
-func (c *arangoClient) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAt - IngestHasSourceAt"))
-}
-
 // Topological queries: queries where node connectivity matters more than node type
 func (c *arangoClient) Neighbors(ctx context.Context, node string, usingOnly []model.Edge) ([]model.Node, error) {
 	panic(fmt.Errorf("not implemented: Neighbors - Neighbors"))

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -17,7 +17,6 @@ package arangodb
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -713,11 +713,9 @@ func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 
 	var hasSourceAtList []*model.HasSourceAt
 	for _, createdValue := range createdValues {
-		var pkg *model.Package = nil
-		var src *model.Source = nil
-		pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+		pkg := generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
 			createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
-		src = generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+		src := generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
 			createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
 
 		hasSourceAt := &model.HasSourceAt{

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -17,19 +17,723 @@ package arangodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/arangodb/go-driver"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
-	panic(fmt.Errorf("not implemented: HasSourceAt - HasSourceAt"))
+	var arangoQueryBuilder *arangoQueryBuilder
+	if hasSourceAtSpec.Package != nil {
+		var combinedHasSourceAt []*model.HasSourceAt
+
+		values := map[string]any{}
+		// pkgVersion hasSourceAt
+		arangoQueryBuilder = setPkgVersionMatchValues(hasSourceAtSpec.Package, values)
+		arangoQueryBuilder.forOutBound(hasSourceAtPkgVersionEdgesStr, "hasSourceAt", "pVersion")
+		setHasSourceAtMatchValues(arangoQueryBuilder, hasSourceAtSpec, values)
+
+		pkgVersionHasMetadata, err := getPkgHasSourceAtForQuery(ctx, c, arangoQueryBuilder, values, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package version hasSourceAt with error: %w", err)
+		}
+
+		combinedHasSourceAt = append(combinedHasSourceAt, pkgVersionHasMetadata...)
+
+		if hasSourceAtSpec.Package.ID == nil {
+			// pkgName hasSourceAt
+			values = map[string]any{}
+			arangoQueryBuilder = setPkgNameMatchValues(hasSourceAtSpec.Package, values)
+			arangoQueryBuilder.forOutBound(hasSourceAtPkgNameEdgesStr, "hasSourceAt", "pName")
+			setHasSourceAtMatchValues(arangoQueryBuilder, hasSourceAtSpec, values)
+
+			pkgNameHasMetadata, err := getPkgHasSourceAtForQuery(ctx, c, arangoQueryBuilder, values, false)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve package name hasSourceAt with error: %w", err)
+			}
+
+			combinedHasSourceAt = append(combinedHasSourceAt, pkgNameHasMetadata...)
+		}
+
+		return combinedHasSourceAt, nil
+	} else {
+		values := map[string]any{}
+		var combinedHasSourceAt []*model.HasSourceAt
+
+		// pkgVersion hasSourceAt
+		arangoQueryBuilder = newForQuery(hasSourceAtsStr, "hasSourceAt")
+		setHasSourceAtMatchValues(arangoQueryBuilder, hasSourceAtSpec, values)
+		arangoQueryBuilder.forInBound(hasSourceAtPkgVersionEdgesStr, "pVersion", "hasSourceAt")
+		arangoQueryBuilder.forInBound(pkgHasVersionStr, "pName", "pVersion")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgVersionHasMetadata, err := getPkgHasSourceAtForQuery(ctx, c, arangoQueryBuilder, values, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package version hasSourceAt  with error: %w", err)
+		}
+		combinedHasSourceAt = append(combinedHasSourceAt, pkgVersionHasMetadata...)
+
+		// pkgName hasSourceAt
+		values = map[string]any{}
+		arangoQueryBuilder = newForQuery(hasSourceAtsStr, "hasSourceAt")
+		setHasSourceAtMatchValues(arangoQueryBuilder, hasSourceAtSpec, values)
+		arangoQueryBuilder.forInBound(hasSourceAtPkgNameEdgesStr, "pName", "hasSourceAt")
+		arangoQueryBuilder.forInBound(pkgHasNameStr, "pNs", "pName")
+		arangoQueryBuilder.forInBound(pkgHasNamespaceStr, "pType", "pNs")
+
+		pkgNameHasMetadata, err := getPkgHasSourceAtForQuery(ctx, c, arangoQueryBuilder, values, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve package name hasSourceAt  with error: %w", err)
+		}
+		combinedHasSourceAt = append(combinedHasSourceAt, pkgNameHasMetadata...)
+
+		return combinedHasSourceAt, nil
+	}
+}
+
+func getPkgHasSourceAtForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder *arangoQueryBuilder, values map[string]any, includeDepPkgVersion bool) ([]*model.HasSourceAt, error) {
+	if includeDepPkgVersion {
+		arangoQueryBuilder.query.WriteString("\n")
+		arangoQueryBuilder.query.WriteString(`RETURN {
+			'pkgVersion': {
+				'type_id': pType._id,
+				'type': pType.type,
+				'namespace_id': pNs._id,
+				'namespace': pNs.namespace,
+				'name_id': pName._id,
+				'name': pName.name,
+				'version_id': pVersion._id,
+				'version': pVersion.version,
+				'subpath': pVersion.subpath,
+				'qualifier_list': pVersion.qualifier_list
+			},
+			'srcName': {
+				'type_id': sType._id,
+				'type': sType.type,
+				'namespace_id': sNs._id,
+				'namespace': sNs.namespace,
+				'name_id': sName._id,
+				'name': sName.name,
+				'commit': sName.commit,
+				'tag': sName.tag
+			},
+			'hasSourceAt_id': hasSourceAt._id,
+			'knownSince': hasSourceAt.knownSince,
+			'justification': hasSourceAt.justification,
+			'collector': hasSourceAt.collector,
+			'origin': hasSourceAt.origin
+		  }`)
+	} else {
+		arangoQueryBuilder.query.WriteString("\n")
+		arangoQueryBuilder.query.WriteString(`RETURN {
+			'pkgVersion': {
+				'type_id': pType._id,
+				'type': pType.type,
+				'namespace_id': pNs._id,
+				'namespace': pNs.namespace,
+				'name_id': pName._id,
+				'name': pName.name
+			},
+			'srcName': {
+				'type_id': sType._id,
+				'type': sType.type,
+				'namespace_id': sNs._id,
+				'namespace': sNs.namespace,
+				'name_id': sName._id,
+				'name': sName.name,
+				'commit': sName.commit,
+				'tag': sName.tag
+			},
+			'hasSourceAt_id': hasSourceAt._id,
+			'knownSince': hasSourceAt.knownSince,
+			'justification': hasSourceAt.justification,
+			'collector': hasSourceAt.collector,
+			'origin': hasSourceAt.origin
+		  }`)
+	}
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasSourceAt")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for HasSourceAt: %w", err)
+	}
+	defer cursor.Close()
+
+	return getHasSourceAtFromCursor(ctx, cursor)
+}
+
+func setHasSourceAtMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSourceAtSpec *model.HasSourceAtSpec, queryValues map[string]any) {
+	if hasSourceAtSpec.ID != nil {
+		arangoQueryBuilder.filter("hasSourceAt", "_id", "==", "@id")
+		queryValues["id"] = *hasSourceAtSpec.ID
+	}
+	if hasSourceAtSpec.KnownSince != nil {
+		arangoQueryBuilder.filter("hasSourceAt", knownSinceStr, ">=", "@"+knownSinceStr)
+		queryValues[knownSinceStr] = *hasSourceAtSpec.KnownSince
+	}
+	if hasSourceAtSpec.Justification != nil {
+		arangoQueryBuilder.filter("hasSourceAt", justification, "==", "@"+justification)
+		queryValues[justification] = *hasSourceAtSpec.Justification
+	}
+	if hasSourceAtSpec.Origin != nil {
+		arangoQueryBuilder.filter("hasSourceAt", origin, "==", "@"+origin)
+		queryValues[origin] = *hasSourceAtSpec.Origin
+	}
+	if hasSourceAtSpec.Collector != nil {
+		arangoQueryBuilder.filter("hasSourceAt", collector, "==", "@"+collector)
+		queryValues[collector] = *hasSourceAtSpec.Collector
+	}
+	if hasSourceAtSpec.Source != nil {
+		arangoQueryBuilder.forOutBound(hasSourceAtEdgesStr, "sName", "hasSourceAt")
+		if hasSourceAtSpec.Source.ID != nil {
+			arangoQueryBuilder.filter("sName", "_id", "==", "@srcId")
+			queryValues["srcId"] = *hasSourceAtSpec.Source.ID
+		}
+		if hasSourceAtSpec.Source.Name != nil {
+			arangoQueryBuilder.filter("sName", "name", "==", "@srcName")
+			queryValues["srcName"] = *hasSourceAtSpec.Source.Name
+		}
+		if hasSourceAtSpec.Source.Commit != nil {
+			arangoQueryBuilder.filter("sName", "commit", "==", "@srcCommit")
+			queryValues["srcCommit"] = *hasSourceAtSpec.Source.Commit
+		}
+		if hasSourceAtSpec.Source.Tag != nil {
+			arangoQueryBuilder.filter("sName", "tag", "==", "@srcTag")
+			queryValues["srcTag"] = *hasSourceAtSpec.Source.Tag
+		}
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sNs", "sName")
+		if hasSourceAtSpec.Source.Namespace != nil {
+			arangoQueryBuilder.filter("sNs", "namespace", "==", "@srcNamespace")
+			queryValues["srcNamespace"] = *hasSourceAtSpec.Source.Namespace
+		}
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+		if hasSourceAtSpec.Source.Type != nil {
+			arangoQueryBuilder.filter("sType", "type", "==", "@srcType")
+			queryValues["srcType"] = *hasSourceAtSpec.Source.Namespace
+		}
+	} else {
+		arangoQueryBuilder.forOutBound(hasSourceAtEdgesStr, "sName", "hasSourceAt")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sNs", "sName")
+		arangoQueryBuilder.forInBound(srcHasNamespaceStr, "sType", "sNs")
+	}
+}
+
+func getHasSourceAtQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.MatchFlags, source *model.SourceInputSpec, hasSourceAt *model.HasSourceAtInputSpec) map[string]any {
+	values := map[string]any{}
+	// add guac keys
+	pkgId := guacPkgId(*pkg)
+	if pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
+		values["pkgNameGuacKey"] = pkgId.NameId
+	} else {
+		values["pkgVersionGuacKey"] = pkgId.VersionId
+	}
+
+	src := guacSrcId(*source)
+	values["srcNameGuacKey"] = src.NameId
+
+	values[knownSinceStr] = hasSourceAt.KnownSince
+	values[justification] = hasSourceAt.Justification
+	values[origin] = hasSourceAt.Origin
+	values[collector] = hasSourceAt.Collector
+
+	return values
 }
 
 func (c *arangoClient) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAt - IngestHasSourceAt"))
+	if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+		query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == @pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == @srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		  LET hasSourceAt = FIRST(
+			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+				  UPDATE {} IN hasSourceAts
+				  RETURN NEW
+		  )
+
+		   			
+		  INSERT { _key: CONCAT("hasSourceAtPkgVersionEdges", firstPkg.versionDoc._key, hasSourceAt._key), _from: firstPkg.versionDoc._id, _to: hasSourceAt._id } INTO hasSourceAtPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("hasSourceAtEdges", hasSourceAt._key, firstSrc.nameDoc._key), _from: hasSourceAt._id, _to: firstSrc.nameDoc._id } INTO hasSourceAtEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'srcName': {
+				'type_id': firstSrc.typeID,
+				'type': firstSrc.type,
+				'namespace_id': firstSrc.namespace_id,
+				'namespace': firstSrc.namespace,
+				'name_id': firstSrc.name_id,
+				'name': firstSrc.name,
+				'commit': firstSrc.commit,
+				'tag': firstSrc.tag
+			},
+			'hasSourceAt_id': hasSourceAt._id,
+			'knownSince': hasSourceAt.knownSince,
+			'justification': hasSourceAt.justification,
+			'collector': hasSourceAt.collector,
+			'origin': hasSourceAt.origin  
+		  }`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasSourceAtQueryValues(&pkg, &pkgMatchType, &source, &hasSourceAt), "IngestHasSourceAt - PkgVersion")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package hasSourceAt: %w", err)
+		}
+		defer cursor.Close()
+
+		hasSourceAtList, err := getHasSourceAtFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasSourceAt from arango cursor: %w", err)
+		}
+
+		if len(hasSourceAtList) == 1 {
+			return hasSourceAtList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of hasSourceAt ingested is greater than one")
+		}
+	} else {
+		query := `
+			LET firstPkg = FIRST(
+				FOR pName in pkgNames
+				  FILTER pName.guacKey == @pkgNameGuacKey
+				FOR pNs in pkgNamespaces
+				  FILTER pNs._id == pName._parent
+				FOR pType in pkgTypes
+				  FILTER pType._id == pNs._parent
+		
+				RETURN {
+				  'typeID': pType._id,
+				  'type': pType.type,
+				  'namespace_id': pNs._id,
+				  'namespace': pNs.namespace,
+				  'name_id': pName._id,
+				  'name': pName.name,
+				  'nameDoc': pName
+				}
+			)
+
+			LET firstSrc = FIRST(
+				FOR sName in srcNames
+				  FILTER sName.guacKey == @srcNameGuacKey
+				FOR sNs in srcNamespaces
+				  FILTER sNs._id == sName._parent
+				FOR sType in srcTypes
+				  FILTER sType._id == sNs._parent
+		
+				RETURN {
+				  'typeID': sType._id,
+				  'type': sType.type,
+				  'namespace_id': sNs._id,
+				  'namespace': sNs.namespace,
+				  'name_id': sName._id,
+				  'name': sName.name,
+				  'commit': sName.commit,
+				  'tag': sName.tag,
+				  'nameDoc': sName
+				}
+			)
+			  
+			  LET hasSourceAt = FIRST(
+				  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, key:@key, value:@value, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+					  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, key:@key, value:@value, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+					  UPDATE {} IN hasSourceAts
+					  RETURN NEW
+			  )
+			  
+			  INSERT { _key: CONCAT("hasSourceAtPkgNameEdges", firstPkg.nameDoc._key, hasSourceAt._key), _from: firstPkg.nameDoc._id, _to: hasSourceAt._id } INTO hasSourceAtPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+		  	  INSERT { _key: CONCAT("hasSourceAtEdges", hasSourceAt._key, firstSrc.nameDoc._key), _from: hasSourceAt._id, _to:firstSrc.nameDoc._id } INTO hasSourceAtEdges OPTIONS { overwriteMode: "ignore" }
+			  
+			  RETURN {
+				'pkgVersion': {
+					'type_id': firstPkg.typeID,
+					'type': firstPkg.type,
+					'namespace_id': firstPkg.namespace_id,
+					'namespace': firstPkg.namespace,
+					'name_id': firstPkg.name_id,
+					'name': firstPkg.name
+				},
+				'srcName': {
+					'type_id': firstSrc.typeID,
+					'type': firstSrc.type,
+					'namespace_id': firstSrc.namespace_id,
+					'namespace': firstSrc.namespace,
+					'name_id': firstSrc.name_id,
+					'name': firstSrc.name,
+					'commit': firstSrc.commit,
+					'tag': firstSrc.tag
+				},
+				'hasSourceAt_id': hasSourceAt._id,
+				'knownSince': hasSourceAt.knownSince,
+				'justification': hasSourceAt.justification,
+				'collector': hasSourceAt.collector,
+				'origin': hasSourceAt.origin  
+			  }`
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, query, getHasSourceAtQueryValues(&pkg, &pkgMatchType, &source, &hasSourceAt), "IngestHasSourceAt - PkgName")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package hasSourceAt: %w", err)
+		}
+		defer cursor.Close()
+
+		hasSourceAtList, err := getHasSourceAtFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasSourceAt from arango cursor: %w", err)
+		}
+
+		if len(hasSourceAtList) == 1 {
+			return hasSourceAtList[0], nil
+		} else {
+			return nil, fmt.Errorf("number of hasSourceAt ingested is greater than one")
+		}
+	}
+
 }
 
 func (c *arangoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAts"))
+	var listOfValues []map[string]any
+
+	for i := range pkgs {
+		listOfValues = append(listOfValues, getHasSourceAtQueryValues(pkgs[i], pkgMatchType, sources[i], hasSourceAts[i]))
+	}
+
+	var documents []string
+	for _, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		documents = append(documents, string(bs))
+	}
+
+	queryValues := map[string]any{}
+	queryValues["documents"] = fmt.Sprint(strings.Join(documents, ","))
+
+	var sb strings.Builder
+
+	sb.WriteString("for doc in [")
+	for i, val := range listOfValues {
+		bs, _ := json.Marshal(val)
+		if i == len(listOfValues)-1 {
+			sb.WriteString(string(bs))
+		} else {
+			sb.WriteString(string(bs) + ",")
+		}
+	}
+	sb.WriteString("]")
+
+	if pkgMatchType.Pkg == model.PkgMatchTypeSpecificVersion {
+		query := `
+		LET firstPkg = FIRST(
+			FOR pVersion in pkgVersions
+			  FILTER pVersion.guacKey == doc.pkgVersionGuacKey
+			FOR pName in pkgNames
+			  FILTER pName._id == pVersion._parent
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'version_id': pVersion._id,
+			  'version': pVersion.version,
+			  'subpath': pVersion.subpath,
+			  'qualifier_list': pVersion.qualifier_list,
+			  'versionDoc': pVersion
+			}
+		)
+
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == doc.srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		  LET hasSourceAt = FIRST(
+			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN hasSourceAts
+				  RETURN NEW
+		  )
+
+		   			
+		  INSERT { _key: CONCAT("hasSourceAtPkgVersionEdges", firstPkg.versionDoc._key, hasSourceAt._key), _from: firstPkg.versionDoc._id, _to: hasSourceAt._id } INTO hasSourceAtPkgVersionEdges OPTIONS { overwriteMode: "ignore" }
+		  INSERT { _key: CONCAT("hasSourceAtEdges", hasSourceAt._key, firstSrc.nameDoc._key), _from: hasSourceAt._id, _to: firstSrc.nameDoc._id } INTO hasSourceAtEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name,
+				'version_id': firstPkg.version_id,
+				'version': firstPkg.version,
+				'subpath': firstPkg.subpath,
+				'qualifier_list': firstPkg.qualifier_list
+			},
+			'srcName': {
+				'type_id': firstSrc.typeID,
+				'type': firstSrc.type,
+				'namespace_id': firstSrc.namespace_id,
+				'namespace': firstSrc.namespace,
+				'name_id': firstSrc.name_id,
+				'name': firstSrc.name,
+				'commit': firstSrc.commit,
+				'tag': firstSrc.tag
+			},
+			'hasSourceAt_id': hasSourceAt._id,
+			'knownSince': hasSourceAt.knownSince,
+			'justification': hasSourceAt.justification,
+			'collector': hasSourceAt.collector,
+			'origin': hasSourceAt.origin  
+		  }`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestHasSourceAts - PkgVersion")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package hasSourceAt: %w", err)
+		}
+		defer cursor.Close()
+
+		ingestHasSourceAtList, err := getHasSourceAtFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasSourceAt from arango cursor: %w", err)
+		}
+
+		var hasSourceAtIDList []string
+		for _, ingestedHasSourceAt := range ingestHasSourceAtList {
+			hasSourceAtIDList = append(hasSourceAtIDList, ingestedHasSourceAt.ID)
+		}
+
+		return hasSourceAtIDList, nil
+
+	} else {
+		query := `
+		LET firstPkg = FIRST(
+			FOR pName in pkgNames
+			  FILTER pName.guacKey == doc.pkgNameGuacKey
+			FOR pNs in pkgNamespaces
+			  FILTER pNs._id == pName._parent
+			FOR pType in pkgTypes
+			  FILTER pType._id == pNs._parent
+	
+			RETURN {
+			  'typeID': pType._id,
+			  'type': pType.type,
+			  'namespace_id': pNs._id,
+			  'namespace': pNs.namespace,
+			  'name_id': pName._id,
+			  'name': pName.name,
+			  'nameDoc': pName
+			}
+		)
+
+		LET firstSrc = FIRST(
+			FOR sName in srcNames
+			  FILTER sName.guacKey == doc.srcNameGuacKey
+			FOR sNs in srcNamespaces
+			  FILTER sNs._id == sName._parent
+			FOR sType in srcTypes
+			  FILTER sType._id == sNs._parent
+	
+			RETURN {
+			  'typeID': sType._id,
+			  'type': sType.type,
+			  'namespace_id': sNs._id,
+			  'namespace': sNs.namespace,
+			  'name_id': sName._id,
+			  'name': sName.name,
+			  'commit': sName.commit,
+			  'tag': sName.tag,
+			  'nameDoc': sName
+			}
+		)
+		  
+		  LET hasSourceAt = FIRST(
+			  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, key:doc.key, value:doc.value, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, key:doc.key, value:doc.value, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPDATE {} IN hasSourceAts
+				  RETURN NEW
+		  )
+		  
+		  INSERT { _key: CONCAT("hasSourceAtPkgNameEdges", firstPkg.nameDoc._key, hasSourceAt._key), _from: firstPkg.nameDoc._id, _to: hasSourceAt._id } INTO hasSourceAtPkgNameEdges OPTIONS { overwriteMode: "ignore" }
+			INSERT { _key: CONCAT("hasSourceAtEdges", hasSourceAt._key, firstSrc.nameDoc._key), _from: hasSourceAt._id, _to:firstSrc.nameDoc._id } INTO hasSourceAtEdges OPTIONS { overwriteMode: "ignore" }
+		  
+		  RETURN {
+			'pkgVersion': {
+				'type_id': firstPkg.typeID,
+				'type': firstPkg.type,
+				'namespace_id': firstPkg.namespace_id,
+				'namespace': firstPkg.namespace,
+				'name_id': firstPkg.name_id,
+				'name': firstPkg.name
+			},
+			'srcName': {
+				'type_id': firstSrc.typeID,
+				'type': firstSrc.type,
+				'namespace_id': firstSrc.namespace_id,
+				'namespace': firstSrc.namespace,
+				'name_id': firstSrc.name_id,
+				'name': firstSrc.name,
+				'commit': firstSrc.commit,
+				'tag': firstSrc.tag
+			},
+			'hasSourceAt_id': hasSourceAt._id,
+			'knownSince': hasSourceAt.knownSince,
+			'justification': hasSourceAt.justification,
+			'collector': hasSourceAt.collector,
+			'origin': hasSourceAt.origin  
+		  }`
+
+		sb.WriteString(query)
+
+		cursor, err := executeQueryWithRetry(ctx, c.db, sb.String(), nil, "IngestHasSourceAts - PkgName")
+		if err != nil {
+			return nil, fmt.Errorf("failed to ingest package hasSourceAt: %w", err)
+		}
+		defer cursor.Close()
+
+		ingestHasSourceAtList, err := getHasSourceAtFromCursor(ctx, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get hasSourceAt from arango cursor: %w", err)
+		}
+
+		var hasSourceAtIDList []string
+		for _, ingestedHasSourceAt := range ingestHasSourceAtList {
+			hasSourceAtIDList = append(hasSourceAtIDList, ingestedHasSourceAt.ID)
+		}
+
+		return hasSourceAtIDList, nil
+	}
+}
+
+func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.HasSourceAt, error) {
+	type collectedData struct {
+		PkgVersion    *dbPkgVersion `json:"pkgVersion"`
+		SrcName       *dbSrcName    `json:"srcName"`
+		HasSourceAtID string        `json:"hasSourceAt_id"`
+		KnownSince    time.Time     `json:"knownSince"`
+		Justification string        `json:"justification"`
+		Collector     string        `json:"collector"`
+		Origin        string        `json:"origin"`
+	}
+
+	var createdValues []collectedData
+	for {
+		var doc collectedData
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to hasSourceAt from cursor: %w", err)
+			}
+		} else {
+			createdValues = append(createdValues, doc)
+		}
+	}
+
+	var hasSourceAtList []*model.HasSourceAt
+	for _, createdValue := range createdValues {
+		var pkg *model.Package = nil
+		var src *model.Source = nil
+		if createdValue.PkgVersion != nil {
+			pkg = generateModelPackage(createdValue.PkgVersion.TypeID, createdValue.PkgVersion.PkgType, createdValue.PkgVersion.NamespaceID, createdValue.PkgVersion.Namespace, createdValue.PkgVersion.NameID,
+				createdValue.PkgVersion.Name, createdValue.PkgVersion.VersionID, createdValue.PkgVersion.Version, createdValue.PkgVersion.Subpath, createdValue.PkgVersion.QualifierList)
+		} else if createdValue.SrcName != nil {
+			src = generateModelSource(createdValue.SrcName.TypeID, createdValue.SrcName.SrcType, createdValue.SrcName.NamespaceID, createdValue.SrcName.Namespace,
+				createdValue.SrcName.NameID, createdValue.SrcName.Name, createdValue.SrcName.Commit, createdValue.SrcName.Tag)
+		}
+
+		hasSourceAt := &model.HasSourceAt{
+			ID:            createdValue.HasSourceAtID,
+			Package:       pkg,
+			Source:        src,
+			KnownSince:    createdValue.KnownSince,
+			Justification: createdValue.Justification,
+			Origin:        createdValue.Collector,
+			Collector:     createdValue.Origin,
+		}
+
+		hasSourceAtList = append(hasSourceAtList, hasSourceAt)
+	}
+	return hasSourceAtList, nil
 }

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
+	panic(fmt.Errorf("not implemented: HasSourceAt - HasSourceAt"))
+}
+
+func (c *arangoClient) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
+	panic(fmt.Errorf("not implemented: IngestHasSourceAt - IngestHasSourceAt"))
+}
+
+func (c *arangoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestHasSourceAts"))
+}

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -15,767 +15,898 @@
 
 package arangodb
 
-// func TestHasSourceAt(t *testing.T) {
-// 	testTime := time.Unix(1e9+5, 0)
-// 	type call struct {
-// 		Pkg   *model.PkgInputSpec
-// 		Src   *model.SourceInputSpec
-// 		Match *model.MatchFlags
-// 		HSA   *model.HasSourceAtInputSpec
-// 	}
-// 	tests := []struct {
-// 		Name         string
-// 		InPkg        []*model.PkgInputSpec
-// 		InSrc        []*model.SourceInputSpec
-// 		Calls        []call
-// 		Query        *model.HasSourceAtSpec
-// 		ExpHSA       []*model.HasSourceAt
-// 		ExpIngestErr bool
-// 		ExpQueryErr  bool
-// 	}{
-// 		{
-// 			Name:  "HappyPath",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "HappyPath All Versions",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeAllVersions,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1outName,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Ingest Same Twice",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query On Justification",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification one",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification two"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification two",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Package",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 				{
-// 					Pkg: p2,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Package: &model.PkgSpec{
-// 					Version: ptrfrom.String("2.11.1"),
-// 				},
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package: p2out,
-// 					Source:  s1out,
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Source",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1, s2},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s2,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Source: &model.SourceSpec{
-// 					Name: ptrfrom.String("myrepo"),
-// 				},
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package: p1out,
-// 					Source:  s1out,
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on KnownSince",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						KnownSince: time.Unix(1e9, 0),
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						KnownSince: testTime,
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				KnownSince: &testTime,
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:    p1out,
-// 					Source:     s1out,
-// 					KnownSince: testTime,
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query Multiple",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification one",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p2,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification two"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification two",
-// 				},
-// 				{
-// 					Package:       p2out,
-// 					Source:        s1out,
-// 					Justification: "test justification two",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query None",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification one",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification three"),
-// 			},
-// 			ExpHSA: nil,
-// 		},
-// 		{
-// 			Name:  "Query ID",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification one",
-// 					},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{
-// 						Justification: "test justification two",
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				ID: ptrfrom.String("9"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification two",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query Name and Version",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeAllVersions,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 				{
-// 					Pkg: p2,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Package: &model.PkgSpec{
-// 					Version: ptrfrom.String(""),
-// 				},
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package: p1out,
-// 					Source:  s1out,
-// 				},
-// 				{
-// 					Package: p1outName,
-// 					Source:  s1out,
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Ingest no pkg",
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			ExpIngestErr: true,
-// 		},
-// 		{
-// 			Name:  "Ingest no src",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			ExpIngestErr: true,
-// 		},
-// 		{
-// 			Name:  "Query bad ID",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkg: p1,
-// 					Src: s1,
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSA: &model.HasSourceAtInputSpec{},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				ID: ptrfrom.String("asdf"),
-// 			},
-// 			ExpQueryErr: true,
-// 		},
-// 	}
-// 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-// 		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-// 	}, cmp.Ignore())
-// 	ctx := context.Background()
-// 	for _, test := range tests {
-// 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := backends.Get("inmem", nil, nil)
-// 			if err != nil {
-// 				t.Fatalf("Could not instantiate testing backend: %v", err)
-// 			}
-// 			for _, p := range test.InPkg {
-// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
-// 					t.Fatalf("Could not ingest package: %v", err)
-// 				}
-// 			}
-// 			for _, s := range test.InSrc {
-// 				if _, err := b.IngestSource(ctx, *s); err != nil {
-// 					t.Fatalf("Could not ingest source: %v", err)
-// 				}
-// 			}
-// 			for _, o := range test.Calls {
-// 				_, err := b.IngestHasSourceAt(ctx, *o.Pkg, *o.Match, *o.Src, *o.HSA)
-// 				if (err != nil) != test.ExpIngestErr {
-// 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
-// 				}
-// 				if err != nil {
-// 					return
-// 				}
-// 			}
-// 			got, err := b.HasSourceAt(ctx, test.Query)
-// 			if (err != nil) != test.ExpQueryErr {
-// 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
-// 			}
-// 			if err != nil {
-// 				return
-// 			}
-// 			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
-// 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
-// 			}
-// 		})
-// 	}
-// }
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
 
-// func TestIngestHasSourceAts(t *testing.T) {
-// 	testTime := time.Unix(1e9+5, 0)
-// 	type call struct {
-// 		Pkgs  []*model.PkgInputSpec
-// 		Srcs  []*model.SourceInputSpec
-// 		Match *model.MatchFlags
-// 		HSAs  []*model.HasSourceAtInputSpec
-// 	}
-// 	tests := []struct {
-// 		Name         string
-// 		InPkg        []*model.PkgInputSpec
-// 		InSrc        []*model.SourceInputSpec
-// 		Calls        []call
-// 		Query        *model.HasSourceAtSpec
-// 		ExpHSA       []*model.HasSourceAt
-// 		ExpIngestErr bool
-// 		ExpQueryErr  bool
-// 	}{
-// 		{
-// 			Name:  "HappyPath",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1},
-// 					Srcs: []*model.SourceInputSpec{s1},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "HappyPath All Versions",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1},
-// 					Srcs: []*model.SourceInputSpec{s1},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeAllVersions,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1outName,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Ingest Same Twice",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1, p1},
-// 					Srcs: []*model.SourceInputSpec{s1, s1},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Justification: ptrfrom.String("test justification"),
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Package",
-// 			InPkg: []*model.PkgInputSpec{p1, p2},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1, p2},
-// 					Srcs: []*model.SourceInputSpec{s1, s1},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Package: &model.PkgSpec{
-// 					Version: ptrfrom.String("2.11.1"),
-// 				},
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p2out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on Source",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1, s2},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1, p1},
-// 					Srcs: []*model.SourceInputSpec{s1, s2},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 						{
-// 							Justification: "test justification",
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				Source: &model.SourceSpec{
-// 					Name: ptrfrom.String("myrepo"),
-// 				},
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:       p1out,
-// 					Source:        s1out,
-// 					Justification: "test justification",
-// 				},
-// 			},
-// 		},
-// 		{
-// 			Name:  "Query on KnownSince",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
-// 			Calls: []call{
-// 				{
-// 					Pkgs: []*model.PkgInputSpec{p1, p1},
-// 					Srcs: []*model.SourceInputSpec{s1, s1},
-// 					Match: &model.MatchFlags{
-// 						Pkg: model.PkgMatchTypeSpecificVersion,
-// 					},
-// 					HSAs: []*model.HasSourceAtInputSpec{
-// 						{
-// 							KnownSince: time.Unix(1e9, 0),
-// 						},
-// 						{
-// 							KnownSince: testTime,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			Query: &model.HasSourceAtSpec{
-// 				KnownSince: &testTime,
-// 			},
-// 			ExpHSA: []*model.HasSourceAt{
-// 				{
-// 					Package:    p1out,
-// 					Source:     s1out,
-// 					KnownSince: testTime,
-// 				},
-// 			},
-// 		},
-// 	}
-// 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-// 		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-// 	}, cmp.Ignore())
-// 	ctx := context.Background()
-// 	for _, test := range tests {
-// 		t.Run(test.Name, func(t *testing.T) {
-// 			b, err := backends.Get("inmem", nil, nil)
-// 			if err != nil {
-// 				t.Fatalf("Could not instantiate testing backend: %v", err)
-// 			}
-// 			for _, p := range test.InPkg {
-// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
-// 					t.Fatalf("Could not ingest package: %v", err)
-// 				}
-// 			}
-// 			for _, s := range test.InSrc {
-// 				if _, err := b.IngestSource(ctx, *s); err != nil {
-// 					t.Fatalf("Could not ingest source: %v", err)
-// 				}
-// 			}
-// 			for _, o := range test.Calls {
-// 				_, err := b.IngestHasSourceAts(ctx, o.Pkgs, o.Match, o.Srcs, o.HSAs)
-// 				if (err != nil) != test.ExpIngestErr {
-// 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
-// 				}
-// 				if err != nil {
-// 					return
-// 				}
-// 			}
-// 			got, err := b.HasSourceAt(ctx, test.Query)
-// 			if (err != nil) != test.ExpQueryErr {
-// 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
-// 			}
-// 			if err != nil {
-// 				return
-// 			}
-// 			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
-// 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
-// 			}
-// 		})
-// 	}
-// }
+	"github.com/google/go-cmp/cmp"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/internal/testing/testdata"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+func TestHasSourceAt(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Pkg   *model.PkgInputSpec
+		Src   *model.SourceInputSpec
+		Match *model.MatchFlags
+		HSA   *model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		Name          string
+		InPkg         []*model.PkgInputSpec
+		InSrc         []*model.SourceInputSpec
+		Calls         []call
+		Query         *model.HasSourceAtSpec
+		QueryID       bool
+		QueryPkgID    bool
+		QuerySourceID bool
+		ExpHSA        []*model.HasSourceAt
+		ExpIngestErr  bool
+		ExpQueryErr   bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath All Versions",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+				{
+					Package:       testdata.P1outName,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest Same Twice",
+			InPkg: []*model.PkgInputSpec{testdata.P3},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P3,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Pkg: testdata.P3,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Version: ptrfrom.String("2.11.1"),
+					Subpath: ptrfrom.String("saved_model_cli.py"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P3out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+				{
+					Package:       testdata.P1outName,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query On Justification",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification one",
+					},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification two",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification two"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification two",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Type:      ptrfrom.String("conan"),
+					Namespace: ptrfrom.String("openssl.org"),
+					Name:      ptrfrom.String("openssl"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Package version ID",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QueryPkgID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Source - tag",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S3},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S3,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("git"),
+					Namespace: ptrfrom.String("github.com/jeff"),
+					Name:      ptrfrom.String("myrepo"),
+					Tag:       ptrfrom.String("v1.0"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P1out,
+					Source:  testdata.S3out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Source - commit",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S4, testdata.S3},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S4,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S3,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("svn"),
+					Namespace: ptrfrom.String("github.com/bob"),
+					Name:      ptrfrom.String("bobsrepo"),
+					Commit:    ptrfrom.String("5e7c41f"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P1out,
+					Source:  testdata.S4out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Source ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S2,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QuerySourceID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P1out,
+					Source:  testdata.S2out,
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						KnownSince: time.Unix(1e9, 0),
+					},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						KnownSince: testTime,
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				KnownSince: &testTime,
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:    testdata.P1out,
+					Source:     testdata.S1out,
+					KnownSince: testTime,
+				},
+			},
+		},
+		{
+			Name:  "Query Multiple",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification one",
+					},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification two",
+					},
+				},
+				{
+					Pkg: testdata.P2,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification two",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification two"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification two",
+				},
+				{
+					Package:       testdata.P2out,
+					Source:        testdata.S1out,
+					Justification: "test justification two",
+				},
+			},
+		},
+		{
+			Name:  "Query None",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification one",
+					},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						Justification: "test justification two",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification three"),
+			},
+			ExpHSA: nil,
+		},
+		{
+			Name:  "Query ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P2,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QueryID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P2out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query Name and Version",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S4},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S4,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Type:      ptrfrom.String("conan"),
+					Namespace: ptrfrom.String("openssl.org"),
+					Name:      ptrfrom.String("openssl"),
+				},
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("svn"),
+					Namespace: ptrfrom.String("github.com/bob"),
+					Name:      ptrfrom.String("bobsrepo"),
+					Commit:    ptrfrom.String("5e7c41f"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S4out,
+				},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestHasSourceAt(ctx, *o.Pkg, *o.Match, *o.Src, *o.HSA)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if test.QueryID {
+					test.Query = &model.HasSourceAtSpec{
+						ID: ptrfrom.String(found.ID),
+					}
+				}
+				if test.QueryPkgID {
+					test.Query = &model.HasSourceAtSpec{
+						Package: &model.PkgSpec{
+							ID: ptrfrom.String(found.Package.Namespaces[0].Names[0].Versions[0].ID),
+						},
+					}
+
+				}
+				if test.QuerySourceID {
+					test.Query = &model.HasSourceAtSpec{
+						Source: &model.SourceSpec{
+							ID: ptrfrom.String(found.Source.Namespaces[0].Names[0].ID),
+						},
+					}
+				}
+			}
+			got, err := b.HasSourceAt(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIngestHasSourceAts(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Pkgs  []*model.PkgInputSpec
+		Srcs  []*model.SourceInputSpec
+		Match *model.MatchFlags
+		HSAs  []*model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		Query        *model.HasSourceAtSpec
+		ExpHSA       []*model.HasSourceAt
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P1},
+					Srcs: []*model.SourceInputSpec{testdata.S1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath All Versions",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P1},
+					Srcs: []*model.SourceInputSpec{testdata.S1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+				{
+					Package:       testdata.P1outName,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest Same Twice",
+			InPkg: []*model.PkgInputSpec{testdata.P3},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P3, testdata.P1},
+					Srcs: []*model.SourceInputSpec{testdata.S1, testdata.S1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Version: ptrfrom.String("2.11.1"),
+					Subpath: ptrfrom.String("saved_model_cli.py"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P3out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+				{
+					Package:       testdata.P1outName,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+					Srcs: []*model.SourceInputSpec{testdata.S1, testdata.S1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Type:      ptrfrom.String("conan"),
+					Namespace: ptrfrom.String("openssl.org"),
+					Name:      ptrfrom.String("openssl"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P4out,
+					Source:        testdata.S1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S3},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P1, testdata.P1},
+					Srcs: []*model.SourceInputSpec{testdata.S1, testdata.S3},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("git"),
+					Namespace: ptrfrom.String("github.com/jeff"),
+					Name:      ptrfrom.String("myrepo"),
+					Tag:       ptrfrom.String("v1.0"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       testdata.P1out,
+					Source:        testdata.S3out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{testdata.P1, testdata.P1},
+					Srcs: []*model.SourceInputSpec{testdata.S1, testdata.S1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							KnownSince: time.Unix(1e9, 0),
+						},
+						{
+							KnownSince: testTime,
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				KnownSince: &testTime,
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:    testdata.P1out,
+					Source:     testdata.S1out,
+					KnownSince: testTime,
+				},
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.IngestHasSourceAts(ctx, o.Pkgs, o.Match, o.Srcs, o.HSAs)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+			got, err := b.HasSourceAt(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TODO (pxp928): add tests back in when implemented
 
 // func TestHasSourceAtNeighbors(t *testing.T) {
 // 	type call struct {
@@ -793,12 +924,12 @@ package arangodb
 // 	}{
 // 		{
 // 			Name:  "HappyPath",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
+// 			InPkg: []*model.PkgInputSpec{testdata.P1},
+// 			InSrc: []*model.SourceInputSpec{testdata.S1},
 // 			Calls: []call{
 // 				{
-// 					Pkg: p1,
-// 					Src: s1,
+// 					Pkg: testdata.P1,
+// 					Src: testdata.S1,
 // 					Match: &model.MatchFlags{
 // 						Pkg: model.PkgMatchTypeSpecificVersion,
 // 					},
@@ -815,12 +946,12 @@ package arangodb
 // 		},
 // 		{
 // 			Name:  "Package Name and Version",
-// 			InPkg: []*model.PkgInputSpec{p1},
-// 			InSrc: []*model.SourceInputSpec{s1},
+// 			InPkg: []*model.PkgInputSpec{testdata.P1},
+// 			InSrc: []*model.SourceInputSpec{testdata.S1},
 // 			Calls: []call{
 // 				{
-// 					Pkg: p1,
-// 					Src: s1,
+// 					Pkg: testdata.P1,
+// 					Src: testdata.S1,
 // 					Match: &model.MatchFlags{
 // 						Pkg: model.PkgMatchTypeSpecificVersion,
 // 					},
@@ -829,8 +960,8 @@ package arangodb
 // 					},
 // 				},
 // 				{
-// 					Pkg: p1,
-// 					Src: s1,
+// 					Pkg: testdata.P1,
+// 					Src: testdata.S1,
 // 					Match: &model.MatchFlags{
 // 						Pkg: model.PkgMatchTypeAllVersions,
 // 					},

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -525,6 +525,258 @@ package arangodb
 // 	}
 // }
 
+// func TestIngestHasSourceAts(t *testing.T) {
+// 	testTime := time.Unix(1e9+5, 0)
+// 	type call struct {
+// 		Pkgs  []*model.PkgInputSpec
+// 		Srcs  []*model.SourceInputSpec
+// 		Match *model.MatchFlags
+// 		HSAs  []*model.HasSourceAtInputSpec
+// 	}
+// 	tests := []struct {
+// 		Name         string
+// 		InPkg        []*model.PkgInputSpec
+// 		InSrc        []*model.SourceInputSpec
+// 		Calls        []call
+// 		Query        *model.HasSourceAtSpec
+// 		ExpHSA       []*model.HasSourceAt
+// 		ExpIngestErr bool
+// 		ExpQueryErr  bool
+// 	}{
+// 		{
+// 			Name:  "HappyPath",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1},
+// 					Srcs: []*model.SourceInputSpec{s1},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "HappyPath All Versions",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1},
+// 					Srcs: []*model.SourceInputSpec{s1},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeAllVersions,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1outName,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Ingest Same Twice",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1, p1},
+// 					Srcs: []*model.SourceInputSpec{s1, s1},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on Package",
+// 			InPkg: []*model.PkgInputSpec{p1, p2},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1, p2},
+// 					Srcs: []*model.SourceInputSpec{s1, s1},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Package: &model.PkgSpec{
+// 					Version: ptrfrom.String("2.11.1"),
+// 				},
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p2out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on Source",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1, s2},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1, p1},
+// 					Srcs: []*model.SourceInputSpec{s1, s2},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 						{
+// 							Justification: "test justification",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Source: &model.SourceSpec{
+// 					Name: ptrfrom.String("myrepo"),
+// 				},
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on KnownSince",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkgs: []*model.PkgInputSpec{p1, p1},
+// 					Srcs: []*model.SourceInputSpec{s1, s1},
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSAs: []*model.HasSourceAtInputSpec{
+// 						{
+// 							KnownSince: time.Unix(1e9, 0),
+// 						},
+// 						{
+// 							KnownSince: testTime,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				KnownSince: &testTime,
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:    p1out,
+// 					Source:     s1out,
+// 					KnownSince: testTime,
+// 				},
+// 			},
+// 		},
+// 	}
+// 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+// 		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+// 	}, cmp.Ignore())
+// 	ctx := context.Background()
+// 	for _, test := range tests {
+// 		t.Run(test.Name, func(t *testing.T) {
+// 			b, err := backends.Get("inmem", nil, nil)
+// 			if err != nil {
+// 				t.Fatalf("Could not instantiate testing backend: %v", err)
+// 			}
+// 			for _, p := range test.InPkg {
+// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
+// 					t.Fatalf("Could not ingest package: %v", err)
+// 				}
+// 			}
+// 			for _, s := range test.InSrc {
+// 				if _, err := b.IngestSource(ctx, *s); err != nil {
+// 					t.Fatalf("Could not ingest source: %v", err)
+// 				}
+// 			}
+// 			for _, o := range test.Calls {
+// 				_, err := b.IngestHasSourceAts(ctx, o.Pkgs, o.Match, o.Srcs, o.HSAs)
+// 				if (err != nil) != test.ExpIngestErr {
+// 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+// 				}
+// 				if err != nil {
+// 					return
+// 				}
+// 			}
+// 			got, err := b.HasSourceAt(ctx, test.Query)
+// 			if (err != nil) != test.ExpQueryErr {
+// 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+// 			}
+// 			if err != nil {
+// 				return
+// 			}
+// 			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+// 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+// 			}
+// 		})
+// 	}
+// }
+
 // func TestHasSourceAtNeighbors(t *testing.T) {
 // 	type call struct {
 // 		Pkg   *model.PkgInputSpec

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -1,0 +1,633 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arangodb
+
+// func TestHasSourceAt(t *testing.T) {
+// 	testTime := time.Unix(1e9+5, 0)
+// 	type call struct {
+// 		Pkg   *model.PkgInputSpec
+// 		Src   *model.SourceInputSpec
+// 		Match *model.MatchFlags
+// 		HSA   *model.HasSourceAtInputSpec
+// 	}
+// 	tests := []struct {
+// 		Name         string
+// 		InPkg        []*model.PkgInputSpec
+// 		InSrc        []*model.SourceInputSpec
+// 		Calls        []call
+// 		Query        *model.HasSourceAtSpec
+// 		ExpHSA       []*model.HasSourceAt
+// 		ExpIngestErr bool
+// 		ExpQueryErr  bool
+// 	}{
+// 		{
+// 			Name:  "HappyPath",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "HappyPath All Versions",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeAllVersions,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1outName,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Ingest Same Twice",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query On Justification",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification one",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification two",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification two"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification two",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on Package",
+// 			InPkg: []*model.PkgInputSpec{p1, p2},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 				{
+// 					Pkg: p2,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Package: &model.PkgSpec{
+// 					Version: ptrfrom.String("2.11.1"),
+// 				},
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package: p2out,
+// 					Source:  s1out,
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on Source",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1, s2},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s2,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Source: &model.SourceSpec{
+// 					Name: ptrfrom.String("myrepo"),
+// 				},
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package: p1out,
+// 					Source:  s1out,
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query on KnownSince",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						KnownSince: time.Unix(1e9, 0),
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						KnownSince: testTime,
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				KnownSince: &testTime,
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:    p1out,
+// 					Source:     s1out,
+// 					KnownSince: testTime,
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query Multiple",
+// 			InPkg: []*model.PkgInputSpec{p1, p2},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification one",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification two",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p2,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification two",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification two"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification two",
+// 				},
+// 				{
+// 					Package:       p2out,
+// 					Source:        s1out,
+// 					Justification: "test justification two",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query None",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification one",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification two",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Justification: ptrfrom.String("test justification three"),
+// 			},
+// 			ExpHSA: nil,
+// 		},
+// 		{
+// 			Name:  "Query ID",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification one",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification two",
+// 					},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				ID: ptrfrom.String("9"),
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package:       p1out,
+// 					Source:        s1out,
+// 					Justification: "test justification two",
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Query Name and Version",
+// 			InPkg: []*model.PkgInputSpec{p1, p2},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeAllVersions,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 				{
+// 					Pkg: p2,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				Package: &model.PkgSpec{
+// 					Version: ptrfrom.String(""),
+// 				},
+// 			},
+// 			ExpHSA: []*model.HasSourceAt{
+// 				{
+// 					Package: p1out,
+// 					Source:  s1out,
+// 				},
+// 				{
+// 					Package: p1outName,
+// 					Source:  s1out,
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:  "Ingest no pkg",
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			ExpIngestErr: true,
+// 		},
+// 		{
+// 			Name:  "Ingest no src",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			ExpIngestErr: true,
+// 		},
+// 		{
+// 			Name:  "Query bad ID",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			Query: &model.HasSourceAtSpec{
+// 				ID: ptrfrom.String("asdf"),
+// 			},
+// 			ExpQueryErr: true,
+// 		},
+// 	}
+// 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+// 		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+// 	}, cmp.Ignore())
+// 	ctx := context.Background()
+// 	for _, test := range tests {
+// 		t.Run(test.Name, func(t *testing.T) {
+// 			b, err := backends.Get("inmem", nil, nil)
+// 			if err != nil {
+// 				t.Fatalf("Could not instantiate testing backend: %v", err)
+// 			}
+// 			for _, p := range test.InPkg {
+// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
+// 					t.Fatalf("Could not ingest package: %v", err)
+// 				}
+// 			}
+// 			for _, s := range test.InSrc {
+// 				if _, err := b.IngestSource(ctx, *s); err != nil {
+// 					t.Fatalf("Could not ingest source: %v", err)
+// 				}
+// 			}
+// 			for _, o := range test.Calls {
+// 				_, err := b.IngestHasSourceAt(ctx, *o.Pkg, *o.Match, *o.Src, *o.HSA)
+// 				if (err != nil) != test.ExpIngestErr {
+// 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+// 				}
+// 				if err != nil {
+// 					return
+// 				}
+// 			}
+// 			got, err := b.HasSourceAt(ctx, test.Query)
+// 			if (err != nil) != test.ExpQueryErr {
+// 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+// 			}
+// 			if err != nil {
+// 				return
+// 			}
+// 			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+// 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+// 			}
+// 		})
+// 	}
+// }
+
+// func TestHasSourceAtNeighbors(t *testing.T) {
+// 	type call struct {
+// 		Pkg   *model.PkgInputSpec
+// 		Src   *model.SourceInputSpec
+// 		Match *model.MatchFlags
+// 		HSA   *model.HasSourceAtInputSpec
+// 	}
+// 	tests := []struct {
+// 		Name         string
+// 		InPkg        []*model.PkgInputSpec
+// 		InSrc        []*model.SourceInputSpec
+// 		Calls        []call
+// 		ExpNeighbors map[string][]string
+// 	}{
+// 		{
+// 			Name:  "HappyPath",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 			},
+// 			ExpNeighbors: map[string][]string{
+// 				"4": []string{"1", "8"}, // Package Version
+// 				"7": []string{"5", "8"}, // Source Name
+// 				"8": []string{"1", "5"}, // HSA
+// 			},
+// 		},
+// 		{
+// 			Name:  "Package Name and Version",
+// 			InPkg: []*model.PkgInputSpec{p1},
+// 			InSrc: []*model.SourceInputSpec{s1},
+// 			Calls: []call{
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeSpecificVersion,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{
+// 						Justification: "test justification",
+// 					},
+// 				},
+// 				{
+// 					Pkg: p1,
+// 					Src: s1,
+// 					Match: &model.MatchFlags{
+// 						Pkg: model.PkgMatchTypeAllVersions,
+// 					},
+// 					HSA: &model.HasSourceAtInputSpec{},
+// 				},
+// 			},
+// 			ExpNeighbors: map[string][]string{
+// 				"3": []string{"1", "1", "9"}, // Package Name
+// 				"4": []string{"1", "8"},      // Package Version
+// 				"7": []string{"5", "8", "9"}, // Source Name
+// 				"8": []string{"1", "5"},      // HSA -> Version
+// 				"9": []string{"1", "5"},      // HSA -> Name
+// 			},
+// 		},
+// 	}
+// 	ctx := context.Background()
+// 	for _, test := range tests {
+// 		t.Run(test.Name, func(t *testing.T) {
+// 			b, err := backends.Get("inmem", nil, nil)
+// 			if err != nil {
+// 				t.Fatalf("Could not instantiate testing backend: %v", err)
+// 			}
+// 			for _, p := range test.InPkg {
+// 				if _, err := b.IngestPackage(ctx, *p); err != nil {
+// 					t.Fatalf("Could not ingest package: %v", err)
+// 				}
+// 			}
+// 			for _, s := range test.InSrc {
+// 				if _, err := b.IngestSource(ctx, *s); err != nil {
+// 					t.Fatalf("Could not ingest source: %v", err)
+// 				}
+// 			}
+// 			for _, o := range test.Calls {
+// 				if _, err := b.IngestHasSourceAt(ctx, *o.Pkg, *o.Match, *o.Src, *o.HSA); err != nil {
+// 					t.Fatalf("Could not ingest HasSourceAt: %v", err)
+// 				}
+// 			}
+// 			for q, r := range test.ExpNeighbors {
+// 				got, err := b.Neighbors(ctx, q, nil)
+// 				if err != nil {
+// 					t.Fatalf("Could not query neighbors: %s", err)
+// 				}
+// 				gotIDs := convNodes(got)
+// 				slices.Sort(r)
+// 				slices.Sort(gotIDs)
+// 				if diff := cmp.Diff(r, gotIDs); diff != "" {
+// 					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+// 				}
+// 			}
+// 		})
+// 	}
+// }

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -80,6 +80,7 @@ type Backend interface {
 	IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) (*model.HasSbom, error)
 	IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error)
 	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error)
+	IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error)
 	IngestHasMetadata(ctx context.Context, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, hasMetadata model.HasMetadataInputSpec) (*model.HasMetadata, error)
 	IngestBulkHasMetadata(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, hasMetadataList []*model.HasMetadataInputSpec) ([]string, error)
 	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, equalArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (*model.HashEqual, error)

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -17,7 +17,6 @@ package inmem
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -58,7 +57,16 @@ func (n *srcMapLink) BuildModelNode(c *demoClient) (model.Node, error) {
 // Ingest HasSourceAt
 
 func (c *demoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAts"))
+	var modelHasMetadataIDs []string
+
+	for i := range hasSourceAts {
+		hasMetadata, err := c.IngestHasSourceAt(ctx, *pkgs[i], *pkgMatchType, *sources[i], *hasSourceAts[i])
+		if err != nil {
+			return nil, gqlerror.Errorf("IngestHasSourceAt failed with err: %v", err)
+		}
+		modelHasMetadataIDs = append(modelHasMetadataIDs, hasMetadata.ID)
+	}
+	return modelHasMetadataIDs, nil
 }
 
 func (c *demoClient) IngestHasSourceAt(ctx context.Context, packageArg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {

--- a/pkg/assembler/backends/inmem/hasSourceAt.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt.go
@@ -17,6 +17,7 @@ package inmem
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -55,6 +56,11 @@ func (n *srcMapLink) BuildModelNode(c *demoClient) (model.Node, error) {
 }
 
 // Ingest HasSourceAt
+
+func (c *demoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestHasSourceAts"))
+}
+
 func (c *demoClient) IngestHasSourceAt(ctx context.Context, packageArg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
 	return c.ingestHasSourceAt(ctx, packageArg, pkgMatchType, source, hasSourceAt, true)
 }

--- a/pkg/assembler/backends/inmem/hasSourceAt_test.go
+++ b/pkg/assembler/backends/inmem/hasSourceAt_test.go
@@ -538,6 +538,258 @@ func TestHasSourceAt(t *testing.T) {
 	}
 }
 
+func TestIngestHasSourceAts(t *testing.T) {
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Pkgs  []*model.PkgInputSpec
+		Srcs  []*model.SourceInputSpec
+		Match *model.MatchFlags
+		HSAs  []*model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		Query        *model.HasSourceAtSpec
+		ExpHSA       []*model.HasSourceAt
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1},
+					Srcs: []*model.SourceInputSpec{s1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       p1out,
+					Source:        s1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "HappyPath All Versions",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1},
+					Srcs: []*model.SourceInputSpec{s1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       p1outName,
+					Source:        s1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Ingest Same Twice",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1, p1},
+					Srcs: []*model.SourceInputSpec{s1, s1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       p1out,
+					Source:        s1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{p1, p2},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1, p2},
+					Srcs: []*model.SourceInputSpec{s1, s1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Version: ptrfrom.String("2.11.1"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       p2out,
+					Source:        s1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1, s2},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1, p1},
+					Srcs: []*model.SourceInputSpec{s1, s2},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							Justification: "test justification",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Source: &model.SourceSpec{
+					Name: ptrfrom.String("myrepo"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:       p1out,
+					Source:        s1out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{p1},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Pkgs: []*model.PkgInputSpec{p1, p1},
+					Srcs: []*model.SourceInputSpec{s1, s1},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							KnownSince: time.Unix(1e9, 0),
+						},
+						{
+							KnownSince: testTime,
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				KnownSince: &testTime,
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:    p1out,
+					Source:     s1out,
+					KnownSince: testTime,
+				},
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := backends.Get("inmem", nil, nil)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.IngestHasSourceAts(ctx, o.Pkgs, o.Match, o.Srcs, o.HSAs)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+			}
+			got, err := b.HasSourceAt(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestHasSourceAtNeighbors(t *testing.T) {
 	type call struct {
 		Pkg   *model.PkgInputSpec

--- a/pkg/assembler/backends/neo4j/hasSourceAt.go
+++ b/pkg/assembler/backends/neo4j/hasSourceAt.go
@@ -159,5 +159,9 @@ func setHasSourceAtValues(sb *strings.Builder, hasSourceAtSpec *model.HasSourceA
 }
 
 func (c *neo4jClient) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (*model.HasSourceAt, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAt - IngestHasSourceAt"))
+	panic(fmt.Errorf("not implemented: IngestHasSourceAt"))
+}
+
+func (c *neo4jClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestHasSourceAts"))
 }

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -7403,15 +7403,6 @@ func (v *HasSourceAtInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns HasSourceAtInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 
-// HasSourceAtResponse is returned by HasSourceAt on success.
-type HasSourceAtResponse struct {
-	// Adds a certification that a package (PackageName or PackageVersion) is built from the source. The returned ID can be empty string.
-	IngestHasSourceAt string `json:"ingestHasSourceAt"`
-}
-
-// GetIngestHasSourceAt returns HasSourceAtResponse.IngestHasSourceAt, and is useful for accessing the field via an interface.
-func (v *HasSourceAtResponse) GetIngestHasSourceAt() string { return v.IngestHasSourceAt }
-
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
 	Justification string `json:"justification"`
@@ -7463,6 +7454,24 @@ type IngestBuildersResponse struct {
 
 // GetIngestBuilders returns IngestBuildersResponse.IngestBuilders, and is useful for accessing the field via an interface.
 func (v *IngestBuildersResponse) GetIngestBuilders() []string { return v.IngestBuilders }
+
+// IngestHasSourceAtResponse is returned by IngestHasSourceAt on success.
+type IngestHasSourceAtResponse struct {
+	// Adds a certification that a package (PackageName or PackageVersion) is built from the source. The returned ID can be empty string.
+	IngestHasSourceAt string `json:"ingestHasSourceAt"`
+}
+
+// GetIngestHasSourceAt returns IngestHasSourceAtResponse.IngestHasSourceAt, and is useful for accessing the field via an interface.
+func (v *IngestHasSourceAtResponse) GetIngestHasSourceAt() string { return v.IngestHasSourceAt }
+
+// IngestHasSourceAtsResponse is returned by IngestHasSourceAts on success.
+type IngestHasSourceAtsResponse struct {
+	// Bulk ingestion of certifications that a package (PackageName or PackageVersion) is built from the source. The returned array of IDs can be a an array of empty string.
+	IngestHasSourceAts []string `json:"ingestHasSourceAts"`
+}
+
+// GetIngestHasSourceAts returns IngestHasSourceAtsResponse.IngestHasSourceAts, and is useful for accessing the field via an interface.
+func (v *IngestHasSourceAtsResponse) GetIngestHasSourceAts() []string { return v.IngestHasSourceAts }
 
 // IngestHashEqualResponse is returned by IngestHashEqual on success.
 type IngestHashEqualResponse struct {
@@ -21369,26 +21378,6 @@ func (v *__HasSBOMPkgsInput) GetPkgs() []PkgInputSpec { return v.Pkgs }
 // GetHasSBOMs returns __HasSBOMPkgsInput.HasSBOMs, and is useful for accessing the field via an interface.
 func (v *__HasSBOMPkgsInput) GetHasSBOMs() []HasSBOMInputSpec { return v.HasSBOMs }
 
-// __HasSourceAtInput is used internally by genqlient
-type __HasSourceAtInput struct {
-	Pkg          PkgInputSpec         `json:"pkg"`
-	PkgMatchType MatchFlags           `json:"pkgMatchType"`
-	Source       SourceInputSpec      `json:"source"`
-	HasSourceAt  HasSourceAtInputSpec `json:"hasSourceAt"`
-}
-
-// GetPkg returns __HasSourceAtInput.Pkg, and is useful for accessing the field via an interface.
-func (v *__HasSourceAtInput) GetPkg() PkgInputSpec { return v.Pkg }
-
-// GetPkgMatchType returns __HasSourceAtInput.PkgMatchType, and is useful for accessing the field via an interface.
-func (v *__HasSourceAtInput) GetPkgMatchType() MatchFlags { return v.PkgMatchType }
-
-// GetSource returns __HasSourceAtInput.Source, and is useful for accessing the field via an interface.
-func (v *__HasSourceAtInput) GetSource() SourceInputSpec { return v.Source }
-
-// GetHasSourceAt returns __HasSourceAtInput.HasSourceAt, and is useful for accessing the field via an interface.
-func (v *__HasSourceAtInput) GetHasSourceAt() HasSourceAtInputSpec { return v.HasSourceAt }
-
 // __IngestArtifactInput is used internally by genqlient
 type __IngestArtifactInput struct {
 	Artifact ArtifactInputSpec `json:"artifact"`
@@ -21420,6 +21409,46 @@ type __IngestBuildersInput struct {
 
 // GetBuilders returns __IngestBuildersInput.Builders, and is useful for accessing the field via an interface.
 func (v *__IngestBuildersInput) GetBuilders() []BuilderInputSpec { return v.Builders }
+
+// __IngestHasSourceAtInput is used internally by genqlient
+type __IngestHasSourceAtInput struct {
+	Pkg          PkgInputSpec         `json:"pkg"`
+	PkgMatchType MatchFlags           `json:"pkgMatchType"`
+	Source       SourceInputSpec      `json:"source"`
+	HasSourceAt  HasSourceAtInputSpec `json:"hasSourceAt"`
+}
+
+// GetPkg returns __IngestHasSourceAtInput.Pkg, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtInput) GetPkg() PkgInputSpec { return v.Pkg }
+
+// GetPkgMatchType returns __IngestHasSourceAtInput.PkgMatchType, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtInput) GetPkgMatchType() MatchFlags { return v.PkgMatchType }
+
+// GetSource returns __IngestHasSourceAtInput.Source, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtInput) GetSource() SourceInputSpec { return v.Source }
+
+// GetHasSourceAt returns __IngestHasSourceAtInput.HasSourceAt, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtInput) GetHasSourceAt() HasSourceAtInputSpec { return v.HasSourceAt }
+
+// __IngestHasSourceAtsInput is used internally by genqlient
+type __IngestHasSourceAtsInput struct {
+	Pkgs         []PkgInputSpec         `json:"pkgs"`
+	PkgMatchType MatchFlags             `json:"pkgMatchType"`
+	Sources      []SourceInputSpec      `json:"sources"`
+	HasSourceAts []HasSourceAtInputSpec `json:"hasSourceAts"`
+}
+
+// GetPkgs returns __IngestHasSourceAtsInput.Pkgs, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtsInput) GetPkgs() []PkgInputSpec { return v.Pkgs }
+
+// GetPkgMatchType returns __IngestHasSourceAtsInput.PkgMatchType, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtsInput) GetPkgMatchType() MatchFlags { return v.PkgMatchType }
+
+// GetSources returns __IngestHasSourceAtsInput.Sources, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtsInput) GetSources() []SourceInputSpec { return v.Sources }
+
+// GetHasSourceAts returns __IngestHasSourceAtsInput.HasSourceAts, and is useful for accessing the field via an interface.
+func (v *__IngestHasSourceAtsInput) GetHasSourceAts() []HasSourceAtInputSpec { return v.HasSourceAts }
 
 // __IngestHashEqualInput is used internally by genqlient
 type __IngestHashEqualInput struct {
@@ -23532,45 +23561,6 @@ func HasSBOMPkgs(
 	return &data, err
 }
 
-// The query or mutation executed by HasSourceAt.
-const HasSourceAt_Operation = `
-mutation HasSourceAt ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
-	ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt)
-}
-`
-
-func HasSourceAt(
-	ctx context.Context,
-	client graphql.Client,
-	pkg PkgInputSpec,
-	pkgMatchType MatchFlags,
-	source SourceInputSpec,
-	hasSourceAt HasSourceAtInputSpec,
-) (*HasSourceAtResponse, error) {
-	req := &graphql.Request{
-		OpName: "HasSourceAt",
-		Query:  HasSourceAt_Operation,
-		Variables: &__HasSourceAtInput{
-			Pkg:          pkg,
-			PkgMatchType: pkgMatchType,
-			Source:       source,
-			HasSourceAt:  hasSourceAt,
-		},
-	}
-	var err error
-
-	var data HasSourceAtResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
 // The query or mutation executed by IngestArtifact.
 const IngestArtifact_Operation = `
 mutation IngestArtifact ($artifact: ArtifactInputSpec!) {
@@ -23692,6 +23682,84 @@ func IngestBuilders(
 	var err error
 
 	var data IngestBuildersResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IngestHasSourceAt.
+const IngestHasSourceAt_Operation = `
+mutation IngestHasSourceAt ($pkg: PkgInputSpec!, $pkgMatchType: MatchFlags!, $source: SourceInputSpec!, $hasSourceAt: HasSourceAtInputSpec!) {
+	ingestHasSourceAt(pkg: $pkg, pkgMatchType: $pkgMatchType, source: $source, hasSourceAt: $hasSourceAt)
+}
+`
+
+func IngestHasSourceAt(
+	ctx context.Context,
+	client graphql.Client,
+	pkg PkgInputSpec,
+	pkgMatchType MatchFlags,
+	source SourceInputSpec,
+	hasSourceAt HasSourceAtInputSpec,
+) (*IngestHasSourceAtResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestHasSourceAt",
+		Query:  IngestHasSourceAt_Operation,
+		Variables: &__IngestHasSourceAtInput{
+			Pkg:          pkg,
+			PkgMatchType: pkgMatchType,
+			Source:       source,
+			HasSourceAt:  hasSourceAt,
+		},
+	}
+	var err error
+
+	var data IngestHasSourceAtResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IngestHasSourceAts.
+const IngestHasSourceAts_Operation = `
+mutation IngestHasSourceAts ($pkgs: [PkgInputSpec!]!, $pkgMatchType: MatchFlags!, $sources: [SourceInputSpec!]!, $hasSourceAts: [HasSourceAtInputSpec!]!) {
+	ingestHasSourceAts(pkgs: $pkgs, pkgMatchType: $pkgMatchType, sources: $sources, hasSourceAts: $hasSourceAts)
+}
+`
+
+func IngestHasSourceAts(
+	ctx context.Context,
+	client graphql.Client,
+	pkgs []PkgInputSpec,
+	pkgMatchType MatchFlags,
+	sources []SourceInputSpec,
+	hasSourceAts []HasSourceAtInputSpec,
+) (*IngestHasSourceAtsResponse, error) {
+	req := &graphql.Request{
+		OpName: "IngestHasSourceAts",
+		Query:  IngestHasSourceAts_Operation,
+		Variables: &__IngestHasSourceAtsInput{
+			Pkgs:         pkgs,
+			PkgMatchType: pkgMatchType,
+			Sources:      sources,
+			HasSourceAts: hasSourceAts,
+		},
+	}
+	var err error
+
+	var data IngestHasSourceAtsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/helpers/assembler.go
+++ b/pkg/assembler/clients/helpers/assembler.go
@@ -286,7 +286,7 @@ func ingestVulnEqual(ctx context.Context, client graphql.Client, ve assembler.Vu
 }
 
 func hasSourceAt(ctx context.Context, client graphql.Client, hsa assembler.HasSourceAtIngest) error {
-	_, err := model.HasSourceAt(ctx, client, *hsa.Pkg, hsa.PkgMatchFlag, *hsa.Src, *hsa.HasSourceAt)
+	_, err := model.IngestHasSourceAt(ctx, client, *hsa.Pkg, hsa.PkgMatchFlag, *hsa.Src, *hsa.HasSourceAt)
 	return err
 }
 

--- a/pkg/assembler/clients/operations/hasSourceAt.graphql
+++ b/pkg/assembler/clients/operations/hasSourceAt.graphql
@@ -17,7 +17,7 @@
 
 # Defines the GraphQL operations to ingest that a package (either at the package version or package name level) has the specified source into GUAC
 
-mutation HasSourceAt(
+mutation IngestHasSourceAt(
   $pkg: PkgInputSpec!
   $pkgMatchType: MatchFlags!
   $source: SourceInputSpec!
@@ -28,5 +28,22 @@ mutation HasSourceAt(
     pkgMatchType: $pkgMatchType
     source: $source
     hasSourceAt: $hasSourceAt
+  )
+}
+
+
+# Defines the GraphQL operations to bulk ingest that a package (either at the package version or package name level) has the specified source into GUAC
+
+mutation IngestHasSourceAts(
+  $pkgs: [PkgInputSpec!]!
+  $pkgMatchType: MatchFlags!
+  $sources: [SourceInputSpec!]!
+  $hasSourceAts: [HasSourceAtInputSpec!]!
+) {
+  ingestHasSourceAts(
+    pkgs: $pkgs
+    pkgMatchType: $pkgMatchType
+    sources: $sources
+    hasSourceAts: $hasSourceAts
   )
 }

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -42,6 +42,7 @@ type MutationResolver interface {
 	IngestSlsa(ctx context.Context, subject model.ArtifactInputSpec, builtFrom []*model.ArtifactInputSpec, builtBy model.BuilderInputSpec, slsa model.SLSAInputSpec) (string, error)
 	IngestSLSAs(ctx context.Context, subjects []*model.ArtifactInputSpec, builtFromList [][]*model.ArtifactInputSpec, builtByList []*model.BuilderInputSpec, slsaList []*model.SLSAInputSpec) ([]string, error)
 	IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) (string, error)
+	IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error)
 	IngestHashEqual(ctx context.Context, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) (string, error)
 	IngestHashEquals(ctx context.Context, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) ([]string, error)
 	IngestDependency(ctx context.Context, pkg model.PkgInputSpec, depPkg model.PkgInputSpec, depPkgMatchType model.MatchFlags, dependency model.IsDependencyInputSpec) (string, error)
@@ -703,6 +704,48 @@ func (ec *executionContext) field_Mutation_ingestHasSourceAt_args(ctx context.Co
 		}
 	}
 	args["hasSourceAt"] = arg3
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ingestHasSourceAts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*model.PkgInputSpec
+	if tmp, ok := rawArgs["pkgs"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgs"))
+		arg0, err = ec.unmarshalNPkgInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkgs"] = arg0
+	var arg1 model.MatchFlags
+	if tmp, ok := rawArgs["pkgMatchType"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgMatchType"))
+		arg1, err = ec.unmarshalNMatchFlags2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐMatchFlags(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pkgMatchType"] = arg1
+	var arg2 []*model.SourceInputSpec
+	if tmp, ok := rawArgs["sources"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sources"))
+		arg2, err = ec.unmarshalNSourceInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐSourceInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["sources"] = arg2
+	var arg3 []*model.HasSourceAtInputSpec
+	if tmp, ok := rawArgs["hasSourceAts"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hasSourceAts"))
+		arg3, err = ec.unmarshalNHasSourceAtInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtInputSpecᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["hasSourceAts"] = arg3
 	return args, nil
 }
 
@@ -3248,6 +3291,61 @@ func (ec *executionContext) fieldContext_Mutation_ingestHasSourceAt(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_ingestHasSourceAt_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_ingestHasSourceAts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_ingestHasSourceAts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IngestHasSourceAts(rctx, fc.Args["pkgs"].([]*model.PkgInputSpec), fc.Args["pkgMatchType"].(model.MatchFlags), fc.Args["sources"].([]*model.SourceInputSpec), fc.Args["hasSourceAts"].([]*model.HasSourceAtInputSpec))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_ingestHasSourceAts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_ingestHasSourceAts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6753,6 +6851,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "ingestHasSourceAt":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_ingestHasSourceAt(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ingestHasSourceAts":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_ingestHasSourceAts(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -637,6 +637,28 @@ func (ec *executionContext) unmarshalNHasSourceAtInputSpec2githubᚗcomᚋguacse
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNHasSourceAtInputSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtInputSpecᚄ(ctx context.Context, v interface{}) ([]*model.HasSourceAtInputSpec, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.HasSourceAtInputSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNHasSourceAtInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtInputSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNHasSourceAtInputSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtInputSpec(ctx context.Context, v interface{}) (*model.HasSourceAtInputSpec, error) {
+	res, err := ec.unmarshalInputHasSourceAtInputSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNHasSourceAtSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐHasSourceAtSpec(ctx context.Context, v interface{}) (model.HasSourceAtSpec, error) {
 	res, err := ec.unmarshalInputHasSourceAtSpec(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -200,6 +200,7 @@ type ComplexityRoot struct {
 		IngestHasSBOMs                  func(childComplexity int, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) int
 		IngestHasSbom                   func(childComplexity int, subject model.PackageOrArtifactInput, hasSbom model.HasSBOMInputSpec) int
 		IngestHasSourceAt               func(childComplexity int, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, hasSourceAt model.HasSourceAtInputSpec) int
+		IngestHasSourceAts              func(childComplexity int, pkgs []*model.PkgInputSpec, pkgMatchType model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) int
 		IngestHashEqual                 func(childComplexity int, artifact model.ArtifactInputSpec, otherArtifact model.ArtifactInputSpec, hashEqual model.HashEqualInputSpec) int
 		IngestHashEquals                func(childComplexity int, artifacts []*model.ArtifactInputSpec, otherArtifacts []*model.ArtifactInputSpec, hashEquals []*model.HashEqualInputSpec) int
 		IngestLicense                   func(childComplexity int, license *model.LicenseInputSpec) int
@@ -1296,6 +1297,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.IngestHasSourceAt(childComplexity, args["pkg"].(model.PkgInputSpec), args["pkgMatchType"].(model.MatchFlags), args["source"].(model.SourceInputSpec), args["hasSourceAt"].(model.HasSourceAtInputSpec)), true
+
+	case "Mutation.ingestHasSourceAts":
+		if e.complexity.Mutation.IngestHasSourceAts == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ingestHasSourceAts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IngestHasSourceAts(childComplexity, args["pkgs"].([]*model.PkgInputSpec), args["pkgMatchType"].(model.MatchFlags), args["sources"].([]*model.SourceInputSpec), args["hasSourceAts"].([]*model.HasSourceAtInputSpec)), true
 
 	case "Mutation.ingestHashEqual":
 		if e.complexity.Mutation.IngestHashEqual == nil {
@@ -3938,6 +3951,13 @@ extend type Mutation {
     source: SourceInputSpec!
     hasSourceAt: HasSourceAtInputSpec!
   ): ID!
+  "Bulk ingestion of certifications that a package (PackageName or PackageVersion) is built from the source. The returned array of IDs can be a an array of empty string."
+  ingestHasSourceAts(
+    pkgs: [PkgInputSpec!]!
+    pkgMatchType: MatchFlags!
+    sources: [SourceInputSpec!]!
+    hasSourceAts: [HasSourceAtInputSpec!]!
+  ):[ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/hashEqual.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
@@ -6,6 +6,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -17,6 +18,11 @@ func (r *mutationResolver) IngestHasSourceAt(ctx context.Context, pkg model.PkgI
 		return "", err
 	}
 	return ingestedHasSourceAt.ID, err
+}
+
+// IngestHasSourceAts is the resolver for the ingestHasSourceAts field.
+func (r *mutationResolver) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	panic(fmt.Errorf("not implemented: IngestHasSourceAts - ingestHasSourceAts"))
 }
 
 // HasSourceAt is the resolver for the HasSourceAt field.

--- a/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers.go
@@ -6,9 +6,9 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // IngestHasSourceAt is the resolver for the ingestHasSourceAt field.
@@ -22,7 +22,14 @@ func (r *mutationResolver) IngestHasSourceAt(ctx context.Context, pkg model.PkgI
 
 // IngestHasSourceAts is the resolver for the ingestHasSourceAts field.
 func (r *mutationResolver) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
-	panic(fmt.Errorf("not implemented: IngestHasSourceAts - ingestHasSourceAts"))
+	funcName := "IngestHasSourceAts"
+	if len(pkgs) != len(sources) {
+		return []string{}, gqlerror.Errorf("%v :: uneven packages and sources for ingestion", funcName)
+	}
+	if len(pkgs) != len(hasSourceAts) {
+		return []string{}, gqlerror.Errorf("%v :: uneven packages and hasSourceAt for ingestion", funcName)
+	}
+	return r.Backend.IngestHasSourceAts(ctx, pkgs, &pkgMatchType, sources, hasSourceAts)
 }
 
 // HasSourceAt is the resolver for the HasSourceAt field.

--- a/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resolvers_test
 
 import (

--- a/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers_test.go
+++ b/pkg/assembler/graphql/resolvers/hasSourceAt.resolvers_test.go
@@ -1,0 +1,117 @@
+package resolvers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+func Test_mutationResolver_IngestHasSourceAt(t *testing.T) {
+	type fields struct {
+		Resolver *Resolver
+	}
+	type args struct {
+		ctx          context.Context
+		pkg          model.PkgInputSpec
+		pkgMatchType model.MatchFlags
+		source       model.SourceInputSpec
+		hasSourceAt  model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mutationResolver{
+				Resolver: tt.fields.Resolver,
+			}
+			got, err := r.IngestHasSourceAt(tt.args.ctx, tt.args.pkg, tt.args.pkgMatchType, tt.args.source, tt.args.hasSourceAt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mutationResolver.IngestHasSourceAt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("mutationResolver.IngestHasSourceAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mutationResolver_IngestHasSourceAts(t *testing.T) {
+	type fields struct {
+		Resolver *Resolver
+	}
+	type args struct {
+		ctx          context.Context
+		pkgs         []*model.PkgInputSpec
+		pkgMatchType model.MatchFlags
+		sources      []*model.SourceInputSpec
+		hasSourceAts []*model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mutationResolver{
+				Resolver: tt.fields.Resolver,
+			}
+			got, err := r.IngestHasSourceAts(tt.args.ctx, tt.args.pkgs, tt.args.pkgMatchType, tt.args.sources, tt.args.hasSourceAts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mutationResolver.IngestHasSourceAts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mutationResolver.IngestHasSourceAts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_queryResolver_HasSourceAt(t *testing.T) {
+	type fields struct {
+		Resolver *Resolver
+	}
+	type args struct {
+		ctx             context.Context
+		hasSourceAtSpec model.HasSourceAtSpec
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*model.HasSourceAt
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &queryResolver{
+				Resolver: tt.fields.Resolver,
+			}
+			got, err := r.HasSourceAt(tt.args.ctx, tt.args.hasSourceAtSpec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("queryResolver.HasSourceAt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("queryResolver.HasSourceAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -66,4 +66,11 @@ extend type Mutation {
     source: SourceInputSpec!
     hasSourceAt: HasSourceAtInputSpec!
   ): ID!
+  "Bulk ingestion of certifications that a package (PackageName or PackageVersion) is built from the source. The returned array of IDs can be a an array of empty string."
+  ingestHasSourceAts(
+    pkgs: [PkgInputSpec!]!
+    pkgMatchType: MatchFlags!
+    sources: [SourceInputSpec!]!
+    hasSourceAts: [HasSourceAtInputSpec!]!
+  ):[ID!]!
 }

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -994,7 +994,7 @@ func ingestHasSourceAt(ctx context.Context, client graphql.Client, graph assembl
 			return fmt.Errorf("error in ingesting src HasSourceAt: %v\n", err)
 		}
 
-		_, err = model.HasSourceAt(ctx, client, *ingest.Pkg, ingest.PkgMatchFlag, *ingest.Src, *ingest.HasSourceAt)
+		_, err = model.IngestHasSourceAt(ctx, client, *ingest.Pkg, ingest.PkgMatchFlag, *ingest.Src, *ingest.HasSourceAt)
 
 		if err != nil {
 			return fmt.Errorf("error in ingesting HasSourceAt: %v\n", err)


### PR DESCRIPTION
# Description of the PR

- Add bulk ingestion for `hasSourceAt`
- update `inmem` with unit tests
- update arango with unit tests
- update resolver with unit tests
- update bulk assembler

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
