### PR TITLE
Ent - Integration test: set postgres:15.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         ports:
           - 7687:7687
       postgres:
-        image: postgres
+        image: postgres:15.4
         env:
           POSTGRES_USER: guac
           POSTGRES_PASSWORD: guac


### PR DESCRIPTION
# Description of the PR

@pxp928 reported thet Ent backend tests are failing: https://github.com/guacsec/guac/actions/runs/6203866065/job/16845132555?pr=1280#step:7:40

I figured out that Postresql 16 has been released 2 days ago (Saturday, Sept 16th) so guac's GH Jobs started using it since the GH `postgres` service in the integration tests runs `postgres` (latest) image.
But Postresql 16 has an issue with Ent (https://github.com/ent/ent/issues/3750) which required a fix in an Ent's library, Ariga/Atlas (https://github.com/ariga/atlas/pull/2094)
So for having the fix we have to wait for Ent's PR for updating Atlas' version to be merged https://github.com/ent/ent/pull/3751 and a new Ent version to be available.

In the meantime, I've created this "workaround" PR to hardcode Postresql 15.4 for integration tests, the version we've been using so far.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
