### PR TITLE
Improve build process with dirt check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_IMAGE_NAME ?= local-organic-guac
 .DEFAULT_GOAL := build
 
 .PHONY: all
-all: test cover fmt lint build generate dirty
+all: test cover fmt lint build generate
 
 # Run the unit tests
 .PHONY: test
@@ -98,7 +98,7 @@ build_bins:
 # Build bins and copy to ./bin to align with docs
 # Separate build_bins as its own target to ensure (workaround) goreleaser finish writing dist/artifacts.json
 .PHONY: build
-build: check-goreleaser-tool-check build_bins
+build: check-goreleaser-tool-check build_bins generate dirty
 	@mkdir -p bin
 	@echo "$(shell cat dist/artifacts.json | jq '.[]| { path: .path, name: .extra.ID } | join(" ")' -r)" | xargs -n 2 sh -c 'cp $$0 ./bin/$$1'
 	@echo "\nThe guac bins are available in ./bin"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_IMAGE_NAME ?= local-organic-guac
 .DEFAULT_GOAL := build
 
 .PHONY: all
-all: test cover fmt lint build generate
+all: test cover fmt lint build generate dirty
 
 # Run the unit tests
 .PHONY: test
@@ -188,6 +188,14 @@ check-mockgen-tool-check:
 check-goreleaser-tool-check:
 	@if ! command -v goreleaser >/dev/null 2>&1; then \
 		echo "goreleaser is not installed. Please install goreleaser and try again."; \
+		exit 1; \
+	fi
+
+.PHONY: dirty
+dirty:
+	@echo "Checking for uncommitted changes"
+	@if ! git diff-index --quiet HEAD --; then \
+		echo "There are uncommitted changes. Please commit or stash them and try again."; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION

# Description of the PR

- Update Makefile to include `dirty` target
- The reason for this check is that if generate produces a different file from what is the source tree, this will catch it.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
