### PR TITLE
use github app token to trigger nightly release

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This workflow requires a GitHub Personal Access Token named PAT_NIGHTLY_RELEASE
-# to work. The token must have read/write permissions on Contents.
-# This is becuase the inbuilt GITHUB_TOKEN will not create a new workflow run -
-# see https://docs.github.com/en/actions/using-workflows/triggering-a-workflow
+# This workflow requires a GitHub App to be registered and installed at the 
+# GitHub Org or personal account level which provides the permissions needed
+# to trigger nightly releases. See details at 
+# https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow.
+# Note that the GitHub App must grant read/write permissions on Contents.
+# This is needed because the inbuilt GITHUB_TOKEN will not trigger a new workflow
+# and we don't want to independently create and manage a bot account -
+# see https://docs.github.com/en/actions/using-workflows/triggering-a-workflow.
 
 name: Nightly Release
 
@@ -38,10 +42,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # tag=v3
 
-      - name: refresh nightly tag
+      - name: Get GitHub App token
+        uses: actions/create-github-app-token@49ce228ea7cddec9f88dd09c5b7740dbac82d7ba # v1.2.1
+        id: app-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Refresh nightly tag
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github-token: ${{ secrets.PAT_NIGHTLY_RELEASE }}   # must use PAT here or the release workflow won't be triggered
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
 
             const { owner, repo } = context.repo


### PR DESCRIPTION
# Description of the PR

This PR makes modifications to the nightly release workflow to use a GitHub App installation token, as a bot, to trigger releases. This will avoid the need to independently create and manage a bot account at the guacsec org.
Though a one time registration and installation of the GitHub App is required.

See context of the solution and rationale at
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow and 
https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
