### PR TITLE
Ent - IngestHasSourceAts implementation

### DIFF
--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -78,7 +78,7 @@ func (b *EntBackend) IngestCertifyBads(ctx context.Context, subjects model.Packa
 		}
 		cb, err := b.IngestCertifyBad(ctx, subject, pkgMatchType, *certifyBads[i])
 		if err != nil {
-			return nil, gqlerror.Errorf("IngestPkgEquals failed with err: %v", err)
+			return nil, gqlerror.Errorf("IngestCertifyBads failed with err: %v", err)
 		}
 		result = append(result, cb)
 	}
@@ -110,7 +110,7 @@ func (b *EntBackend) IngestCertifyGoods(ctx context.Context, subjects model.Pack
 		}
 		cg, err := b.IngestCertifyGood(ctx, subject, pkgMatchType, *certifyGoods[i])
 		if err != nil {
-			return nil, gqlerror.Errorf("IngestPkgEquals failed with err: %v", err)
+			return nil, gqlerror.Errorf("IngestCertifyGoods failed with err: %v", err)
 		}
 		result = append(result, cg)
 	}

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -27,6 +27,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcenamespace"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcetype"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func (b *EntBackend) HasSourceAt(ctx context.Context, filter *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
@@ -74,6 +75,18 @@ func (b *EntBackend) IngestHasSourceAt(ctx context.Context, pkg model.PkgInputSp
 	}
 
 	return toModelHasSourceAt(record.Unwrap()), nil
+}
+
+func (b *EntBackend) IngestHasSourceAts(ctx context.Context, pkgs []*model.PkgInputSpec, pkgMatchType *model.MatchFlags, sources []*model.SourceInputSpec, hasSourceAts []*model.HasSourceAtInputSpec) ([]string, error) {
+	var result []string
+	for i := range hasSourceAts {
+		hsa, err := b.IngestHasSourceAt(ctx, *pkgs[i], *pkgMatchType, *sources[i], *hasSourceAts[i])
+		if err != nil {
+			return nil, gqlerror.Errorf("IngestHasSourceAts failed with err: %v", err)
+		}
+		result = append(result, hsa.ID)
+	}
+	return result, nil
 }
 
 func upsertHasSourceAt(ctx context.Context, client *ent.Tx, pkg model.PkgInputSpec, pkgMatchType model.MatchFlags, source model.SourceInputSpec, spec model.HasSourceAtInputSpec) (*ent.HasSourceAt, error) {
@@ -272,6 +285,8 @@ func toModelHasSourceAt(record *ent.HasSourceAt) *model.HasSourceAt {
 		pkg = toModelPackage(backReferencePackageVersion(record.Edges.PackageVersion))
 	} else {
 		pkg = toModelPackage(backReferencePackageName(record.Edges.AllVersions))
+		// in this case, the expected response is package name with an empty package version array
+		pkg.Namespaces[0].Names[0].Versions = []*model.PackageVersion{}
 	}
 
 	return &model.HasSourceAt{


### PR DESCRIPTION
# Description of the PR

Ent backend:

- `IngestHasSourceAts` implementation with tests (as usual tests reflect the inmem ones)
- fix typo introduced in https://github.com/guacsec/guac/pull/1295

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
