### PR TITLE
Ent - IngestArtifactID,IngestArtifactIDs implementations

### DIFF
--- a/pkg/assembler/backends/ent/backend/artifact_test.go
+++ b/pkg/assembler/backends/ent/backend/artifact_test.go
@@ -26,7 +26,7 @@ func (s *Suite) Test_IngestArtifacts() {
 	tests := []struct {
 		name           string
 		artifactInputs []*model.ArtifactInputSpec
-		want           []*model.Artifact
+		want           []string
 		wantErr        bool
 	}{{
 		name: "sha256",
@@ -40,16 +40,7 @@ func (s *Suite) Test_IngestArtifacts() {
 			Algorithm: "sha512",
 			Digest:    "374ab8f711235830769aa5f0b31ce9b72c5670074b34cb302cdafe3b606233ee92ee01e298e5701f15cc7087714cd9abd7ddb838a6e1206b3642de16d9fc9dd7",
 		}},
-		want: []*model.Artifact{{
-			Algorithm: "sha256",
-			Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
-		}, {
-			Algorithm: "sha1",
-			Digest:    "7a8f47318e4676dacb0142afa0b83029cd7befd9",
-		}, {
-			Algorithm: "sha512",
-			Digest:    "374ab8f711235830769aa5f0b31ce9b72c5670074b34cb302cdafe3b606233ee92ee01e298e5701f15cc7087714cd9abd7ddb838a6e1206b3642de16d9fc9dd7",
-		}},
+		want:    []string{"1", "2", "3"},
 		wantErr: false,
 	}}
 
@@ -58,7 +49,7 @@ func (s *Suite) Test_IngestArtifacts() {
 			be, err := GetBackend(s.Client)
 			s.NoError(err)
 
-			got, err := be.IngestArtifacts(s.Ctx, tt.artifactInputs)
+			got, err := be.IngestArtifactIDs(s.Ctx, tt.artifactInputs)
 			if (err != nil) != tt.wantErr {
 				s.T().Errorf("demoClient.IngestArtifact() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/assembler/backends/ent/backend/certify_test.go
+++ b/pkg/assembler/backends/ent/backend/certify_test.go
@@ -569,7 +569,7 @@ func (s *Suite) TestCertifyBad() {
 				}
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				}
 			}
@@ -1152,7 +1152,7 @@ func (s *Suite) TestCertifyGood() {
 				}
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				}
 			}

--- a/pkg/assembler/backends/ent/backend/hashequal_test.go
+++ b/pkg/assembler/backends/ent/backend/hashequal_test.go
@@ -467,10 +467,10 @@ func (s *Suite) TestHashEquals() {
 			}
 			artifactIDs := make([]string, len(test.InArt))
 			for i, a := range test.InArt {
-				if v, err := b.IngestArtifact(ctx, a); err != nil {
+				if v, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				} else {
-					artifactIDs[i] = v.ID
+					artifactIDs[i] = v
 				}
 			}
 

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -66,10 +66,10 @@ func (s *Suite) TestNode() {
 
 			ids := make([]string, 0, len(test.Expected))
 			for _, inA := range test.InArt {
-				if a, err := b.IngestArtifact(ctx, inA); err != nil {
+				if a, err := b.IngestArtifactID(ctx, inA); err != nil {
 					s.T().Fatalf("Could not ingest artifact: %v", err)
 				} else {
-					ids = append(ids, a.ID)
+					ids = append(ids, a)
 				}
 			}
 
@@ -112,13 +112,13 @@ func (s *Suite) TestNodes() {
 	be, err := GetBackend(s.Client)
 	s.Require().NoError(err)
 
-	v, err := be.IngestArtifact(s.Ctx, a1)
+	v, err := be.IngestArtifactID(s.Ctx, a1)
 	s.Require().NoError(err)
 
 	p, err := be.IngestPackage(s.Ctx, *p4)
 	s.Require().NoError(err)
 
-	nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
+	nodes, err := be.Nodes(s.Ctx, []string{v, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
 	s.Require().NoError(err)
 	if diff := cmp.Diff(a1out, nodes[0], ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -216,7 +216,7 @@ func (s *Suite) TestOccurrenceHappyPath() {
 	_, err = be.IngestPackage(s.Ctx, *p1)
 	s.Require().NoError(err)
 
-	_, err = be.IngestArtifact(s.Ctx, a1)
+	_, err = be.IngestArtifactID(s.Ctx, a1)
 	s.Require().NoError(err)
 
 	occ, err := be.IngestOccurrence(s.Ctx,
@@ -565,7 +565,7 @@ func (s *Suite) TestOccurrence() {
 			s.Require().NoError(err, "Could not instantiate testing backend")
 
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					s.T().Fatalf("Could not ingest artifact: %v", err)
 				}
 			}

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -474,7 +474,7 @@ func (s *Suite) Test_HasSBOM() {
 				}
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					s.T().Fatalf("Could not ingest artifact: %v", err)
 				}
 			}
@@ -714,7 +714,7 @@ func (s *Suite) TestIngestHasSBOMs() {
 				}
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				}
 			}

--- a/pkg/assembler/backends/ent/backend/search_test.go
+++ b/pkg/assembler/backends/ent/backend/search_test.go
@@ -39,7 +39,7 @@ func (s *Suite) Test_FindSoftware() {
 	}
 
 	for _, art := range []*model.ArtifactInputSpec{a1} {
-		if _, err := b.IngestArtifact(s.Ctx, art); err != nil {
+		if _, err := b.IngestArtifactID(s.Ctx, art); err != nil {
 			s.NoError(err)
 		}
 	}

--- a/pkg/assembler/backends/ent/backend/slsa_test.go
+++ b/pkg/assembler/backends/ent/backend/slsa_test.go
@@ -511,7 +511,7 @@ func (s *Suite) TestHasSLSA() {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				}
 			}
@@ -747,7 +747,7 @@ func (s *Suite) TestIngestHasSLSAs() {
 				t.Fatalf("Could not instantiate testing backend: %v", err)
 			}
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 					t.Fatalf("Could not ingest artifact: %v", err)
 				}
 			}

--- a/pkg/assembler/backends/ent/backend/software_test.go
+++ b/pkg/assembler/backends/ent/backend/software_test.go
@@ -133,7 +133,7 @@ func (s *Suite) TestIngestOccurrence_Package() {
 	_, err = be.IngestPackage(s.Ctx, *p1)
 	s.NoError(err)
 
-	_, err = be.IngestArtifact(s.Ctx, &model.ArtifactInputSpec{
+	_, err = be.IngestArtifactID(s.Ctx, &model.ArtifactInputSpec{
 		Algorithm: "sha256", Digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
 	})
 	s.NoError(err)

--- a/pkg/assembler/backends/ent/backend/vex_test.go
+++ b/pkg/assembler/backends/ent/backend/vex_test.go
@@ -843,7 +843,7 @@ package backend
 // 				}
 // 			}
 // 			for _, a := range test.InArt {
-// 				if _, err := b.IngestArtifact(ctx, a); err != nil {
+// 				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 // 					t.Fatalf("Could not ingest artifact: %a", err)
 // 				}
 // 			}
@@ -991,7 +991,7 @@ package backend
 //				}
 //			}
 //			for _, a := range test.InArt {
-//				if _, err := b.IngestArtifact(ctx, a); err != nil {
+//				if _, err := b.IngestArtifactID(ctx, a); err != nil {
 //					t.Fatalf("Could not ingest artifact: %a", err)
 //				}
 //			}


### PR DESCRIPTION
# Description of the PR

Ent backend

- `IngestArtifactID` and `IngestArtifactIDs` implementations
- `IngestArtifact` and `IngestArtifacts` removed
-  changes consistently all of the tests involved

Refers to https://github.com/guacsec/guac/issues/1198

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
