### PR TITLE
update docker manifest name in nightly releases

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -41,7 +41,7 @@ dockers:
       - "--builder={{ .Env.DOCKER_CONTEXT }}"
 
 docker_manifests:
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:nightly"
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -41,7 +41,7 @@ dockers:
       - "--builder={{ .Env.DOCKER_CONTEXT }}"
 
 docker_manifests:
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}"
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"
@@ -214,7 +214,6 @@ changelog:
       - "^test:"
 
 # Anything above this line should be identical to .goreleaser.yaml 
-# EXCEPT - dockers.docker_manifests.name_template
 # The following are specifically for nightly build
 # Without Goreleaser Pro, we have to replicate this config file for different builds
 release:


### PR DESCRIPTION
# Description of the PR

The docker manifest in the nightly releases are named [`nightly`](https://github.com/guacsec/guac/pkgs/container/guac/129561709?tag=nightly) instead of `v0-nightly` which is the release tag. This is inconsistent with `.goreleaser.yaml ` and with the expected manifest name of `v0-nightly` in the `.env` file in the nightly release compose tarball. 