### PR TITLE
fix bug in hasSLSA for arango

### DIFF
--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -144,7 +144,7 @@ func getSLSAValues(subject model.ArtifactInputSpec, builtFrom []*model.Artifact,
 	values["algorithm"] = strings.ToLower(subject.Algorithm)
 	values["digest"] = strings.ToLower(subject.Digest)
 
-	values["uri"] = strings.ToLower(builtBy.URI)
+	values["uri"] = builtBy.URI
 	// To ensure consistency, always sort the checks by key
 	predicateMap := map[string]string{}
 	var keys []string
@@ -165,7 +165,7 @@ func getSLSAValues(subject model.ArtifactInputSpec, builtFrom []*model.Artifact,
 	for _, bf := range builtFrom {
 		builtFromIDList = append(builtFromIDList, bf.ID)
 		splitID := strings.Split(bf.ID, "/")
-		builtFromKeyList = append(builtFromKeyList, splitID[0])
+		builtFromKeyList = append(builtFromKeyList, splitID[1])
 	}
 
 	values[builtFromStr] = builtFromIDList


### PR DESCRIPTION
# Description of the PR

- fix a bug in hasSLSA around the `builtFromKeyList` and `builder` query
- added new tests to ensure fix

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
