### PR TITLE
Fixed breaking change by bumping openVex to new release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nats-io/nats-server/v2 v2.9.21
 	github.com/nats-io/nats.go v1.28.0
-	github.com/openvex/go-vex v0.2.1
+	github.com/openvex/go-vex v0.2.5
 	github.com/ossf/scorecard/v4 v4.12.0
 	github.com/package-url/packageurl-go v0.1.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/openvex/go-vex v0.2.1 h1:OiZlTwYnT7jQjv68JRk+CmEcz+YAQhNQkJxg6kSkvuc=
-github.com/openvex/go-vex v0.2.1/go.mod h1:BkkoLLIZxS5D8yDKM9pe6eRDHF00H2PuqNBnOxaExz0=
+github.com/openvex/go-vex v0.2.5 h1:41utdp2rHgAGCsG+UbjmfMG5CWQxs15nGqir1eRgSrQ=
+github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
 github.com/ossf/scorecard/v4 v4.12.0 h1:fEk45FVb9/Xj6ehMQM5StmzVQvLyYtXlnjeY/EHHyr0=
 github.com/ossf/scorecard/v4 v4.12.0/go.mod h1:iIomr5tcWRa3xTseaBSgTZ3YwPCubX+4mc/5APag9S8=
 github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=

--- a/internal/testing/testdata/exampledata/open-vex-affected.json
+++ b/internal/testing/testdata/exampledata/open-vex-affected.json
@@ -1,19 +1,22 @@
 {
-  "@context": "",
-  "@id": "merged-vex-67124ea942ef30e1f42f3f2bf405fbbc4f5a56e6e87684fc5cd957212fa3e025",
-  "author": "Unknown Author",
-  "role": "Document Creator",
-  "timestamp": "2023-01-19T02:36:03.290252574-06:00",
-  "version": "",
-  "statements": [
-    {
-      "vulnerability": "CVE-1234-5678",
-      "timestamp": "2022-12-22T20:56:05-05:00",
-      "products": [
-        "pkg:apk/wolfi/bash@1.0.0"
-      ],
-      "status": "affected",
-      "action_statement": "This is a test action statement"
-    }
-  ]
+    "@context": "",
+    "@id": "merged-vex-67124ea942ef30e1f42f3f2bf405fbbc4f5a56e6e87684fc5cd957212fa3e025",
+    "author": "Unknown Author",
+    "role": "Document Creator",
+    "timestamp": "2023-01-19T02:36:03.290252574-06:00",
+    "version": 0,
+    "statements": [
+        {
+            "vulnerability": {
+               "name": "CVE-1234-5678"
+            },
+            "products": [
+                {
+                    "@id": "pkg:apk/wolfi/bash@1.0.0"
+                }
+            ],
+            "status": "affected",
+            "action_statement": "This is a test action statement"
+        }
+    ]
 }

--- a/internal/testing/testdata/exampledata/open-vex-not-affected.json
+++ b/internal/testing/testdata/exampledata/open-vex-not-affected.json
@@ -4,16 +4,20 @@
     "author": "Wolfi J. Inkinson",
     "role": "Senior VEXing Engineer",
     "timestamp": "2023-01-09T21:23:03.579712389-06:00",
-    "version": "1",
+    "version": 1,
     "statements": [
         {
-            "vulnerability": "CVE-2023-12345",
+            "vulnerability": {
+                "name": "CVE-2023-12345"
+            },
             "products": [
-                "pkg:oci/git@sha256:23a264e6e429852221a963e9f17338ba3f5796dc7086e46439a6f4482cf6e0cb"
-            ],
-            "subcomponents": [
-                "pkg:apk/alpine/git@2.38.1-r0?arch=x86_64",
-                "pkg:apk/alpine/git@2.38.1-r0?arch=ppc64le"
+                {
+                    "@id": "pkg:oci/git@sha256:23a264e6e429852221a963e9f17338ba3f5796dc7086e46439a6f4482cf6e0cb",
+                    "subcomponents": [
+                        { "@id": "pkg:apk/alpine/git@2.38.1-r0?arch=x86_64" },
+                        { "@id": "pkg:apk/alpine/git@2.38.1-r0?arch=ppc64le" }
+                    ]
+                }
             ],
             "status": "not_affected",
             "justification": "inline_mitigations_already_exist",

--- a/pkg/ingestor/parser/open_vex/parser_open_vex.go
+++ b/pkg/ingestor/parser/open_vex/parser_open_vex.go
@@ -67,7 +67,7 @@ func (c *openVEXParser) Parse(ctx context.Context, doc *processor.Document) erro
 	}
 
 	for _, s := range openVex.Statements {
-		vuln, err := helpers.CreateVulnInput(s.Vulnerability)
+		vuln, err := helpers.CreateVulnInput(string(s.Vulnerability.Name))
 		if err != nil {
 			return fmt.Errorf("failed to create vulnerability input: %w", err)
 		}
@@ -132,11 +132,11 @@ func (c *openVEXParser) generateVexIngest(vulnInput *generated.VulnerabilityInpu
 		ingest.Vulnerability = vulnInput
 
 		var err error
-		if ingest.Pkg, err = helpers.PurlToPkg(p); err != nil {
+		if ingest.Pkg, err = helpers.PurlToPkg(p.ID); err != nil {
 			return nil, err
 		}
 
-		c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, p)
+		c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, p.ID)
 
 		vi = append(vi, ingest)
 	}


### PR DESCRIPTION
# Description of the PR

* Fixes breaking changes in https://github.com/guacsec/guac/pull/1290


# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
