### PR TITLE
fix/openvex

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2190,10 +2190,11 @@ var (
 				VulnerabilityID: "cve-1234-5678",
 			},
 			VexData: &generated.VexStatementInputSpec{
-				KnownSince: parseRfc3339("2023-01-19T02:36:03.290252574-06:00"),
-				Origin:     "merged-vex-67124ea942ef30e1f42f3f2bf405fbbc4f5a56e6e87684fc5cd957212fa3e025",
-				Status:     generated.VexStatusAffected,
-				Statement:  "This is a test action statement",
+				KnownSince:       parseRfc3339("2023-01-19T02:36:03.290252574-06:00"),
+				Origin:           "merged-vex-67124ea942ef30e1f42f3f2bf405fbbc4f5a56e6e87684fc5cd957212fa3e025",
+				Status:           generated.VexStatusAffected,
+				VexJustification: generated.VexJustificationNotProvided,
+				Statement:        "This is a test action statement",
 			},
 		},
 	}

--- a/pkg/handler/processor/guesser/type_guesser.go
+++ b/pkg/handler/processor/guesser/type_guesser.go
@@ -27,6 +27,7 @@ func init() {
 	_ = RegisterDocumentTypeGuesser(&spdxTypeGuesser{}, "spdx")
 	_ = RegisterDocumentTypeGuesser(&scorecardTypeGuesser{}, "scorecard")
 	_ = RegisterDocumentTypeGuesser(&cycloneDXTypeGuesser{}, "cyclonedx")
+	_ = RegisterDocumentTypeGuesser(&openVexTypeGuesser{}, "openvex")
 	_ = RegisterDocumentTypeGuesser(&depsDevTypeGuesser{}, "deps.dev")
 	_ = RegisterDocumentTypeGuesser(&csafTypeGuesser{}, "csaf")
 }

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -34,6 +34,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor/dsse"
 	"github.com/guacsec/guac/pkg/handler/processor/guesser"
 	"github.com/guacsec/guac/pkg/handler/processor/ite6"
+	"github.com/guacsec/guac/pkg/handler/processor/open_vex"
 	"github.com/guacsec/guac/pkg/handler/processor/scorecard"
 	"github.com/guacsec/guac/pkg/handler/processor/spdx"
 	"github.com/guacsec/guac/pkg/logging"
@@ -53,6 +54,7 @@ func init() {
 	_ = RegisterDocumentProcessor(&dsse.DSSEProcessor{}, processor.DocumentDSSE)
 	_ = RegisterDocumentProcessor(&spdx.SPDXProcessor{}, processor.DocumentSPDX)
 	_ = RegisterDocumentProcessor(&csaf.CSAFProcessor{}, processor.DocumentCsaf)
+	_ = RegisterDocumentProcessor(&open_vex.OpenVEXProcessor{}, processor.DocumentOpenVEX)
 	_ = RegisterDocumentProcessor(&scorecard.ScorecardProcessor{}, processor.DocumentScorecard)
 	_ = RegisterDocumentProcessor(&cyclonedx.CycloneDXProcessor{}, processor.DocumentCycloneDX)
 	_ = RegisterDocumentProcessor(&deps_dev.DepsDev{}, processor.DocumentDepsDev)

--- a/pkg/ingestor/parser/open_vex/parser_open_vex.go
+++ b/pkg/ingestor/parser/open_vex/parser_open_vex.go
@@ -118,6 +118,8 @@ func (c *openVEXParser) generateVexIngest(vulnInput *generated.VulnerabilityInpu
 
 		if vexStatus, ok := vexStatusMap[vex.Status(status)]; ok {
 			vd.Status = vexStatus
+		} else {
+			return nil, fmt.Errorf("invalid status for openVEX: %s", status)
 		}
 
 		if vd.Status == generated.VexStatusNotAffected {
@@ -126,7 +128,11 @@ func (c *openVEXParser) generateVexIngest(vulnInput *generated.VulnerabilityInpu
 			vd.Statement = vexStatement.ActionStatement
 		}
 
-		vd.VexJustification = justificationsMap[vexStatement.Justification]
+		if just, ok := justificationsMap[vexStatement.Justification]; ok {
+			vd.VexJustification = just
+		} else {
+			vd.VexJustification = generated.VexJustificationNotProvided
+		}
 
 		ingest.VexData = &vd
 		ingest.Vulnerability = vulnInput

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -32,6 +32,7 @@ import (
 	"github.com/guacsec/guac/pkg/ingestor/parser/cyclonedx"
 	"github.com/guacsec/guac/pkg/ingestor/parser/deps_dev"
 	"github.com/guacsec/guac/pkg/ingestor/parser/dsse"
+	"github.com/guacsec/guac/pkg/ingestor/parser/open_vex"
 	"github.com/guacsec/guac/pkg/ingestor/parser/scorecard"
 	"github.com/guacsec/guac/pkg/ingestor/parser/slsa"
 	"github.com/guacsec/guac/pkg/ingestor/parser/spdx"
@@ -50,6 +51,7 @@ func init() {
 	_ = RegisterDocumentParser(scorecard.NewScorecardParser, processor.DocumentScorecard)
 	_ = RegisterDocumentParser(deps_dev.NewDepsDevParser, processor.DocumentDepsDev)
 	_ = RegisterDocumentParser(csaf.NewCsafParser, processor.DocumentCsaf)
+	_ = RegisterDocumentParser(open_vex.NewOpenVEXParser, processor.DocumentOpenVEX)
 	_ = RegisterDocumentParser(cdxVex.NewCdxVexParser, processor.DocumentCdxVex)
 }
 


### PR DESCRIPTION
# Description of the PR

add register for guesser, processor, and parser. fix unknown status and justification.

Discovered during the demo, these changes are needed in order to ingest openVEX documents from the collectors. 
`go run ./cmd/guacone collect files ../guac-data/open-vex-not-affected.json`

FYI @nathannaveen 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
