### PR TITLE
S3 collector implementation

### DIFF
--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -35,15 +35,15 @@ import (
 
 // s3Options flags for configuring the command
 type s3Options struct {
-	s3url      string // base url of the s3 to collect from
-	s3bucket   string // name of bucket to collect from
-	s3item     string // s3 item (only for non-polling behaviour)
-	region     string // AWS region, for s3/sqs configuration (defaults to us-east-1)
-	queues     string // comma-separated list of queues/topics (only for polling behaviour)
-	mp         string // message provider name (sqs or kafka, will default to kafka)
-	mpEndpoint string // endpoint for the message provider (only for polling behaviour)
-	poll       bool   // polling or non-polling behaviour? (defaults to non-polling)
-	graphqlEndpoint   string // endpoint for the graphql server
+	s3url             string                        // base url of the s3 to collect from
+	s3bucket          string                        // name of bucket to collect from
+	s3item            string                        // s3 item (only for non-polling behaviour)
+	region            string                        // AWS region, for s3/sqs configuration (defaults to us-east-1)
+	queues            string                        // comma-separated list of queues/topics (only for polling behaviour)
+	mp                string                        // message provider name (sqs or kafka, will default to kafka)
+	mpEndpoint        string                        // endpoint for the message provider (only for polling behaviour)
+	poll              bool                          // polling or non-polling behaviour? (defaults to non-polling)
+	graphqlEndpoint   string                        // endpoint for the graphql server
 	csubClientOptions csub_client.CsubClientOptions // options for the collectsub client
 }
 

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -177,7 +177,7 @@ func validateS3Opts(args []string, s3bucket string, s3item string, mp string, mp
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"s3-bucket", "s3-item", "s3-mp", "s3-mp-host", "s3-mp-port", "s3-queues", "s3-region"})
+	set, err := cli.BuildFlags([]string{"s3-bucket", "s3-item", "s3-mp", "s3-mp-host", "s3-mp-port", "s3-queues", "s3-region", "poll"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %s", err)
 		os.Exit(1)

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -1,0 +1,154 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/collector/s3"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
+)
+
+// s3Options flags for configuring the command
+type s3Options struct {
+	s3hostname string // hostname of the s3 provider
+	s3port     string // port of the s3 provider
+	region     string // AWS region, for s3/sqs configuration (defaults to us-east-1)
+	queues     string // comma-separated list of queues/topics
+	mp         string // message provider name (sqs or kafka, will default to kafka)
+	mpHostname string // hostname for the message provider
+	mpPort     string // port for the message provider
+}
+
+var s3Opts s3Options
+
+var s3Cmd = &cobra.Command{
+	Use:   "s3 [flags]",
+	Short: "listens to kafka/sqs s3 events to download documents and add them to the GUAC graph",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		s3Opts, err := validateS3Opts(s3Opts.s3hostname, s3Opts.s3port, s3Opts.mp, s3Opts.mpHostname, s3Opts.mpPort, s3Opts.queues, s3Opts.region)
+		if err != nil {
+			os.Exit(1)
+		}
+
+		s3Collector, err := s3.NewS3Collector(s3.S3CollectorConfig{
+			S3Host:              s3Opts.s3hostname,
+			S3Port:              s3Opts.s3port,
+			MessageProvider:     s3Opts.mp,
+			MessageProviderHost: s3Opts.mpHostname,
+			MessageProviderPort: s3Opts.mpPort,
+			Queues:              s3Opts.queues,
+			Region:              s3Opts.region,
+		})
+		if err != nil {
+			logger.Errorf("unable to create s3 collector: %v", err)
+			os.Exit(1)
+		}
+
+		err = collector.RegisterDocumentCollector(s3Collector, s3.S3CollectorType)
+		if err != nil {
+			logger.Errorf("unable to register s3 collector: %v\n", err)
+			os.Exit(1)
+		}
+
+		csubClient, err := csub_client.NewClient(viper.GetString("csub-addr"))
+		if err != nil {
+			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
+			csubClient = nil
+		} else {
+			defer csubClient.Close()
+		}
+
+		errFound := false
+
+		_, s3ctx := errgroup.WithContext(ctx)
+		emit := func(d *processor.Document) error {
+			err := ingestor.Ingest(s3ctx, d, viper.GetString("gql-addr"), csubClient)
+
+			if err != nil {
+				errFound = true
+				return fmt.Errorf("unable to ingest document: %w", err)
+			}
+			return nil
+		}
+
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("collector ended gracefully")
+				return true
+			}
+			logger.Errorf("collector ended with error: %v", err)
+			return false
+		}
+
+		if err := collector.Collect(ctx, emit, errHandler); err != nil {
+			logger.Fatal(err)
+		}
+
+		if errFound {
+			logger.Fatalf("completed ingestion with error")
+		} else {
+			logger.Infof("completed ingestion")
+		}
+	},
+}
+
+func validateS3Opts(s3hostname string, s3port string, mp string, mpHostname string, mpPort string, queues string, region string) (s3Options, error) {
+	var opts s3Options
+	if len(s3hostname) == 0 {
+		return opts, fmt.Errorf("expected s3 hostname")
+	}
+	if len(s3port) == 0 {
+		return opts, fmt.Errorf("expected s3 port")
+	}
+	if len(mpHostname) == 0 {
+		return opts, fmt.Errorf("expected hostname for message provider")
+	}
+	if len(mpPort) == 0 {
+		return opts, fmt.Errorf("expected port for message provider")
+	}
+	if len(queues) == 0 {
+		return opts, fmt.Errorf("expected at least one queue")
+	}
+
+	opts = s3Options{s3hostname, s3port, region, queues, mp, mpHostname, mpPort}
+
+	return opts, nil
+}
+
+func init() {
+	s3Cmd.Flags().StringVarP(&s3Opts.s3hostname, "s3-host", "", "", "hostname for s3")
+	s3Cmd.Flags().StringVarP(&s3Opts.s3port, "s3-port", "", "", "port for s3")
+	s3Cmd.Flags().StringVarP(&s3Opts.mp, "mp", "m", "", "message provider (sqs or kafka, defaults to kafka)")
+	s3Cmd.Flags().StringVarP(&s3Opts.mpHostname, "mp-host", "", "", "hostname for the message provider (sqs/kafka)")
+	s3Cmd.Flags().StringVarP(&s3Opts.mpPort, "mp-port", "", "", "port for the message provider (sqs/kafka)")
+	s3Cmd.Flags().StringVarP(&s3Opts.queues, "queues", "", "", "comma-separated list of queue/topic names")
+	s3Cmd.Flags().StringVarP(&s3Opts.region, "region", "", "us-east-1", "aws region, defaults to us-east-1")
+	collectCmd.AddCommand(s3Cmd)
+}

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -47,8 +47,6 @@ type s3Options struct {
 	poll       bool   // polling or non-polling behaviour? (defaults to non-polling)
 }
 
-var s3Opts s3Options
-
 var s3Cmd = &cobra.Command{
 	Use:   "s3 [flags] s3hostname s3port",
 	Short: "listens to kafka/sqs s3 events to download documents and add them to the GUAC graph, or directly downloads from s3",

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -67,7 +67,7 @@ var s3Cmd = &cobra.Command{
 			viper.GetString("s3-mp-port"),
 			viper.GetString("s3-queues"),
 			viper.GetString("s3-region"),
-			viper.GetBool("s3-poll"),
+			viper.GetBool("poll"),
 		)
 		if err != nil {
 			logger.Errorf("failed to validate flags: %v", err)

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -155,10 +155,6 @@ func validateS3Opts(graphqlEndpoint string, csubAddr string, csubTls bool, csubT
 		if len(queues) == 0 {
 			return opts, fmt.Errorf("expected at least one queue")
 		}
-	} else {
-		if len(s3item) == 0 {
-			return opts, fmt.Errorf("expected s3 item")
-		}
 	}
 
 	if len(s3bucket) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/regclient/regclient v0.5.3
-	github.com/regclient/regclient v0.5.1
 	github.com/segmentio/kafka-go v0.4.42
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sigstore/sigstore v1.7.4

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,21 @@ require (
 	github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/arangodb/go-velocypack v0.0.0-20200318135517-5af53c29c67e // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.11 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.13.31 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.37 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.31 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.38 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.1.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.32 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.31 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.13.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.21.1 // indirect
+	github.com/aws/smithy-go v1.14.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.7.0 // indirect
@@ -130,6 +145,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
 	github.com/owenrumney/go-sarif/v2 v2.2.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
@@ -189,6 +205,10 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/arangodb/go-driver v1.6.0
 	github.com/aws/aws-sdk-go v1.46.2
+	github.com/aws/aws-sdk-go-v2 v1.20.0
+	github.com/aws/aws-sdk-go-v2/config v1.18.32
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.1
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/gobwas/glob v0.2.3
@@ -213,6 +233,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/regclient/regclient v0.5.3
+	github.com/regclient/regclient v0.5.1
+	github.com/segmentio/kafka-go v0.4.42
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sigstore/sigstore v1.7.4
 	github.com/spdx/tools-golang v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.0 h1:Wgjft9X4W5pMeu
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.0/go.mod h1:FWNzS4+zcWAP05IF7TDYTY1ysZAzIvogxWaDT9p8fsA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.38.1 h1:mTgFVlfQT8gikc5+/HwD8UL9jnUro5MGv8n/VEYF12I=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.38.1/go.mod h1:6SOWLiobcZZshbmECRTADIRYliPL0etqFSigauQEeT0=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.24.1 h1:KbGaxApdPOT2ZWqJiQY5ApnpNhUGbGTjYiKAidlFwp8=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.24.1/go.mod h1:+phkm4aFvcM4jbsDRGoZ+mD8MMvksHF459Xpy5Z90f0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.13.1 h1:DSNpSbfEgFXRV+IfEcKE5kTbqxm+MeF5WgyeRlsLnHY=
 github.com/aws/aws-sdk-go-v2/service/sso v1.13.1/go.mod h1:TC9BubuFMVScIU+TLKamO6VZiYTkYoEHqlSQwAe2omw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.1 h1:hd0SKLMdOL/Sl6Z0np1PX9LeH2gqNtBe0MhTedA8MGI=
@@ -450,6 +452,7 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
@@ -557,6 +560,8 @@ github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/
 github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
+github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -595,6 +600,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/secure-systems-lab/go-securesystemslib v0.7.0 h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg=
 github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xeGtfIqFy7Do03K4cdCY0A/GlJLDKLHI=
+github.com/segmentio/kafka-go v0.4.42 h1:qffhBZCz4WcWyNuHEclHjIMLs2slp6mZO8px+5W5tfU=
+github.com/segmentio/kafka-go v0.4.42/go.mod h1:d0g15xPMqoUookug0OU75DhGZxXwCFxSLeJ4uphwJzg=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -680,6 +687,12 @@ github.com/xanzy/go-gitlab v0.93.0 h1:/Fy4akqKIQasZgQ2xj2xJBrEZ+iCW+iC+9qLEt19tg
 github.com/xanzy/go-gitlab v0.93.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
+github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
+github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
+github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -812,6 +825,7 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
@@ -930,6 +944,7 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -98,11 +98,14 @@ func init() {
 	// S3 flags
 	set.String("s3-host", "", "hostname for the s3 provider")
 	set.String("s3-port", "", "port for the s3 provider")
-	set.String("s3-mp", "", "message provider (sqs or kafka, defaults to kafka)")
-	set.String("s3-mp-host", "", "hostname for the message provider (sqs/kafka)")
-	set.String("s3-mp-port", "", "port for the message provider (sqs/kafka)")
+	set.String("s3-bucket", "", "bucket in the s3 provider")
+	set.String("s3-item", "", "item in the s3 provider")
+	set.String("s3-mp", "kafka", "message provider (sqs or kafka)")
+	set.String("s3-mp-host", "", "hostname for the message provider")
+	set.String("s3-mp-port", "", "port for the message provider")
 	set.String("s3-queues", "", "comma-separated list of queue/topic names")
-	set.String("s3-region", "us-east-1", "aws region, defaults to us-east-1")
+	set.String("s3-region", "us-east-1", "aws region")
+	set.Bool("s3-poll", false, "polling or non-polling behaviour")
 
 	set.VisitAll(func(f *pflag.Flag) {
 		flagStore[f.Name] = f

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -96,13 +96,11 @@ func init() {
 	set.String("gcp-credentials-path", "", "Path to the Google Cloud service account credentials json file.\nAlternatively you can set GOOGLE_APPLICATION_CREDENTIALS=<path> in your environment.")
 
 	// S3 flags
-	set.String("s3-host", "", "hostname for the s3 provider")
-	set.String("s3-port", "", "port for the s3 provider")
+	set.String("s3-url", "", "url of the s3 endpoint")
 	set.String("s3-bucket", "", "bucket in the s3 provider")
 	set.String("s3-item", "", "item in the s3 provider")
 	set.String("s3-mp", "kafka", "message provider (sqs or kafka)")
-	set.String("s3-mp-host", "", "hostname for the message provider")
-	set.String("s3-mp-port", "", "port for the message provider")
+	set.String("s3-mp-endpoint", "", "endpoint for the message provider")
 	set.String("s3-queues", "", "comma-separated list of queue/topic names")
 	set.String("s3-region", "us-east-1", "aws region")
 

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -105,7 +105,6 @@ func init() {
 	set.String("s3-mp-port", "", "port for the message provider")
 	set.String("s3-queues", "", "comma-separated list of queue/topic names")
 	set.String("s3-region", "us-east-1", "aws region")
-	set.Bool("s3-poll", false, "polling or non-polling behaviour")
 
 	set.VisitAll(func(f *pflag.Flag) {
 		flagStore[f.Name] = f

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -95,6 +95,15 @@ func init() {
 	// Google Cloud platform flags
 	set.String("gcp-credentials-path", "", "Path to the Google Cloud service account credentials json file.\nAlternatively you can set GOOGLE_APPLICATION_CREDENTIALS=<path> in your environment.")
 
+	// S3 flags
+	set.String("s3-host", "", "hostname for the s3 provider")
+	set.String("s3-port", "", "port for the s3 provider")
+	set.String("s3-mp", "", "message provider (sqs or kafka, defaults to kafka)")
+	set.String("s3-mp-host", "", "hostname for the message provider (sqs/kafka)")
+	set.String("s3-mp-port", "", "port for the message provider (sqs/kafka)")
+	set.String("s3-queues", "", "comma-separated list of queue/topic names")
+	set.String("s3-region", "us-east-1", "aws region, defaults to us-east-1")
+
 	set.VisitAll(func(f *pflag.Flag) {
 		flagStore[f.Name] = f
 	})

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -59,7 +59,7 @@ func GetDefaultBucket(hostname string, port string, region string) Bucket {
 func (d S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error loading AWS SDK config: %v", err)
+		return nil, fmt.Errorf("error loading AWS SDK config: %w", err)
 	}
 
 	addr := fmt.Sprintf("http://%s:%s/%s/", d.hostname, d.port, bucket)
@@ -77,23 +77,23 @@ func (d S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) 
 
 	resp, err := client.GetObject(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("unable to download file: %v", err)
+		return nil, fmt.Errorf("unable to download file: %w", err)
 	}
 	defer resp.Body.Close()
 
 	buf := new(bytes.Buffer)
 	n, err := io.Copy(buf, resp.Body)
 	if err != nil || n == 0 {
-		return nil, fmt.Errorf("unable to read file contents: %v", err)
+		return nil, fmt.Errorf("unable to read file contents: %w", err)
 	}
 
-	return buf.Bytes(), err
+	return buf.Bytes(), nil
 }
 
 func (d S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error loading AWS SDK config: %v", err)
+		return "", fmt.Errorf("error loading AWS SDK config: %w", err)
 	}
 
 	addr := fmt.Sprintf("http://%s:%s/%s/", d.hostname, d.port, bucket)
@@ -105,7 +105,7 @@ func (d S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (
 
 	headObject, err := client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(item)})
 	if err != nil {
-		return "", fmt.Errorf("could not get head object: %v", err)
+		return "", fmt.Errorf("could not get head object: %w", err)
 	}
 
 	if headObject.ContentEncoding == nil {

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -19,10 +19,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"io"
 )
 
 type BuildBucket interface {

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -34,7 +34,7 @@ type BucketBuilder struct {
 }
 
 func (bd *BucketBuilder) GetBucket(hostname string, port string, region string) Bucket {
-	return &S3Bucket{
+	return &s3Bucket{
 		hostname,
 		port,
 		region,
@@ -46,17 +46,17 @@ type Bucket interface {
 	GetEncoding(ctx context.Context, bucket string, item string) (string, error)
 }
 
-type S3Bucket struct {
+type s3Bucket struct {
 	hostname string
 	port     string
 	region   string
 }
 
 func GetDefaultBucket(hostname string, port string, region string) Bucket {
-	return &S3Bucket{hostname, port, region}
+	return &s3Bucket{hostname, port, region}
 }
 
-func (d *S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
+func (d *s3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS SDK config: %w", err)
@@ -90,7 +90,7 @@ func (d *S3Bucket) DownloadFile(ctx context.Context, bucket string, item string)
 	return buf.Bytes(), nil
 }
 
-func (d *S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
+func (d *s3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error loading AWS SDK config: %w", err)

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -33,8 +33,8 @@ type BuildBucket interface {
 type BucketBuilder struct {
 }
 
-func (bd BucketBuilder) GetBucket(hostname string, port string, region string) Bucket {
-	return S3Bucket{
+func (bd *BucketBuilder) GetBucket(hostname string, port string, region string) Bucket {
+	return &S3Bucket{
 		hostname,
 		port,
 		region,
@@ -53,10 +53,10 @@ type S3Bucket struct {
 }
 
 func GetDefaultBucket(hostname string, port string, region string) Bucket {
-	return S3Bucket{hostname, port, region}
+	return &S3Bucket{hostname, port, region}
 }
 
-func (d S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
+func (d *S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS SDK config: %w", err)
@@ -90,7 +90,7 @@ func (d S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) 
 	return buf.Bytes(), nil
 }
 
-func (d S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
+func (d *S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error loading AWS SDK config: %w", err)

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -1,0 +1,115 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucket
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"io"
+)
+
+type BuildBucket interface {
+	GetDownloader(hostname string, port string, region string) Bucket
+}
+
+type BucketBuilder struct {
+}
+
+func (bd BucketBuilder) GetBucket(hostname string, port string, region string) Bucket {
+	return S3Bucket{
+		hostname,
+		port,
+		region,
+	}
+}
+
+type Bucket interface {
+	DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error)
+	GetEncoding(ctx context.Context, bucket string, item string) (string, error)
+}
+
+type S3Bucket struct {
+	hostname string
+	port     string
+	region   string
+}
+
+func GetDefaultBucket(hostname string, port string, region string) Bucket {
+	return S3Bucket{hostname, port, region}
+}
+
+func (d S3Bucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error loading AWS SDK config: %v", err)
+	}
+
+	addr := fmt.Sprintf("http://%s:%s/%s/", d.hostname, d.port, bucket)
+	cfg.Region = d.region
+
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(addr)
+	})
+
+	// Create a GetObjectInput with the bucket name and object key.
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(item),
+	}
+
+	resp, err := client.GetObject(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("unable to download file: %v", err)
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	n, err := io.Copy(buf, resp.Body)
+	if err != nil || n == 0 {
+		return nil, fmt.Errorf("unable to read file contents: %v", err)
+	}
+
+	return buf.Bytes(), err
+}
+
+func (d S3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("error loading AWS SDK config: %v", err)
+	}
+
+	addr := fmt.Sprintf("http://%s:%s/%s/", d.hostname, d.port, bucket)
+	cfg.Region = d.region
+
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(addr)
+	})
+
+	headObject, err := client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(item)})
+	if err != nil {
+		return "", fmt.Errorf("could not get head object: %v", err)
+	}
+
+	if headObject.ContentEncoding == nil {
+		return "", nil
+	}
+
+	return *headObject.ContentEncoding, nil
+}

--- a/pkg/handler/collector/s3/bucket/bucket.go
+++ b/pkg/handler/collector/s3/bucket/bucket.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 type BuildBucket interface {
@@ -93,6 +94,7 @@ func (d *s3Bucket) DownloadFile(ctx context.Context, bucket string, item string)
 }
 
 func (d *s3Bucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
+	logger := logging.FromContext(ctx)
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error loading AWS SDK config: %w", err)
@@ -107,6 +109,8 @@ func (d *s3Bucket) GetEncoding(ctx context.Context, bucket string, item string) 
 			o.Region = d.region
 		}
 	})
+
+	logger.Infof("Downloading document %v from bucket %v", item, bucket)
 
 	headObject, err := client.HeadObject(context.Background(), &s3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(item)})
 	if err != nil {

--- a/pkg/handler/collector/s3/bucket/encoding.go
+++ b/pkg/handler/collector/s3/bucket/encoding.go
@@ -21,18 +21,12 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
-const (
-	BZIP2   = "BZIP2"
-	ZSTD    = "ZSTD"
-	UNKNOWN = "UNKNOWN"
-)
-
 func ExtractEncoding(encoding string, filename string) processor.EncodingType {
 	switch encoding {
-	case BZIP2:
-		return BZIP2
-	case ZSTD:
-		return ZSTD
+	case "BZIP2":
+		return processor.EncodingBzip2
+	case "ZSTD":
+		return processor.EncodingZstd
 	default:
 		return FromFile(filename)
 	}
@@ -43,10 +37,10 @@ func FromFile(file string) processor.EncodingType {
 	extension := strs[len(strs)-1]
 	switch extension {
 	case "bz2":
-		return BZIP2
+		return processor.EncodingBzip2
 	case "zst":
-		return ZSTD
+		return processor.EncodingZstd
 	default:
-		return UNKNOWN
+		return processor.EncodingUnknown
 	}
 }

--- a/pkg/handler/collector/s3/bucket/encoding.go
+++ b/pkg/handler/collector/s3/bucket/encoding.go
@@ -16,8 +16,9 @@
 package bucket
 
 import (
-	"github.com/guacsec/guac/pkg/handler/processor"
 	"strings"
+
+	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
 const (

--- a/pkg/handler/collector/s3/bucket/encoding.go
+++ b/pkg/handler/collector/s3/bucket/encoding.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucket
+
+import (
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"strings"
+)
+
+const (
+	BZIP2   = "BZIP2"
+	ZSTD    = "ZSTD"
+	UNKNOWN = "UNKNOWN"
+)
+
+func ExtractEncoding(encoding string, filename string) processor.EncodingType {
+	switch encoding {
+	case BZIP2:
+		return BZIP2
+	case ZSTD:
+		return ZSTD
+	default:
+		return FromFile(filename)
+	}
+}
+
+func FromFile(file string) processor.EncodingType {
+	strs := strings.Split(file, ".")
+	extension := strs[len(strs)-1]
+	switch extension {
+	case "bz2":
+		return BZIP2
+	case "zst":
+		return ZSTD
+	default:
+		return UNKNOWN
+	}
+}

--- a/pkg/handler/collector/s3/bucket/encoding.go
+++ b/pkg/handler/collector/s3/bucket/encoding.go
@@ -22,7 +22,7 @@ import (
 )
 
 func ExtractEncoding(encoding string, filename string) processor.EncodingType {
-	switch encoding {
+	switch strings.ToUpper(encoding) {
 	case "BZIP2":
 		return processor.EncodingBzip2
 	case "ZSTD":

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -81,7 +81,7 @@ func (k *KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 
 	m, err := k.reader.ReadMessage(ctx)
 	if err != nil {
-		return &KafkaMessage{}, fmt.Errorf("error receiving message, skipping: %w\n", err)
+		return &KafkaMessage{}, fmt.Errorf("error receiving message, skipping: %w", err)
 	}
 	logger.Debugf("Message at offset %d: %s = %s\n", m.Offset, string(m.Key), string(m.Value))
 

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -68,7 +68,6 @@ func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
 		Brokers:   []string{fmt.Sprintf("%s:%s", kafkaHostname, kafkaPort)},
 		Topic:     kafkaTopic,
 		Partition: 0,
-		MaxBytes:  10e6,
 	})
 	err := kafkaProvider.reader.SetOffset(kafka.LastOffset)
 	if err != nil {

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -19,9 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/segmentio/kafka-go"
-	"strings"
 )
 
 type KafkaProvider struct {

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -82,7 +82,7 @@ func (k *KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 
 	m, err := k.reader.ReadMessage(ctx)
 	if err != nil {
-		fmt.Println(err.Error())
+		return &KafkaMessage{}, fmt.Errorf("error receiving message, skipping: %w\n", err)
 	}
 	logger.Debugf("Message at offset %d: %s = %s\n", m.Offset, string(m.Key), string(m.Value))
 

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -81,7 +81,7 @@ func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
 func (k KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	logger := logging.FromContext(ctx)
 
-	m, err := k.reader.ReadMessage(context.Background())
+	m, err := k.reader.ReadMessage(ctx)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -90,7 +90,7 @@ func (k KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	msg := KafkaMessage{}
 	err = json.Unmarshal(m.Value, &msg)
 	if err != nil {
-		return msg, fmt.Errorf("error parsing JSON: %v", err)
+		return msg, fmt.Errorf("error parsing JSON: %w", err)
 	}
 
 	return msg, err
@@ -100,7 +100,7 @@ func (k KafkaProvider) Close(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
 	if err := k.reader.Close(); err != nil {
-		logger.Errorf("failed to close reader:", err)
+		logger.Errorf("failed to close reader: %v", err)
 		return err
 	}
 

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -35,14 +35,14 @@ type KafkaMessage struct {
 	Key       string `json:"Key"`
 }
 
-func (m KafkaMessage) GetEvent() (EventName, error) {
+func (m *KafkaMessage) GetEvent() (EventName, error) {
 	if m.EventName == "s3:ObjectCreated:Put" {
 		return PUT, nil
 	}
 	return "", nil
 }
 
-func (m KafkaMessage) GetBucket() (string, error) {
+func (m *KafkaMessage) GetBucket() (string, error) {
 	info := strings.Split(m.Key, "/")
 	if len(info) < 2 {
 		return "", fmt.Errorf("invalid format of key: %s", m.Key)
@@ -50,7 +50,7 @@ func (m KafkaMessage) GetBucket() (string, error) {
 	return info[0], nil
 }
 
-func (m KafkaMessage) GetItem() (string, error) {
+func (m *KafkaMessage) GetItem() (string, error) {
 	info := strings.Split(m.Key, "/")
 	if len(info) < 2 {
 		return "", fmt.Errorf("invalid format of item: %s", m.Key)
@@ -78,7 +78,7 @@ func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
 	return kafkaProvider, nil
 }
 
-func (k KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
+func (k *KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	logger := logging.FromContext(ctx)
 
 	m, err := k.reader.ReadMessage(ctx)
@@ -90,13 +90,13 @@ func (k KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	msg := KafkaMessage{}
 	err = json.Unmarshal(m.Value, &msg)
 	if err != nil {
-		return msg, fmt.Errorf("error parsing JSON: %w", err)
+		return &msg, fmt.Errorf("error parsing JSON: %w", err)
 	}
 
-	return msg, err
+	return &msg, err
 }
 
-func (k KafkaProvider) Close(ctx context.Context) error {
+func (k *KafkaProvider) Close(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
 	if err := k.reader.Close(); err != nil {

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -51,11 +51,12 @@ func (m *KafkaMessage) GetBucket() (string, error) {
 }
 
 func (m *KafkaMessage) GetItem() (string, error) {
-	info := strings.Split(m.Key, "/")
-	if len(info) < 2 {
-		return "", fmt.Errorf("invalid format of item: %s", m.Key)
+	idx := strings.Index(m.Key, "/")
+	if idx > 0 {
+		return m.Key[idx:], nil
+	} else {
+		return "", fmt.Errorf("invalid format of key: %s", m.Key)
 	}
-	return info[1], nil
 }
 
 func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -1,0 +1,107 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/segmentio/kafka-go"
+	"strings"
+)
+
+type KafkaProvider struct {
+	// Kafka-specific configuration fields
+	reader *kafka.Reader
+}
+
+type KafkaMessage struct {
+	EventName string `json:"EventName"`
+	Key       string `json:"Key"`
+}
+
+func (m KafkaMessage) GetEvent() (EventName, error) {
+	if m.EventName == "s3:ObjectCreated:Put" {
+		return PUT, nil
+	}
+	return "", nil
+}
+
+func (m KafkaMessage) GetBucket() (string, error) {
+	info := strings.Split(m.Key, "/")
+	if len(info) < 2 {
+		return "", fmt.Errorf("invalid format of key: %s", m.Key)
+	}
+	return info[0], nil
+}
+
+func (m KafkaMessage) GetItem() (string, error) {
+	info := strings.Split(m.Key, "/")
+	if len(info) < 2 {
+		return "", fmt.Errorf("invalid format of item: %s", m.Key)
+	}
+	return info[1], nil
+}
+
+func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
+	kafkaHostname := mpConfig.Host
+	kafkaPort := mpConfig.Port
+	kafkaTopic := mpConfig.Queue
+
+	kafkaProvider := KafkaProvider{}
+	kafkaProvider.reader = kafka.NewReader(kafka.ReaderConfig{
+		Brokers:   []string{fmt.Sprintf("%s:%s", kafkaHostname, kafkaPort)},
+		Topic:     kafkaTopic,
+		Partition: 0,
+		MaxBytes:  10e6,
+	})
+	err := kafkaProvider.reader.SetOffset(kafka.LastOffset)
+	if err != nil {
+		return KafkaProvider{}, err
+	}
+
+	return kafkaProvider, nil
+}
+
+func (k KafkaProvider) ReceiveMessage(ctx context.Context) (Message, error) {
+	logger := logging.FromContext(ctx)
+
+	m, err := k.reader.ReadMessage(context.Background())
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	logger.Debugf("Message at offset %d: %s = %s\n", m.Offset, string(m.Key), string(m.Value))
+
+	msg := KafkaMessage{}
+	err = json.Unmarshal(m.Value, &msg)
+	if err != nil {
+		return msg, fmt.Errorf("error parsing JSON: %v", err)
+	}
+
+	return msg, err
+}
+
+func (k KafkaProvider) Close(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+
+	if err := k.reader.Close(); err != nil {
+		logger.Errorf("failed to close reader:", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -59,13 +59,11 @@ func (m *KafkaMessage) GetItem() (string, error) {
 }
 
 func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
-	kafkaHostname := mpConfig.Host
-	kafkaPort := mpConfig.Port
 	kafkaTopic := mpConfig.Queue
 
 	kafkaProvider := KafkaProvider{}
 	kafkaProvider.reader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:   []string{fmt.Sprintf("%s:%s", kafkaHostname, kafkaPort)},
+		Brokers:   []string{mpConfig.Endpoint},
 		Topic:     kafkaTopic,
 		Partition: 0,
 	})

--- a/pkg/handler/collector/s3/messaging/message.go
+++ b/pkg/handler/collector/s3/messaging/message.go
@@ -53,15 +53,17 @@ type MpBuilder struct {
 }
 
 // GetMessageProvider Returns a MessageProvider with the given config. Defaults to Kafka provider if no MESSAGE_PROVIDER environment variable is found
-func (mb MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessageProvider, error) {
+func (mb *MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessageProvider, error) {
 	switch config.Provider {
 	case "sqs":
-		return NewSqsProvider(config)
+		provider, err := NewSqsProvider(config)
+		return &provider, err
 	default:
-		return NewKafkaProvider(config)
+		provider, err := NewKafkaProvider(config)
+		return &provider, err
 	}
 }
 
 func GetDefaultMessageProviderBuilder() MessageProviderBuilder {
-	return MpBuilder{}
+	return &MpBuilder{}
 }

--- a/pkg/handler/collector/s3/messaging/message.go
+++ b/pkg/handler/collector/s3/messaging/message.go
@@ -38,8 +38,7 @@ type MessageProvider interface {
 
 type MessageProviderConfig struct {
 	Queue    string
-	Host     string
-	Port     string
+	Endpoint string
 	Provider string
 	Region   string
 }

--- a/pkg/handler/collector/s3/messaging/message.go
+++ b/pkg/handler/collector/s3/messaging/message.go
@@ -1,0 +1,67 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import "context"
+
+type EventName string
+
+const (
+	PUT EventName = "PUT"
+)
+
+// Message A generic message related to an S3 bucket and item
+type Message interface {
+	GetEvent() (EventName, error)
+	GetBucket() (string, error)
+	GetItem() (string, error)
+}
+
+// MessageProvider Reads and returns messages from a given queue (or topic)
+type MessageProvider interface {
+	ReceiveMessage(ctx context.Context) (Message, error)
+	Close(ctx context.Context) error
+}
+
+type MessageProviderConfig struct {
+	Queue    string
+	Host     string
+	Port     string
+	Provider string
+	Region   string
+}
+
+// MessageProviderBuilder Returns a builder for a MessageProvider
+type MessageProviderBuilder interface {
+	GetMessageProvider(config MessageProviderConfig) (MessageProvider, error)
+}
+
+type MpBuilder struct {
+}
+
+// GetMessageProvider Returns a MessageProvider with the given config. Defaults to Kafka provider if no MESSAGE_PROVIDER environment variable is found
+func (mb MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessageProvider, error) {
+	switch config.Provider {
+	case "sqs":
+		return NewSqsProvider(config)
+	default:
+		return NewKafkaProvider(config)
+	}
+}
+
+func GetDefaultMessageProviderBuilder() (MessageProviderBuilder, error) {
+	return MpBuilder{}, nil
+}

--- a/pkg/handler/collector/s3/messaging/message.go
+++ b/pkg/handler/collector/s3/messaging/message.go
@@ -49,11 +49,11 @@ type MessageProviderBuilder interface {
 	GetMessageProvider(config MessageProviderConfig) (MessageProvider, error)
 }
 
-type MpBuilder struct {
+type mpBuilder struct {
 }
 
 // GetMessageProvider Returns a MessageProvider with the given config. Defaults to Kafka provider if no MESSAGE_PROVIDER environment variable is found
-func (mb *MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessageProvider, error) {
+func (mb *mpBuilder) GetMessageProvider(config MessageProviderConfig) (MessageProvider, error) {
 	switch config.Provider {
 	case "sqs":
 		provider, err := NewSqsProvider(config)
@@ -65,5 +65,5 @@ func (mb *MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessagePr
 }
 
 func GetDefaultMessageProviderBuilder() MessageProviderBuilder {
-	return &MpBuilder{}
+	return &mpBuilder{}
 }

--- a/pkg/handler/collector/s3/messaging/message.go
+++ b/pkg/handler/collector/s3/messaging/message.go
@@ -62,6 +62,6 @@ func (mb MpBuilder) GetMessageProvider(config MessageProviderConfig) (MessagePro
 	}
 }
 
-func GetDefaultMessageProviderBuilder() (MessageProviderBuilder, error) {
-	return MpBuilder{}, nil
+func GetDefaultMessageProviderBuilder() MessageProviderBuilder {
+	return MpBuilder{}
 }

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -113,9 +113,7 @@ func (s *SqsProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	// Get URL of queue
 	urlResult, err := s.client.GetQueueUrl(ctx, gQInput)
 	if err != nil {
-		fmt.Println("Got an error getting the queue URL:")
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("Got an error getting the queue URL : %w", err)
 	}
 
 	addr := urlResult.QueueUrl
@@ -155,7 +153,7 @@ func (s *SqsProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 			}
 			_, err = s.client.DeleteMessage(context.TODO(), deleteInput)
 			if err != nil {
-				logger.Errorf("error deleting message: %v\n", err)
+				return nil, fmt.Errorf("error deleting message: %w", err)
 			}
 			logger.Debugf("Message deleted from the queue")
 

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/guacsec/guac/pkg/logging"
@@ -89,7 +90,7 @@ func NewSqsProvider(mpConfig MessageProviderConfig) (SqsProvider, error) {
 
 	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
 		if mpConfig.Endpoint != "" {
-			o.EndpointResolver = sqs.EndpointResolverFromURL(mpConfig.Endpoint)
+			o.BaseEndpoint = aws.String(mpConfig.Endpoint)
 		}
 		if mpConfig.Region != "" {
 			o.Region = mpConfig.Region

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -123,8 +123,7 @@ func (s *SqsProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	default:
 		receiveOutput, err := s.client.ReceiveMessage(ctx, receiveInput)
 		if err != nil {
-			fmt.Printf("error receiving message, skipping: %v\n", err)
-			//continue
+			return &SqsMessage{}, fmt.Errorf("error receiving message, skipping: %w\n", err)
 		}
 
 		messages := receiveOutput.Messages

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -1,0 +1,156 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+type SqsProvider struct {
+	client   *sqs.Client
+	hostname string
+	port     string
+	queue    string
+}
+
+type SqsBucket struct {
+	Name string `json:"name"`
+}
+
+type SqsObject struct {
+	Key string `json:"key"`
+}
+
+type SqsS3 struct {
+	Object SqsObject `json:"object"`
+	Bucket SqsBucket `json:"bucket"`
+}
+
+type SqsRecord struct {
+	EventName string `json:"eventName"`
+	S3        SqsS3  `json:"s3"`
+}
+
+type SqsMessage struct {
+	Records []SqsRecord `json:"Records"`
+}
+
+func (m SqsMessage) GetEvent() (EventName, error) {
+	if len(m.Records) == 0 {
+		return "", fmt.Errorf("error getting event from message %s", m)
+	}
+
+	if m.Records[0].EventName == "ObjectCreated:Put" {
+		return PUT, nil
+	}
+
+	return "", nil
+}
+
+func (m SqsMessage) GetBucket() (string, error) {
+	if len(m.Records) == 0 {
+		return "", fmt.Errorf("error getting bucket from message %s", m)
+	}
+	return m.Records[0].S3.Bucket.Name, nil
+}
+
+func (m SqsMessage) GetItem() (string, error) {
+	if len(m.Records) == 0 {
+		return "", fmt.Errorf("error getting item from message %s", m)
+	}
+	return m.Records[0].S3.Object.Key, nil
+}
+
+func NewSqsProvider(mpConfig MessageProviderConfig) (SqsProvider, error) {
+	sqsHostname := mpConfig.Host
+	sqsPort := mpConfig.Port
+	sqsQueue := mpConfig.Queue
+	sqsProvider := SqsProvider{}
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return SqsProvider{}, fmt.Errorf("error loading AWS SDK config: %v", err)
+	}
+
+	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		o.BaseEndpoint = aws.String(fmt.Sprintf("http://%s:%s", sqsHostname, sqsPort))
+		o.Region = mpConfig.Region
+	})
+
+	sqsProvider.client = client
+	sqsProvider.hostname = sqsHostname
+	sqsProvider.port = sqsPort
+	sqsProvider.queue = sqsQueue
+
+	return sqsProvider, nil
+}
+
+func (s SqsProvider) ReceiveMessage(ctx context.Context) (Message, error) {
+	logger := logging.FromContext(ctx)
+
+	addr := fmt.Sprintf("http://%s:%s/000000000000/%s", s.hostname, s.port, s.queue)
+
+	// Receive messages from the queue
+	receiveInput := &sqs.ReceiveMessageInput{
+		QueueUrl:            &addr,
+		MaxNumberOfMessages: 1,
+		WaitTimeSeconds:     10,
+	}
+
+	for {
+		receiveOutput, err := s.client.ReceiveMessage(ctx, receiveInput)
+		if err != nil {
+			fmt.Printf("error receiving message, skipping: %v\n", err)
+			continue
+		}
+
+		messages := receiveOutput.Messages
+		if len(messages) > 0 {
+			message := receiveOutput.Messages[0]
+			logger.Debugf("Received message: %v\n", *message.Body)
+
+			var msg SqsMessage
+			err := json.Unmarshal([]byte(*message.Body), &msg)
+			if err != nil {
+				fmt.Println("Error:", err)
+				return SqsMessage{}, err
+			}
+
+			// Delete the received message from the queue (stardard sqs procedure)
+			deleteInput := &sqs.DeleteMessageInput{
+				QueueUrl:      &addr,
+				ReceiptHandle: message.ReceiptHandle,
+			}
+			_, err = s.client.DeleteMessage(context.TODO(), deleteInput)
+			if err != nil {
+				logger.Errorf("error deleting message: %v\n", err)
+			}
+			logger.Debugf("Message deleted from the queue")
+
+			return msg, nil
+		}
+	}
+}
+
+func (s SqsProvider) Close(ctx context.Context) error {
+	return nil
+}

--- a/pkg/handler/collector/s3/messaging/sqs.go
+++ b/pkg/handler/collector/s3/messaging/sqs.go
@@ -133,7 +133,7 @@ func (s *SqsProvider) ReceiveMessage(ctx context.Context) (Message, error) {
 	default:
 		receiveOutput, err := s.client.ReceiveMessage(ctx, receiveInput)
 		if err != nil {
-			return &SqsMessage{}, fmt.Errorf("error receiving message, skipping: %w\n", err)
+			return &SqsMessage{}, fmt.Errorf("error receiving message, skipping: %w", err)
 		}
 
 		messages := receiveOutput.Messages

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -59,12 +59,12 @@ func NewS3Collector(cfg S3CollectorConfig) *S3Collector {
 	return s3collector
 }
 
-func (s S3Collector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+func (s *S3Collector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
 
 	if s.config.Poll {
-		retrieveWithPoll(s, ctx, docChannel)
+		retrieveWithPoll(*s, ctx, docChannel)
 	} else {
-		retrieve(s, ctx, docChannel)
+		retrieve(*s, ctx, docChannel)
 	}
 
 	return nil
@@ -234,6 +234,6 @@ func getDownloader(s S3Collector) bucket.Bucket {
 	return downloader
 }
 
-func (s S3Collector) Type() string {
+func (s *S3Collector) Type() string {
 	return S3CollectorType
 }

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -113,7 +113,7 @@ func retrieveWithPoll(s S3Collector, ctx context.Context, docChannel chan<- *pro
 
 			defer func() {
 				if r := recover(); r != nil {
-					fmt.Println("recovered from panic:", r)
+					logger.Errorf("recovered from panic: %v", r)
 				}
 			}()
 

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -187,7 +187,12 @@ func retrieveWithPoll(s S3Collector, ctx context.Context, docChannel chan<- *pro
 							Source:    "S3",
 						},
 					}
-					docChannel <- doc
+					select {
+					case docChannel <- doc:
+					case <-cncCtx.Done():
+						logger.Infof("Shutting down collector for queue %s...\n", queue)
+						return
+					}
 				}
 			}
 

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -113,7 +113,7 @@ func retrieveWithPoll(s S3Collector, ctx context.Context, docChannel chan<- *pro
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Send cancellation in case of receiving SIGINT
+	// Send cancellation in case of receiving SIGINT/SIGTERM
 	go func(cancel context.CancelFunc) {
 		<-sigChan
 		cancel()
@@ -137,6 +137,7 @@ func retrieveWithPoll(s S3Collector, ctx context.Context, docChannel chan<- *pro
 				logger.Errorf("error getting message provider for queue %v: %v", queue, err)
 				return
 			}
+			defer mp.Close(cncCtx)
 
 			for {
 				select {

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -1,0 +1,175 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3
+
+import (
+	"context"
+	"fmt"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/bucket"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/messaging"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	S3CollectorType = "S3CollectorType"
+)
+
+type S3Collector struct {
+	config S3CollectorConfig
+}
+
+type S3CollectorConfig struct {
+	MessageProvider     string
+	MessageProviderHost string
+	MessageProviderPort string
+	S3Host              string
+	S3Port              string
+	Region              string // optional (defaults to us-east-1, assumes same region for s3 and sqs)
+	Queues              string
+	MpBuilder           messaging.MessageProviderBuilder // optional
+	BucketBuilder       bucket.BuildBucket               // optional
+	SigChan             chan os.Signal                   // optional
+}
+
+func NewS3Collector(cfg S3CollectorConfig) (*S3Collector, error) {
+	s3collector := &S3Collector{
+		config: cfg,
+	}
+	return s3collector, nil
+}
+
+func (s S3Collector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
+	queues := strings.Split(s.config.Queues, ",")
+	downloader := getDownloader(s)
+	sigChan := s.config.SigChan
+
+	var wg sync.WaitGroup
+	for _, queue := range queues {
+		wg.Add(1)
+
+		go func(queue string) {
+			mp, err := getMessageProvider(s, queue)
+			if err != nil {
+				logger.Errorf("error getting message provider for queue %v: %v", queue, err)
+				return
+			}
+
+			for {
+				select {
+				case <-sigChan:
+					logger.Infof("Shutting down collector for queue %s...\n", queue)
+					break
+				default:
+					m, err := mp.ReceiveMessage(ctx)
+					if err != nil {
+						logger.Infof("error while receiving message, skipping: %v\n", err)
+						continue
+					}
+
+					if e, er := m.GetEvent(); e != messaging.PUT {
+						if er != nil {
+							logger.Debugf("skipping message: %v\n", er)
+						}
+						continue
+					}
+					bucketName, err := m.GetBucket()
+					if err != nil {
+						logger.Errorf("skipping message: %v\n", err)
+						continue
+					}
+					item, err := m.GetItem()
+					if err != nil {
+						logger.Errorf("skipping message: %v\n", err)
+					}
+
+					blob, err := downloader.DownloadFile(ctx, bucketName, item)
+					if err != nil {
+						logger.Errorf("could not download item %v, skipping: %v", item, err)
+						continue
+					}
+
+					enc, err := downloader.GetEncoding(ctx, bucketName, item)
+					if err != nil {
+						logger.Errorf("could not get encoding for item %v, skipping: %v", item, err)
+						continue
+					}
+
+					doc := &processor.Document{
+						Blob:     blob,
+						Type:     processor.DocumentUnknown,
+						Format:   processor.FormatUnknown,
+						Encoding: bucket.ExtractEncoding(enc, item),
+						SourceInformation: processor.SourceInformation{
+							Collector: S3CollectorType,
+							Source:    "S3",
+						},
+					}
+					docChannel <- doc
+				}
+			}
+
+		}(queue)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func getMessageProvider(s S3Collector, queue string) (messaging.MessageProvider, error) {
+	var err error
+	var mpBuilder messaging.MessageProviderBuilder
+	if s.config.MpBuilder != nil {
+		mpBuilder = s.config.MpBuilder
+	} else {
+		mpBuilder, err = messaging.GetDefaultMessageProviderBuilder()
+		if err != nil {
+			return nil, fmt.Errorf("error getting message provider: %v", err)
+		}
+	}
+
+	mp, err := mpBuilder.GetMessageProvider(messaging.MessageProviderConfig{
+		Queue:    queue,
+		Host:     s.config.MessageProviderHost,
+		Port:     s.config.MessageProviderPort,
+		Provider: s.config.MessageProvider,
+		Region:   s.config.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating message provider: %s", err)
+	}
+
+	return mp, nil
+}
+
+func getDownloader(s S3Collector) bucket.Bucket {
+	var downloader bucket.Bucket
+	if s.config.BucketBuilder != nil {
+		downloader = s.config.BucketBuilder.GetDownloader(s.config.S3Host, s.config.S3Port, s.config.Region)
+	} else {
+		downloader = bucket.GetDefaultBucket(s.config.S3Host, s.config.S3Port, s.config.Region)
+	}
+	return downloader
+}
+
+func (s S3Collector) Type() string {
+	return S3CollectorType
+}

--- a/pkg/handler/collector/s3/s3.go
+++ b/pkg/handler/collector/s3/s3.go
@@ -18,13 +18,14 @@ package s3
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"sync"
+
 	"github.com/guacsec/guac/pkg/handler/collector/s3/bucket"
 	"github.com/guacsec/guac/pkg/handler/collector/s3/messaging"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
-	"os"
-	"strings"
-	"sync"
 )
 
 const (

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -164,8 +164,6 @@ func TestQueuesSplitPolling(t *testing.T) {
 	os.Stdout = oldStdout // restoring the real stdout
 	out := <-outC
 
-	fmt.Println(out)
-
 	if !strings.Contains(out, "returning message for queue q1") {
 		t.Errorf("message for q1 not returned")
 	}

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -20,16 +20,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/guacsec/guac/pkg/handler/collector"
-	"github.com/guacsec/guac/pkg/handler/collector/s3/bucket"
-	"github.com/guacsec/guac/pkg/handler/collector/s3/messaging"
-	"github.com/guacsec/guac/pkg/handler/processor"
 	"io"
 	"os"
 	"os/signal"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/bucket"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/messaging"
+	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
 // Test message

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -137,7 +136,7 @@ func testQueuesSplitPolling(t *testing.T, ctx context.Context) {
 	go func() {
 		err := collector.Collect(cancelCtx, em, eh)
 		if err != nil {
-			fmt.Printf("error collecting: %v", err)
+			t.Errorf("error collecting: %v", err)
 		}
 		wg.Done()
 	}()
@@ -190,7 +189,7 @@ func testNoPolling(t *testing.T, ctx context.Context) {
 
 	err := collector.Collect(ctx, em, eh)
 	if err != nil {
-		fmt.Printf("error collecting: %v", err)
+		t.Errorf("error collecting: %v", err)
 	}
 
 	if len(s) == 0 {

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -108,7 +109,7 @@ func TestQueuesSplit(t *testing.T) {
 	ctx := context.Background()
 
 	sigChan := make(chan os.Signal, 1)
-	s3Collector, _ := NewS3Collector(S3CollectorConfig{
+	s3Collector := NewS3Collector(S3CollectorConfig{
 		Queues:        "q1,q2",
 		MpBuilder:     TestMpBuilder{},
 		BucketBuilder: TestBucketBuilder{},
@@ -149,7 +150,7 @@ func TestQueuesSplit(t *testing.T) {
 		}
 	}()
 	time.Sleep(5 * time.Second)
-	signal.Notify(sigChan, os.Interrupt)
+	signal.Notify(sigChan, syscall.SIGINT)
 
 	w.Close()
 	os.Stdout = oldStdout // restoring the real stdout

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -1,0 +1,171 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/bucket"
+	"github.com/guacsec/guac/pkg/handler/collector/s3/messaging"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test message
+type TestMessage struct {
+	item   string
+	bucket string
+	event  messaging.EventName
+}
+
+func (msg TestMessage) GetEvent() (messaging.EventName, error) {
+	return msg.event, nil
+}
+
+func (msg TestMessage) GetBucket() (string, error) {
+	return msg.bucket, nil
+}
+
+func (msg TestMessage) GetItem() (string, error) {
+	return msg.item, nil
+}
+
+// Test Message Provider
+type TestProvider struct {
+	queue string
+}
+
+func NewTestProvider(queue string) TestProvider {
+	return TestProvider{queue}
+}
+
+func (t TestProvider) ReceiveMessage(context.Context) (messaging.Message, error) {
+	fmt.Printf("returning message for queue %s\n", t.queue)
+	time.Sleep(2 * time.Second)
+
+	return TestMessage{
+		item:   "item",
+		bucket: t.queue,
+		event:  messaging.PUT,
+	}, nil
+}
+
+func (t TestProvider) Close(ctx context.Context) error {
+	return nil
+}
+
+// Test Message Provider builder
+type TestMpBuilder struct {
+}
+
+func (tb TestMpBuilder) GetMessageProvider(config messaging.MessageProviderConfig) (messaging.MessageProvider, error) {
+	return NewTestProvider(config.Queue), nil
+}
+
+// Test Bucket
+type TestBucket struct {
+}
+
+func (td TestBucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
+	fmt.Printf("downloading file with bucket %s and name %s\n", bucket, item)
+	return []byte{1, 2, 3}, nil
+}
+
+func (td TestBucket) GetEncoding(ctx context.Context, bucket string, item string) (string, error) {
+	return "", nil
+}
+
+type TestBucketBuilder struct {
+}
+
+func (td TestBucketBuilder) GetDownloader(hostname string, port string, region string) bucket.Bucket {
+	return TestBucket{}
+}
+
+func TestQueuesSplit(t *testing.T) {
+	ctx := context.Background()
+
+	sigChan := make(chan os.Signal, 1)
+	s3Collector, _ := NewS3Collector(S3CollectorConfig{
+		Queues:        "q1,q2",
+		MpBuilder:     TestMpBuilder{},
+		BucketBuilder: TestBucketBuilder{},
+		SigChan:       sigChan,
+	})
+
+	if err := collector.RegisterDocumentCollector(s3Collector, S3CollectorType); err != nil &&
+		!errors.Is(err, collector.ErrCollectorOverwrite) {
+		t.Fatalf("could not register collector: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	outC := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, err := io.Copy(&buf, r)
+		if err != nil {
+			return
+		}
+		outC <- buf.String()
+	}()
+
+	var s []*processor.Document
+	em := func(d *processor.Document) error {
+		s = append(s, d)
+		return nil
+	}
+	eh := func(err error) bool {
+		return true
+	}
+
+	go func() {
+		err := collector.Collect(ctx, em, eh)
+		if err != nil {
+			fmt.Printf("error collecting: %v", err)
+		}
+	}()
+	time.Sleep(5 * time.Second)
+	signal.Notify(sigChan, os.Interrupt)
+
+	w.Close()
+	os.Stdout = oldStdout // restoring the real stdout
+	out := <-outC
+
+	fmt.Println(out)
+
+	if !strings.Contains(out, "returning message for queue q1") {
+		t.Errorf("message for q1 not returned")
+	}
+	if !strings.Contains(out, "returning message for queue q2") {
+		t.Errorf("message for q2 not returned")
+	}
+	if !strings.Contains(out, "downloading file with bucket q1 and name item") {
+		t.Errorf("not downloading from bucket q1")
+	}
+	if !strings.Contains(out, "downloading file with bucket q2 and name item") {
+		t.Errorf("not downloading from bucket q2")
+	}
+}

--- a/pkg/handler/collector/s3/s3_test.go
+++ b/pkg/handler/collector/s3/s3_test.go
@@ -84,6 +84,10 @@ func (tb *TestMpBuilder) GetMessageProvider(config messaging.MessageProviderConf
 type TestBucket struct {
 }
 
+func (td *TestBucket) ListFiles(ctx context.Context, bucket string, token *string, max int32) ([]string, *string, error) {
+	return []string{"no-poll-item"}, nil, nil
+}
+
 func (td *TestBucket) DownloadFile(ctx context.Context, bucket string, item string) ([]byte, error) {
 	return []byte("{\"key\": \"value\"}"), nil
 }


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
This PR creates a new `guacone collect` command which connects to a source of S3 "upload" events (sqs of kafka), downloads a document from a bucket whenever a message is received, and ingests it into guac.

- docker-compose files for leveraging s3/sqs/kafka infrastructure can be found [here](https://github.com/jmle/trustification-compose)
- Related to [this issue](https://github.com/guacsec/guac/issues/1020).

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
