### PR TITLE
OSV certifier: bulk ingest

### DIFF
--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -83,16 +83,12 @@ var osvCmd = &cobra.Command{
 		packageQuery := root_package.NewPackageQuery(gqlclient, 0)
 
 		totalNum := 0
+		var totalDocs []*processor.Document
 		gotErr := false
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
-
-			if err != nil {
-				gotErr = true
-				return fmt.Errorf("unable to ingest document: %v", err)
-			}
+			totalDocs = append(totalDocs, d)
 			return nil
 		}
 
@@ -127,8 +123,14 @@ var osvCmd = &cobra.Command{
 		case <-done:
 			logger.Infof("All certifiers completed")
 		}
-		cf()
 		wg.Wait()
+
+		err = ingestor.BulkIngest(ctx, totalDocs, opts.graphqlEndpoint, csubClient)
+		if err != nil {
+			gotErr = true
+			logger.Errorf("unable to ingest documents: %v", err)
+		}
+		cf()
 
 		if gotErr {
 			logger.Errorf("completed ingestion with errors")

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -125,7 +125,7 @@ var osvCmd = &cobra.Command{
 		}
 		wg.Wait()
 
-		err = ingestor.BulkIngest(ctx, totalDocs, opts.graphqlEndpoint, csubClient)
+		err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, csubClient)
 		if err != nil {
 			gotErr = true
 			logger.Errorf("unable to ingest documents: %v", err)

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -69,7 +69,7 @@ func Ingest(ctx context.Context, d *processor.Document, graphqlEndpoint string, 
 	return nil
 }
 
-func BulkIngest(ctx context.Context, docs []*processor.Document, graphqlEndpoint string, csubClient csub_client.Client) error {
+func MergedIngest(ctx context.Context, docs []*processor.Document, graphqlEndpoint string, csubClient csub_client.Client) error {
 	logger := logging.FromContext(ctx)
 	// Get pipeline of components
 	processorFunc := GetProcessor(ctx)
@@ -92,8 +92,23 @@ func BulkIngest(ctx context.Context, docs []*processor.Document, graphqlEndpoint
 			return fmt.Errorf("unable to ingest doc tree: %v", err)
 		}
 		for i := range preds {
+			predicates[0].CertifyScorecard = append(predicates[0].CertifyScorecard, preds[i].CertifyScorecard...)
+			predicates[0].IsDependency = append(predicates[0].IsDependency, preds[i].IsDependency...)
+			predicates[0].IsOccurrence = append(predicates[0].IsOccurrence, preds[i].IsOccurrence...)
+			predicates[0].HasSlsa = append(predicates[0].HasSlsa, preds[i].HasSlsa...)
 			predicates[0].CertifyVuln = append(predicates[0].CertifyVuln, preds[i].CertifyVuln...)
 			predicates[0].VulnEqual = append(predicates[0].VulnEqual, preds[i].VulnEqual...)
+			predicates[0].HasSourceAt = append(predicates[0].HasSourceAt, preds[i].HasSourceAt...)
+			predicates[0].CertifyBad = append(predicates[0].CertifyBad, preds[i].CertifyBad...)
+			predicates[0].CertifyGood = append(predicates[0].CertifyGood, preds[i].CertifyGood...)
+			predicates[0].HasSBOM = append(predicates[0].HasSBOM, preds[i].HasSBOM...)
+			predicates[0].HashEqual = append(predicates[0].HashEqual, preds[i].HashEqual...)
+			predicates[0].PkgEqual = append(predicates[0].PkgEqual, preds[i].PkgEqual...)
+			predicates[0].Vex = append(predicates[0].Vex, preds[i].Vex...)
+			predicates[0].PointOfContact = append(predicates[0].PointOfContact, preds[i].PointOfContact...)
+			predicates[0].VulnMetadata = append(predicates[0].VulnMetadata, preds[i].VulnMetadata...)
+			predicates[0].HasMetadata = append(predicates[0].HasMetadata, preds[i].HasMetadata...)
+			predicates[0].CertifyLegal = append(predicates[0].CertifyLegal, preds[i].CertifyLegal...)
 		}
 		idstrings = append(idstrings, idstrs...)
 	}


### PR DESCRIPTION
# Description of the PR

Currently the OSV certifier ingests one `CertifuVuln` (with corresponding `Package` and `Vulnerability`) one by one without fully leveraging the guac's bulk ingestion capabilities.
It looks related to invoking `ingestor.Ingest` for each `processor.Document`
I've tried to collect all the `processor.Document`s first and then create a new `ingestor.BulkIngest` func that collects all of the `assembler.IngestPredicates` (generated by `ingestorFunc`) into the 0th element of `predicates` array.

In this way, the call to `assemblerFunc` \ `GetBulkAssembler` will send all the data invoking each mutation just once.

Since I've never worked on this part of guac, I've added only `CertifyVuln` and `VulnEqual` on purpose in order to get feedback and if the approach is fine, I'll extend to other arrays within `IngestPredicates` struct

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
