### PR TITLE
psuedopause nightly release for now

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -27,7 +27,7 @@ name: Nightly Release
 on:
   workflow_dispatch: # testing only, trigger manually to test it works
   schedule:
-    - cron: '44 4 * * *'   #UTC
+    - cron: '44 4 1 1 *'   #UTC
 
 env:
   NIGHTLY_RELEASE_TAG: v0-nightly   #goreleaser enforces semver on tags

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -26,8 +26,8 @@ name: Nightly Release
 
 on:
   workflow_dispatch: # testing only, trigger manually to test it works
-  schedule:
-    - cron: '44 4 1 1 *'   #UTC
+  # schedule:
+  #   - cron: '44 4 * * *'   #UTC
 
 env:
   NIGHTLY_RELEASE_TAG: v0-nightly   #goreleaser enforces semver on tags


### PR DESCRIPTION
pseudo-Pausing nightly release in the meantime to respond to https://github.com/guacsec/guac/issues/1298

CC: @sudo-bmitch

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
