### PR TITLE
Remove version name from compose tarball.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,8 +171,8 @@ jobs:
           cp docker-compose.yml guac-compose/
           cp -r container_files guac-compose/
           sed -i s/local-organic-guac/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-compose/.env
-          tar -zcvf guac-compose-${{ github.ref_name }}.tar.gz guac-compose/
+          tar -zcvf guac-compose.tar.gz guac-compose/
           rm -rf guac-compose/
-          gh release upload ${{ github.ref_name }} guac-compose-${{ github.ref_name }}.tar.gz
-          rm guac-compose-${{ github.ref_name }}.tar.gz
+          gh release upload ${{ github.ref_name }} guac-compose.tar.gz
+          rm guac-compose.tar.gz
         shell: bash


### PR DESCRIPTION
# Description of the PR

Remove the version number from the name of the compose tarball. This makes it so that we can have a permalink to the latest release, and use that in the docs: https://docs.guac.sh/setup/#step-1-download-guac

ex:  https://github.com/guacsec/guac/releases/latest/download/guacone-linux-amd64 always will download the latest guacone. The binaries and other files don't have a version in the name.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
