### PR TITLE
update maintainers (-rgreinho)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,5 +8,4 @@
 "lumjjb", "Brandon Lum", "Google", "lumb@google.com"
 "pxp928", "Parth Patel", "Kusari", "parth@kusari.dev"
 "SantiagoTorres", "Santiago Torres", "Purdue University", "santiagotorres@purdue.edu"
-"rgreinho", "Rémy Greinhofer", "Citi", "remy.greinhofer@gmail.com"
 "jeffmendoza", "Jeff Mendoza", "Kusari", "jlm@jlm.name"


### PR DESCRIPTION
Thanks to @rgreinho for their contributions to the initial stages of GUAC. They will be stepping down from maintainership due to not being able to remain active in the project. 

In accordance to [maintainer governance](https://github.com/guacsec/guac/blob/main/GOVERNANCE.md#maintainership)