### PR TITLE
Ent - IngestOccurrences implementation

### DIFF
--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -98,9 +98,21 @@ func (b *EntBackend) IsOccurrence(ctx context.Context, query *model.IsOccurrence
 }
 
 func (b *EntBackend) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
-	// funcName := "IngestOccurrences"
-
-	return nil, nil
+	var models []*model.IsOccurrence
+	for i := range occurrences {
+		var subject model.PackageOrSourceInput
+		if len(subjects.Packages) > 0 {
+			subject = model.PackageOrSourceInput{Package: subjects.Packages[i]}
+		} else {
+			subject = model.PackageOrSourceInput{Source: subjects.Sources[i]}
+		}
+		modelOccurrence, err := b.IngestOccurrence(ctx, subject, *artifacts[i], *occurrences[i])
+		if err != nil {
+			return nil, gqlerror.Errorf("IngestOccurrences failed with element #%v with err: %v", i, err)
+		}
+		models = append(models, modelOccurrence)
+	}
+	return models, nil
 }
 
 func (b *EntBackend) IngestOccurrence(ctx context.Context,


### PR DESCRIPTION
# Description of the PR

Ent - IngestOccurrences implementation was an empty func so I've implemented it and added the related tests from the `inmem` ones.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
