### PR TITLE
Change version list to map

### DIFF
--- a/pkg/assembler/backends/inmem/helpers_test.go
+++ b/pkg/assembler/backends/inmem/helpers_test.go
@@ -1,0 +1,162 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmem
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+// helper functions to canonically compare nodes
+
+// this file is a duplicate of testhelpers_test.go -- pkg_test.go is in
+// the inmem package, so it cannot use the definitions in testhelpers_test.go
+
+////////////////////// comparison functions //////////////////////
+
+func LessPackageQualifier(a, b *model.PackageQualifier) int {
+	return cmp.Compare(a.Key+a.Value, b.Key+b.Value)
+}
+
+func LessPackageVersion(a, b *model.PackageVersion) int {
+	if res := cmp.Compare(a.Version, b.Version); res != 0 {
+		return res
+	}
+	if res := cmp.Compare(a.Subpath, b.Subpath); res != 0 {
+		return res
+	}
+
+	for i := 0; i < len(a.Qualifiers); i++ {
+		if res := LessPackageQualifier(a.Qualifiers[i], b.Qualifiers[i]); res != 0 {
+			return res
+		}
+	}
+
+	return 0
+}
+func LessName(a, b *model.PackageName) int {
+	if res := cmp.Compare(a.Name, b.Name); res != 0 {
+		return res
+	}
+	if res := len(a.Versions) - len(b.Versions); res != 0 {
+		return res
+	}
+
+	for i := 0; i < len(a.Versions); i++ {
+		if res := LessPackageVersion(a.Versions[i], b.Versions[i]); res != 0 {
+			return res
+		}
+	}
+	return 0
+}
+func LessNameSpace(a, b *model.PackageNamespace) int {
+	if res := cmp.Compare(a.Namespace, b.Namespace); res != 0 {
+		return res
+	}
+	if res := len(a.Names) - len(b.Names); res != 0 {
+		return res
+	}
+
+	for i := 0; i < len(a.Names); i++ {
+		if res := LessName(a.Names[i], b.Names[i]); res != 0 {
+			return res
+		}
+	}
+	return 0
+}
+func LessPackage(a, b *model.Package) int {
+	if res := cmp.Compare(a.Type, b.Type); res != 0 {
+		return res
+	}
+	if res := len(a.Namespaces) - len(b.Namespaces); res != 0 {
+		return res
+	}
+
+	for i := 0; i < len(a.Namespaces); i++ {
+		if res := LessNameSpace(a.Namespaces[i], b.Namespaces[i]); res != 0 {
+			return res
+		}
+	}
+	return 0
+}
+func LessPkgEquals(a, b *model.PkgEqual) int {
+	aStr := a.Justification + a.Origin + a.Collector
+	bStr := b.Justification + b.Origin + b.Collector
+
+	if res := cmp.Compare(aStr, bStr); res != 0 {
+		return res
+	}
+	if res := len(a.Packages) - len(b.Packages); res != 0 {
+		return res
+	}
+
+	for i := 0; i < len(a.Packages); i++ {
+		if res := LessPackage(a.Packages[i], b.Packages[i]); res != 0 {
+			return res
+		}
+	}
+	return 0
+}
+
+////////////////////// making canonical //////////////////////
+
+func MakeCanonicalPkgEqualSlice(s []*model.PkgEqual) {
+	for _, pe := range s {
+		MakeCanonicalPkgEquals(pe)
+	}
+	slices.SortFunc(s, LessPkgEquals)
+}
+
+func MakeCanonicalPackageSlice(s []*model.Package) {
+	for _, p := range s {
+		MakeCanonicalPackage(p)
+	}
+	slices.SortFunc(s, LessPackage)
+}
+
+func MakeCanonicalPkgEquals(n *model.PkgEqual) {
+	for _, child := range n.Packages {
+		MakeCanonicalPackage(child)
+	}
+	slices.SortFunc(n.Packages, LessPackage)
+}
+
+func MakeCanonicalPackage(n *model.Package) {
+	for _, child := range n.Namespaces {
+		MakeCanonicalNamespace(child)
+	}
+	slices.SortFunc(n.Namespaces, LessNameSpace)
+}
+
+func MakeCanonicalNamespace(n *model.PackageNamespace) {
+	for _, child := range n.Names {
+		MakeCanonicalName(child)
+	}
+	slices.SortFunc(n.Names, LessName)
+}
+
+func MakeCanonicalName(n *model.PackageName) {
+	for _, child := range n.Versions {
+		MakeCanonicalPackageVersion(child)
+	}
+	slices.SortFunc(n.Versions, LessPackageVersion)
+}
+
+func MakeCanonicalPackageVersion(n *model.PackageVersion) {
+	slices.SortFunc(n.Qualifiers, LessPackageQualifier)
+}

--- a/pkg/assembler/backends/inmem/pkgEqual_test.go
+++ b/pkg/assembler/backends/inmem/pkgEqual_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/backends"
+	"github.com/guacsec/guac/pkg/assembler/backends/inmem"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -443,13 +444,10 @@ func TestPkgEqual(t *testing.T) {
 			if err != nil {
 				return
 			}
-			// less := func(a, b *model.Package) bool { return a.Version < b.Version }
-			// for _, he := range got {
-			// 	slices.SortFunc(he.Packages, less)
-			// }
-			// for _, he := range test.ExpHE {
-			// 	slices.SortFunc(he.Packages, less)
-			// }
+
+			inmem.MakeCanonicalPkgEqualSlice(got)
+			inmem.MakeCanonicalPkgEqualSlice(test.ExpHE)
+
 			if diff := cmp.Diff(test.ExpHE, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
@@ -657,6 +655,10 @@ func TestIngestPkgEquals(t *testing.T) {
 			if err != nil {
 				return
 			}
+
+			inmem.MakeCanonicalPkgEqualSlice(got)
+			inmem.MakeCanonicalPkgEqualSlice(test.ExpHE)
+
 			if diff := cmp.Diff(test.ExpHE, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
# Description of the PR

Changes the representation of versions in the inmem database to a map instead of a list, for better performance. 

The keys of this map are created by joining the version, subpath, and sorted qualifiers of a `pkgVersionNode`, and hashing the result. 

There is no longer an order to the versions, so tests in `pkg_test.go` and `pkgEqual_test.go` didn't pass consistently. As a result I wrote some helper functions to sort all of the nested lists in the nodes. `pkg_test.go` and `pkgEqual_test.go` are in different packages (`inmem` and `inmem_test`), and I don't think that `pkg_test.go` can be easily changed to be in the `inmem_test` package, so I added the helper functions in two duplicate files. This isn't ideal, so let me know if there is a better solution to this. 

Makes progress on #1234

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged


