### PR TITLE
Fixed Race Condition in ingestor/verifier Test

### DIFF
--- a/pkg/ingestor/verifier/verifier_test.go
+++ b/pkg/ingestor/verifier/verifier_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	jsoniter "github.com/json-iterator/go"
@@ -33,6 +34,7 @@ import (
 
 var (
 	json = jsoniter.ConfigCompatibleWithStandardLibrary
+	once sync.Once
 	// Taken from: https://slsa.dev/provenance/v0.1#example
 	ite6SLSA = `
 	{
@@ -127,7 +129,10 @@ func (m *mockSigstoreVerifier) Type() VerifierType {
 
 func TestVerifyIdentity(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
-	err := RegisterVerifier(newMockSigstoreVerifier(), "sigstore")
+	var err error
+	once.Do(func() {
+		err = RegisterVerifier(newMockSigstoreVerifier(), "sigstore")
+	})
 	if err != nil {
 		t.Errorf("RegisterVerifier() failed with error: %v", err)
 	}


### PR DESCRIPTION


# Description of the PR

- Fixed the race condition bug in test
- For https://github.com/guacsec/guac/issues/1336

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
