### PR TITLE
Fixed Race Conditions for parser_dsee_test and prometheus_test

### DIFF
--- a/pkg/ingestor/parser/dsse/parser_dsse_test.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse_test.go
@@ -17,21 +17,28 @@ package dsse
 
 import (
 	"context"
+	"sync"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/mockverifier"
+	"github.com/guacsec/guac/pkg/ingestor/verifier"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
-	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/guacsec/guac/pkg/logging"
 )
 
+var once sync.Once
+
 func Test_DsseParser(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
-	err := verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
+	var err error
+	once.Do(func() {
+		err = verifier.RegisterVerifier(mockverifier.NewMockSigstoreVerifier(), "sigstore")
+	})
 	if err != nil {
 		t.Errorf("verifier.RegisterVerifier() failed with error: %v", err)
 	}

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
+
 package metrics
 
 import (


### PR DESCRIPTION

# Description of the PR

- fixed the data race condition
- skipped race condition for prometheus 
- for #1336 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
