### PR TITLE
Fix lint errors and increase golangci-lint timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 3m
+  timeout: 6m
   skip-files:
     - ".*\\.pb\\.go$"
     - "pkg/assembler/generated/.*"

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
@@ -91,9 +91,9 @@ func setupOneProvider(t *testing.T) {
 
 func randomData(t *testing.T, n int) []byte {
 	t.Helper()
-	rand.Seed(time.Now().UnixNano())
+	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	data := make([]byte, n)
-	if _, err := rand.Read(data[:]); err != nil {
+	if _, err := gen.Read(data[:]); err != nil {
 		t.Fatal(err)
 	}
 	return data


### PR DESCRIPTION
# Description of the PR

Fix the lint error introduced by #1333 and increase the timeout for golangci-lint, because it has been timing out in some runs ([lint error and timeout](https://github.com/guacsec/guac/actions/runs/6407784628) , [timeout](https://github.com/guacsec/guac/actions/runs/6397336962)). 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All CI checks are passing (tests and formatting)

