### PR TITLE
Bump github.com/nats-io/nats-server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/moby/buildkit v0.12.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nats-io/jwt/v2 v2.4.1 // indirect
+	github.com/nats-io/jwt/v2 v2.5.2 // indirect
 	github.com/nats-io/nkeys v0.4.5 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
@@ -200,7 +200,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nats-io/nats-server/v2 v2.9.21
+	github.com/nats-io/nats-server/v2 v2.10.1
 	github.com/nats-io/nats.go v1.30.1
 	github.com/openvex/go-vex v0.2.5
 	github.com/ossf/scorecard/v4 v4.12.0
@@ -214,6 +214,6 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/vektah/gqlparser/v2 v2.5.10
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -508,10 +508,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
-github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
-github.com/nats-io/nats-server/v2 v2.9.21 h1:2TBTh0UDE74eNXQmV4HofsmRSCiVN0TH2Wgrp6BD6fk=
-github.com/nats-io/nats-server/v2 v2.9.21/go.mod h1:ozqMZc2vTHcNcblOiXMWIXkf8+0lDGAi5wQcG+O1mHU=
+github.com/nats-io/jwt/v2 v2.5.2 h1:DhGH+nKt+wIkDxM6qnVSKjokq5t59AZV5HRcFW0zJwU=
+github.com/nats-io/jwt/v2 v2.5.2/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
+github.com/nats-io/nats-server/v2 v2.10.1 h1:MIJ614dhOIdo71iSzY8ln78miXwrYvlvXHUyS+XdKZQ=
+github.com/nats-io/nats-server/v2 v2.10.1/go.mod h1:3PMvMSu2cuK0J9YInRLWdFpFsswKKGUS77zVSAudRto=
 github.com/nats-io/nats.go v1.30.1 h1:o5RND+GaKgzNm2IOSLmHunWs6vH0GooAAaZZitiGJWk=
 github.com/nats-io/nats.go v1.30.1/go.mod h1:dcfhUgmQNN4GJEfIb2f9R7Fow+gzBF4emzDHrVBd5qM=
 github.com/nats-io/nkeys v0.4.5 h1:Zdz2BUlFm4fJlierwvGK+yl20IAKUm7eV6AAZXEhkPk=
@@ -727,8 +727,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -119,8 +119,8 @@ func getArangoConfig() *ArangoConfig {
 	}
 }
 
-func lessArtifact(a, b *model.Artifact) bool {
-	return a.Digest < b.Digest
+func lessArtifact(a, b *model.Artifact) int {
+	return strings.Compare(a.Digest, b.Digest)
 }
 
 func Test_IngestArtifacts(t *testing.T) {

--- a/pkg/assembler/backends/arangodb/builder_test.go
+++ b/pkg/assembler/backends/arangodb/builder_test.go
@@ -116,8 +116,8 @@ func Test_IngestBuilder(t *testing.T) {
 	}
 }
 
-func lessBuilder(a, b *model.Builder) bool {
-	return a.URI < b.URI
+func lessBuilder(a, b *model.Builder) int {
+	return strings.Compare(a.URI, b.URI)
 }
 
 func Test_IngestBuilders(t *testing.T) {

--- a/pkg/assembler/backends/arangodb/hashEqual_test.go
+++ b/pkg/assembler/backends/arangodb/hashEqual_test.go
@@ -510,7 +510,7 @@ func TestHashEqual(t *testing.T) {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}
@@ -820,7 +820,7 @@ func TestIngestHashEquals(t *testing.T) {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}

--- a/pkg/assembler/backends/arangodb/pkg_test.go
+++ b/pkg/assembler/backends/arangodb/pkg_test.go
@@ -771,8 +771,9 @@ func Test_PackagesName(t *testing.T) {
 	}
 }
 
-func lessPkg(a, b *model.Package) bool {
-	return a.Namespaces[0].Names[0].Name < b.Namespaces[0].Names[0].Name
+func lessPkg(a, b *model.Package) int {
+	return strings.Compare(a.Namespaces[0].Names[0].Name,
+		b.Namespaces[0].Names[0].Name)
 }
 
 func Test_IngestPackages(t *testing.T) {

--- a/pkg/assembler/backends/arangodb/src_test.go
+++ b/pkg/assembler/backends/arangodb/src_test.go
@@ -29,8 +29,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func lessSource(a, b *model.Source) bool {
-	return a.Namespaces[0].Namespace < b.Namespaces[0].Namespace
+func lessSource(a, b *model.Source) int {
+	return strings.Compare(a.Namespaces[0].Namespace,
+		b.Namespaces[0].Namespace)
 }
 
 func Test_IngestSources(t *testing.T) {

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -29,8 +29,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func lessCve(a, b *model.Vulnerability) bool {
-	return a.VulnerabilityIDs[0].VulnerabilityID < b.VulnerabilityIDs[0].VulnerabilityID
+func lessCve(a, b *model.Vulnerability) int {
+	return strings.Compare(a.VulnerabilityIDs[0].VulnerabilityID,
+		b.VulnerabilityIDs[0].VulnerabilityID)
 }
 
 func TestVulnerability(t *testing.T) {

--- a/pkg/assembler/backends/ent/backend/backend.go
+++ b/pkg/assembler/backends/ent/backend/backend.go
@@ -22,16 +22,12 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
 	"github.com/vektah/gqlparser/v2/gqlerror"
-	"golang.org/x/exp/slices"
 
 	// Import regular postgres driver
 	_ "github.com/lib/pq"
 )
 
-var (
-	PathContains = slices.Contains[string]
-	Errorf       = gqlerror.Errorf
-)
+var Errorf = gqlerror.Errorf
 
 // MaxPageSize is the maximum number of results that will be returned in a single query.
 const MaxPageSize = 1000

--- a/pkg/assembler/backends/ent/backend/hashequal_test.go
+++ b/pkg/assembler/backends/ent/backend/hashequal_test.go
@@ -19,6 +19,7 @@ package backend
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -520,7 +521,7 @@ func (s *Suite) TestHashEqual() {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}
@@ -787,7 +788,7 @@ func (s *Suite) TestIngestHashEquals() {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}

--- a/pkg/assembler/backends/ent/backend/license_test.go
+++ b/pkg/assembler/backends/ent/backend/license_test.go
@@ -19,6 +19,7 @@ package backend
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -191,8 +192,8 @@ func (s *Suite) TestLicense() {
 	}
 }
 
-func lessLic(a, b *model.License) bool {
-	return a.Name < b.Name
+func lessLic(a, b *model.License) int {
+	return strings.Compare(a.Name, b.Name)
 }
 
 func (s *Suite) TestIngestLicenses() {

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -33,6 +33,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 )
 
 func (b *EntBackend) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
@@ -64,15 +65,15 @@ func (b *EntBackend) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*m
 		),
 	)
 
-	if PathContains(paths, "namespaces") || !isGQL {
+	if slices.Contains(paths, "namespaces") || !isGQL {
 		query.WithNamespaces(func(q *ent.PackageNamespaceQuery) {
 			q.Where(optionalPredicate(pkgSpec.Namespace, packagenamespace.NamespaceEQ))
 
-			if PathContains(paths, "namespaces.names") || !isGQL {
+			if slices.Contains(paths, "namespaces.names") || !isGQL {
 				q.WithNames(func(q *ent.PackageNameQuery) {
 					q.Where(optionalPredicate(pkgSpec.Name, packagename.NameEQ))
 
-					if PathContains(paths, "namespaces.names.versions") || !isGQL {
+					if slices.Contains(paths, "namespaces.names.versions") || !isGQL {
 						q.WithVersions(func(q *ent.PackageVersionQuery) {
 							q.Where(
 								optionalPredicate(pkgSpec.ID, IDEQ),

--- a/pkg/assembler/backends/ent/backend/vulnerability_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability_test.go
@@ -108,8 +108,9 @@ var noVulnOut = &model.VulnerabilityID{
 	VulnerabilityID: "",
 }
 
-func lessCve(a, b *model.Vulnerability) bool {
-	return a.VulnerabilityIDs[0].VulnerabilityID < b.VulnerabilityIDs[0].VulnerabilityID
+func lessCve(a, b *model.Vulnerability) int {
+	return strings.Compare(a.VulnerabilityIDs[0].VulnerabilityID,
+		b.VulnerabilityIDs[0].VulnerabilityID)
 }
 
 func (s *Suite) TestVulnerability() {

--- a/pkg/assembler/backends/inmem/hashEqual_test.go
+++ b/pkg/assembler/backends/inmem/hashEqual_test.go
@@ -440,7 +440,7 @@ func TestHashEqual(t *testing.T) {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}
@@ -709,7 +709,7 @@ func TestIngestHashEquals(t *testing.T) {
 			if err != nil {
 				return
 			}
-			less := func(a, b *model.Artifact) bool { return a.Digest < b.Digest }
+			less := func(a, b *model.Artifact) int { return strings.Compare(a.Digest, b.Digest) }
 			for _, he := range got {
 				slices.SortFunc(he.Artifacts, less)
 			}

--- a/pkg/assembler/backends/inmem/license_test.go
+++ b/pkg/assembler/backends/inmem/license_test.go
@@ -179,8 +179,8 @@ func TestLicense(t *testing.T) {
 	}
 }
 
-func lessLic(a, b *model.License) bool {
-	return a.Name < b.Name
+func lessLic(a, b *model.License) int {
+	return strings.Compare(a.Name, b.Name)
 }
 
 func TestIngestLicenses(t *testing.T) {

--- a/pkg/assembler/backends/inmem/vulnerability_test.go
+++ b/pkg/assembler/backends/inmem/vulnerability_test.go
@@ -107,8 +107,9 @@ var noVulnOut = &model.VulnerabilityID{
 	VulnerabilityID: "",
 }
 
-func lessCve(a, b *model.Vulnerability) bool {
-	return a.VulnerabilityIDs[0].VulnerabilityID < b.VulnerabilityIDs[0].VulnerabilityID
+func lessCve(a, b *model.Vulnerability) int {
+	return strings.Compare(a.VulnerabilityIDs[0].VulnerabilityID,
+		b.VulnerabilityIDs[0].VulnerabilityID)
 }
 
 func TestVulnerability(t *testing.T) {


### PR DESCRIPTION
This also bumped golang.org/x/exp which included some breaking changes. We will move off golang.org/x/exp/slices onto the stdlib one soon.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
