### PR TITLE
Feature/arango node query with updates to inmem unit tests

### DIFF
--- a/pkg/assembler/backends/arangodb/artifact.go
+++ b/pkg/assembler/backends/arangodb/artifact.go
@@ -300,6 +300,7 @@ func (c *arangoClient) buildArtifactResponseByID(ctx context.Context, id string,
 			return nil, fmt.Errorf("number of artifact nodes found for ID: %s is greater than one", id)
 		}
 		return foundArtifacts[0], nil
+	} else {
+		return nil, fmt.Errorf("id type does not match for artifact query: %s", id)
 	}
-	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -338,3 +338,93 @@ func Test_Artifacts(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildArtifactResponseByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	tests := []struct {
+		name          string
+		artifactInput *model.ArtifactInputSpec
+		artifactSpec  *model.ArtifactSpec
+		idInFilter    bool
+		want          *model.Artifact
+		wantErr       bool
+	}{{
+		name: "sha256",
+		artifactInput: &model.ArtifactInputSpec{
+			Algorithm: "sha256",
+			Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+		},
+		artifactSpec: &model.ArtifactSpec{
+			Algorithm: ptrfrom.String("sha256"),
+			Digest:    ptrfrom.String("6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"),
+		},
+		want: &model.Artifact{
+			Algorithm: "sha256",
+			Digest:    "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+		},
+		wantErr: false,
+	}, {
+		name: "sha1",
+		artifactInput: &model.ArtifactInputSpec{
+			Algorithm: "sha1",
+			Digest:    "7A8F47318E4676DACB0142AFA0B83029CD7BEFD9",
+		},
+		artifactSpec: &model.ArtifactSpec{
+			Algorithm: ptrfrom.String("sha1"),
+			Digest:    ptrfrom.String("7A8F47318E4676DACB0142AFA0B83029CD7BEFD9"),
+		},
+		want: &model.Artifact{
+			Algorithm: "sha1",
+			Digest:    "7a8f47318e4676dacb0142afa0b83029cd7befd9",
+		},
+		wantErr: false,
+	}, {
+		name: "sha512",
+		artifactInput: &model.ArtifactInputSpec{
+			Algorithm: "sha512",
+			Digest:    "374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7",
+		},
+		artifactSpec: &model.ArtifactSpec{
+			Algorithm: ptrfrom.String("sha512"),
+			Digest:    ptrfrom.String("374AB8F711235830769AA5F0B31CE9B72C5670074B34CB302CDAFE3B606233EE92EE01E298E5701F15CC7087714CD9ABD7DDB838A6E1206B3642DE16D9FC9DD7"),
+		},
+		idInFilter: true,
+		want: &model.Artifact{
+			Algorithm: "sha512",
+			Digest:    "374ab8f711235830769aa5f0b31ce9b72c5670074b34cb302cdafe3b606233ee92ee01e298e5701f15cc7087714cd9abd7ddb838a6e1206b3642de16d9fc9dd7",
+		},
+		wantErr: false,
+	}}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ingestedArt, err := b.IngestArtifact(ctx, tt.artifactInput)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("demoClient.IngestArtifact() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.idInFilter {
+				tt.artifactSpec.ID = &ingestedArt.ID
+			}
+			got, err := b.(*arangoClient).buildArtifactResponseByID(ctx, ingestedArt.ID, tt.artifactSpec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("arangoClient.buildPackageResponseFromID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/builder.go
+++ b/pkg/assembler/backends/arangodb/builder.go
@@ -187,6 +187,7 @@ func (c *arangoClient) buildBuilderResponseByID(ctx context.Context, id string, 
 			return nil, fmt.Errorf("number of builder nodes found for ID: %s is greater than one", id)
 		}
 		return foundBuilders[0], nil
+	} else {
+		return nil, fmt.Errorf("id type does not match for builder query: %s", id)
 	}
-	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/builder_test.go
+++ b/pkg/assembler/backends/arangodb/builder_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -932,3 +932,42 @@ func getCertifyBadFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mode
 	}
 	return certifyBadList, nil
 }
+
+func (c *arangoClient) buildCertifyBadByID(ctx context.Context, id string, filter *model.CertifyBadSpec) (*model.CertifyBad, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	pvl := []*model.PackageVersion{}
+	if idSplit[0] == certifyBadsStr {
+		var foundPkgVersion *model.PackageVersion
+		var err error
+
+		foundPkgVersion, id, err = c.queryPkgVersionNodeByID(ctx, id, filter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pkg version node by ID with error: %w", err)
+		}
+		pvl = append(pvl, foundPkgVersion)
+	}
+
+	idSplit = strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	certifyBad := model.CertifyBad{
+		ID:            nodeID(link.id),
+		Subject:       subj,
+		Justification: link.justification,
+		Origin:        link.origin,
+		Collector:     link.collector,
+	}
+	return &certifyBad, nil
+}

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -27,6 +27,14 @@ import (
 
 func (c *arangoClient) CertifyBad(ctx context.Context, certifyBadSpec *model.CertifyBadSpec) ([]*model.CertifyBad, error) {
 
+	if certifyBadSpec != nil && certifyBadSpec.ID != nil {
+		cb, err := c.buildCertifyBadByID(ctx, *certifyBadSpec.ID, certifyBadSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildCertifyBadByID failed with an error: %w", err)
+		}
+		return []*model.CertifyBad{cb}, nil
+	}
+
 	var arangoQueryBuilder *arangoQueryBuilder
 	if certifyBadSpec.Subject != nil {
 		var combinedCertifyBad []*model.CertifyBad
@@ -1038,7 +1046,7 @@ func (c *arangoClient) queryCertifyBadNodeByID(ctx context.Context, filter *mode
 		certifyBad.Subject = builtSource
 	} else if collectedValues[0].ArtifactID != nil {
 		var builtArtifact *model.Artifact
-		if filter.Subject != nil && filter.Subject.Source != nil {
+		if filter.Subject != nil && filter.Subject.Artifact != nil {
 			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -1049,12 +1049,12 @@ func (c *arangoClient) queryCertifyBadNodeByID(ctx context.Context, filter *mode
 		if filter.Subject != nil && filter.Subject.Artifact != nil {
 			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+				return nil, fmt.Errorf("failed to get artifact from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
 			}
 		} else {
 			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, nil)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+				return nil, fmt.Errorf("failed to get artifact from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
 			}
 		}
 		certifyBad.Subject = builtArtifact

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -945,29 +946,112 @@ func (c *arangoClient) buildCertifyBadByID(ctx context.Context, id string, filte
 		return nil, fmt.Errorf("invalid ID: %s", id)
 	}
 
-	pvl := []*model.PackageVersion{}
 	if idSplit[0] == certifyBadsStr {
-		var foundPkgVersion *model.PackageVersion
-		var err error
-
-		foundPkgVersion, id, err = c.queryPkgVersionNodeByID(ctx, id, filter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get pkg version node by ID with error: %w", err)
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.CertifyBadSpec{
+				ID: ptrfrom.String(id),
+			}
 		}
-		pvl = append(pvl, foundPkgVersion)
+		return c.queryCertifyBadNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryCertifyBadNodeByID(ctx context.Context, filter *model.CertifyBadSpec) (*model.CertifyBad, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(certifyBadsStr, "certifyBad")
+	setCertifyBadMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN certifyBad`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryCertifyBadNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyBad: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbCertifyBad struct {
+		CertifyBadID  string  `json:"_id"`
+		PackageID     *string `json:"packageID"`
+		SourceID      *string `json:"sourceID"`
+		ArtifactID    *string `json:"artifactID"`
+		Justification string  `json:"justification"`
+		Collector     string  `json:"collector"`
+		Origin        string  `json:"origin"`
 	}
 
-	idSplit = strings.Split(id, "/")
-	if len(idSplit) != 2 {
-		return nil, fmt.Errorf("invalid ID: %s", id)
+	var collectedValues []dbCertifyBad
+	for {
+		var doc dbCertifyBad
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to certifyBad from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
 	}
 
-	certifyBad := model.CertifyBad{
-		ID:            nodeID(link.id),
-		Subject:       subj,
-		Justification: link.justification,
-		Origin:        link.origin,
-		Collector:     link.collector,
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of certifyBad nodes found for ID: %s is greater than one", *filter.ID)
 	}
-	return &certifyBad, nil
+
+	certifyBad := &model.CertifyBad{
+		ID:            collectedValues[0].CertifyBadID,
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Origin,
+		Collector:     collectedValues[0].Collector,
+	}
+
+	if collectedValues[0].PackageID != nil {
+		var builtPackage *model.Package
+		if filter.Subject != nil && filter.Subject.Package != nil {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, filter.Subject.Package)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		} else {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		}
+		certifyBad.Subject = builtPackage
+	} else if collectedValues[0].SourceID != nil {
+		var builtSource *model.Source
+		if filter.Subject != nil && filter.Subject.Source != nil {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, filter.Subject.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		} else {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		}
+		certifyBad.Subject = builtSource
+	} else if collectedValues[0].ArtifactID != nil {
+		var builtArtifact *model.Artifact
+		if filter.Subject != nil && filter.Subject.Source != nil {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		} else {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		}
+		certifyBad.Subject = builtArtifact
+	} else {
+		return nil, fmt.Errorf("failed to get subject from certifyBad")
+	}
+	return certifyBad, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -963,8 +963,9 @@ func (c *arangoClient) buildCertifyBadByID(ctx context.Context, id string, filte
 			}
 		}
 		return c.queryCertifyBadNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyBad query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyBadNodeByID(ctx context.Context, filter *model.CertifyBadSpec) (*model.CertifyBad, error) {

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -587,7 +587,7 @@ func TestCertifyBad(t *testing.T) {
 			Query: &model.CertifyBadSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -1098,6 +1098,40 @@ func Test_buildCertifyBadByID(t *testing.T) {
 			},
 			ExpCB: &model.CertifyBad{
 				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source - no filter",
+			InSrc: []*model.SourceInputSpec{testdata.S3},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S3,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.S3out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact - no filter",
+			InArt: []*model.ArtifactInputSpec{testdata.A3},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Artifact: testdata.A3,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.A3out,
 				Justification: "test justification",
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -195,7 +193,7 @@ func TestCertifyBad(t *testing.T) {
 		},
 		{
 			Name:  "Query on Package",
-			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InPkg: []*model.PkgInputSpec{testdata.P4},
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			Calls: []call{
 				{
@@ -965,6 +963,190 @@ func TestIngestCertifyBads(t *testing.T) {
 				}
 			}
 			got, err := b.CertifyBad(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpCB, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildCertifyBadByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		CB    *model.CertifyBadInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Call         call
+		Query        *model.CertifyBadSpec
+		ExpCB        *model.CertifyBad
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Package: testdata.P1,
+				},
+				Match: &model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+
+			Query: &model.CertifyBadSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.P1out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Package: testdata.P4,
+				},
+				Match: &model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
+						Version:   ptrfrom.String("3.0.3"),
+					},
+				},
+			},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S2,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Artifact: testdata.A2,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpCB: &model.CertifyBad{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S1,
+				},
+				CB: &model.CertifyBadInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			found, err := b.IngestCertifyBad(ctx, test.Call.Sub, test.Call.Match, *test.Call.CB)
+			if (err != nil) != test.ExpIngestErr {
+				t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+			}
+			if err != nil {
+				return
+			}
+
+			got, err := b.(*arangoClient).buildCertifyBadByID(ctx, found.ID, test.Query)
 			if (err != nil) != test.ExpQueryErr {
 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
 			}

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -1062,12 +1062,12 @@ func (c *arangoClient) queryCertifyGoodNodeByID(ctx context.Context, filter *mod
 		if filter.Subject != nil && filter.Subject.Artifact != nil {
 			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+				return nil, fmt.Errorf("failed to get artifact from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
 			}
 		} else {
 			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, nil)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+				return nil, fmt.Errorf("failed to get artifact from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
 			}
 		}
 		certifyGood.Subject = builtArtifact

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -976,8 +976,9 @@ func (c *arangoClient) buildCertifyGoodByID(ctx context.Context, id string, filt
 			}
 		}
 		return c.queryCertifyGoodNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyGood query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyGoodNodeByID(ctx context.Context, filter *model.CertifyGoodSpec) (*model.CertifyGood, error) {

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -938,8 +938,8 @@ func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 		certifyGood := &model.CertifyGood{
 			ID:            createdValue.CertifyGoodID,
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 		if pkg != nil {
 			certifyGood.Subject = pkg

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -21,10 +21,20 @@ import (
 	"strings"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) CertifyGood(ctx context.Context, certifyGoodSpec *model.CertifyGoodSpec) ([]*model.CertifyGood, error) {
+
+	if certifyGoodSpec != nil && certifyGoodSpec.ID != nil {
+		cg, err := c.buildCertifyGoodByID(ctx, *certifyGoodSpec.ID, certifyGoodSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildCertifyGoodByID failed with an error: %w", err)
+		}
+		return []*model.CertifyGood{cg}, nil
+	}
+
 	var arangoQueryBuilder *arangoQueryBuilder
 	if certifyGoodSpec.Subject != nil {
 		var combinedCertifyGood []*model.CertifyGood
@@ -943,4 +953,126 @@ func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 		certifyGoodList = append(certifyGoodList, certifyGood)
 	}
 	return certifyGoodList, nil
+}
+
+func (c *arangoClient) buildCertifyGoodByID(ctx context.Context, id string, filter *model.CertifyGoodSpec) (*model.CertifyGood, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == certifyGoodsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.CertifyGoodSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryCertifyGoodNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryCertifyGoodNodeByID(ctx context.Context, filter *model.CertifyGoodSpec) (*model.CertifyGood, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(certifyGoodsStr, "certifyGood")
+	setCertifyGoodMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN certifyGood`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryCertifyGoodNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyGood: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbCertifyGood struct {
+		CertifyGoodID string  `json:"_id"`
+		PackageID     *string `json:"packageID"`
+		SourceID      *string `json:"sourceID"`
+		ArtifactID    *string `json:"artifactID"`
+		Justification string  `json:"justification"`
+		Collector     string  `json:"collector"`
+		Origin        string  `json:"origin"`
+	}
+
+	var collectedValues []dbCertifyGood
+	for {
+		var doc dbCertifyGood
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to certifyGood from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of certifyGood nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	certifyGood := &model.CertifyGood{
+		ID:            collectedValues[0].CertifyGoodID,
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Origin,
+		Collector:     collectedValues[0].Collector,
+	}
+
+	if collectedValues[0].PackageID != nil {
+		var builtPackage *model.Package
+		if filter.Subject != nil && filter.Subject.Package != nil {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, filter.Subject.Package)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		} else {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		}
+		certifyGood.Subject = builtPackage
+	} else if collectedValues[0].SourceID != nil {
+		var builtSource *model.Source
+		if filter.Subject != nil && filter.Subject.Source != nil {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, filter.Subject.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		} else {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		}
+		certifyGood.Subject = builtSource
+	} else if collectedValues[0].ArtifactID != nil {
+		var builtArtifact *model.Artifact
+		if filter.Subject != nil && filter.Subject.Artifact != nil {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		} else {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		}
+		certifyGood.Subject = builtArtifact
+	} else {
+		return nil, fmt.Errorf("failed to get subject from certifyGood")
+	}
+	return certifyGood, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -571,7 +569,7 @@ func TestCertifyGood(t *testing.T) {
 			},
 		},
 		{
-			Name:  "Query good ID",
+			Name:  "Query bad ID",
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			Calls: []call{
 				{
@@ -586,7 +584,7 @@ func TestCertifyGood(t *testing.T) {
 			Query: &model.CertifyGoodSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -962,6 +960,224 @@ func TestIngestCertifyGoods(t *testing.T) {
 				}
 			}
 			got, err := b.CertifyGood(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpCG, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildCertifyGoodByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		CG    *model.CertifyGoodInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Call         call
+		Query        *model.CertifyGoodSpec
+		ExpCG        *model.CertifyGood
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Package: testdata.P1,
+				},
+				Match: &model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+
+			Query: &model.CertifyGoodSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.P1out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Package: testdata.P4,
+				},
+				Match: &model.MatchFlags{
+					Pkg: model.PkgMatchTypeSpecificVersion,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
+						Version:   ptrfrom.String("3.0.3"),
+					},
+				},
+			},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S2,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Artifact: testdata.A2,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source - no filter",
+			InSrc: []*model.SourceInputSpec{testdata.S3},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S3,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.S3out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact - no filter",
+			InArt: []*model.ArtifactInputSpec{testdata.A3},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Artifact: testdata.A3,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{},
+			ExpCG: &model.CertifyGood{
+				Subject:       testdata.A3out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Call: call{
+				Sub: model.PackageSourceOrArtifactInput{
+					Source: testdata.S1,
+				},
+				CG: &model.CertifyGoodInputSpec{
+					Justification: "test justification",
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			found, err := b.IngestCertifyGood(ctx, test.Call.Sub, test.Call.Match, *test.Call.CG)
+			if (err != nil) != test.ExpIngestErr {
+				t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+			}
+			if err != nil {
+				return
+			}
+
+			got, err := b.(*arangoClient).buildCertifyGoodByID(ctx, found.ID, test.Query)
 			if (err != nil) != test.ExpQueryErr {
 				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
 			}

--- a/pkg/assembler/backends/arangodb/certifyLegal.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal.go
@@ -29,11 +29,11 @@ import (
 func (c *arangoClient) CertifyLegal(ctx context.Context, certifyLegalSpec *model.CertifyLegalSpec) ([]*model.CertifyLegal, error) {
 
 	if certifyLegalSpec != nil && certifyLegalSpec.ID != nil {
-		cg, err := c.buildCertifyLegalByID(ctx, *certifyLegalSpec.ID, certifyLegalSpec)
+		cl, err := c.buildCertifyLegalByID(ctx, *certifyLegalSpec.ID, certifyLegalSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildCertifyLegalByID failed with an error: %w", err)
 		}
-		return []*model.CertifyLegal{cg}, nil
+		return []*model.CertifyLegal{cl}, nil
 	}
 
 	var aqb *arangoQueryBuilder

--- a/pkg/assembler/backends/arangodb/certifyLegal.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal.go
@@ -911,8 +911,9 @@ func (c *arangoClient) buildCertifyLegalByID(ctx context.Context, id string, fil
 			}
 		}
 		return c.queryCertifyLegalNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyLegal query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyLegalNodeByID(ctx context.Context, filter *model.CertifyLegalSpec) (*model.CertifyLegal, error) {

--- a/pkg/assembler/backends/arangodb/certifyLegal.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal.go
@@ -22,10 +22,19 @@ import (
 	"time"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) CertifyLegal(ctx context.Context, certifyLegalSpec *model.CertifyLegalSpec) ([]*model.CertifyLegal, error) {
+
+	if certifyLegalSpec != nil && certifyLegalSpec.ID != nil {
+		cg, err := c.buildCertifyLegalByID(ctx, *certifyLegalSpec.ID, certifyLegalSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildCertifyLegalByID failed with an error: %w", err)
+		}
+		return []*model.CertifyLegal{cg}, nil
+	}
 
 	var aqb *arangoQueryBuilder
 	if certifyLegalSpec.Subject != nil {
@@ -879,4 +888,137 @@ func (c *arangoClient) getCertifyLegalFromCursor(ctx context.Context,
 		certifyLegalList = append(certifyLegalList, certifyLegal)
 	}
 	return certifyLegalList, nil
+}
+
+func (c *arangoClient) buildCertifyLegalByID(ctx context.Context, id string, filter *model.CertifyLegalSpec) (*model.CertifyLegal, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == certifyLegalsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.CertifyLegalSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryCertifyLegalNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryCertifyLegalNodeByID(ctx context.Context, filter *model.CertifyLegalSpec) (*model.CertifyLegal, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(certifyLegalsStr, "certifyLegal")
+	setCertifyLegalMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN certifyLegal`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryCertifyLegalNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyLegal: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbCertifyLegal struct {
+		CertifyLegalID     string    `json:"_id"`
+		PackageID          *string   `json:"packageID"`
+		SourceID           *string   `json:"sourceID"`
+		DeclaredLicense    string    `json:"declaredLicense"`
+		DeclaredLicenses   []string  `json:"declaredLicenses"`
+		DiscoveredLicense  string    `json:"discoveredLicense"`
+		DiscoveredLicenses []string  `json:"discoveredLicenses"`
+		Attribution        string    `json:"attribution"`
+		Justification      string    `json:"justification"`
+		TimeScanned        time.Time `json:"timeScanned"`
+		Collector          string    `json:"collector"`
+		Origin             string    `json:"origin"`
+	}
+
+	var collectedValues []dbCertifyLegal
+	for {
+		var doc dbCertifyLegal
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to certifyLegal from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of certifyLegal nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	certifyLegal := &model.CertifyLegal{
+		ID:                collectedValues[0].CertifyLegalID,
+		DeclaredLicense:   collectedValues[0].DeclaredLicense,
+		DiscoveredLicense: collectedValues[0].DiscoveredLicense,
+		Attribution:       collectedValues[0].Attribution,
+		Justification:     collectedValues[0].Justification,
+		TimeScanned:       collectedValues[0].TimeScanned,
+		Origin:            collectedValues[0].Origin,
+		Collector:         collectedValues[0].Collector,
+	}
+
+	dec, err := c.getLicensesByID(ctx, collectedValues[0].DeclaredLicenses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Declared License IDs into nodes: %w", err)
+	}
+	certifyLegal.DeclaredLicenses = dec
+
+	dis, err := c.getLicensesByID(ctx, collectedValues[0].DiscoveredLicenses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Discovered License IDs into nodes: %w", err)
+	}
+	certifyLegal.DiscoveredLicenses = dis
+
+	if !licenseMatch(filter.DeclaredLicenses, dec) || !licenseMatch(filter.DiscoveredLicenses, dis) {
+		return nil, fmt.Errorf("failed to match filter with declared or discovered licenses")
+	}
+
+	if collectedValues[0].PackageID != nil {
+		var builtPackage *model.Package
+		if filter.Subject != nil && filter.Subject.Package != nil {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, filter.Subject.Package)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		} else {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		}
+		certifyLegal.Subject = builtPackage
+	} else if collectedValues[0].SourceID != nil {
+		var builtSource *model.Source
+		if filter.Subject != nil && filter.Subject.Source != nil {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, filter.Subject.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		} else {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		}
+		certifyLegal.Subject = builtSource
+	} else {
+		return nil, fmt.Errorf("failed to get subject from certifyLegal")
+	}
+	return certifyLegal, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyLegal_test.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyLegal_test.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -683,6 +681,207 @@ func TestLegals(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpLegal, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildCertifyLegalByID(t *testing.T) {
+	type call struct {
+		PkgSrc model.PackageOrSourceInput
+		Dec    []*model.LicenseInputSpec
+		Dis    []*model.LicenseInputSpec
+		Legal  *model.CertifyLegalInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InLic        []*model.LicenseInputSpec
+		Calls        []call
+		Query        *model.CertifyLegalSpec
+		ExpLegal     *model.CertifyLegal
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InLic: []*model.LicenseInputSpec{testdata.L1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Dec: []*model.LicenseInputSpec{testdata.L1},
+					Legal: &model.CertifyLegalInputSpec{
+						Justification: "test justification 2",
+					},
+				},
+			},
+			ExpLegal: &model.CertifyLegal{
+				Subject:          testdata.P1out,
+				DeclaredLicenses: []*model.License{testdata.L1out},
+				Justification:    "test justification 2",
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P2},
+			InLic: []*model.LicenseInputSpec{testdata.L1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P2,
+					},
+					Dec: []*model.LicenseInputSpec{testdata.L1},
+					Legal: &model.CertifyLegalInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				Subject: &model.PackageOrSourceSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+				},
+			},
+			ExpLegal: &model.CertifyLegal{
+				Subject:          testdata.P2out,
+				DeclaredLicenses: []*model.License{testdata.L1out},
+				Justification:    "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InLic: []*model.LicenseInputSpec{testdata.L1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Source: testdata.S1,
+					},
+					Dec: []*model.LicenseInputSpec{testdata.L1},
+					Legal: &model.CertifyLegalInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				Subject: &model.PackageOrSourceSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("myrepo"),
+					},
+				},
+			},
+			ExpLegal: &model.CertifyLegal{
+				Subject:          testdata.S1out,
+				DeclaredLicenses: []*model.License{testdata.L1out},
+				Justification:    "test justification",
+			},
+		},
+		{
+			Name:  "Query on License",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InLic: []*model.LicenseInputSpec{testdata.L1, testdata.L2},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Source: testdata.S1,
+					},
+					Dec: []*model.LicenseInputSpec{testdata.L1, testdata.L2},
+					Legal: &model.CertifyLegalInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				DeclaredLicenses: []*model.LicenseSpec{
+					{Name: ptrfrom.String("GPL-2.0-or-later")},
+				},
+			},
+			ExpLegal: &model.CertifyLegal{
+				Subject:          testdata.S1out,
+				DeclaredLicenses: []*model.License{testdata.L1out, testdata.L2out},
+				Justification:    "test justification",
+			},
+		},
+		{
+			Name:  "Query on License inline",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InLic: []*model.LicenseInputSpec{testdata.L1, testdata.L4},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Source: testdata.S1,
+					},
+					Dec: []*model.LicenseInputSpec{testdata.L1, testdata.L4},
+					Legal: &model.CertifyLegalInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				DeclaredLicenses: []*model.LicenseSpec{
+					{Inline: &testdata.InlineLicense},
+				},
+			},
+			ExpLegal: &model.CertifyLegal{
+				Subject:          testdata.S1out,
+				DeclaredLicenses: []*model.License{testdata.L1out, testdata.L4out},
+				Justification:    "test justification",
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := getBackend(ctx, arangArg)
+			if err != nil {
+				t.Fatalf("Could not instantiate testing backend: %v", err)
+			}
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InLic {
+				if _, err := b.IngestLicense(ctx, a); err != nil {
+					t.Fatalf("Could not ingest license: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				cl, err := b.IngestCertifyLegal(ctx, o.PkgSrc, o.Dec, o.Dis, o.Legal)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildCertifyLegalByID(ctx, cl.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpLegal, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -417,4 +418,126 @@ func getCertifyScorecardFromCursor(ctx context.Context, cursor driver.Cursor) ([
 		certifyScorecardList = append(certifyScorecardList, certifyScorecard)
 	}
 	return certifyScorecardList, nil
+}
+
+func (c *arangoClient) buildCertifyGoodByID(ctx context.Context, id string, filter *model.CertifyGoodSpec) (*model.CertifyGood, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == certifyGoodsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.CertifyGoodSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryCertifyGoodNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryCertifyScorecardNodeByID(ctx context.Context, filter *model.CertifyGoodSpec) (*model.CertifyGood, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(certifyGoodsStr, "certifyGood")
+	setCertifyGoodMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN certifyGood`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryCertifyGoodNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for certifyGood: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbCertifyGood struct {
+		CertifyGoodID string  `json:"_id"`
+		PackageID     *string `json:"packageID"`
+		SourceID      *string `json:"sourceID"`
+		ArtifactID    *string `json:"artifactID"`
+		Justification string  `json:"justification"`
+		Collector     string  `json:"collector"`
+		Origin        string  `json:"origin"`
+	}
+
+	var collectedValues []dbCertifyGood
+	for {
+		var doc dbCertifyGood
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to certifyGood from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of certifyGood nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	certifyGood := &model.CertifyGood{
+		ID:            collectedValues[0].CertifyGoodID,
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Origin,
+		Collector:     collectedValues[0].Collector,
+	}
+
+	if collectedValues[0].PackageID != nil {
+		var builtPackage *model.Package
+		if filter.Subject != nil && filter.Subject.Package != nil {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, filter.Subject.Package)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		} else {
+			builtPackage, err = c.buildPackageResponseFromID(ctx, *collectedValues[0].PackageID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].PackageID, err)
+			}
+		}
+		certifyGood.Subject = builtPackage
+	} else if collectedValues[0].SourceID != nil {
+		var builtSource *model.Source
+		if filter.Subject != nil && filter.Subject.Source != nil {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, filter.Subject.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		} else {
+			builtSource, err = c.buildSourceResponseFromID(ctx, *collectedValues[0].SourceID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", *collectedValues[0].SourceID, err)
+			}
+		}
+		certifyGood.Subject = builtSource
+	} else if collectedValues[0].ArtifactID != nil {
+		var builtArtifact *model.Artifact
+		if filter.Subject != nil && filter.Subject.Artifact != nil {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, filter.Subject.Artifact)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		} else {
+			builtArtifact, err = c.buildArtifactResponseByID(ctx, *collectedValues[0].ArtifactID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", *collectedValues[0].ArtifactID, err)
+			}
+		}
+		certifyGood.Subject = builtArtifact
+	} else {
+		return nil, fmt.Errorf("failed to get subject from certifyGood")
+	}
+	return certifyGood, nil
 }

--- a/pkg/assembler/backends/arangodb/certifyScorecard.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard.go
@@ -450,8 +450,9 @@ func (c *arangoClient) buildCertifyScorecardByID(ctx context.Context, id string,
 			}
 		}
 		return c.queryCertifyScorecardNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyScorecard query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyScorecardNodeByID(ctx context.Context, filter *model.CertifyScorecardSpec) (*model.CertifyScorecard, error) {

--- a/pkg/assembler/backends/arangodb/certifyScorecard_test.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyScorecard_test.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -506,7 +504,7 @@ func TestCertifyScorecard(t *testing.T) {
 			Query: &model.CertifyScorecardSpec{
 				ID: ptrfrom.String("4294967296"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -760,6 +758,133 @@ func TestIngestScorecards(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpSC, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildCertifyScorecardByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Src *model.SourceInputSpec
+		SC  *model.ScorecardInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		Query        *model.CertifyScorecardSpec
+		ExpSC        *model.CertifyScorecard
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query Source",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Src: testdata.S2,
+					SC: &model.ScorecardInputSpec{
+						Origin: "test origin",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				Source: &model.SourceSpec{
+					Namespace: ptrfrom.String("github.com/bob"),
+				},
+			},
+			ExpSC: &model.CertifyScorecard{
+				Source: testdata.S2out,
+				Scorecard: &model.Scorecard{
+					Checks: []*model.ScorecardCheck{},
+					Origin: "test origin",
+				},
+			},
+		},
+		{
+			Name:  "Query ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Src: testdata.S1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			ExpSC: &model.CertifyScorecard{
+				Source: testdata.S1out,
+				Scorecard: &model.Scorecard{
+					Checks:           []*model.ScorecardCheck{},
+					AggregateScore:   1.5,
+					TimeScanned:      time.Unix(1e9, 0),
+					ScorecardVersion: "123",
+					ScorecardCommit:  "abc",
+				},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Src: testdata.S1,
+					SC: &model.ScorecardInputSpec{
+						AggregateScore:   1.5,
+						TimeScanned:      time.Unix(1e9, 0),
+						ScorecardVersion: "123",
+						ScorecardCommit:  "abc",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				ID: ptrfrom.String("4294967296"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestScorecard(ctx, *o.Src, *o.SC)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+
+				got, err := b.(*arangoClient).buildCertifyScorecardByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpSC, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -754,8 +754,9 @@ func (c *arangoClient) buildCertifyVexByID(ctx context.Context, id string, filte
 			}
 		}
 		return c.queryCertifyVexNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyVex query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyVexNodeByID(ctx context.Context, filter *model.CertifyVEXStatementSpec) (*model.CertifyVEXStatement, error) {

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -37,11 +37,11 @@ const (
 func (c *arangoClient) CertifyVEXStatement(ctx context.Context, certifyVEXStatementSpec *model.CertifyVEXStatementSpec) ([]*model.CertifyVEXStatement, error) {
 
 	if certifyVEXStatementSpec != nil && certifyVEXStatementSpec.ID != nil {
-		sc, err := c.buildCertifyVexByID(ctx, *certifyVEXStatementSpec.ID, certifyVEXStatementSpec)
+		vex, err := c.buildCertifyVexByID(ctx, *certifyVEXStatementSpec.ID, certifyVEXStatementSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildCertifyVexByID failed with an error: %w", err)
 		}
-		return []*model.CertifyVEXStatement{sc}, nil
+		return []*model.CertifyVEXStatement{vex}, nil
 	}
 
 	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -1315,6 +1313,236 @@ func TestVEXBulkIngest(t *testing.T) {
 			if diff := cmp.Diff(test.ExpVEX, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func Test_buildCertifyVexByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub  model.PackageOrArtifactInput
+		Vuln *model.VulnerabilityInputSpec
+		In   *model.VexStatementInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InArt        []*model.ArtifactInputSpec
+		InVuln       []*model.VulnerabilityInputSpec
+		Calls        []call
+		Query        *model.CertifyVEXStatementSpec
+		QueryID      bool
+		QueryPkgID   bool
+		QueryArtID   bool
+		QueryVulnID  bool
+		ExpVEX       *model.CertifyVEXStatement
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "Query on Package",
+			InPkg:  []*model.PkgInputSpec{testdata.P1},
+			InArt:  []*model.ArtifactInputSpec{},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.O1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			Query: &model.CertifyVEXStatementSpec{
+				Subject: &model.PackageOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String(""),
+					},
+				},
+			},
+			ExpVEX: &model.CertifyVEXStatement{
+				Subject: testdata.P1out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				VexJustification: "test justification",
+				KnownSince:       time.Unix(1e9, 0),
+			},
+		},
+		{
+			Name:   "Query on Artifact",
+			InPkg:  []*model.PkgInputSpec{},
+			InArt:  []*model.ArtifactInputSpec{testdata.A1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					Vuln: testdata.O1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			Query: &model.CertifyVEXStatementSpec{
+				Subject: &model.PackageOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha256"),
+					},
+				},
+			},
+			ExpVEX: &model.CertifyVEXStatement{
+				Subject: testdata.A1out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				VexJustification: "test justification",
+				KnownSince:       time.Unix(1e9, 0),
+			},
+		},
+		{
+			Name:   "Query on Artifact",
+			InPkg:  []*model.PkgInputSpec{},
+			InArt:  []*model.ArtifactInputSpec{testdata.A1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Artifact: testdata.A1,
+					},
+					Vuln: testdata.O1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			ExpVEX: &model.CertifyVEXStatement{
+				Subject: testdata.A1out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				VexJustification: "test justification",
+				KnownSince:       time.Unix(1e9, 0),
+			},
+		},
+		{
+			Name:   "Query on Vuln",
+			InPkg:  []*model.PkgInputSpec{testdata.P1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.O1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			Query: &model.CertifyVEXStatementSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type:            ptrfrom.String("osv"),
+					VulnerabilityID: ptrfrom.String("cve-2014-8140"),
+				},
+			},
+			ExpVEX: &model.CertifyVEXStatement{
+				Subject: testdata.P1out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				VexJustification: "test justification",
+				KnownSince:       time.Unix(1e9, 0),
+			},
+		},
+		{
+			Name:   "Query on ID",
+			InPkg:  []*model.PkgInputSpec{testdata.P1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O2},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Vuln: testdata.O2,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+					},
+				},
+			},
+			QueryID: true,
+			ExpVEX: &model.CertifyVEXStatement{
+				Subject: testdata.P1out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O2out},
+				},
+				VexJustification: "test justification",
+				KnownSince:       time.Unix(1e9, 0),
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %a", err)
+				}
+			}
+			for _, v := range test.InVuln {
+				if _, err := b.IngestVulnerability(ctx, *v); err != nil {
+					t.Fatalf("Could not ingest vulnerability: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestVEXStatement(ctx, o.Sub, *o.Vuln, *o.In)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildCertifyVexByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpVEX, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -498,8 +498,9 @@ func (c *arangoClient) buildCertifyVulnByID(ctx context.Context, id string, filt
 			}
 		}
 		return c.queryCertifyVulnNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for certifyVuln query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryCertifyVulnNodeByID(ctx context.Context, filter *model.CertifyVulnSpec) (*model.CertifyVuln, error) {

--- a/pkg/assembler/backends/arangodb/certifyVuln_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -1425,6 +1423,233 @@ func TestIngestCertifyVulns(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpVuln, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildCertifyVulnByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Pkg         *model.PkgInputSpec
+		Vuln        *model.VulnerabilityInputSpec
+		CertifyVuln *model.ScanMetadataInput
+	}
+
+	tests := []struct {
+		InPkg        []*model.PkgInputSpec
+		Name         string
+		InVuln       []*model.VulnerabilityInputSpec
+		Calls        []call
+		ExpVuln      *model.CertifyVuln
+		Query        *model.CertifyVulnSpec
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "Certify NoVuln",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.NoVulnInput},
+			InPkg:  []*model.PkgInputSpec{testdata.P2},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.NoVulnInput,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type: ptrfrom.String("noVuln"),
+				},
+			},
+			ExpVuln: &model.CertifyVuln{
+
+				Package: testdata.P2out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "novuln",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.NoVulnOut},
+				},
+				Metadata: vmd1,
+			},
+		},
+		{
+			Name:   "Certify OSV",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			InPkg:  []*model.PkgInputSpec{testdata.P2},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.O1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type: ptrfrom.String("osv"),
+				},
+			},
+			ExpVuln: &model.CertifyVuln{
+				Package: testdata.P2out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				Metadata: vmd1,
+			},
+		},
+		{
+			Name:   "Certify GHSA",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.G1},
+			InPkg:  []*model.PkgInputSpec{testdata.P2},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.G1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					VulnerabilityID: &testdata.G1.VulnerabilityID,
+				},
+			},
+			ExpVuln: &model.CertifyVuln{
+				Package: testdata.P2out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "ghsa",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+				},
+				Metadata: vmd1,
+			},
+		},
+		{
+			Name:   "Query on GHSA",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.G1},
+			InPkg:  []*model.PkgInputSpec{testdata.P2},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.G1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					VulnerabilityID: &testdata.G1.VulnerabilityID,
+				},
+			},
+			ExpVuln: &model.CertifyVuln{
+				Package: testdata.P2out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "ghsa",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+				},
+				Metadata: vmd1,
+			},
+		},
+		{
+			Name:   "Query ID",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.G1},
+			InPkg:  []*model.PkgInputSpec{testdata.P2},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.G1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+					},
+				},
+			},
+			ExpVuln: &model.CertifyVuln{
+				Package: testdata.P2out,
+				Vulnerability: &model.Vulnerability{
+					Type:             "ghsa",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+				},
+				Metadata: vmd1,
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, g := range test.InVuln {
+				if _, err := b.IngestVulnerability(ctx, *g); err != nil {
+					t.Fatalf("Could not ingest vulnerability: %a", err)
+				}
+			}
+			if _, err := b.IngestPackages(ctx, test.InPkg); err != nil {
+				t.Fatalf("Could not ingest packages: %v", err)
+			}
+
+			for _, o := range test.Calls {
+				record, err := b.IngestCertifyVuln(ctx, *o.Pkg, *o.Vuln, *o.CertifyVuln)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+
+				got, err := b.(*arangoClient).buildCertifyVulnByID(ctx, record.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpVuln, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/certifyVuln_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -1000,8 +1000,8 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 			Value:         createdValue.Value,
 			Timestamp:     createdValue.Timestamp,
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 
 		if pkg != nil {

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -34,11 +34,11 @@ const (
 func (c *arangoClient) HasMetadata(ctx context.Context, hasMetadataSpec *model.HasMetadataSpec) ([]*model.HasMetadata, error) {
 
 	if hasMetadataSpec != nil && hasMetadataSpec.ID != nil {
-		cv, err := c.buildHasMetadataByID(ctx, *hasMetadataSpec.ID, hasMetadataSpec)
+		hm, err := c.buildHasMetadataByID(ctx, *hasMetadataSpec.ID, hasMetadataSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildHasMetadataByID failed with an error: %w", err)
 		}
-		return []*model.HasMetadata{cv}, nil
+		return []*model.HasMetadata{hm}, nil
 	}
 
 	var arangoQueryBuilder *arangoQueryBuilder

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -1048,8 +1048,9 @@ func (c *arangoClient) buildHasMetadataByID(ctx context.Context, id string, filt
 			}
 		}
 		return c.queryHasMetadataNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for hasMetadata query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryHasMetadataNodeByID(ctx context.Context, filter *model.HasMetadataSpec) (*model.HasMetadata, error) {

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -1066,7 +1066,7 @@ func (c *arangoClient) queryHasMetadataNodeByID(ctx context.Context, filter *mod
 	defer cursor.Close()
 
 	type dbHasMetadata struct {
-		CertifyBadID  string    `json:"_id"`
+		HasMetadataID string    `json:"_id"`
 		PackageID     *string   `json:"packageID"`
 		SourceID      *string   `json:"sourceID"`
 		ArtifactID    *string   `json:"artifactID"`
@@ -1098,7 +1098,7 @@ func (c *arangoClient) queryHasMetadataNodeByID(ctx context.Context, filter *mod
 	}
 
 	hasMetadata := &model.HasMetadata{
-		ID:            collectedValues[0].CertifyBadID,
+		ID:            collectedValues[0].HasMetadataID,
 		Key:           collectedValues[0].Key,
 		Value:         collectedValues[0].Value,
 		Timestamp:     collectedValues[0].Timestamp,

--- a/pkg/assembler/backends/arangodb/hasMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -756,7 +754,7 @@ func TestHasMetadata(t *testing.T) {
 			Query: &model.HasMetadataSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -1144,6 +1142,255 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func Test_buildHasMetadataByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		HM    *model.HasMetadataInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.HasMetadataSpec
+		ExpHM        *model.HasMetadata
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Package without filter",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source without filter",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact without filter",
+			InSrc: []*model.SourceInputSpec{},
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpHM: &model.HasMetadata{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestHasMetadata(ctx, o.Sub, o.Match, *o.HM)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildHasMetadataByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -592,8 +592,9 @@ func (c *arangoClient) buildHasSbomByID(ctx context.Context, id string, filter *
 			}
 		}
 		return c.queryHasSbomNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for hasSBOM query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryHasSbomNodeByID(ctx context.Context, filter *model.HasSBOMSpec) (*model.HasSbom, error) {

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -28,11 +28,11 @@ import (
 func (c *arangoClient) HasSBOM(ctx context.Context, hasSBOMSpec *model.HasSBOMSpec) ([]*model.HasSbom, error) {
 
 	if hasSBOMSpec != nil && hasSBOMSpec.ID != nil {
-		cv, err := c.buildHasSbomByID(ctx, *hasSBOMSpec.ID, hasSBOMSpec)
+		sbom, err := c.buildHasSbomByID(ctx, *hasSBOMSpec.ID, hasSBOMSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildHasSbomByID failed with an error: %w", err)
 		}
-		return []*model.HasSbom{cv}, nil
+		return []*model.HasSbom{sbom}, nil
 	}
 
 	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -547,8 +547,8 @@ func getHasSBOMFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.H
 			Algorithm:        createdValue.Algorithm,
 			Digest:           createdValue.Digest,
 			DownloadLocation: createdValue.DownloadLocation,
-			Origin:           createdValue.Collector,
-			Collector:        createdValue.Origin,
+			Origin:           createdValue.Origin,
+			Collector:        createdValue.Collector,
 		}
 		if pkg != nil {
 			hasSBOM.Subject = pkg

--- a/pkg/assembler/backends/arangodb/hasSBOM_test.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -514,8 +514,9 @@ func (c *arangoClient) buildHasSlsaByID(ctx context.Context, id string, filter *
 			}
 		}
 		return c.queryHasSlsaNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for hasSLSA query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryHasSlsaNodeByID(ctx context.Context, filter *model.HasSLSASpec) (*model.HasSlsa, error) {

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -39,11 +39,11 @@ const (
 func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASpec) ([]*model.HasSlsa, error) {
 
 	if hasSLSASpec != nil && hasSLSASpec.ID != nil {
-		cv, err := c.buildHasSlsaByID(ctx, *hasSLSASpec.ID, hasSLSASpec)
+		slsa, err := c.buildHasSlsaByID(ctx, *hasSLSASpec.ID, hasSLSASpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildHasSlsaByID failed with an error: %w", err)
 		}
-		return []*model.HasSlsa{cv}, nil
+		return []*model.HasSlsa{slsa}, nil
 	}
 
 	// TODO (pxp928): Optimize/add other queries based on input and starting node/edge for most efficient retrieval (like from builtBy/builtFrom if specified)

--- a/pkg/assembler/backends/arangodb/hasSLSA_test.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -617,7 +615,7 @@ func TestHasSLSA(t *testing.T) {
 			Query: &model.HasSLSASpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -899,6 +897,230 @@ func TestIngestHasSLSAs(t *testing.T) {
 			if diff := cmp.Diff(test.ExpHS, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func Test_buildHasSlsaByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub  *model.ArtifactInputSpec
+		BF   []*model.ArtifactInputSpec
+		BB   *model.BuilderInputSpec
+		SLSA *model.SLSAInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InArt        []*model.ArtifactInputSpec
+		InBld        []*model.BuilderInputSpec
+		Calls        []call
+		Query        *model.HasSLSASpec
+		ExpHS        *model.HasSlsa
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on Subject",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			InBld: []*model.BuilderInputSpec{testdata.B1},
+			Calls: []call{
+				{
+					Sub: testdata.A1,
+					BF:  []*model.ArtifactInputSpec{testdata.A2},
+					BB:  testdata.B1,
+					SLSA: &model.SLSAInputSpec{
+						BuildType: "test type one",
+					},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				Subject: &model.ArtifactSpec{
+					Algorithm: ptrfrom.String("sha256"),
+					Digest:    ptrfrom.String("6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"),
+				},
+				BuildType: ptrfrom.String("test type one"),
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A1out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B1out,
+					BuiltFrom: []*model.Artifact{testdata.A2out},
+					BuildType: "test type one",
+				},
+			},
+		},
+		{
+			Name:  "Query on Subject ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A2, testdata.A3},
+			InBld: []*model.BuilderInputSpec{testdata.B1},
+			Calls: []call{
+				{
+					Sub:  testdata.A3,
+					BF:   []*model.ArtifactInputSpec{testdata.A2},
+					BB:   testdata.B1,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A3out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B1out,
+					BuiltFrom: []*model.Artifact{testdata.A2out},
+				},
+			},
+		},
+		{
+			Name:  "Query on Materials",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A4},
+			InBld: []*model.BuilderInputSpec{testdata.B1},
+			Calls: []call{
+				{
+					Sub:  testdata.A1,
+					BF:   []*model.ArtifactInputSpec{testdata.A4},
+					BB:   testdata.B1,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				BuiltFrom: []*model.ArtifactSpec{{
+					Digest: ptrfrom.String("5a787865sd676dacb0142afa0b83029cd7befd9"),
+				}},
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A1out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B1out,
+					BuiltFrom: []*model.Artifact{testdata.A4out},
+				},
+			},
+		},
+		{
+			Name:  "Query on Builder",
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			InBld: []*model.BuilderInputSpec{testdata.B2},
+			Calls: []call{
+				{
+					Sub:  testdata.A1,
+					BF:   []*model.ArtifactInputSpec{testdata.A2},
+					BB:   testdata.B2,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				BuiltBy: &model.BuilderSpec{
+					URI: ptrfrom.String("qwer"),
+				},
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A1out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B2out,
+					BuiltFrom: []*model.Artifact{testdata.A2out},
+				},
+			},
+		},
+		{
+			Name:  "Query on Builder ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A2, testdata.A3},
+			InBld: []*model.BuilderInputSpec{testdata.B2},
+			Calls: []call{
+				{
+					Sub:  testdata.A3,
+					BF:   []*model.ArtifactInputSpec{testdata.A2},
+					BB:   testdata.B2,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A3out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B2out,
+					BuiltFrom: []*model.Artifact{testdata.A2out},
+				},
+			},
+		},
+		{
+			Name:  "Query on ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			InBld: []*model.BuilderInputSpec{testdata.B1, testdata.B2},
+			Calls: []call{
+				{
+					Sub:  testdata.A1,
+					BF:   []*model.ArtifactInputSpec{testdata.A2},
+					BB:   testdata.B2,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			ExpHS: &model.HasSlsa{
+				Subject: testdata.A1out,
+				Slsa: &model.Slsa{
+					BuiltBy:   testdata.B2out,
+					BuiltFrom: []*model.Artifact{testdata.A2out},
+				},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			InBld: []*model.BuilderInputSpec{testdata.B2},
+			Calls: []call{
+				{
+					Sub:  testdata.A1,
+					BF:   []*model.ArtifactInputSpec{testdata.A2},
+					BB:   testdata.B2,
+					SLSA: &model.SLSAInputSpec{},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, bld := range test.InBld {
+				if _, err := b.IngestBuilder(ctx, bld); err != nil {
+					t.Fatalf("Could not ingest builder: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestSLSA(ctx, *o.Sub, o.BF, *o.BB, *o.SLSA)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildHasSlsaByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpHS, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/assembler/backends/arangodb/hasSLSA_test.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -29,11 +29,11 @@ import (
 func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
 
 	if hasSourceAtSpec != nil && hasSourceAtSpec.ID != nil {
-		cv, err := c.buildHasSourceAtByID(ctx, *hasSourceAtSpec.ID, hasSourceAtSpec)
+		hs, err := c.buildHasSourceAtByID(ctx, *hasSourceAtSpec.ID, hasSourceAtSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildHasSourceAtByID failed with an error: %w", err)
 		}
-		return []*model.HasSourceAt{cv}, nil
+		return []*model.HasSourceAt{hs}, nil
 	}
 
 	var arangoQueryBuilder *arangoQueryBuilder

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -723,8 +723,8 @@ func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 			Source:        src,
 			KnownSince:    createdValue.KnownSince,
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 
 		hasSourceAtList = append(hasSourceAtList, hasSourceAt)

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -767,8 +767,9 @@ func (c *arangoClient) buildHasSourceAtByID(ctx context.Context, id string, filt
 			}
 		}
 		return c.queryHasSourceAtNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for hasSourceAt query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *model.HasSourceAtSpec) (*model.HasSourceAt, error) {

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -785,7 +785,7 @@ func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *mod
 	defer cursor.Close()
 
 	type dbHasSourceAt struct {
-		CertifyBadID  string    `json:"_id"`
+		HasSourceAtID string    `json:"_id"`
 		PackageID     string    `json:"packageID"`
 		SourceID      string    `json:"sourceID"`
 		KnownSince    time.Time `json:"knownSince"`
@@ -824,7 +824,7 @@ func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *mod
 	}
 
 	return &model.HasSourceAt{
-		ID:            collectedValues[0].CertifyBadID,
+		ID:            collectedValues[0].HasSourceAtID,
 		Package:       builtPackage,
 		Source:        builtSource,
 		KnownSince:    collectedValues[0].KnownSince,

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -22,10 +22,20 @@ import (
 	"time"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) HasSourceAt(ctx context.Context, hasSourceAtSpec *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
+
+	if hasSourceAtSpec != nil && hasSourceAtSpec.ID != nil {
+		cv, err := c.buildHasSourceAtByID(ctx, *hasSourceAtSpec.ID, hasSourceAtSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildHasSourceAtByID failed with an error: %w", err)
+		}
+		return []*model.HasSourceAt{cv}, nil
+	}
+
 	var arangoQueryBuilder *arangoQueryBuilder
 	if hasSourceAtSpec.Package != nil {
 		var combinedHasSourceAt []*model.HasSourceAt
@@ -165,14 +175,14 @@ func getPkgHasSourceAtForQuery(ctx context.Context, c *arangoClient, arangoQuery
 	return getHasSourceAtFromCursor(ctx, cursor)
 }
 
-func setHasSourceAtMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSourceAtSpec *model.HasSourceAtSpec, queryValues map[string]any) {
+func queryHasSourceAtBasedOnFilter(arangoQueryBuilder *arangoQueryBuilder, hasSourceAtSpec *model.HasSourceAtSpec, queryValues map[string]any) {
 	if hasSourceAtSpec.ID != nil {
 		arangoQueryBuilder.filter("hasSourceAt", "_id", "==", "@hasSourceAtId")
 		queryValues["hasSourceAtId"] = *hasSourceAtSpec.ID
 	}
 	if hasSourceAtSpec.KnownSince != nil {
 		arangoQueryBuilder.filter("hasSourceAt", knownSinceStr, ">=", "@"+knownSinceStr)
-		queryValues[knownSinceStr] = *hasSourceAtSpec.KnownSince
+		queryValues[knownSinceStr] = hasSourceAtSpec.KnownSince.UTC()
 	}
 	if hasSourceAtSpec.Justification != nil {
 		arangoQueryBuilder.filter("hasSourceAt", justification, "==", "@"+justification)
@@ -186,6 +196,10 @@ func setHasSourceAtMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSource
 		arangoQueryBuilder.filter("hasSourceAt", collector, "==", "@"+collector)
 		queryValues[collector] = *hasSourceAtSpec.Collector
 	}
+}
+
+func setHasSourceAtMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasSourceAtSpec *model.HasSourceAtSpec, queryValues map[string]any) {
+	queryHasSourceAtBasedOnFilter(arangoQueryBuilder, hasSourceAtSpec, queryValues)
 	if hasSourceAtSpec.Source != nil {
 		arangoQueryBuilder.forOutBound(hasSourceAtEdgesStr, "sName", "hasSourceAt")
 		if hasSourceAtSpec.Source.ID != nil {
@@ -234,7 +248,7 @@ func getHasSourceAtQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Matc
 	src := guacSrcId(*source)
 	values["srcNameGuacKey"] = src.NameId
 
-	values[knownSinceStr] = hasSourceAt.KnownSince
+	values[knownSinceStr] = hasSourceAt.KnownSince.UTC()
 	values[justification] = hasSourceAt.Justification
 	values[origin] = hasSourceAt.Origin
 	values[collector] = hasSourceAt.Collector
@@ -730,4 +744,91 @@ func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 		hasSourceAtList = append(hasSourceAtList, hasSourceAt)
 	}
 	return hasSourceAtList, nil
+}
+
+func (c *arangoClient) buildHasSourceAtByID(ctx context.Context, id string, filter *model.HasSourceAtSpec) (*model.HasSourceAt, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == hasSourceAtsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.HasSourceAtSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryHasSourceAtNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *model.HasSourceAtSpec) (*model.HasSourceAt, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(hasSourceAtsStr, "hasSourceAt")
+	queryHasSourceAtBasedOnFilter(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN hasSourceAt`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryHasSourceAtNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for hasSourceAt: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbHasSourceAt struct {
+		CertifyBadID  string    `json:"_id"`
+		PackageID     string    `json:"packageID"`
+		SourceID      string    `json:"sourceID"`
+		KnownSince    time.Time `json:"knownSince"`
+		Justification string    `json:"justification"`
+		Collector     string    `json:"collector"`
+		Origin        string    `json:"origin"`
+	}
+
+	var collectedValues []dbHasSourceAt
+	for {
+		var doc dbHasSourceAt
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to hasSourceAt from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of hasSourceAt nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	builtPackage, err := c.buildPackageResponseFromID(ctx, collectedValues[0].PackageID, filter.Package)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", collectedValues[0].PackageID, err)
+	}
+
+	builtSource, err := c.buildSourceResponseFromID(ctx, collectedValues[0].SourceID, filter.Source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source from ID: %s, with error: %w", collectedValues[0].SourceID, err)
+	}
+
+	return &model.HasSourceAt{
+		ID:            collectedValues[0].CertifyBadID,
+		Package:       builtPackage,
+		Source:        builtSource,
+		KnownSince:    collectedValues[0].KnownSince,
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Origin,
+	}, nil
 }

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -892,6 +890,309 @@ func TestIngestHasSourceAts(t *testing.T) {
 				}
 				if err != nil {
 					return
+				}
+			}
+			got, err := b.HasSourceAt(ctx, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildHasSourceAtByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	testTime := time.Unix(1e9+5, 0)
+	type call struct {
+		Pkg   *model.PkgInputSpec
+		Src   *model.SourceInputSpec
+		Match *model.MatchFlags
+		HSA   *model.HasSourceAtInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		Calls        []call
+		Query        *model.HasSourceAtSpec
+		ExpHSA       *model.HasSourceAt
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Type:      ptrfrom.String("conan"),
+					Namespace: ptrfrom.String("openssl.org"),
+					Name:      ptrfrom.String("openssl"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Package version ID",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QueryPkgID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Source - tag",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S3},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S3,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("git"),
+					Namespace: ptrfrom.String("github.com/jeff"),
+					Name:      ptrfrom.String("myrepo"),
+					Tag:       ptrfrom.String("v1.0"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P1out,
+					Source:  testdata.S3out,
+				},
+			},
+		},
+		{
+			Name:  "Query on Source ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S2,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QuerySourceID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P1out,
+					Source:  testdata.S2out,
+				},
+			},
+		},
+		{
+			Name:  "Query ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P2,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			QueryID: true,
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P2out,
+					Source:  testdata.S1out,
+				},
+			},
+		},
+		{
+			Name:  "Query Name and Version",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InSrc: []*model.SourceInputSpec{testdata.S4},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeAllVersions,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+				{
+					Pkg: testdata.P4,
+					Src: testdata.S4,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				Package: &model.PkgSpec{
+					Type:      ptrfrom.String("conan"),
+					Namespace: ptrfrom.String("openssl.org"),
+					Name:      ptrfrom.String("openssl"),
+				},
+				Source: &model.SourceSpec{
+					Type:      ptrfrom.String("svn"),
+					Namespace: ptrfrom.String("github.com/bob"),
+					Name:      ptrfrom.String("bobsrepo"),
+					Commit:    ptrfrom.String("5e7c41f"),
+				},
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package: testdata.P4out,
+					Source:  testdata.S4out,
+				},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: false,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestHasSourceAt(ctx, *o.Pkg, *o.Match, *o.Src, *o.HSA)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if test.QueryID {
+					test.Query = &model.HasSourceAtSpec{
+						ID: ptrfrom.String(found.ID),
+					}
+				}
+				if test.QueryPkgID {
+					test.Query = &model.HasSourceAtSpec{
+						Package: &model.PkgSpec{
+							ID: ptrfrom.String(found.Package.Namespaces[0].Names[0].Versions[0].ID),
+						},
+					}
+
+				}
+				if test.QuerySourceID {
+					test.Query = &model.HasSourceAtSpec{
+						Source: &model.SourceSpec{
+							ID: ptrfrom.String(found.Source.Namespaces[0].Names[0].ID),
+						},
+					}
 				}
 			}
 			got, err := b.HasSourceAt(ctx, test.Query)

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -570,7 +570,7 @@ func TestHasSourceAt(t *testing.T) {
 			Query: &model.HasSourceAtSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -917,7 +917,6 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
-	testTime := time.Unix(1e9+5, 0)
 	type call struct {
 		Pkg   *model.PkgInputSpec
 		Src   *model.SourceInputSpec
@@ -936,17 +935,9 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 	}{
 		{
 			Name:  "Query on Package",
-			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
+			InPkg: []*model.PkgInputSpec{testdata.P4},
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			Calls: []call{
-				{
-					Pkg: testdata.P1,
-					Src: testdata.S1,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
 				{
 					Pkg: testdata.P4,
 					Src: testdata.S1,
@@ -963,11 +954,9 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 					Name:      ptrfrom.String("openssl"),
 				},
 			},
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P4out,
-					Source:  testdata.S1out,
-				},
+			ExpHSA: &model.HasSourceAt{
+				Package: testdata.P4out,
+				Source:  testdata.S1out,
 			},
 		},
 		{
@@ -984,27 +973,16 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 					HSA: &model.HasSourceAtInputSpec{},
 				},
 			},
-			QueryPkgID: true,
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P4out,
-					Source:  testdata.S1out,
-				},
+			ExpHSA: &model.HasSourceAt{
+				Package: testdata.P4out,
+				Source:  testdata.S1out,
 			},
 		},
 		{
 			Name:  "Query on Source - tag",
 			InPkg: []*model.PkgInputSpec{testdata.P1},
-			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S3},
+			InSrc: []*model.SourceInputSpec{testdata.S3},
 			Calls: []call{
-				{
-					Pkg: testdata.P1,
-					Src: testdata.S1,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
 				{
 					Pkg: testdata.P1,
 					Src: testdata.S3,
@@ -1022,11 +1000,9 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 					Tag:       ptrfrom.String("v1.0"),
 				},
 			},
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P1out,
-					Source:  testdata.S3out,
-				},
+			ExpHSA: &model.HasSourceAt{
+				Package: testdata.P1out,
+				Source:  testdata.S3out,
 			},
 		},
 		{
@@ -1043,12 +1019,9 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 					HSA: &model.HasSourceAtInputSpec{},
 				},
 			},
-			QuerySourceID: true,
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P1out,
-					Source:  testdata.S2out,
-				},
+			ExpHSA: &model.HasSourceAt{
+				Package: testdata.P1out,
+				Source:  testdata.S2out,
 			},
 		},
 		{
@@ -1056,14 +1029,6 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			Calls: []call{
-				{
-					Pkg: testdata.P1,
-					Src: testdata.S1,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
 				{
 					Pkg: testdata.P2,
 					Src: testdata.S1,
@@ -1073,62 +1038,9 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 					HSA: &model.HasSourceAtInputSpec{},
 				},
 			},
-			QueryID: true,
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P2out,
-					Source:  testdata.S1out,
-				},
-			},
-		},
-		{
-			Name:  "Query Name and Version",
-			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P4},
-			InSrc: []*model.SourceInputSpec{testdata.S4},
-			Calls: []call{
-				{
-					Pkg: testdata.P1,
-					Src: testdata.S1,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
-				{
-					Pkg: testdata.P1,
-					Src: testdata.S1,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeAllVersions,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
-				{
-					Pkg: testdata.P4,
-					Src: testdata.S4,
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					HSA: &model.HasSourceAtInputSpec{},
-				},
-			},
-			Query: &model.HasSourceAtSpec{
-				Package: &model.PkgSpec{
-					Type:      ptrfrom.String("conan"),
-					Namespace: ptrfrom.String("openssl.org"),
-					Name:      ptrfrom.String("openssl"),
-				},
-				Source: &model.SourceSpec{
-					Type:      ptrfrom.String("svn"),
-					Namespace: ptrfrom.String("github.com/bob"),
-					Name:      ptrfrom.String("bobsrepo"),
-					Commit:    ptrfrom.String("5e7c41f"),
-				},
-			},
-			ExpHSA: []*model.HasSourceAt{
-				{
-					Package: testdata.P4out,
-					Source:  testdata.S4out,
-				},
+			ExpHSA: &model.HasSourceAt{
+				Package: testdata.P2out,
+				Source:  testdata.S1out,
 			},
 		},
 		{
@@ -1148,7 +1060,7 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 			Query: &model.HasSourceAtSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -1174,36 +1086,16 @@ func Test_buildHasSourceAtByID(t *testing.T) {
 				if err != nil {
 					return
 				}
-				if test.QueryID {
-					test.Query = &model.HasSourceAtSpec{
-						ID: ptrfrom.String(found.ID),
-					}
+				got, err := b.(*arangoClient).buildHasSourceAtByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
 				}
-				if test.QueryPkgID {
-					test.Query = &model.HasSourceAtSpec{
-						Package: &model.PkgSpec{
-							ID: ptrfrom.String(found.Package.Namespaces[0].Names[0].Versions[0].ID),
-						},
-					}
-
+				if err != nil {
+					return
 				}
-				if test.QuerySourceID {
-					test.Query = &model.HasSourceAtSpec{
-						Source: &model.SourceSpec{
-							ID: ptrfrom.String(found.Source.Namespaces[0].Names[0].ID),
-						},
-					}
+				if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 				}
-			}
-			got, err := b.HasSourceAt(ctx, test.Query)
-			if (err != nil) != test.ExpQueryErr {
-				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
-			}
-			if err != nil {
-				return
-			}
-			if diff := cmp.Diff(test.ExpHSA, got, ignoreID); diff != "" {
-				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -29,11 +29,11 @@ import (
 func (c *arangoClient) HashEqual(ctx context.Context, hashEqualSpec *model.HashEqualSpec) ([]*model.HashEqual, error) {
 
 	if hashEqualSpec != nil && hashEqualSpec.ID != nil {
-		cv, err := c.buildHashEqualByID(ctx, *hashEqualSpec.ID, hashEqualSpec)
+		he, err := c.buildHashEqualByID(ctx, *hashEqualSpec.ID, hashEqualSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildHashEqualByID failed with an error: %w", err)
 		}
-		return []*model.HashEqual{cv}, nil
+		return []*model.HashEqual{he}, nil
 	}
 
 	values := map[string]any{}

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -356,8 +356,9 @@ func (c *arangoClient) buildHashEqualByID(ctx context.Context, id string, filter
 			}
 		}
 		return c.queryHashEqualNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for hashEqual query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryHashEqualNodeByID(ctx context.Context, filter *model.HashEqualSpec) (*model.HashEqual, error) {

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -317,8 +317,8 @@ func getHashEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model
 			ID:            createdValue.HashEqualId,
 			Artifacts:     []*model.Artifact{createdValue.Artifact, createdValue.EqualArtifact},
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 		hashEqualList = append(hashEqualList, hashEqual)
 	}

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -22,10 +22,20 @@ import (
 	"strings"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (c *arangoClient) HashEqual(ctx context.Context, hashEqualSpec *model.HashEqualSpec) ([]*model.HashEqual, error) {
+
+	if hashEqualSpec != nil && hashEqualSpec.ID != nil {
+		cv, err := c.buildHashEqualByID(ctx, *hashEqualSpec.ID, hashEqualSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildHashEqualByID failed with an error: %w", err)
+		}
+		return []*model.HashEqual{cv}, nil
+	}
+
 	values := map[string]any{}
 	if hashEqualSpec.Artifacts != nil {
 		if len(hashEqualSpec.Artifacts) == 1 {
@@ -323,4 +333,92 @@ func getHashEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model
 		hashEqualList = append(hashEqualList, hashEqual)
 	}
 	return hashEqualList, nil
+}
+
+func (c *arangoClient) buildHashEqualByID(ctx context.Context, id string, filter *model.HashEqualSpec) (*model.HashEqual, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == hashEqualsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.HashEqualSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryHashEqualNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryHashEqualNodeByID(ctx context.Context, filter *model.HashEqualSpec) (*model.HashEqual, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(hashEqualsStr, "hashEqual")
+	setHashEqualMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN hashEqual`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryHashEqualNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for hashEqual: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbHashEqual struct {
+		HashEqualID     string `json:"_id"`
+		ArtifactID      string `json:"artifactID"`
+		EqualArtifactID string `json:"equalArtifactID"`
+		Justification   string `json:"justification"`
+		Collector       string `json:"collector"`
+		Origin          string `json:"origin"`
+	}
+
+	var collectedValues []dbHashEqual
+	for {
+		var doc dbHashEqual
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to hashEqual from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of hashEqual nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	hashEqual := &model.HashEqual{
+		ID:            collectedValues[0].HashEqualID,
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Origin,
+		Collector:     collectedValues[0].Collector,
+	}
+
+	builtArtifact, err := c.buildArtifactResponseByID(ctx, collectedValues[0].ArtifactID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get artifact from ID: %s, with error: %w", collectedValues[0].ArtifactID, err)
+	}
+	hashEqual.Artifacts = append(hashEqual.Artifacts, builtArtifact)
+
+	builtEqualArtifact, err := c.buildArtifactResponseByID(ctx, collectedValues[0].EqualArtifactID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get equal artifact from ID: %s, with error: %w", collectedValues[0].EqualArtifactID, err)
+	}
+	hashEqual.Artifacts = append(hashEqual.Artifacts, builtEqualArtifact)
+
+	return hashEqual, nil
 }

--- a/pkg/assembler/backends/arangodb/hashEqual_test.go
+++ b/pkg/assembler/backends/arangodb/hashEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/hashEqual_test.go
+++ b/pkg/assembler/backends/arangodb/hashEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -464,7 +462,7 @@ func TestHashEqual(t *testing.T) {
 			Query: &model.HashEqualSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -829,6 +827,104 @@ func TestIngestHashEquals(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpHE, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildHashEqualByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		A1 *model.ArtifactInputSpec
+		A2 *model.ArtifactInputSpec
+		HE *model.HashEqualInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.HashEqualSpec
+		ExpHE        *model.HashEqual
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2, testdata.A3},
+			Calls: []call{
+				{
+					A1: testdata.A1,
+					A2: testdata.A3,
+					HE: &model.HashEqualInputSpec{},
+				},
+			},
+			ExpHE: &model.HashEqual{
+				Artifacts: []*model.Artifact{testdata.A3out, testdata.A1out},
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2, testdata.A3},
+			Calls: []call{
+				{
+					A1: testdata.A1,
+					A2: testdata.A2,
+					HE: &model.HashEqualInputSpec{},
+				},
+				{
+					A1: testdata.A2,
+					A2: testdata.A3,
+					HE: &model.HashEqualInputSpec{},
+				},
+				{
+					A1: testdata.A1,
+					A2: testdata.A3,
+					HE: &model.HashEqualInputSpec{},
+				},
+			},
+			Query: &model.HashEqualSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestHashEqual(ctx, *o.A1, *o.A2, *o.HE)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildHashEqualByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpHE, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -853,8 +853,9 @@ func (c *arangoClient) buildIsDependencyByID(ctx context.Context, id string, fil
 			}
 		}
 		return c.queryIsDependencyNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for isDependency query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryIsDependencyNodeByID(ctx context.Context, filter *model.IsDependencySpec) (*model.IsDependency, error) {

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -914,7 +914,7 @@ func (c *arangoClient) queryIsDependencyNodeByID(ctx context.Context, filter *mo
 
 	builtDepPackage, err := c.buildPackageResponseFromID(ctx, collectedValues[0].DepPackageID, filter.DependencyPackage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", collectedValues[0].DepPackageID, err)
+		return nil, fmt.Errorf("failed to get dependency package from ID: %s, with error: %w", collectedValues[0].DepPackageID, err)
 	}
 
 	return &model.IsDependency{

--- a/pkg/assembler/backends/arangodb/isDependency_test.go
+++ b/pkg/assembler/backends/arangodb/isDependency_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (
@@ -1089,7 +1091,6 @@ func Test_buildIsDependencyByID(t *testing.T) {
 				DependencyPackage: testdata.P4outName,
 			},
 		},
-
 		{
 			Name:  "Query on ID",
 			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},

--- a/pkg/assembler/backends/arangodb/isDependency_test.go
+++ b/pkg/assembler/backends/arangodb/isDependency_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -707,7 +705,7 @@ func TestIsDependency(t *testing.T) {
 			Query: &model.IsDependencySpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 		{
 			Name:  "IsDep from version to version",
@@ -1009,6 +1007,175 @@ func TestIsDependencies(t *testing.T) {
 				got, err := b.IngestDependencies(ctx, o.P1s, o.P2s, o.MF, o.IDs)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpID, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
+		})
+	}
+}
+
+func Test_buildIsDependencyByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		P1 *model.PkgInputSpec
+		P2 *model.PkgInputSpec
+		MF model.MatchFlags
+		ID *model.IsDependencyInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		Calls        []call
+		Query        *model.IsDependencySpec
+		ExpID        *model.IsDependency
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on pkg",
+			InPkg: []*model.PkgInputSpec{testdata.P2, testdata.P3},
+			Calls: []call{
+				{
+					P1: testdata.P2,
+					P2: testdata.P3,
+					MF: mAll,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			Query: &model.IsDependencySpec{
+				Package: &model.PkgSpec{
+					Name:    ptrfrom.String("tensorflow"),
+					Version: ptrfrom.String("2.11.1"),
+				},
+			},
+			ExpID: &model.IsDependency{
+				Package:           testdata.P2out,
+				DependencyPackage: testdata.P2outName,
+			},
+		},
+		{
+			Name:  "Query on dep pkg",
+			InPkg: []*model.PkgInputSpec{testdata.P2, testdata.P4},
+			Calls: []call{
+				{
+					P1: testdata.P2,
+					P2: testdata.P4,
+					MF: mAll,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			Query: &model.IsDependencySpec{
+				DependencyPackage: &model.PkgSpec{
+					Name: ptrfrom.String("openssl"),
+				},
+			},
+			ExpID: &model.IsDependency{
+				Package:           testdata.P2out,
+				DependencyPackage: testdata.P4outName,
+			},
+		},
+
+		{
+			Name:  "Query on ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P2,
+					MF: mAll,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			ExpID: &model.IsDependency{
+				Package:           testdata.P1out,
+				DependencyPackage: testdata.P2outName,
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P3},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P3,
+					MF: mAll,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			Query: &model.IsDependencySpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+		{
+			Name:  "Query on pkg ID",
+			InPkg: []*model.PkgInputSpec{testdata.P2, testdata.P4},
+			Calls: []call{
+				{
+					P1: testdata.P4,
+					P2: testdata.P2,
+					MF: mSpecific,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			ExpID: &model.IsDependency{
+				Package:           testdata.P4out,
+				DependencyPackage: testdata.P2out,
+			},
+		},
+		{
+			Name:  "Query on dep pkg ID",
+			InPkg: []*model.PkgInputSpec{testdata.P2, testdata.P4},
+			Calls: []call{
+				{
+					P1: testdata.P2,
+					P2: testdata.P4,
+					MF: mSpecific,
+					ID: &model.IsDependencyInputSpec{},
+				},
+			},
+			ExpID: &model.IsDependency{
+				Package:           testdata.P2out,
+				DependencyPackage: testdata.P4out,
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, a := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *a); err != nil {
+					t.Fatalf("Could not ingest pkg: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestDependency(ctx, *o.P1, *o.P2, o.MF, *o.ID)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildIsDependencyByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
 				}
 				if err != nil {
 					return

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -684,8 +684,9 @@ func (c *arangoClient) buildIsOccurrenceByID(ctx context.Context, id string, fil
 			}
 		}
 		return c.queryIsOccurrenceNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for isOccurrence query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryIsOccurrenceNodeByID(ctx context.Context, filter *model.IsOccurrenceSpec) (*model.IsOccurrence, error) {

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -29,11 +29,11 @@ import (
 func (c *arangoClient) IsOccurrence(ctx context.Context, isOccurrenceSpec *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error) {
 
 	if isOccurrenceSpec != nil && isOccurrenceSpec.ID != nil {
-		d, err := c.buildIsOccurrenceByID(ctx, *isOccurrenceSpec.ID, isOccurrenceSpec)
+		io, err := c.buildIsOccurrenceByID(ctx, *isOccurrenceSpec.ID, isOccurrenceSpec)
 		if err != nil {
 			return nil, fmt.Errorf("buildIsOccurrenceByID failed with an error: %w", err)
 		}
-		return []*model.IsOccurrence{d}, nil
+		return []*model.IsOccurrence{io}, nil
 	}
 
 	// TODO (pxp928): Optimization of the query can be done by starting from the occurrence artifact node (if specified)

--- a/pkg/assembler/backends/arangodb/isOccurrence.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence.go
@@ -635,8 +635,8 @@ func getIsOccurrenceFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mo
 			ID:            createdValue.IsOccurrenceID,
 			Artifact:      createdValue.Artifact,
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 		if pkg != nil {
 			isOccurrence.Subject = pkg

--- a/pkg/assembler/backends/arangodb/isOccurrence_test.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -28,28 +26,6 @@ import (
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
-
-// func convNode(n model.Node) hasID {
-// 	// All nodes have a json "id"
-// 	// Only getting top-level id however
-// 	var h hasID
-// 	b, _ := json.Marshal(n)
-// 	_ = json.Unmarshal(b, &h)
-// 	return h
-// }
-
-// func convNodes(ns []model.Node) []string {
-// 	var ids []string
-// 	for _, n := range ns {
-// 		h := convNode(n)
-// 		ids = append(ids, h.ID)
-// 	}
-// 	return ids
-// }
-
-// type hasID struct {
-// 	ID string `json:"id"`
-// }
 
 func TestOccurrence(t *testing.T) {
 	ctx := context.Background()
@@ -411,7 +387,8 @@ func TestOccurrence(t *testing.T) {
 			Query: &model.IsOccurrenceSpec{
 				ID: ptrfrom.String("12345"),
 			},
-			ExpOcc: nil,
+			ExpOcc:      nil,
+			ExpQueryErr: true,
 		},
 		{
 			Name:  "Query on ID",
@@ -500,7 +477,7 @@ func TestOccurrence(t *testing.T) {
 			Query: &model.IsOccurrenceSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -689,6 +666,263 @@ func TestIngestOccurrences(t *testing.T) {
 					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 				}
 			}
+		})
+	}
+}
+
+func Test_buildIsOccurrenceByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		PkgSrc     model.PackageOrSourceInput
+		Artifact   *model.ArtifactInputSpec
+		Occurrence *model.IsOccurrenceInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.IsOccurrenceSpec
+		ExpOcc       *model.IsOccurrence
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on Artifact",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InArt: []*model.ArtifactInputSpec{testdata.A4},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Artifact: testdata.A4,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			Query: &model.IsOccurrenceSpec{
+				Artifact: &model.ArtifactSpec{
+					Algorithm: ptrfrom.String("sha1"),
+					Digest:    ptrfrom.String("5a787865sd676dacb0142afa0b83029cd7befd9"),
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.P1out,
+				Artifact:      testdata.A4out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InArt: []*model.ArtifactInputSpec{testdata.A4},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Artifact: testdata.A4,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.P1out,
+				Artifact:      testdata.A4out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P4,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			Query: &model.IsOccurrenceSpec{
+				Subject: &model.PackageOrSourceSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("3.0.3"),
+					},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.P4out,
+				Artifact:      testdata.A1out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on Package ID",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P4,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.P4out,
+				Artifact:      testdata.A1out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Source: testdata.S1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			Query: &model.IsOccurrenceSpec{
+				Subject: &model.PackageOrSourceSpec{
+					Source: &model.SourceSpec{},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.S1out,
+				Artifact:      testdata.A1out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on Source ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Source: testdata.S1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.S1out,
+				Artifact:      testdata.A1out,
+				Justification: "justification",
+			},
+		},
+		{
+			Name:  "Query on ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpOcc: &model.IsOccurrence{
+				Subject:       testdata.P1out,
+				Artifact:      testdata.A1out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: testdata.P1,
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						Justification: "justification",
+					},
+				},
+			},
+			Query: &model.IsOccurrenceSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestOccurrence(ctx, o.PkgSrc, *o.Artifact, *o.Occurrence)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildIsOccurrenceByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpOcc, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/assembler/backends/arangodb/isOccurrence_test.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/license.go
+++ b/pkg/assembler/backends/arangodb/license.go
@@ -293,6 +293,17 @@ func (c *arangoClient) getLicensesByID(ctx context.Context, licIDs []string) ([]
 	return getLicenses(ctx, cursor)
 }
 
+func (c *arangoClient) getLicenseByID(ctx context.Context, licID string) (*model.License, error) {
+	licenses, err := c.getLicensesByID(ctx, []string{licID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get license by ID for: %s, with error: %w", licID, err)
+	}
+	if len(licenses) != 1 {
+		return nil, fmt.Errorf("number of license nodes found for ID: %s is greater than one", licID)
+	}
+	return licenses[0], nil
+}
+
 func licenseMatch(filters []*model.LicenseSpec, values []*model.License) bool {
 	left := slices.Clone(values)
 

--- a/pkg/assembler/backends/arangodb/license_test.go
+++ b/pkg/assembler/backends/arangodb/license_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/path.go
+++ b/pkg/assembler/backends/arangodb/path.go
@@ -47,6 +47,8 @@ func (c *arangoClient) Node(ctx context.Context, nodeID string) (model.Node, err
 		return c.buildBuilderResponseByID(ctx, nodeID, nil)
 	case artifactsStr:
 		return c.buildArtifactResponseByID(ctx, nodeID, nil)
+	case certifyBadsStr:
+		return c.buildCertifyBadByID(ctx, nodeID, nil)
 	}
 	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/path.go
+++ b/pkg/assembler/backends/arangodb/path.go
@@ -41,6 +41,8 @@ func (c *arangoClient) Node(ctx context.Context, nodeID string) (model.Node, err
 		return c.buildPackageResponseFromID(ctx, nodeID, nil)
 	case srcNamesStr, srcNamespacesStr, srcTypesStr:
 		return c.buildSourceResponseFromID(ctx, nodeID, nil)
+	case vulnerabilitiesStr, vulnTypesStr:
+		return c.buildVulnResponseByID(ctx, nodeID, nil)
 	}
 	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/path.go
+++ b/pkg/assembler/backends/arangodb/path.go
@@ -47,14 +47,55 @@ func (c *arangoClient) Node(ctx context.Context, nodeID string) (model.Node, err
 		return c.buildBuilderResponseByID(ctx, nodeID, nil)
 	case artifactsStr:
 		return c.buildArtifactResponseByID(ctx, nodeID, nil)
+	case licensesStr:
+		return c.getLicenseByID(ctx, nodeID)
 	case certifyBadsStr:
 		return c.buildCertifyBadByID(ctx, nodeID, nil)
 	case certifyGoodsStr:
 		return c.buildCertifyGoodByID(ctx, nodeID, nil)
+	case certifyLegalsStr:
+		return c.buildCertifyLegalByID(ctx, nodeID, nil)
+	case scorecardStr:
+		return c.buildCertifyScorecardByID(ctx, nodeID, nil)
+	case certifyVEXsStr:
+		return c.buildCertifyVexByID(ctx, nodeID, nil)
+	case certifyVulnsStr:
+		return c.buildCertifyVulnByID(ctx, nodeID, nil)
+	case hashEqualsStr:
+		return c.buildHashEqualByID(ctx, nodeID, nil)
+	case hasMetadataStr:
+		return c.buildHasMetadataByID(ctx, nodeID, nil)
+	case hasSBOMsStr:
+		return c.buildHasSbomByID(ctx, nodeID, nil)
+	case hasSLSAsStr:
+		return c.buildHasSlsaByID(ctx, nodeID, nil)
+	case hasSourceAtsStr:
+		return c.buildHasSourceAtByID(ctx, nodeID, nil)
+	case isDependenciesStr:
+		return c.buildIsDependencyByID(ctx, nodeID, nil)
+	case isOccurrencesStr:
+		return c.buildIsOccurrenceByID(ctx, nodeID, nil)
+	case pkgEqualsStr:
+		return c.buildPkgEqualByID(ctx, nodeID, nil)
+	case pointOfContactStr:
+		return c.buildPointOfContactByID(ctx, nodeID, nil)
+	case vulnEqualsStr:
+		return c.buildVulnEqualByID(ctx, nodeID, nil)
+	case vulnMetadataStr:
+		return c.buildVulnerabilityMetadataByID(ctx, nodeID, nil)
+	default:
+		return nil, fmt.Errorf("unknown ID for node query: %s", nodeID)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) Nodes(ctx context.Context, nodeIDs []string) ([]model.Node, error) {
-	panic(fmt.Errorf("not implemented: Nodes"))
+	rv := make([]model.Node, 0, len(nodeIDs))
+	for _, id := range nodeIDs {
+		n, err := c.Node(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, n)
+	}
+	return rv, nil
 }

--- a/pkg/assembler/backends/arangodb/path.go
+++ b/pkg/assembler/backends/arangodb/path.go
@@ -43,6 +43,10 @@ func (c *arangoClient) Node(ctx context.Context, nodeID string) (model.Node, err
 		return c.buildSourceResponseFromID(ctx, nodeID, nil)
 	case vulnerabilitiesStr, vulnTypesStr:
 		return c.buildVulnResponseByID(ctx, nodeID, nil)
+	case buildersStr:
+		return c.buildBuilderResponseByID(ctx, nodeID, nil)
+	case artifactsStr:
+		return c.buildArtifactResponseByID(ctx, nodeID, nil)
 	}
 	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/path.go
+++ b/pkg/assembler/backends/arangodb/path.go
@@ -49,6 +49,8 @@ func (c *arangoClient) Node(ctx context.Context, nodeID string) (model.Node, err
 		return c.buildArtifactResponseByID(ctx, nodeID, nil)
 	case certifyBadsStr:
 		return c.buildCertifyBadByID(ctx, nodeID, nil)
+	case certifyGoodsStr:
+		return c.buildCertifyGoodByID(ctx, nodeID, nil)
 	}
 	return nil, nil
 }

--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -413,6 +413,13 @@ func setPkgVersionMatchValues(pkgSpec *model.PkgSpec, queryValues map[string]any
 }
 
 func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
+	if pkgSpec != nil && pkgSpec.ID != nil {
+		p, err := c.buildPackageResponseFromID(ctx, *pkgSpec.ID, pkgSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildPackageResponseFromID failed with an error: %w", err)
+		}
+		return []*model.Package{p}, nil
+	}
 
 	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {
 		// fields: [type namespaces namespaces.namespace namespaces.names namespaces.names.name namespaces.names.versions

--- a/pkg/assembler/backends/arangodb/pkgEqual.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual.go
@@ -657,8 +657,9 @@ func (c *arangoClient) buildPkgEqualByID(ctx context.Context, id string, filter 
 			}
 		}
 		return c.queryPkgEqualNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for pkgEqual query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryPkgEqualNodeByID(ctx context.Context, filter *model.PkgEqualSpec) (*model.PkgEqual, error) {

--- a/pkg/assembler/backends/arangodb/pkgEqual.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual.go
@@ -618,8 +618,8 @@ func getPkgEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.
 			ID:            createdValue.PkgEqualId,
 			Packages:      []*model.Package{pkg, equalPkg},
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 		pkgEqualList = append(pkgEqualList, pkgEqual)
 	}

--- a/pkg/assembler/backends/arangodb/pkgEqual.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual.go
@@ -22,11 +22,21 @@ import (
 	"strings"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	purl "github.com/package-url/packageurl-go"
 )
 
 func (c *arangoClient) PkgEqual(ctx context.Context, pkgEqualSpec *model.PkgEqualSpec) ([]*model.PkgEqual, error) {
+
+	if pkgEqualSpec != nil && pkgEqualSpec.ID != nil {
+		pe, err := c.buildPkgEqualByID(ctx, *pkgEqualSpec.ID, pkgEqualSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildPkgEqualByID failed with an error: %w", err)
+		}
+		return []*model.PkgEqual{pe}, nil
+	}
+
 	values := map[string]any{}
 	if pkgEqualSpec.Packages != nil {
 		if len(pkgEqualSpec.Packages) == 1 {
@@ -624,4 +634,89 @@ func getPkgEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model.
 		pkgEqualList = append(pkgEqualList, pkgEqual)
 	}
 	return pkgEqualList, nil
+}
+
+func (c *arangoClient) buildPkgEqualByID(ctx context.Context, id string, filter *model.PkgEqualSpec) (*model.PkgEqual, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == pkgEqualsStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.PkgEqualSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryPkgEqualNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryPkgEqualNodeByID(ctx context.Context, filter *model.PkgEqualSpec) (*model.PkgEqual, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(pkgEqualsStr, "pkgEqual")
+	setPkgEqualMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN pkgEqual`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryPkgEqualNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for pkgEqual: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbPkgEqual struct {
+		PkgEqualID     string `json:"_id"`
+		PackageID      string `json:"packageID"`
+		EqualPackageID string `json:"equalPackageID"`
+		Justification  string `json:"justification"`
+		Collector      string `json:"collector"`
+		Origin         string `json:"origin"`
+	}
+
+	var collectedValues []dbPkgEqual
+	for {
+		var doc dbPkgEqual
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to pkgEqual from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of pkgEqual nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	builtPackage, err := c.buildPackageResponseFromID(ctx, collectedValues[0].PackageID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get package from ID: %s, with error: %w", collectedValues[0].PackageID, err)
+	}
+
+	builtEqualPackage, err := c.buildPackageResponseFromID(ctx, collectedValues[0].EqualPackageID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get equal package from ID: %s, with error: %w", collectedValues[0].EqualPackageID, err)
+	}
+
+	return &model.PkgEqual{
+		ID:            collectedValues[0].PkgEqualID,
+		Packages:      []*model.Package{builtPackage, builtEqualPackage},
+		Justification: collectedValues[0].Justification,
+		Origin:        collectedValues[0].Collector,
+		Collector:     collectedValues[0].Origin,
+	}, nil
 }

--- a/pkg/assembler/backends/arangodb/pkgEqual_test.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/pkgEqual_test.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -566,7 +564,7 @@ func TestPkgEqual(t *testing.T) {
 			Query: &model.PkgEqualSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -1033,6 +1031,117 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 				t.Errorf("purl mismatch wanted: %s, got: %s", tt.expectedPurlUri, got)
 				return
 			}
+		})
+	}
+}
+
+func Test_buildPkgEqualByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		P1 *model.PkgInputSpec
+		P2 *model.PkgInputSpec
+		HE *model.PkgEqualInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		Calls        []call
+		Query        *model.PkgEqualSpec
+		ExpHE        *model.PkgEqual
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on pkg ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P2,
+					HE: &model.PkgEqualInputSpec{
+						Justification: "test justification two",
+					},
+				},
+			},
+			ExpHE: &model.PkgEqual{
+				Packages:      []*model.Package{testdata.P1out, testdata.P2out},
+				Justification: "test justification two",
+			},
+		},
+		{
+			Name:  "Query on ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P3},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P3,
+					HE: &model.PkgEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpHE: &model.PkgEqual{
+				Packages:      []*model.Package{testdata.P1out, testdata.P3out},
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P3},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P3,
+					HE: &model.PkgEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.PkgEqualSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, a := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *a); err != nil {
+					t.Fatalf("Could not ingest pkg: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestPkgEqual(ctx, *o.P1, *o.P2, *o.HE)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildPkgEqualByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpHE, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/assembler/backends/arangodb/pointOfContact.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact.go
@@ -280,7 +280,7 @@ func setPointOfContactMatchValues(arangoQueryBuilder *arangoQueryBuilder, PointO
 	}
 	if PointOfContactSpec.Since != nil {
 		arangoQueryBuilder.filter("pointOfContact", sinceStr, ">=", "@"+sinceStr)
-		queryValues[sinceStr] = *PointOfContactSpec.Since
+		queryValues[sinceStr] = PointOfContactSpec.Since.UTC()
 	}
 	if PointOfContactSpec.Justification != nil {
 		arangoQueryBuilder.filter("pointOfContact", justification, "==", "@"+justification)
@@ -316,7 +316,7 @@ func getPointOfContactQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.M
 
 	values[emailStr] = pointOfContact.Email
 	values[infoStr] = pointOfContact.Info
-	values[sinceStr] = pointOfContact.Since
+	values[sinceStr] = pointOfContact.Since.UTC()
 	values[justification] = pointOfContact.Justification
 	values[origin] = pointOfContact.Origin
 	values[collector] = pointOfContact.Collector

--- a/pkg/assembler/backends/arangodb/pointOfContact.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact.go
@@ -1049,8 +1049,9 @@ func (c *arangoClient) buildPointOfContactByID(ctx context.Context, id string, f
 			}
 		}
 		return c.queryPointOfContactNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for PointOfContact query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryPointOfContactNodeByID(ctx context.Context, filter *model.PointOfContactSpec) (*model.PointOfContact, error) {

--- a/pkg/assembler/backends/arangodb/pointOfContact.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact.go
@@ -1001,8 +1001,8 @@ func getPointOfContactFromCursor(ctx context.Context, cursor driver.Cursor) ([]*
 			Info:          createdValue.Info,
 			Since:         createdValue.Since,
 			Justification: createdValue.Justification,
-			Origin:        createdValue.Collector,
-			Collector:     createdValue.Origin,
+			Origin:        createdValue.Origin,
+			Collector:     createdValue.Collector,
 		}
 
 		if pkg != nil {

--- a/pkg/assembler/backends/arangodb/pointOfContact_test.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/pointOfContact_test.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -767,7 +765,7 @@ func TestPointOfContact(t *testing.T) {
 			Query: &model.PointOfContactSpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -1154,6 +1152,252 @@ func TestIngestPointOfContacts(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpPC, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildPointOfContactByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Sub   model.PackageSourceOrArtifactInput
+		Match *model.MatchFlags
+		POC   *model.PointOfContactInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InPkg        []*model.PkgInputSpec
+		InSrc        []*model.SourceInputSpec
+		InArt        []*model.ArtifactInputSpec
+		Calls        []call
+		Query        *model.PointOfContactSpec
+		ExpPoc       *model.PointOfContact
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:  "Query on Package",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Type:      ptrfrom.String("conan"),
+						Namespace: ptrfrom.String("openssl.org"),
+						Name:      ptrfrom.String("openssl"),
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Package version ID",
+			InPkg: []*model.PkgInputSpec{testdata.P4},
+			InSrc: []*model.SourceInputSpec{},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P4,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.P4out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source",
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Source: &model.SourceSpec{
+						Name: ptrfrom.String("bobsrepo"),
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Source ID",
+			InPkg: []*model.PkgInputSpec{},
+			InSrc: []*model.SourceInputSpec{testdata.S2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S2,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.S2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Artifact: &model.ArtifactSpec{
+						Algorithm: ptrfrom.String("sha1"),
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query on Artifact ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query ID",
+			InArt: []*model.ArtifactInputSpec{testdata.A2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Artifact: testdata.A2,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpPoc: &model.PointOfContact{
+				Subject:       testdata.A2out,
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:  "Query bad ID",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Source: testdata.S1,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				ID: ptrfrom.String("asdf"),
+			},
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, p := range test.InPkg {
+				if _, err := b.IngestPackage(ctx, *p); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, *s); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InArt {
+				if _, err := b.IngestArtifact(ctx, a); err != nil {
+					t.Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestPointOfContact(ctx, o.Sub, o.Match, *o.POC)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildPointOfContactByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpPoc, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -298,6 +298,13 @@ func setSrcMatchValues(srcSpec *model.SourceSpec, queryValues map[string]any) *a
 }
 
 func (c *arangoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec) ([]*model.Source, error) {
+	if sourceSpec != nil && sourceSpec.ID != nil {
+		p, err := c.buildSourceResponseFromID(ctx, *sourceSpec.ID, sourceSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildSourceResponseFromID failed with an error: %w", err)
+		}
+		return []*model.Source{p}, nil
+	}
 
 	// fields: [type namespaces namespaces.namespace namespaces.names namespaces.names.name namespaces.names.tag namespaces.names.commit]
 	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {

--- a/pkg/assembler/backends/arangodb/src_test.go
+++ b/pkg/assembler/backends/arangodb/src_test.go
@@ -432,15 +432,15 @@ func Test_buildSourceResponseFromID(t *testing.T) {
 	}, cmp.Ignore())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ingestedPkg, err := b.IngestSource(ctx, *tt.srcInput)
+			ingestedSrc, err := b.IngestSource(ctx, *tt.srcInput)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("arangoClient.IngestSource() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.idInFilter {
-				tt.srcFilter.ID = &ingestedPkg.Namespaces[0].Names[0].ID
+				tt.srcFilter.ID = &ingestedSrc.Namespaces[0].Names[0].ID
 			}
-			got, err := b.(*arangoClient).buildSourceResponseFromID(ctx, ingestedPkg.Namespaces[0].Names[0].ID, tt.srcFilter)
+			got, err := b.(*arangoClient).buildSourceResponseFromID(ctx, ingestedSrc.Namespaces[0].Names[0].ID, tt.srcFilter)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("arangoClient.buildSourceResponseFromID() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/assembler/backends/arangodb/vulnEqual.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual.go
@@ -477,8 +477,9 @@ func (c *arangoClient) buildVulnEqualByID(ctx context.Context, id string, filter
 			}
 		}
 		return c.queryVulnEqualNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for VulnEqual query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryVulnEqualNodeByID(ctx context.Context, filter *model.VulnEqualSpec) (*model.VulnEqual, error) {

--- a/pkg/assembler/backends/arangodb/vulnEqual.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual.go
@@ -439,8 +439,8 @@ func getVulnEqualFromCursor(ctx context.Context, cursor driver.Cursor) ([]*model
 			ID:              createdValue.VulnEqualId,
 			Vulnerabilities: []*model.Vulnerability{vuln, equalVuln},
 			Justification:   createdValue.Justification,
-			Origin:          createdValue.Collector,
-			Collector:       createdValue.Origin,
+			Origin:          createdValue.Origin,
+			Collector:       createdValue.Collector,
 		}
 		vulnEqualList = append(vulnEqualList, vulnEqual)
 	}

--- a/pkg/assembler/backends/arangodb/vulnEqual_test.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -569,6 +567,7 @@ func TestVulnEqual(t *testing.T) {
 				ID: ptrfrom.String("123456"),
 			},
 			ExpVulnEqual: nil,
+			ExpQueryErr:  true,
 		},
 		{
 			Name: "Query Error",
@@ -586,7 +585,7 @@ func TestVulnEqual(t *testing.T) {
 			Query: &model.VulnEqualSpec{
 				ID: ptrfrom.String("-123"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
@@ -830,6 +829,149 @@ func TestIngestVulnEquals(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpVulnEqual, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildVulnEqualByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Vuln      *model.VulnerabilityInputSpec
+		OtherVuln *model.VulnerabilityInputSpec
+		In        *model.VulnEqualInputSpec
+	}
+	tests := []struct {
+		Name         string
+		InVuln       []*model.VulnerabilityInputSpec
+		Calls        []call
+		Query        *model.VulnEqualSpec
+		ExpVulnEqual *model.VulnEqual
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "Query on vuln Equal ID",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O2, testdata.C1},
+			Calls: []call{
+				{
+					Vuln:      testdata.O2,
+					OtherVuln: testdata.C1,
+					In: &model.VulnEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpVulnEqual: &model.VulnEqual{
+				Vulnerabilities: []*model.Vulnerability{
+					{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.C1out},
+					},
+					{
+						Type:             "osv",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.O2out},
+					},
+				},
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:   "Query on ID",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1, testdata.G1},
+			Calls: []call{
+				{
+					Vuln:      testdata.O1,
+					OtherVuln: testdata.G1,
+					In: &model.VulnEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			ExpVulnEqual: &model.VulnEqual{
+				Vulnerabilities: []*model.Vulnerability{
+					{
+						Type:             "osv",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+					},
+					{
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+					},
+				},
+				Justification: "test justification",
+			},
+		},
+		{
+			Name:   "Query ID not found",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1, testdata.C1, testdata.C2, testdata.G1},
+			Calls: []call{
+				{
+					Vuln:      testdata.O1,
+					OtherVuln: testdata.C1,
+					In: &model.VulnEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Vuln:      testdata.O1,
+					OtherVuln: testdata.C2,
+					In: &model.VulnEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Vuln:      testdata.O1,
+					OtherVuln: testdata.G1,
+					In: &model.VulnEqualInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.VulnEqualSpec{
+				ID: ptrfrom.String("123456"),
+			},
+			ExpVulnEqual: nil,
+			ExpQueryErr:  true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, g := range test.InVuln {
+				if _, err := b.IngestVulnerability(ctx, *g); err != nil {
+					t.Fatalf("Could not ingest vulnerability: %a", err)
+				}
+			}
+			for _, o := range test.Calls {
+				found, err := b.IngestVulnEqual(ctx, *o.Vuln, *o.OtherVuln, *o.In)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildVulnEqualByID(ctx, found.ID, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpVulnEqual, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/vulnEqual_test.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -123,7 +123,7 @@ func setVulnMetadataMatchValues(arangoQueryBuilder *arangoQueryBuilder, vulnMeta
 	}
 	if vulnMetadata.Timestamp != nil {
 		arangoQueryBuilder.filter("vulnMetadata", timeStampStr, "==", "@"+timeStampStr)
-		queryValues[timeStampStr] = *vulnMetadata.Timestamp
+		queryValues[timeStampStr] = vulnMetadata.Timestamp.UTC()
 	}
 	if vulnMetadata.Origin != nil {
 		arangoQueryBuilder.filter("vulnMetadata", origin, "==", "@"+origin)
@@ -146,7 +146,7 @@ func getVulnMetadataQueryValues(vulnerability *model.VulnerabilityInputSpec, vul
 
 	values[scoreTypeStr] = vulnerabilityMetadata.ScoreType
 	values[scoreValueStr] = vulnerabilityMetadata.ScoreValue
-	values[timeStampStr] = vulnerabilityMetadata.Timestamp
+	values[timeStampStr] = vulnerabilityMetadata.Timestamp.UTC()
 	values[origin] = vulnerabilityMetadata.Origin
 	values[collector] = vulnerabilityMetadata.Collector
 

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -391,7 +391,10 @@ func (c *arangoClient) buildVulnerabilityMetadataByID(ctx context.Context, id st
 func (c *arangoClient) queryVulnerabilityMetadataNodeByID(ctx context.Context, filter *model.VulnerabilityMetadataSpec) (*model.VulnerabilityMetadata, error) {
 	values := map[string]any{}
 	arangoQueryBuilder := newForQuery(vulnMetadataStr, "vulnMetadata")
-	setVulnMetadataMatchValues(arangoQueryBuilder, filter, values)
+	err := setVulnMetadataMatchValues(arangoQueryBuilder, filter, values)
+	if err != nil {
+		return nil, fmt.Errorf("setting match values for vuln metadata resulted in error: %w", err)
+	}
 	arangoQueryBuilder.query.WriteString("\n")
 	arangoQueryBuilder.query.WriteString(`RETURN vulnMetadata`)
 

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/arangodb/go-driver"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
@@ -32,6 +33,14 @@ const (
 )
 
 func (c *arangoClient) VulnerabilityMetadata(ctx context.Context, vulnerabilityMetadataSpec *model.VulnerabilityMetadataSpec) ([]*model.VulnerabilityMetadata, error) {
+
+	if vulnerabilityMetadataSpec != nil && vulnerabilityMetadataSpec.ID != nil {
+		cv, err := c.buildVulnerabilityMetadataByID(ctx, *vulnerabilityMetadataSpec.ID, vulnerabilityMetadataSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildVulnerabilityMetadataByID failed with an error: %w", err)
+		}
+		return []*model.VulnerabilityMetadata{cv}, nil
+	}
 
 	var arangoQueryBuilder *arangoQueryBuilder
 	if vulnerabilityMetadataSpec.Vulnerability != nil {
@@ -352,4 +361,87 @@ func geVulnMetadataFromCursor(ctx context.Context, cursor driver.Cursor) ([]*mod
 		vulnMetadataList = append(vulnMetadataList, vulnMetadata)
 	}
 	return vulnMetadataList, nil
+}
+
+func (c *arangoClient) buildVulnerabilityMetadataByID(ctx context.Context, id string, filter *model.VulnerabilityMetadataSpec) (*model.VulnerabilityMetadata, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	if idSplit[0] == vulnMetadataStr {
+		if filter != nil {
+			filter.ID = ptrfrom.String(id)
+		} else {
+			filter = &model.VulnerabilityMetadataSpec{
+				ID: ptrfrom.String(id),
+			}
+		}
+		return c.queryVulnerabilityMetadataNodeByID(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (c *arangoClient) queryVulnerabilityMetadataNodeByID(ctx context.Context, filter *model.VulnerabilityMetadataSpec) (*model.VulnerabilityMetadata, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(vulnMetadataStr, "vulnMetadata")
+	setVulnMetadataMatchValues(arangoQueryBuilder, filter, values)
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN vulnMetadata`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryVulnerabilityMetadataNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for vulnMetadata: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type dbVulnMetadata struct {
+		VulnMetadataID  string                       `json:"_id"`
+		VulnerabilityID string                       `json:"vulnerabilityID"`
+		ScoreType       model.VulnerabilityScoreType `json:"scoreType"`
+		ScoreValue      float64                      `json:"scoreValue"`
+		Timestamp       time.Time                    `json:"timestamp"`
+		Collector       string                       `json:"collector"`
+		Origin          string                       `json:"origin"`
+	}
+
+	var collectedValues []dbVulnMetadata
+	for {
+		var doc dbVulnMetadata
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to vulnMetadata from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of vulnMetadata nodes found for ID: %s is greater than one", *filter.ID)
+	}
+
+	builtVuln, err := c.buildVulnResponseByID(ctx, collectedValues[0].VulnerabilityID, filter.Vulnerability)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vulnerability from ID: %s, with error: %w", collectedValues[0].VulnerabilityID, err)
+	}
+
+	return &model.VulnerabilityMetadata{
+		ID:            collectedValues[0].VulnMetadataID,
+		Vulnerability: builtVuln,
+		ScoreType:     collectedValues[0].ScoreType,
+		ScoreValue:    collectedValues[0].ScoreValue,
+		Timestamp:     collectedValues[0].Timestamp,
+		Origin:        collectedValues[0].Origin,
+		Collector:     collectedValues[0].Collector,
+	}, nil
 }

--- a/pkg/assembler/backends/arangodb/vulnMetadata.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata.go
@@ -384,8 +384,9 @@ func (c *arangoClient) buildVulnerabilityMetadataByID(ctx context.Context, id st
 			}
 		}
 		return c.queryVulnerabilityMetadataNodeByID(ctx, filter)
+	} else {
+		return nil, fmt.Errorf("id type does not match for Vulnerability Metadata query: %s", id)
 	}
-	return nil, nil
 }
 
 func (c *arangoClient) queryVulnerabilityMetadataNodeByID(ctx context.Context, filter *model.VulnerabilityMetadataSpec) (*model.VulnerabilityMetadata, error) {

--- a/pkg/assembler/backends/arangodb/vulnMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -1330,6 +1328,160 @@ func TestIngestVulnMetadatas(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.ExpVuln, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildVulnerabilityMetadataByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	type call struct {
+		Vuln         *model.VulnerabilityInputSpec
+		VulnMetadata *model.VulnerabilityMetadataInputSpec
+	}
+
+	tests := []struct {
+		Name         string
+		InVuln       []*model.VulnerabilityInputSpec
+		Calls        []call
+		ExpVuln      *model.VulnerabilityMetadata
+		Query        *model.VulnerabilityMetadataSpec
+		ExpIngestErr bool
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "OSV",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Vuln: testdata.O1,
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+						ScoreValue: 7.9,
+						Timestamp:  testdata.T1,
+						Collector:  "test collector",
+						Origin:     "test origin",
+					},
+				},
+			},
+			Query: &model.VulnerabilityMetadataSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type: ptrfrom.String("osv"),
+				},
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: &model.VulnerabilityMetadata{
+				Vulnerability: &model.Vulnerability{
+					Type:             "osv",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+				},
+				ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+				ScoreValue: 7.9,
+				Timestamp:  testdata.T1,
+				Collector:  "test collector",
+				Origin:     "test origin",
+			},
+		},
+		{
+			Name:   "Certify GHSA",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.G1},
+			Calls: []call{
+				{
+					Vuln: testdata.G1,
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:  model.VulnerabilityScoreTypeEPSSv1,
+						ScoreValue: 0.95,
+						Timestamp:  testdata.T1,
+						Collector:  "test collector",
+						Origin:     "test origin",
+					},
+				},
+			},
+			Query: &model.VulnerabilityMetadataSpec{
+				Vulnerability: &model.VulnerabilitySpec{
+					Type: ptrfrom.String("ghsa"),
+				},
+				Collector: ptrfrom.String("test collector"),
+			},
+			ExpVuln: &model.VulnerabilityMetadata{
+				Vulnerability: &model.Vulnerability{
+					Type:             "ghsa",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+				},
+				ScoreType:  model.VulnerabilityScoreTypeEPSSv1,
+				ScoreValue: 0.95,
+				Timestamp:  testdata.T1,
+				Collector:  "test collector",
+				Origin:     "test origin",
+			},
+		},
+		{
+			Name:   "Query on ID",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.G1},
+			Calls: []call{
+				{
+					Vuln: testdata.G1,
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+						ScoreValue: 8.9,
+						Timestamp:  testdata.T1,
+						Collector:  "test collector",
+						Origin:     "test origin",
+					},
+				},
+			},
+			ExpVuln: &model.VulnerabilityMetadata{
+				Vulnerability: &model.Vulnerability{
+					Type:             "ghsa",
+					VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
+				},
+				ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+				ScoreValue: 8.9,
+				Timestamp:  testdata.T1,
+				Collector:  "test collector",
+				Origin:     "test origin",
+			},
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, g := range test.InVuln {
+				_, err := b.IngestVulnerability(ctx, *g)
+				if err != nil {
+					t.Fatalf("Could not ingest vulnerability: %a", err)
+				}
+
+			}
+			for _, o := range test.Calls {
+				record, err := b.IngestVulnerabilityMetadata(ctx, *o.Vuln, *o.VulnMetadata)
+				if (err != nil) != test.ExpIngestErr {
+					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+				}
+				if err != nil {
+					return
+				}
+				got, err := b.(*arangoClient).buildVulnerabilityMetadataByID(ctx, record, test.Query)
+				if (err != nil) != test.ExpQueryErr {
+					t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				}
+				if err != nil {
+					return
+				}
+				if diff := cmp.Diff(test.ExpVuln, got, ignoreID); diff != "" {
+					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/assembler/backends/arangodb/vulnMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (
@@ -1348,7 +1350,6 @@ func Test_buildVulnerabilityMetadataByID(t *testing.T) {
 		Vuln         *model.VulnerabilityInputSpec
 		VulnMetadata *model.VulnerabilityMetadataInputSpec
 	}
-
 	tests := []struct {
 		Name         string
 		InVuln       []*model.VulnerabilityInputSpec

--- a/pkg/assembler/backends/arangodb/vulnerability.go
+++ b/pkg/assembler/backends/arangodb/vulnerability.go
@@ -333,3 +333,154 @@ func getVulnerabilities(ctx context.Context, cursor driver.Cursor) ([]*model.Vul
 	}
 	return vulnerabilities, nil
 }
+
+// Builds a model.Vulnerability to send as GraphQL response, starting from id.
+// The optional filter allows restricting output (on selection operations).
+func (c *arangoClient) buildVulnResponseByID(ctx context.Context, id string, filter *model.VulnerabilitySpec) (*model.Vulnerability, error) {
+	if filter != nil && filter.ID != nil {
+		if *filter.ID != id {
+			return nil, fmt.Errorf("ID does not match filter")
+		}
+	}
+
+	if filter != nil && filter.NoVuln != nil && *filter.NoVuln {
+		filter.Type = ptrfrom.String(noVulnType)
+		filter.VulnerabilityID = ptrfrom.String("")
+	}
+
+	idSplit := strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	vl := []*model.VulnerabilityID{}
+	if idSplit[0] == vulnerabilitiesStr {
+		var foundVulnID *model.VulnerabilityID
+		var err error
+
+		foundVulnID, id, err = c.queryVulnIDNodeByID(ctx, id, filter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get vulnID node by ID with error: %w", err)
+		}
+		vl = append(vl, foundVulnID)
+	}
+
+	idSplit = strings.Split(id, "/")
+	if len(idSplit) != 2 {
+		return nil, fmt.Errorf("invalid ID: %s", id)
+	}
+
+	var v *model.Vulnerability
+	if idSplit[0] == vulnTypesStr {
+		var err error
+		v, err = c.queryVulnTypeNodeByID(ctx, id, filter, vl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get vuln type node by ID with error: %w", err)
+		}
+	}
+	return v, nil
+}
+
+func (c *arangoClient) queryVulnIDNodeByID(ctx context.Context, id string, filter *model.VulnerabilitySpec) (*model.VulnerabilityID, string, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(vulnerabilitiesStr, "vVulnID")
+	arangoQueryBuilder.filter("vVulnID", "_id", "==", "@id")
+	values["id"] = id
+	if filter != nil && filter.VulnerabilityID != nil {
+		arangoQueryBuilder.filter("vVulnID", "vulnerabilityID", "==", "@vulnerabilityID")
+		values["vulnerabilityID"] = strings.ToLower(*filter.VulnerabilityID)
+	}
+
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		"vuln_id": vVulnID._id,
+		"vuln": vVulnID.vulnerabilityID,
+		'parent': vVulnID._parent
+  	}`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryVulnIDNodeByID")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to query for vuln ID: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	type parsedVulnId struct {
+		// VulnID is the ID of the vulnerability node within the database
+		VulnID string `json:"vuln_id"`
+		// Vuln is the actual vulnerabilityID within the vulnerability ID node within the database
+		Vuln   string `json:"vuln"`
+		Parent string `json:"parent"`
+	}
+
+	var collectedValues []parsedVulnId
+	for {
+		var doc parsedVulnId
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, "", fmt.Errorf("failed to vuln ID from cursor: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, "", fmt.Errorf("number of vuln ID nodes found for ID: %s is greater than one", id)
+	}
+
+	return &model.VulnerabilityID{
+		ID:              collectedValues[0].VulnID,
+		VulnerabilityID: collectedValues[0].Vuln,
+	}, collectedValues[0].Parent, nil
+}
+
+func (c *arangoClient) queryVulnTypeNodeByID(ctx context.Context, id string, filter *model.VulnerabilitySpec, vl []*model.VulnerabilityID) (*model.Vulnerability, error) {
+	values := map[string]any{}
+	arangoQueryBuilder := newForQuery(vulnTypesStr, "vType")
+	arangoQueryBuilder.filter("vType", "_id", "==", "@id")
+	values["id"] = id
+
+	if filter.Type != nil {
+		arangoQueryBuilder.filter("vType", "type", "==", "@vulnType")
+		values["vulnType"] = strings.ToLower(*filter.Type)
+	}
+	arangoQueryBuilder.query.WriteString("\n")
+	arangoQueryBuilder.query.WriteString(`RETURN {
+		"type_id": vType._id,
+		"type": vType.type
+	}`)
+
+	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "queryVulnTypeNodeByID")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query for vuln type: %w, values: %v", err, values)
+	}
+	defer cursor.Close()
+
+	var collectedValues []dbVulnType
+	for {
+		var doc dbVulnType
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if err != nil {
+			if driver.IsNoMoreDocuments(err) {
+				break
+			} else {
+				return nil, fmt.Errorf("failed to query vuln type: %w", err)
+			}
+		} else {
+			collectedValues = append(collectedValues, doc)
+		}
+	}
+
+	if len(collectedValues) != 1 {
+		return nil, fmt.Errorf("number of vuln type nodes found for ID: %s is greater than one", id)
+	}
+
+	return &model.Vulnerability{
+		ID:               collectedValues[0].TypeID,
+		Type:             collectedValues[0].VulnType,
+		VulnerabilityIDs: vl,
+	}, nil
+}

--- a/pkg/assembler/backends/arangodb/vulnerability.go
+++ b/pkg/assembler/backends/arangodb/vulnerability.go
@@ -451,7 +451,7 @@ func (c *arangoClient) queryVulnTypeNodeByID(ctx context.Context, id string, fil
 	arangoQueryBuilder.filter("vType", "_id", "==", "@id")
 	values["id"] = id
 
-	if filter.Type != nil {
+	if filter != nil && filter.Type != nil {
 		arangoQueryBuilder.filter("vType", "type", "==", "@vulnType")
 		values["vulnType"] = strings.ToLower(*filter.Type)
 	}

--- a/pkg/assembler/backends/arangodb/vulnerability.go
+++ b/pkg/assembler/backends/arangodb/vulnerability.go
@@ -55,6 +55,14 @@ func (c *arangoClient) Vulnerabilities(ctx context.Context, vulnSpec *model.Vuln
 		vulnSpec.VulnerabilityID = ptrfrom.String("")
 	}
 
+	if vulnSpec != nil && vulnSpec.ID != nil {
+		p, err := c.buildVulnResponseByID(ctx, *vulnSpec.ID, vulnSpec)
+		if err != nil {
+			return nil, fmt.Errorf("buildVulnResponseByID failed with an error: %w", err)
+		}
+		return []*model.Vulnerability{p}, nil
+	}
+
 	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {
 		// fields: [type vulnerabilityIDs ]
 		fields := getPreloads(ctx)

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package arangodb
 
 import (

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -204,7 +204,7 @@ func TestVulnerability(t *testing.T) {
 			Query: &model.VulnerabilitySpec{
 				ID: ptrfrom.String("12345"),
 			},
-			Exp: nil,
+			ExpQueryErr: true,
 		},
 		{
 			Name:    "Query invalid ID",
@@ -212,7 +212,7 @@ func TestVulnerability(t *testing.T) {
 			Query: &model.VulnerabilitySpec{
 				ID: ptrfrom.String("asdf"),
 			},
-			ExpQueryErr: false,
+			ExpQueryErr: true,
 		},
 	}
 	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package arangodb
 
 import (
@@ -445,6 +443,116 @@ func TestIngestVulnerabilities(t *testing.T) {
 			}
 			slices.SortFunc(got, lessCve)
 			if diff := cmp.Diff(test.exp, got, ignoreID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_buildVulnResponseByID(t *testing.T) {
+	ctx := context.Background()
+	arangArg := getArangoConfig()
+	err := deleteDatabase(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error deleting arango database: %v", err)
+	}
+	b, err := getBackend(ctx, arangArg)
+	if err != nil {
+		t.Fatalf("error creating arango backend: %v", err)
+	}
+	tests := []struct {
+		Name         string
+		Ingest       *model.VulnerabilityInputSpec
+		ExpIngestErr bool
+		Query        *model.VulnerabilitySpec
+		QueryID      bool
+		Exp          *model.Vulnerability
+		ExpQueryErr  bool
+	}{
+		{
+			Name:   "HappyPath",
+			Ingest: testdata.C1,
+			Query:  &model.VulnerabilitySpec{},
+			Exp: &model.Vulnerability{
+				Type:             "cve",
+				VulnerabilityIDs: []*model.VulnerabilityID{testdata.C1out},
+			},
+		},
+		{
+			Name:   "Query by type - noVuln",
+			Ingest: testdata.NoVulnInput,
+			Query: &model.VulnerabilitySpec{
+				Type: ptrfrom.String("noVuln"),
+			},
+			Exp: &model.Vulnerability{
+				Type:             "novuln",
+				VulnerabilityIDs: []*model.VulnerabilityID{testdata.NoVulnOut},
+			},
+		},
+		{
+			Name:   "Query by type - noVuln with boolean",
+			Ingest: testdata.NoVulnInput,
+			Query: &model.VulnerabilitySpec{
+				NoVuln: ptrfrom.Bool(true),
+			},
+			Exp: &model.Vulnerability{
+				Type:             "novuln",
+				VulnerabilityIDs: []*model.VulnerabilityID{testdata.NoVulnOut},
+			},
+		},
+		{
+			Name:   "Query by vulnID",
+			Ingest: testdata.C3,
+			Query: &model.VulnerabilitySpec{
+				Type:            ptrfrom.String("cve"),
+				VulnerabilityID: ptrfrom.String("CVE-2014-8140"),
+			},
+			Exp: &model.Vulnerability{
+				Type:             "cve",
+				VulnerabilityIDs: []*model.VulnerabilityID{testdata.C3out},
+			},
+		},
+		{
+			Name:   "Query by vulnID - noVuln",
+			Ingest: testdata.NoVulnInput,
+			Query: &model.VulnerabilitySpec{
+				Type: ptrfrom.String("noVuln"),
+			},
+			Exp: &model.Vulnerability{
+				Type:             "novuln",
+				VulnerabilityIDs: []*model.VulnerabilityID{testdata.NoVulnOut},
+			},
+		},
+		{
+			Name:   "Query none ID",
+			Ingest: testdata.C3,
+			Query: &model.VulnerabilitySpec{
+				ID: ptrfrom.String("12345"),
+			},
+			Exp:         nil,
+			ExpQueryErr: true,
+		},
+	}
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			found, err := b.IngestVulnerability(ctx, *test.Ingest)
+			if (err != nil) != test.ExpIngestErr {
+				t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+			}
+			if err != nil {
+				return
+			}
+			got, err := b.(*arangoClient).buildVulnResponseByID(ctx, found.VulnerabilityIDs[0].ID, test.Query)
+			if (err != nil) != test.ExpQueryErr {
+				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.Exp, got, ignoreID); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
# Description of the PR

- Implement query node by ID for Arango (singular and plural) 
- add new unit tests to each noun and verb
- add unit tests for inmem backend for query by Node query (previously missing)

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
