### PR TITLE
add flag to toggle getting deps.dev dependencies

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -59,6 +59,7 @@ services:
   - colsub addr
   - collector/certifier name
   - polling options
+  - flag to toggle retrieving deps 
 
 ## Collectors and Certifiers
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -59,7 +59,7 @@ services:
   - colsub addr
   - collector/certifier name
   - polling options
-  - flag to toggle retrieving deps 
+  - flag to toggle retrieving deps
 
 ## Collectors and Certifiers
 

--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/collectsub/client"
 	csubclient "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
@@ -123,5 +124,15 @@ func validateDepsDevFlags(natsAddr string, csubAddr string, csubTls bool, csubTl
 }
 
 func init() {
+	set, err := cli.BuildFlags([]string{"retrieve-dependencies"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	depsDevCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(depsDevCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
 	rootCmd.AddCommand(depsDevCmd)
 }

--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -40,6 +40,8 @@ type depsDevOptions struct {
 	natsAddr string
 	// run as poll collector
 	poll bool
+	// query for dependencies
+	retrieveDependencies bool
 }
 
 var depsDevCmd = &cobra.Command{
@@ -57,6 +59,7 @@ var depsDevCmd = &cobra.Command{
 			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("use-csub"),
 			viper.GetBool("service-poll"),
+			viper.GetBool("retrieve-dependencies"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -65,7 +68,7 @@ var depsDevCmd = &cobra.Command{
 		}
 
 		// Register collector
-		depsDevCollector, err := deps_dev.NewDepsCollector(ctx, opts.dataSource, opts.poll, 30*time.Second)
+		depsDevCollector, err := deps_dev.NewDepsCollector(ctx, opts.dataSource, opts.poll, opts.retrieveDependencies, 30*time.Second)
 		if err != nil {
 			logger.Errorf("unable to register oci collector: %v", err)
 		}
@@ -78,10 +81,11 @@ var depsDevCmd = &cobra.Command{
 	},
 }
 
-func validateDepsDevFlags(natsAddr string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, useCsub bool, poll bool, args []string) (depsDevOptions, error) {
+func validateDepsDevFlags(natsAddr string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, useCsub bool, poll bool, retrieveDependencies bool, args []string) (depsDevOptions, error) {
 	var opts depsDevOptions
 	opts.natsAddr = natsAddr
 	opts.poll = poll
+	opts.retrieveDependencies = retrieveDependencies
 
 	if useCsub {
 		csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"nats-addr", "csub-addr", "use-csub", "service-poll", "retrieve-dependencies"})
+	set, err := cli.BuildFlags([]string{"nats-addr", "csub-addr", "use-csub", "service-poll"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"nats-addr", "csub-addr", "use-csub", "service-poll"})
+	set, err := cli.BuildFlags([]string{"nats-addr", "csub-addr", "use-csub", "service-poll", "retrieve-dependencies"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1981,6 +1981,86 @@ var (
 		"UpdateTime":"2022-11-21T17:45:50.52Z"
 	 }`
 
+	CollectedForeignTypesNoDeps = `{
+		"CurrentPackage":{
+		   "name":"foreign-types",
+		   "namespace":"",
+		   "qualifiers":null,
+		   "subpath":"",
+		   "type":"cargo",
+		   "version":"0.3.2"
+		},
+		"Scorecard":{
+		   "aggregateScore":4.599999904632568,
+		   "checks":[
+			  {
+				 "check":"Maintained",
+				 "score":5
+			  },
+			  {
+				 "check":"CII-Best-Practices",
+				 "score":0
+			  },
+			  {
+				 "check":"Signed-Releases",
+				 "score":-1
+			  },
+			  {
+				 "check":"Packaging",
+				 "score":-1
+			  },
+			  {
+				 "check":"Dangerous-Workflow",
+				 "score":10
+			  },
+			  {
+				 "check":"Binary-Artifacts",
+				 "score":10
+			  },
+			  {
+				 "check":"Token-Permissions",
+				 "score":0
+			  },
+			  {
+				 "check":"Pinned-Dependencies",
+				 "score":7
+			  },
+			  {
+				 "check":"Fuzzing",
+				 "score":0
+			  },
+			  {
+				 "check":"Vulnerabilities",
+				 "score":10
+			  },
+			  {
+				 "check":"Branch-Protection",
+				 "score":0
+			  },
+			  {
+				 "check":"License",
+				 "score":10
+			  },
+			  {
+				 "check":"Security-Policy",
+				 "score":0
+			  }
+		   ],
+		   "collector":"",
+		   "origin":"",
+		   "scorecardCommit":"6c5de2c32a4b8f60211e8e8eb94f8d3370a11b93",
+		   "scorecardVersion":"v4.10.5-77-g6c5de2c",
+		   "timeScanned":"2022-11-21T17:45:50.52Z"
+		},
+		"Source":{
+		   "commit":null,
+		   "name":"foreign-types",
+		   "namespace":"github.com/sfackler",
+		   "tag":null,
+		   "type":"git"
+		},
+		"UpdateTime":"2022-11-21T17:45:50.52Z"
+	 }`
 	CollectedForeignTypes = `{
 		"CurrentPackage":{
 		   "name":"foreign-types",

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -75,6 +75,9 @@ func init() {
 
 	set.Bool("service-poll", true, "sets the collector or certifier to polling mode")
 	set.BoolP("poll", "p", false, "sets the collector or certifier to polling mode")
+
+	set.Bool("retrieve-dependencies", true, "enable the deps.dev collector to retrieve package dependencies")
+
 	set.StringP("interval", "i", "5m", "if polling set interval, m, h, s, etc.")
 
 	set.BoolP("cert-good", "g", false, "enable to certifyGood, otherwise defaults to certifyBad")


### PR DESCRIPTION
# Description of the PR

Adds the flag `retrieve-deps` to guaccollect. When set to false, the deps.dev collector only queries for metadata (scorecard and source) and not for dependencies. The default setting is true. 

Also, a log message (level info) was added to log when the dependencies for a package are retrieved. 

Fixes #1359. 

## Behavior 
After starting Guac and ingesting an SBOM, running `guaccollect deps_dev --retrieve-dependencies=false` does not lead to any new IsDependency nodes appearing and results in logs look like 

> {"level":"info","ts":1696975519.9959376,"caller":"deps_dev/deps_dev.go:197","msg":"obtained additional metadata for package: pkg:golang/4d63.com/gocheckcompilerdirectives@v1.2.1"}
{"level":"info","ts":1696975520.0867465,"caller":"deps_dev/deps_dev.go:197","msg":"obtained additional metadata for package: pkg:golang/4d63.com/gochecknoglobals@v0.2.1"}
{"level":"info","ts":1696975520.166465,"caller":"deps_dev/deps_dev.go:197","msg":"obtained additional metadata for package: pkg:golang/github.com/4meepo/tagalign@v1.3.2"}
{"level":"info","ts":1696975520.2557125,"caller":"deps_dev/deps_dev.go:197","msg":"obtained additional metadata for package: pkg:golang/github.com/Abirdcfly/dupword@v0.0.12"}
...

Running  `guaccollect deps_dev` instead results in the normal expected behavior: dependencies are ingested and the logs indicate both metadata and dependency retrievals. 




# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] All CI checks are passing (tests and formatting)
