### PR TITLE
refactor(depversion): avoid unnecessary byte/string conversion

### DIFF
--- a/pkg/misc/depversion/depversion.go
+++ b/pkg/misc/depversion/depversion.go
@@ -172,7 +172,7 @@ var almostValidConstraint = regexp.MustCompile(`^(?P<op1>[><~^=]{1,3})v?(?P<semv
 var dashRangeRegexp = regexp.MustCompile(`(v?(?P<semver1>(?P<major1>0|[1-9]\d*)(\.(?P<minor1>0|[1-9]\d*))?(\.(?P<patch1>0|[1-9]\d*))?(?:-(?P<prerelease1>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata1>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)\s\s*-\s*(v?(?P<semver2>(?P<major2>0|[1-9]\d*)(\.(?P<minor2>0|[1-9]\d*))?(\.(?P<patch2>0|[1-9]\d*))?(?:-(?P<prerelease2>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata2>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)`)
 
 func almostSemVer(s string) bool {
-	return !exactSvR.Match([]byte(s)) && almostExactSvR.Match([]byte(s))
+	return !exactSvR.MatchString(s) && almostExactSvR.MatchString(s)
 }
 
 func fixAlmostSemVer(s string) (string, error) {
@@ -184,23 +184,23 @@ func fixAlmostSemVer(s string) (string, error) {
 }
 
 func isSemver(s string) bool {
-	return exactSvR.Match([]byte(s))
+	return exactSvR.MatchString(s)
 }
 
 func isSemVerWildcard(s string) bool {
-	return !exactSvR.Match([]byte(s)) && exactSvRWithWildcard.Match([]byte(s))
+	return !exactSvR.MatchString(s) && exactSvRWithWildcard.MatchString(s)
 }
 
 func isValidConstraint(s string) bool {
-	return validConstraint.Match([]byte(s))
+	return validConstraint.MatchString(s)
 }
 
 func isAlmostValidConstraint(s string) bool {
-	return almostValidConstraint.Match([]byte(s))
+	return almostValidConstraint.MatchString(s)
 }
 
 func isDashRange(s string) bool {
-	return dashRangeRegexp.Match([]byte(s))
+	return dashRangeRegexp.MatchString(s)
 }
 
 func ParseVersionRange(s string) (VersionMatchObject, error) {
@@ -389,7 +389,7 @@ func getConstraint(s string) (string, error) {
 	}
 
 	// check if its java ranges
-	if rangeRegexp.Match([]byte(s)) {
+	if rangeRegexp.MatchString(s) {
 		matches := rangeRegexp.FindStringSubmatch(s)
 		semver1Idx := rangeRegexp.SubexpIndex("semver1")
 		semver2Idx := rangeRegexp.SubexpIndex("semver2")


### PR DESCRIPTION
# Description of the PR

We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance gain.

Benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := exactSvR.Match([]byte("1.0.0")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := exactSvR.MatchString("1.0.0"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/guacsec/guac/pkg/misc/depversion
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 4203973	       286.3 ns/op	       5 B/op	       1 allocs/op
BenchmarkMatchString-16    	 4403889	       230.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/guacsec/guac/pkg/misc/depversion	2.800s
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
