### PR TITLE
Support TLS for csub server and clients

### DIFF
--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/guacsec/guac/pkg/collectsub/client"
 	csubclient "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/collectsub/datasource/csubsource"
@@ -52,6 +53,8 @@ var depsDevCmd = &cobra.Command{
 		opts, err := validateDepsDevFlags(
 			viper.GetString("nats-addr"),
 			viper.GetString("csub-addr"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("use-csub"),
 			viper.GetBool("service-poll"),
 			args)
@@ -75,13 +78,17 @@ var depsDevCmd = &cobra.Command{
 	},
 }
 
-func validateDepsDevFlags(natsAddr string, csubAddr string, useCsub bool, poll bool, args []string) (depsDevOptions, error) {
+func validateDepsDevFlags(natsAddr string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, useCsub bool, poll bool, args []string) (depsDevOptions, error) {
 	var opts depsDevOptions
 	opts.natsAddr = natsAddr
 	opts.poll = poll
 
 	if useCsub {
-		c, err := csubclient.NewClient(csubAddr)
+		csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+		if err != nil {
+			return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+		}
+		c, err := csubclient.NewClient(csubOpts)
 		if err != nil {
 			return opts, err
 		}

--- a/cmd/guaccollect/cmd/oci.go
+++ b/cmd/guaccollect/cmd/oci.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/guacsec/guac/pkg/collectsub/client"
 	csubclient "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/collectsub/datasource/csubsource"
@@ -53,6 +54,8 @@ var ociCmd = &cobra.Command{
 		opts, err := validateOCIFlags(
 			viper.GetString("nats-addr"),
 			viper.GetString("csub-addr"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("use-csub"),
 			viper.GetBool("service-poll"),
 			args)
@@ -76,13 +79,17 @@ var ociCmd = &cobra.Command{
 	},
 }
 
-func validateOCIFlags(natsAddr string, csubAddr string, useCsub bool, poll bool, args []string) (ociOptions, error) {
+func validateOCIFlags(natsAddr string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, useCsub bool, poll bool, args []string) (ociOptions, error) {
 	var opts ociOptions
 	opts.natsAddr = natsAddr
 	opts.poll = poll
 
 	if useCsub {
-		c, err := csubclient.NewClient(csubAddr)
+		csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+		if err != nil {
+			return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+		}
+		c, err := csubclient.NewClient(csubOpts)
 		if err != nil {
 			return opts, err
 		}

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -34,9 +34,11 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-type csubClientOptions struct {
-	addr string
-}
+// type csubClientOptions struct {
+// 	addr          string
+// 	tls           bool
+// 	tlsSkipVerify bool
+// }
 
 var csubClientCmd = &cobra.Command{
 	Use:   "csub-client",
@@ -47,8 +49,10 @@ func setupCsubClient(cmd *cobra.Command, args []string) (context.Context, client
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)
 
-	opts, err := validateCsubClientFlags(
+	opts, err := client.ValidateCsubClientFlags(
 		viper.GetString("csub-addr"),
+		viper.GetBool("csub-tls"),
+		viper.GetBool("csub-tls-skip-verify"),
 	)
 	if err != nil {
 		fmt.Printf("unable to validate flags: %v\n", err)
@@ -57,17 +61,11 @@ func setupCsubClient(cmd *cobra.Command, args []string) (context.Context, client
 	}
 
 	// Start csub listening server
-	csubClient, err := client.NewClient(opts.addr)
+	csubClient, err := client.NewClient(opts)
 	if err != nil {
 		logger.Fatalf("unable to create csub server: %v", err)
 	}
 	return ctx, csubClient
-}
-
-func validateCsubClientFlags(addr string) (csubClientOptions, error) {
-	return csubClientOptions{
-		addr: addr,
-	}, nil
 }
 
 /*

--- a/cmd/guacone/cmd/gcs_test.go
+++ b/cmd/guacone/cmd/gcs_test.go
@@ -60,7 +60,7 @@ func TestValidateGCSFlags(t *testing.T) {
 				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
 			}
 
-			o, err := validateGCSFlags("", "", tc.credentialsPath, tc.args)
+			o, err := validateGCSFlags("", "", false, false, tc.credentialsPath, tc.args)
 			if err != nil {
 				if tc.errorMsg != err.Error() {
 					t.Errorf("expected error message: %s, got: %s", tc.errorMsg, err.Error())

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
@@ -35,9 +36,9 @@ import (
 )
 
 type ociOptions struct {
-	graphqlEndpoint string
-	dataSource      datasource.CollectSource
-	csubAddr        string
+	graphqlEndpoint   string
+	dataSource        datasource.CollectSource
+	csubClientOptions client.CsubClientOptions
 }
 
 var ociCmd = &cobra.Command{
@@ -51,6 +52,8 @@ var ociCmd = &cobra.Command{
 		opts, err := validateOCIFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -66,7 +69,7 @@ var ociCmd = &cobra.Command{
 		}
 
 		// initialize collectsub client
-		csubClient, err := csub_client.NewClient(opts.csubAddr)
+		csubClient, err := csub_client.NewClient(opts.csubClientOptions)
 		if err != nil {
 			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
 			csubClient = nil
@@ -109,10 +112,15 @@ var ociCmd = &cobra.Command{
 	},
 }
 
-func validateOCIFlags(gqlEndpoint string, csubAddr string, args []string) (ociOptions, error) {
+func validateOCIFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, args []string) (ociOptions, error) {
 	var opts ociOptions
 	opts.graphqlEndpoint = gqlEndpoint
-	opts.csubAddr = csubAddr
+
+	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	if err != nil {
+		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+	}
+	opts.csubClientOptions = csubOpts
 
 	if len(args) < 1 {
 		return opts, fmt.Errorf("expected positional argument for image_path")
@@ -127,7 +135,6 @@ func validateOCIFlags(gqlEndpoint string, csubAddr string, args []string) (ociOp
 		})
 	}
 
-	var err error
 	opts.dataSource, err = inmemsource.NewInmemDataSources(&datasource.DataSources{
 		OciDataSources: sources,
 	})

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"gql-addr", "csub-addr"})
+	set, err := cli.BuildFlags([]string{"gql-addr", "csub-addr", "csub-tls", "csub-tls-skip-verify"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -33,14 +33,18 @@ func init() {
 	// names for config file.
 	set.String("nats-addr", "nats://127.0.0.1:4222", "address to connect to NATs Server")
 	set.String("csub-addr", "localhost:2782", "address to connect to collect-sub service")
+	set.Bool("csub-tls", false, "enable tls connection to the server")
+	set.Bool("csub-tls-skip-verify", false, "skip verifying server certificate (for self-signed certificates for example)")
 	set.Bool("use-csub", true, "use collectsub server for datasource")
 
 	set.Int("csub-listen-port", 2782, "port to listen to on collect-sub service")
+	set.String("csub-tls-cert-file", "", "path to the TLS certificate in PEM format for collect-sub service")
+	set.String("csub-tls-key-file", "", "path to the TLS key in PEM format for collect-sub service")
 
 	set.String("gql-backend", "inmem", "backend used for graphql api server: [inmem | arango (experimental) | ent (experimental) | neo4j (unmaintained)]")
 	set.Int("gql-listen-port", 8080, "port used for graphql api server")
-	set.String("gql-tls-cert-file", "", "path to the TLS certificate in PEM format")
-	set.String("gql-tls-key-file", "", "path to the TLS key in PEM format")
+	set.String("gql-tls-cert-file", "", "path to the TLS certificate in PEM format for graphql api server")
+	set.String("gql-tls-key-file", "", "path to the TLS key in PEM format for graphql api server")
 	set.Bool("gql-debug", false, "debug flag which enables the graphQL playground")
 	set.Bool("gql-trace", false, "flag which enables tracing of graphQL requests and responses on the console")
 

--- a/pkg/collectsub/server/server.go
+++ b/pkg/collectsub/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/guacsec/guac/pkg/logging"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -38,19 +39,23 @@ type server struct {
 	pb.UnimplementedColectSubscriberServiceServer
 
 	// Db points to the backend DB, public for mocking testing purposes.
-	Db   db.CollectSubscriberDb
-	port int
+	Db          db.CollectSubscriberDb
+	port        int
+	tlsCertFile string
+	tlsKeyFile  string
 }
 
-func NewServer(port int) (*server, error) {
+func NewServer(port int, tlsCertFile string, tlsKeyFile string) (*server, error) {
 	db, err := simpledb.NewSimpleDb()
 	if err != nil {
 		return nil, err
 	}
 
 	return &server{
-		Db:   db,
-		port: port,
+		Db:          db,
+		port:        port,
+		tlsCertFile: tlsCertFile,
+		tlsKeyFile:  tlsKeyFile,
 	}, nil
 }
 
@@ -120,6 +125,7 @@ func (s *server) Serve(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error opening port %d when starting csub server: %w", s.port, err)
 	}
+
 	opts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(
 			grpc_middleware.ChainUnaryServer(
@@ -129,6 +135,15 @@ func (s *server) Serve(ctx context.Context) error {
 			)),
 		grpc.MaxRecvMsgSize(16777216),
 	}
+
+	if s.tlsCertFile != "" && s.tlsKeyFile != "" {
+		creds, err := credentials.NewServerTLSFromFile(s.tlsCertFile, s.tlsKeyFile)
+		if err != nil {
+			return fmt.Errorf("error loading credentials from certificate: %s and key %s: %w", s.tlsCertFile, s.tlsKeyFile, err)
+		}
+		opts = append(opts, grpc.Creds(creds))
+	}
+
 	gs := grpc.NewServer(opts...)
 
 	pb.RegisterColectSubscriberServiceServer(gs, s)


### PR DESCRIPTION
# Description of the PR

Allow CollectSub gRPC server and clients to communicate over TLS.

To start a server with TLS enabled, you need to provide a certificate and key

```
./bin/guaccsub --csub-tls-cert-file ./ca.crt --csub-tls-key-file ./ca.key
```

Clients can use `--csub-tls` to enable encryption. Optionally, you can spoecify `--csub-tls-skip-verify` to disable server certificate verification (which is needed for self-signed certs).

```
bin/guacone csub-client  --csub-tls --csub-tls-skip-verify ...
```


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
