### PR TITLE
Ent - HasMetadata: fix ingesting same twice

### DIFF
--- a/pkg/assembler/backends/ent/backend/hasMetadata.go
+++ b/pkg/assembler/backends/ent/backend/hasMetadata.go
@@ -236,7 +236,7 @@ func toModelHasMetadata(v *ent.HasMetadata) *model.HasMetadata {
 func hasMetadataInputPredicate(subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, filter model.HasMetadataInputSpec) predicate.HasMetadata {
 	var subjectSpec *model.PackageSourceOrArtifactSpec
 	if subject.Package != nil {
-		if pkgMatchType != nil || pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
+		if pkgMatchType != nil && pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
 			subject.Package.Version = nil
 		}
 		subjectSpec = &model.PackageSourceOrArtifactSpec{

--- a/pkg/assembler/backends/ent/backend/hasMetadata_test.go
+++ b/pkg/assembler/backends/ent/backend/hasMetadata_test.go
@@ -204,6 +204,43 @@ func (s *Suite) TestHasMetadata() {
 			},
 		},
 		{
+			Name:  "Ingest same twice with version",
+			InPkg: []*model.PkgInputSpec{p2},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p2,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p2,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Justification: "test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Justification: ptrfrom.String("test justification"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       p2out,
+					Justification: "test justification",
+				},
+			},
+		},
+		{
 			Name:  "Ingest two different keys",
 			InPkg: []*model.PkgInputSpec{p1},
 			Calls: []call{


### PR DESCRIPTION
# Description of the PR

Spotted an issue when ingesting twice with a package having the `version`.
So created a test and fixed it.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
