### PR TITLE
fix noVuln type not showing up when querying for known

### DIFF
--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -332,8 +332,12 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 	switch nodeType {
 	case certifyVulnStr:
 		for _, certVuln := range collectedNeighbors.certifyVulns {
-			for _, vuln := range certVuln.Vulnerability.VulnerabilityIDs {
-				tableRows = append(tableRows, table.Row{certifyVulnStr, certVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
+			if certVuln.Vulnerability.Type != noVulnType {
+				for _, vuln := range certVuln.Vulnerability.VulnerabilityIDs {
+					tableRows = append(tableRows, table.Row{certifyVulnStr, certVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
+				}
+			} else {
+				tableRows = append(tableRows, table.Row{certifyVulnStr, certVuln.Id, "vulnerability ID: " + noVulnType})
 			}
 		}
 	case badLinkStr:


### PR DESCRIPTION
# Description of the PR

fixes #1388 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
