### PR TITLE
Certifier OSV: fixed emit func when polling

### DIFF
--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -192,7 +192,7 @@ var osvCmd = &cobra.Command{
 		wg.Wait()
 		cf()
 
-		if gotErr == 1 {
+		if atomic.LoadInt32(&gotErr) == 1 {
 			logger.Errorf("completed ingestion with errors")
 		} else {
 			logger.Infof("completed ingesting %v documents", totalNum)

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -129,6 +129,13 @@ var osvCmd = &cobra.Command{
 					}
 				}
 			}
+			if len(totalDocs) > 0 {
+				err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, csubClient)
+				if err != nil {
+					gotErr = true
+					logger.Errorf("unable to ingest documents: %v", err)
+				}
+			}
 		}()
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {


### PR DESCRIPTION
# Description of the PR

Fixes #1387 

New Goroutine to "flush" the documents collected in the `totalDocs` based upon one condition being true:

- a 30 seconds ticker
- 1000 documents appended to `totalDocs` 

This also fixes the other bug, i.e. not exiting with `CTRL-C` 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
