### PR TITLE
edit arangosearch view to exclude subpath search results

### DIFF
--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -734,13 +734,16 @@ func getBackend(ctx context.Context, args backends.BackendArgs) (backends.Backen
 			CommitInterval:        ptrfrom.Int64(10 * 60 * 1000),
 			ConsolidationInterval: ptrfrom.Int64(10 * 60 * 1000),
 			Links: driver.ArangoSearchLinks{
+				// Only index the version string since guac files creates a lot of noise in the index
+				// from the name of the file being in the subpath
+				// TODO : would be a good addition to have an excludes from search field instead so files can be filtered
 				pkgVersionsStr: driver.ArangoSearchElementProperties{
 					Analyzers:          []string{"identity", "text_en", "customgram"},
 					IncludeAllFields:   ptrfrom.Bool(false),
 					TrackListPositions: ptrfrom.Bool(false),
 					StoreValues:        driver.ArangoSearchStoreValuesNone,
 					Fields: map[string]driver.ArangoSearchElementProperties{
-						"guacKey": {},
+						"version": {},
 					},
 					InBackground: ptrfrom.Bool(true),
 				},

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -31,7 +31,9 @@ func (c *arangoClient) FindSoftware(ctx context.Context, searchText string) ([]m
 	query := `
 
 FOR doc in GuacSearch
-SEARCH PHRASE(doc.guacKey, @searchText, "text_en") || PHRASE(doc.guacKey, @searchText, "customgram") || doc.digest == @searchText
+SEARCH PHRASE(doc.guacKey, @searchText, "text_en") || PHRASE(doc.guacKey, @searchText, "customgram") || 
+	PHRASE(doc.version, @searchText, "text_en") || PHRASE(doc.version, @searchText, "customgram") ||
+	doc.digest == @searchText 
 
 LET parsedDoc =
     IS_SAME_COLLECTION(doc, "pkgNames") ?


### PR DESCRIPTION
# Description of the PR


Due to there being a ton of filenames, the current stop gap fix is to not index in the arangosearch for subpath values. The longer term solution should probably look more like being able to query package /source or other software tried with a wildcard search, or have search allow exclusion of certain words.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
