### PR TITLE
Updating Arango and Ent with KnownSince

### DIFF
--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -37,6 +37,7 @@ const (
 	origin          string        = "origin"
 	collector       string        = "collector"
 	justification   string        = "justification"
+	knownSince      string        = "knownSince"
 	maxRetires      int           = 100
 	retryTimer      time.Duration = time.Microsecond
 	guacEmpty       string        = "guac-empty-@@"

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -173,7 +173,7 @@ func getSrcCertifyBadForQuery(ctx context.Context, c *arangoClient, arangoQueryB
 		'certifyBad_id': certifyBad._id,
 		'justification': certifyBad.justification,
 		'collector': certifyBad.collector,
-		'knownSince': certifyBad.knownSince
+		'knownSince': certifyBad.knownSince,
 		'origin': certifyBad.origin
 	  }`)
 
@@ -278,8 +278,9 @@ func setCertifyBadMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBad
 		queryValues[collector] = *certifyBadSpec.Collector
 	}
 	if certifyBadSpec.KnownSince != nil {
+		certifyBadKnownSince := *certifyBadSpec.KnownSince
 		arangoQueryBuilder.filter("certifyBad", "knownSince", ">=", "@"+knownSince)
-		queryValues[collector] = *certifyBadSpec.KnownSince
+		queryValues[knownSince] = certifyBadKnownSince.UTC()
 	}
 }
 
@@ -304,7 +305,7 @@ func getCertifyBadQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Match
 	values["justification"] = certifyBad.Justification
 	values["origin"] = certifyBad.Origin
 	values["collector"] = certifyBad.Collector
-	values[knownSince] = certifyBad.KnownSince
+	values[knownSince] = certifyBad.KnownSince.UTC()
 
 	return values
 }
@@ -625,8 +626,8 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 		)
 		  
 		  LET certifyBad = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
-				  INSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
+			  UPSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+				  INSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
 				  UPDATE {} IN certifyBads
 				  RETURN NEW
 		  )
@@ -691,8 +692,8 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 			)
 			  
 			  LET certifyBad = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
-					  INSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
+				  UPSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+					  INSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
 					  UPDATE {} IN certifyBads
 					  RETURN NEW
 			  )
@@ -765,8 +766,8 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 		  
 		LET certifyBad = FIRST(
-			UPSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
-				INSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
+			UPSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+				INSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
 				UPDATE {} IN certifyBads
 				RETURN NEW
 		)
@@ -854,8 +855,8 @@ func (c *arangoClient) IngestCertifyBads(ctx context.Context, subjects model.Pac
 		)
 		  
 		LET certifyBad = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
-				INSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:@knownSince } 
+			UPSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+				INSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
 				UPDATE {} IN certifyBads
 				RETURN NEW
 		)

--- a/pkg/assembler/backends/arangodb/certifyBad.go
+++ b/pkg/assembler/backends/arangodb/certifyBad.go
@@ -278,7 +278,7 @@ func setCertifyBadMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyBad
 		queryValues[collector] = *certifyBadSpec.Collector
 	}
 	if certifyBadSpec.KnownSince != nil {
-		arangoQueryBuilder.filter("certifyBad", "knownSince", "==", "@"+knownSince)
+		arangoQueryBuilder.filter("certifyBad", "knownSince", ">=", "@"+knownSince)
 		queryValues[collector] = *certifyBadSpec.KnownSince
 	}
 }

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-var zeroTime = time.Unix(0, 0)
-
 func TestCertifyBad(t *testing.T) {
 	ctx := context.Background()
 	arangArg := getArangoConfig()
@@ -42,6 +40,8 @@ func TestCertifyBad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -209,7 +209,7 @@ func TestCertifyBad(t *testing.T) {
 					},
 					CB: &model.CertifyBadInputSpec{
 						Justification: "test justification one",
-						KnownSince:    zeroTime,
+						KnownSince:    curTime,
 					},
 				},
 				{
@@ -221,19 +221,19 @@ func TestCertifyBad(t *testing.T) {
 					},
 					CB: &model.CertifyBadInputSpec{
 						Justification: "test justification two",
-						KnownSince:    zeroTime,
+						KnownSince:    timeAfterOneSecond,
 					},
 				},
 			},
 			Query: &model.CertifyBadSpec{
 				Justification: ptrfrom.String("test justification one"),
-				KnownSince:    ptrfrom.Time(zeroTime),
+				KnownSince:    ptrfrom.Time(curTime),
 			},
 			ExpCB: []*model.CertifyBad{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification one",
-					KnownSince:    zeroTime,
+					KnownSince:    curTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -75,19 +75,16 @@ func TestCertifyBad(t *testing.T) {
 					},
 					CB: &model.CertifyBadInputSpec{
 						Justification: "test justification",
-						KnownSince:    zeroTime,
 					},
 				},
 			},
 			Query: &model.CertifyBadSpec{
 				Justification: ptrfrom.String("test justification"),
-				KnownSince:    ptrfrom.Time(zeroTime),
 			},
 			ExpCB: []*model.CertifyBad{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification",
-					KnownSince:    zeroTime,
 				},
 			},
 		},
@@ -196,6 +193,47 @@ func TestCertifyBad(t *testing.T) {
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification one",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: &model.CertifyBadInputSpec{
+						Justification: "test justification one",
+						KnownSince:    zeroTime,
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: &model.CertifyBadInputSpec{
+						Justification: "test justification two",
+						KnownSince:    zeroTime,
+					},
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Justification: ptrfrom.String("test justification one"),
+				KnownSince:    ptrfrom.Time(zeroTime),
+			},
+			ExpCB: []*model.CertifyBad{
+				{
+					Subject:       testdata.P1out,
+					Justification: "test justification one",
+					KnownSince:    zeroTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -21,12 +21,15 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
+
+var zeroTime = time.Unix(0, 0)
 
 func TestCertifyBad(t *testing.T) {
 	ctx := context.Background()
@@ -72,16 +75,19 @@ func TestCertifyBad(t *testing.T) {
 					},
 					CB: &model.CertifyBadInputSpec{
 						Justification: "test justification",
+						KnownSince:    zeroTime,
 					},
 				},
 			},
 			Query: &model.CertifyBadSpec{
 				Justification: ptrfrom.String("test justification"),
+				KnownSince:    ptrfrom.Time(zeroTime),
 			},
 			ExpCB: []*model.CertifyBad{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification",
+					KnownSince:    zeroTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -19,13 +19,12 @@ package arangodb
 
 import (
 	"context"
-	"strings"
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"strings"
+	"testing"
 )
 
 func TestCertifyGood(t *testing.T) {
@@ -190,6 +189,47 @@ func TestCertifyGood(t *testing.T) {
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification one",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification one",
+						KnownSince:    zeroTime,
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: testdata.P1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification two",
+						KnownSince:    zeroTime,
+					},
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				Justification: ptrfrom.String("test justification one"),
+				KnownSince:    ptrfrom.Time(zeroTime),
+			},
+			ExpCG: []*model.CertifyGood{
+				{
+					Subject:       testdata.P1out,
+					Justification: "test justification one",
+					KnownSince:    zeroTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCertifyGood(t *testing.T) {
@@ -38,6 +39,8 @@ func TestCertifyGood(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -205,7 +208,7 @@ func TestCertifyGood(t *testing.T) {
 					},
 					CG: &model.CertifyGoodInputSpec{
 						Justification: "test justification one",
-						KnownSince:    zeroTime,
+						KnownSince:    curTime,
 					},
 				},
 				{
@@ -217,19 +220,19 @@ func TestCertifyGood(t *testing.T) {
 					},
 					CG: &model.CertifyGoodInputSpec{
 						Justification: "test justification two",
-						KnownSince:    zeroTime,
+						KnownSince:    timeAfterOneSecond,
 					},
 				},
 			},
 			Query: &model.CertifyGoodSpec{
 				Justification: ptrfrom.String("test justification one"),
-				KnownSince:    ptrfrom.Time(zeroTime),
+				KnownSince:    ptrfrom.Time(curTime),
 			},
 			ExpCG: []*model.CertifyGood{
 				{
 					Subject:       testdata.P1out,
 					Justification: "test justification one",
-					KnownSince:    zeroTime,
+					KnownSince:    curTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -19,13 +19,14 @@ package arangodb
 
 import (
 	"context"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestCertifyGood(t *testing.T) {

--- a/pkg/assembler/backends/arangodb/hasSBOM_test.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -39,6 +40,8 @@ func TestHasSBOM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating arango backend: %v", err)
 	}
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
 	type call struct {
 		Sub model.PackageOrArtifactInput
 		HS  *model.HasSBOMInputSpec
@@ -138,6 +141,41 @@ func TestHasSBOM(t *testing.T) {
 				{
 					Subject: testdata.P1out,
 					URI:     "test uri one",
+				},
+			},
+		},
+		{
+			Name:  "Query on URI",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						URI:        "test uri one",
+						KnownSince: curTime,
+					},
+				},
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: testdata.P1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						URI:        "test uri two",
+						KnownSince: timeAfterOneSecond,
+					},
+				},
+			},
+			Query: &model.HasSBOMSpec{
+				URI:        ptrfrom.String("test uri one"),
+				KnownSince: ptrfrom.Time(curTime),
+			},
+			ExpHS: []*model.HasSbom{
+				{
+					Subject:    testdata.P1out,
+					URI:        "test uri one",
+					KnownSince: curTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -125,6 +125,7 @@ func queryCertifications(ctx context.Context, client *ent.Client, typ certificat
 		optionalPredicate(filter.Collector, certification.CollectorEQ),
 		optionalPredicate(filter.Origin, certification.OriginEQ),
 		optionalPredicate(filter.Justification, certification.JustificationEQ),
+		optionalPredicate(filter.KnownSince, certification.KnownSinceEQ),
 	}
 
 	if filter.Subject != nil {
@@ -160,13 +161,15 @@ func upsertCertification[T certificationInputSpec](ctx context.Context, client *
 			SetType(certification.TypeBAD).
 			SetJustification(v.Justification).
 			SetOrigin(v.Origin).
-			SetCollector(v.Collector)
+			SetCollector(v.Collector).
+			SetKnownSince(v.KnownSince)
 	case model.CertifyGoodInputSpec:
 		insert.
 			SetType(certification.TypeGOOD).
 			SetJustification(v.Justification).
 			SetOrigin(v.Origin).
-			SetCollector(v.Collector)
+			SetCollector(v.Collector).
+			SetKnownSince(v.KnownSince)
 	default:
 		log.Printf("Unknown spec: %+T", v)
 	}
@@ -176,6 +179,7 @@ func upsertCertification[T certificationInputSpec](ctx context.Context, client *
 		certification.FieldCollector,
 		certification.FieldOrigin,
 		certification.FieldJustification,
+		certification.FieldKnownSince,
 	}
 	var conflictWhere *sql.Predicate
 
@@ -280,6 +284,7 @@ func toModelCertifyBad(v *ent.Certification) *model.CertifyBad {
 		Origin:        v.Origin,
 		Collector:     v.Collector,
 		Subject:       sub,
+		KnownSince:    v.KnownSince,
 	}
 }
 
@@ -306,5 +311,6 @@ func toModelCertifyGood(v *ent.Certification) *model.CertifyGood {
 		Origin:        v.Origin,
 		Collector:     v.Collector,
 		Subject:       sub,
+		KnownSince:    v.KnownSince,
 	}
 }

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -169,7 +169,7 @@ func upsertCertification[T certificationInputSpec](ctx context.Context, client *
 			SetJustification(v.Justification).
 			SetOrigin(v.Origin).
 			SetCollector(v.Collector).
-			SetKnownSince(v.KnownSince)
+			SetKnownSince(v.KnownSince.UTC())
 	default:
 		log.Printf("Unknown spec: %+T", v)
 	}

--- a/pkg/assembler/backends/ent/backend/certify_test.go
+++ b/pkg/assembler/backends/ent/backend/certify_test.go
@@ -27,9 +27,6 @@ import (
 )
 
 func (s *Suite) TestCertifyBad() {
-	curTime := time.Now()
-	timeAfterOneSecond := curTime.Add(time.Second)
-
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -149,31 +146,19 @@ func (s *Suite) TestCertifyBad() {
 					},
 					CB: &model.CertifyBadInputSpec{
 						Justification: "test justification one",
-						KnownSince:    curTime,
-					},
-				},
-				{
-					Sub: model.PackageSourceOrArtifactInput{
-						Package: p1,
-					},
-					Match: &model.MatchFlags{
-						Pkg: model.PkgMatchTypeSpecificVersion,
-					},
-					CB: &model.CertifyBadInputSpec{
-						Justification: "test justification two",
-						KnownSince:    timeAfterOneSecond,
+						KnownSince:    time.Unix(1e9, 0),
 					},
 				},
 			},
 			Query: &model.CertifyBadSpec{
 				Justification: ptrfrom.String("test justification one"),
-				KnownSince:    ptrfrom.Time(curTime),
+				KnownSince:    ptrfrom.Time(time.Unix(1e9, 0)),
 			},
 			ExpCB: []*model.CertifyBad{
 				{
 					Subject:       p1out,
 					Justification: "test justification one",
-					KnownSince:    curTime,
+					KnownSince:    time.Unix(1e9, 0),
 				},
 			},
 		},
@@ -613,8 +598,6 @@ func (s *Suite) TestCertifyBad() {
 }
 
 func (s *Suite) TestIngestCertifyBads() {
-	curTime := time.Now()
-
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInputs
 		Match *model.MatchFlags
@@ -733,11 +716,11 @@ func (s *Suite) TestIngestCertifyBads() {
 					CB: []*model.CertifyBadInputSpec{
 						{
 							Justification: "test justification",
-							KnownSince:    curTime,
+							KnownSince:    time.Unix(1e9, 0),
 						},
 						{
 							Justification: "test justification",
-							KnownSince:    curTime,
+							KnownSince:    time.Unix(1e9, 0),
 						},
 					},
 				},
@@ -748,7 +731,7 @@ func (s *Suite) TestIngestCertifyBads() {
 					CB: []*model.CertifyBadInputSpec{
 						{
 							Justification: "test justification",
-							KnownSince:    curTime,
+							KnownSince:    time.Unix(1e9, 0),
 						},
 					},
 				},
@@ -759,12 +742,13 @@ func (s *Suite) TestIngestCertifyBads() {
 						Version: ptrfrom.String("2.11.1"),
 					},
 				},
+				KnownSince: ptrfrom.Time(time.Unix(1e9, 0)),
 			},
 			ExpCB: []*model.CertifyBad{
 				{
 					Subject:       p2out,
 					Justification: "test justification",
-					KnownSince:    curTime,
+					KnownSince:    time.Unix(1e9, 0),
 				},
 			},
 		},
@@ -951,9 +935,6 @@ func (s *Suite) TestIngestCertifyBads() {
 }
 
 func (s *Suite) TestCertifyGood() {
-	curTime := time.Now()
-	timeAfterOneSecond := curTime.Add(time.Second)
-
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -1073,7 +1054,7 @@ func (s *Suite) TestCertifyGood() {
 					},
 					CG: &model.CertifyGoodInputSpec{
 						Justification: "test justification one",
-						KnownSince:    curTime,
+						KnownSince:    time.Unix(1e9, 0),
 					},
 				},
 				{
@@ -1085,19 +1066,19 @@ func (s *Suite) TestCertifyGood() {
 					},
 					CG: &model.CertifyGoodInputSpec{
 						Justification: "test justification two",
-						KnownSince:    timeAfterOneSecond,
+						KnownSince:    time.Unix(1e9, 0),
 					},
 				},
 			},
 			Query: &model.CertifyGoodSpec{
 				Justification: ptrfrom.String("test justification one"),
-				KnownSince:    ptrfrom.Time(curTime),
+				KnownSince:    ptrfrom.Time(time.Unix(1e9, 0)),
 			},
 			ExpCG: []*model.CertifyGood{
 				{
 					Subject:       p1out,
 					Justification: "test justification one",
-					KnownSince:    curTime,
+					KnownSince:    time.Unix(1e9, 0),
 				},
 			},
 		},

--- a/pkg/assembler/backends/ent/backend/certify_test.go
+++ b/pkg/assembler/backends/ent/backend/certify_test.go
@@ -19,6 +19,7 @@ package backend
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -26,6 +27,9 @@ import (
 )
 
 func (s *Suite) TestCertifyBad() {
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
+
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -129,6 +133,47 @@ func (s *Suite) TestCertifyBad() {
 				{
 					Subject:       p1out,
 					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on Justification",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: &model.CertifyBadInputSpec{
+						Justification: "test justification one",
+						KnownSince:    curTime,
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: &model.CertifyBadInputSpec{
+						Justification: "test justification two",
+						KnownSince:    timeAfterOneSecond,
+					},
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Justification: ptrfrom.String("test justification one"),
+				KnownSince:    ptrfrom.Time(curTime),
+			},
+			ExpCB: []*model.CertifyBad{
+				{
+					Subject:       p1out,
+					Justification: "test justification one",
+					KnownSince:    curTime,
 				},
 			},
 		},
@@ -568,6 +613,8 @@ func (s *Suite) TestCertifyBad() {
 }
 
 func (s *Suite) TestIngestCertifyBads() {
+	curTime := time.Now()
+
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInputs
 		Match *model.MatchFlags
@@ -668,6 +715,56 @@ func (s *Suite) TestIngestCertifyBads() {
 				&model.CertifyBad{
 					Subject:       p1out,
 					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{p1, p2},
+			InSrc: []*model.SourceInputSpec{s1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1, p2},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: []*model.CertifyBadInputSpec{
+						{
+							Justification: "test justification",
+							KnownSince:    curTime,
+						},
+						{
+							Justification: "test justification",
+							KnownSince:    curTime,
+						},
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Sources: []*model.SourceInputSpec{s1},
+					},
+					CB: []*model.CertifyBadInputSpec{
+						{
+							Justification: "test justification",
+							KnownSince:    curTime,
+						},
+					},
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				Subject: &model.PackageSourceOrArtifactSpec{
+					Package: &model.PkgSpec{
+						Version: ptrfrom.String("2.11.1"),
+					},
+				},
+			},
+			ExpCB: []*model.CertifyBad{
+				{
+					Subject:       p2out,
+					Justification: "test justification",
+					KnownSince:    curTime,
 				},
 			},
 		},
@@ -854,6 +951,9 @@ func (s *Suite) TestIngestCertifyBads() {
 }
 
 func (s *Suite) TestCertifyGood() {
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
+
 	type call struct {
 		Sub   model.PackageSourceOrArtifactInput
 		Match *model.MatchFlags
@@ -957,6 +1057,47 @@ func (s *Suite) TestCertifyGood() {
 				{
 					Subject:       p1out,
 					Justification: "test justification",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification one",
+						KnownSince:    curTime,
+					},
+				},
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: p1,
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						Justification: "test justification two",
+						KnownSince:    timeAfterOneSecond,
+					},
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				Justification: ptrfrom.String("test justification one"),
+				KnownSince:    ptrfrom.Time(curTime),
+			},
+			ExpCG: []*model.CertifyGood{
+				{
+					Subject:       p1out,
+					Justification: "test justification one",
+					KnownSince:    curTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/ent/backend/sbom.go
+++ b/pkg/assembler/backends/ent/backend/sbom.go
@@ -82,7 +82,7 @@ func (b *EntBackend) IngestHasSbom(ctx context.Context, subject model.PackageOrA
 			SetDownloadLocation(spec.DownloadLocation).
 			SetOrigin(spec.Origin).
 			SetCollector(spec.Collector).
-			SetKnownSince(spec.KnownSince)
+			SetKnownSince(spec.KnownSince.UTC())
 
 		// If a new column is included in the conflict columns, it must be added to the Indexes() function in the schema
 		conflictColumns := []string{

--- a/pkg/assembler/backends/ent/backend/sbom.go
+++ b/pkg/assembler/backends/ent/backend/sbom.go
@@ -38,6 +38,7 @@ func (b *EntBackend) HasSBOM(ctx context.Context, spec *model.HasSBOMSpec) ([]*m
 		optionalPredicate(spec.Collector, billofmaterials.CollectorEQ),
 		optionalPredicate(spec.DownloadLocation, billofmaterials.DownloadLocationEQ),
 		optionalPredicate(spec.Origin, billofmaterials.OriginEQ),
+		optionalPredicate(spec.KnownSince, billofmaterials.KnownSinceEQ),
 		// billofmaterials.AnnotationsMatchSpec(spec.Annotations),
 	}
 
@@ -80,13 +81,16 @@ func (b *EntBackend) IngestHasSbom(ctx context.Context, subject model.PackageOrA
 			SetDigest(strings.ToLower(spec.Digest)).
 			SetDownloadLocation(spec.DownloadLocation).
 			SetOrigin(spec.Origin).
-			SetCollector(spec.Collector)
+			SetCollector(spec.Collector).
+			SetKnownSince(spec.KnownSince)
 
+		// If a new column is included in the conflict columns, it must be added to the Indexes() function in the schema
 		conflictColumns := []string{
 			billofmaterials.FieldURI,
 			billofmaterials.FieldAlgorithm,
 			billofmaterials.FieldDigest,
 			billofmaterials.FieldDownloadLocation,
+			billofmaterials.FieldKnownSince,
 		}
 
 		var conflictWhere *sql.Predicate

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -27,9 +27,6 @@ import (
 )
 
 func (s *Suite) Test_HasSBOM() {
-	curTime := time.Now()
-	timeAfterOneSecond := curTime.Add(time.Second)
-
 	type call struct {
 		Sub  model.PackageOrArtifactInput
 		Spec *model.HasSBOMInputSpec
@@ -139,25 +136,17 @@ func (s *Suite) Test_HasSBOM() {
 						Package: p1,
 					},
 					Spec: &model.HasSBOMInputSpec{
-						KnownSince: curTime,
-					},
-				},
-				{
-					Sub: model.PackageOrArtifactInput{
-						Package: p1,
-					},
-					Spec: &model.HasSBOMInputSpec{
-						KnownSince: timeAfterOneSecond,
+						KnownSince: time.Unix(1e9, 0),
 					},
 				},
 			},
 			Query: &model.HasSBOMSpec{
-				KnownSince: ptrfrom.Time(curTime),
+				KnownSince: ptrfrom.Time(time.Unix(1e9, 0)),
 			},
 			Expected: []*model.HasSbom{
 				{
 					Subject:    p1out,
-					KnownSince: curTime,
+					KnownSince: time.Unix(1e9, 0),
 				},
 			},
 		},
@@ -553,9 +542,6 @@ func (s *Suite) Test_HasSBOM() {
 }
 
 func (s *Suite) TestIngestHasSBOMs() {
-	curTime := time.Now()
-	timeAfterOneSecond := curTime.Add(time.Second)
-
 	type call struct {
 		Sub model.PackageOrArtifactInputs
 		HS  []*model.HasSBOMInputSpec
@@ -661,21 +647,18 @@ func (s *Suite) TestIngestHasSBOMs() {
 					},
 					HS: []*model.HasSBOMInputSpec{
 						{
-							KnownSince: curTime,
-						},
-						{
-							KnownSince: timeAfterOneSecond,
+							KnownSince: time.Unix(1e9, 0),
 						},
 					},
 				},
 			},
 			Query: &model.HasSBOMSpec{
-				KnownSince: ptrfrom.Time(curTime),
+				KnownSince: ptrfrom.Time(time.Unix(1e9, 0)),
 			},
 			ExpHS: []*model.HasSbom{
 				{
 					Subject:    p1out,
-					KnownSince: curTime,
+					KnownSince: time.Unix(1e9, 0),
 				},
 			},
 		},

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -19,6 +19,7 @@ package backend
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -26,6 +27,9 @@ import (
 )
 
 func (s *Suite) Test_HasSBOM() {
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
+
 	type call struct {
 		Sub  model.PackageOrArtifactInput
 		Spec *model.HasSBOMInputSpec
@@ -123,6 +127,37 @@ func (s *Suite) Test_HasSBOM() {
 				{
 					Subject: p1out,
 					URI:     "test uri one",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: p1,
+					},
+					Spec: &model.HasSBOMInputSpec{
+						KnownSince: curTime,
+					},
+				},
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: p1,
+					},
+					Spec: &model.HasSBOMInputSpec{
+						KnownSince: timeAfterOneSecond,
+					},
+				},
+			},
+			Query: &model.HasSBOMSpec{
+				KnownSince: ptrfrom.Time(curTime),
+			},
+			Expected: []*model.HasSbom{
+				{
+					Subject:    p1out,
+					KnownSince: curTime,
 				},
 			},
 		},
@@ -518,6 +553,9 @@ func (s *Suite) Test_HasSBOM() {
 }
 
 func (s *Suite) TestIngestHasSBOMs() {
+	curTime := time.Now()
+	timeAfterOneSecond := curTime.Add(time.Second)
+
 	type call struct {
 		Sub model.PackageOrArtifactInputs
 		HS  []*model.HasSBOMInputSpec
@@ -610,6 +648,34 @@ func (s *Suite) TestIngestHasSBOMs() {
 				{
 					Subject: p1out,
 					URI:     "test uri one",
+				},
+			},
+		},
+		{
+			Name:  "Query on KnownSince",
+			InPkg: []*model.PkgInputSpec{p1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Packages: []*model.PkgInputSpec{p1, p1},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							KnownSince: curTime,
+						},
+						{
+							KnownSince: timeAfterOneSecond,
+						},
+					},
+				},
+			},
+			Query: &model.HasSBOMSpec{
+				KnownSince: ptrfrom.Time(curTime),
+			},
+			ExpHS: []*model.HasSbom{
+				{
+					Subject:    p1out,
+					KnownSince: curTime,
 				},
 			},
 		},

--- a/pkg/assembler/backends/ent/backend/transforms.go
+++ b/pkg/assembler/backends/ent/backend/transforms.go
@@ -212,6 +212,7 @@ func toModelHasSBOM(sbom *ent.BillOfMaterials) *model.HasSbom {
 		DownloadLocation: sbom.DownloadLocation,
 		Origin:           sbom.Origin,
 		Collector:        sbom.Collector,
+		KnownSince:       sbom.KnownSince,
 	}
 }
 

--- a/pkg/assembler/backends/ent/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials.go
@@ -5,6 +5,7 @@ package ent
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
@@ -34,6 +35,8 @@ type BillOfMaterials struct {
 	Origin string `json:"origin,omitempty"`
 	// GUAC collector for the document
 	Collector string `json:"collector,omitempty"`
+	// KnownSince holds the value of the "known_since" field.
+	KnownSince time.Time `json:"known_since,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the BillOfMaterialsQuery when eager-loading is set.
 	Edges        BillOfMaterialsEdges `json:"edges"`
@@ -88,6 +91,8 @@ func (*BillOfMaterials) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case billofmaterials.FieldURI, billofmaterials.FieldAlgorithm, billofmaterials.FieldDigest, billofmaterials.FieldDownloadLocation, billofmaterials.FieldOrigin, billofmaterials.FieldCollector:
 			values[i] = new(sql.NullString)
+		case billofmaterials.FieldKnownSince:
+			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -158,6 +163,12 @@ func (bom *BillOfMaterials) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				bom.Collector = value.String
+			}
+		case billofmaterials.FieldKnownSince:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field known_since", values[i])
+			} else if value.Valid {
+				bom.KnownSince = value.Time
 			}
 		default:
 			bom.selectValues.Set(columns[i], values[i])
@@ -232,6 +243,9 @@ func (bom *BillOfMaterials) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(bom.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("known_since=")
+	builder.WriteString(bom.KnownSince.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
@@ -28,6 +28,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldKnownSince holds the string denoting the known_since field in the database.
+	FieldKnownSince = "known_since"
 	// EdgePackage holds the string denoting the package edge name in mutations.
 	EdgePackage = "package"
 	// EdgeArtifact holds the string denoting the artifact edge name in mutations.
@@ -61,6 +63,7 @@ var Columns = []string{
 	FieldDownloadLocation,
 	FieldOrigin,
 	FieldCollector,
+	FieldKnownSince,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -119,6 +122,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByKnownSince orders the results by the known_since field.
+func ByKnownSince(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKnownSince, opts...).ToFunc()
 }
 
 // ByPackageField orders the results by package field.

--- a/pkg/assembler/backends/ent/billofmaterials/where.go
+++ b/pkg/assembler/backends/ent/billofmaterials/where.go
@@ -3,6 +3,8 @@
 package billofmaterials
 
 import (
+	"time"
+
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
@@ -91,6 +93,11 @@ func Origin(v string) predicate.BillOfMaterials {
 // Collector applies equality check predicate on the "collector" field. It's identical to CollectorEQ.
 func Collector(v string) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.FieldEQ(FieldCollector, v))
+}
+
+// KnownSince applies equality check predicate on the "known_since" field. It's identical to KnownSinceEQ.
+func KnownSince(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldEQ(FieldKnownSince, v))
 }
 
 // PackageIDEQ applies the EQ predicate on the "package_id" field.
@@ -541,6 +548,46 @@ func CollectorEqualFold(v string) predicate.BillOfMaterials {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// KnownSinceEQ applies the EQ predicate on the "known_since" field.
+func KnownSinceEQ(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldEQ(FieldKnownSince, v))
+}
+
+// KnownSinceNEQ applies the NEQ predicate on the "known_since" field.
+func KnownSinceNEQ(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldNEQ(FieldKnownSince, v))
+}
+
+// KnownSinceIn applies the In predicate on the "known_since" field.
+func KnownSinceIn(vs ...time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceNotIn applies the NotIn predicate on the "known_since" field.
+func KnownSinceNotIn(vs ...time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldNotIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceGT applies the GT predicate on the "known_since" field.
+func KnownSinceGT(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldGT(FieldKnownSince, v))
+}
+
+// KnownSinceGTE applies the GTE predicate on the "known_since" field.
+func KnownSinceGTE(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldGTE(FieldKnownSince, v))
+}
+
+// KnownSinceLT applies the LT predicate on the "known_since" field.
+func KnownSinceLT(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldLT(FieldKnownSince, v))
+}
+
+// KnownSinceLTE applies the LTE predicate on the "known_since" field.
+func KnownSinceLTE(v time.Time) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldLTE(FieldKnownSince, v))
 }
 
 // HasPackage applies the HasEdge predicate on the "package" edge.

--- a/pkg/assembler/backends/ent/billofmaterials_create.go
+++ b/pkg/assembler/backends/ent/billofmaterials_create.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -87,6 +88,12 @@ func (bomc *BillOfMaterialsCreate) SetCollector(s string) *BillOfMaterialsCreate
 	return bomc
 }
 
+// SetKnownSince sets the "known_since" field.
+func (bomc *BillOfMaterialsCreate) SetKnownSince(t time.Time) *BillOfMaterialsCreate {
+	bomc.mutation.SetKnownSince(t)
+	return bomc
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (bomc *BillOfMaterialsCreate) SetPackage(p *PackageVersion) *BillOfMaterialsCreate {
 	return bomc.SetPackageID(p.ID)
@@ -149,6 +156,9 @@ func (bomc *BillOfMaterialsCreate) check() error {
 	if _, ok := bomc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "BillOfMaterials.collector"`)}
 	}
+	if _, ok := bomc.mutation.KnownSince(); !ok {
+		return &ValidationError{Name: "known_since", err: errors.New(`ent: missing required field "BillOfMaterials.known_since"`)}
+	}
 	return nil
 }
 
@@ -199,6 +209,10 @@ func (bomc *BillOfMaterialsCreate) createSpec() (*BillOfMaterials, *sqlgraph.Cre
 	if value, ok := bomc.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := bomc.mutation.KnownSince(); ok {
+		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)
+		_node.KnownSince = value
 	}
 	if nodes := bomc.mutation.PackageIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -394,6 +408,18 @@ func (u *BillOfMaterialsUpsert) UpdateCollector() *BillOfMaterialsUpsert {
 	return u
 }
 
+// SetKnownSince sets the "known_since" field.
+func (u *BillOfMaterialsUpsert) SetKnownSince(v time.Time) *BillOfMaterialsUpsert {
+	u.Set(billofmaterials.FieldKnownSince, v)
+	return u
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsert) UpdateKnownSince() *BillOfMaterialsUpsert {
+	u.SetExcluded(billofmaterials.FieldKnownSince)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -557,6 +583,20 @@ func (u *BillOfMaterialsUpsertOne) SetCollector(v string) *BillOfMaterialsUpsert
 func (u *BillOfMaterialsUpsertOne) UpdateCollector() *BillOfMaterialsUpsertOne {
 	return u.Update(func(s *BillOfMaterialsUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetKnownSince sets the "known_since" field.
+func (u *BillOfMaterialsUpsertOne) SetKnownSince(v time.Time) *BillOfMaterialsUpsertOne {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsertOne) UpdateKnownSince() *BillOfMaterialsUpsertOne {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.UpdateKnownSince()
 	})
 }
 
@@ -886,6 +926,20 @@ func (u *BillOfMaterialsUpsertBulk) SetCollector(v string) *BillOfMaterialsUpser
 func (u *BillOfMaterialsUpsertBulk) UpdateCollector() *BillOfMaterialsUpsertBulk {
 	return u.Update(func(s *BillOfMaterialsUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetKnownSince sets the "known_since" field.
+func (u *BillOfMaterialsUpsertBulk) SetKnownSince(v time.Time) *BillOfMaterialsUpsertBulk {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsertBulk) UpdateKnownSince() *BillOfMaterialsUpsertBulk {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.UpdateKnownSince()
 	})
 }
 

--- a/pkg/assembler/backends/ent/billofmaterials_update.go
+++ b/pkg/assembler/backends/ent/billofmaterials_update.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -105,6 +106,12 @@ func (bomu *BillOfMaterialsUpdate) SetCollector(s string) *BillOfMaterialsUpdate
 	return bomu
 }
 
+// SetKnownSince sets the "known_since" field.
+func (bomu *BillOfMaterialsUpdate) SetKnownSince(t time.Time) *BillOfMaterialsUpdate {
+	bomu.mutation.SetKnownSince(t)
+	return bomu
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (bomu *BillOfMaterialsUpdate) SetPackage(p *PackageVersion) *BillOfMaterialsUpdate {
 	return bomu.SetPackageID(p.ID)
@@ -185,6 +192,9 @@ func (bomu *BillOfMaterialsUpdate) sqlSave(ctx context.Context) (n int, err erro
 	}
 	if value, ok := bomu.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := bomu.mutation.KnownSince(); ok {
+		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)
 	}
 	if bomu.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -340,6 +350,12 @@ func (bomuo *BillOfMaterialsUpdateOne) SetCollector(s string) *BillOfMaterialsUp
 	return bomuo
 }
 
+// SetKnownSince sets the "known_since" field.
+func (bomuo *BillOfMaterialsUpdateOne) SetKnownSince(t time.Time) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.SetKnownSince(t)
+	return bomuo
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (bomuo *BillOfMaterialsUpdateOne) SetPackage(p *PackageVersion) *BillOfMaterialsUpdateOne {
 	return bomuo.SetPackageID(p.ID)
@@ -450,6 +466,9 @@ func (bomuo *BillOfMaterialsUpdateOne) sqlSave(ctx context.Context) (_node *Bill
 	}
 	if value, ok := bomuo.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := bomuo.mutation.KnownSince(); ok {
+		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)
 	}
 	if bomuo.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/certification.go
+++ b/pkg/assembler/backends/ent/certification.go
@@ -5,6 +5,7 @@ package ent
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
@@ -36,6 +37,8 @@ type Certification struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// KnownSince holds the value of the "known_since" field.
+	KnownSince time.Time `json:"known_since,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CertificationQuery when eager-loading is set.
 	Edges        CertificationEdges `json:"edges"`
@@ -120,6 +123,8 @@ func (*Certification) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case certification.FieldType, certification.FieldJustification, certification.FieldOrigin, certification.FieldCollector:
 			values[i] = new(sql.NullString)
+		case certification.FieldKnownSince:
+			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -192,6 +197,12 @@ func (c *Certification) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				c.Collector = value.String
+			}
+		case certification.FieldKnownSince:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field known_since", values[i])
+			} else if value.Valid {
+				c.KnownSince = value.Time
 			}
 		default:
 			c.selectValues.Set(columns[i], values[i])
@@ -280,6 +291,9 @@ func (c *Certification) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(c.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("known_since=")
+	builder.WriteString(c.KnownSince.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/certification/certification.go
+++ b/pkg/assembler/backends/ent/certification/certification.go
@@ -32,6 +32,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldKnownSince holds the string denoting the known_since field in the database.
+	FieldKnownSince = "known_since"
 	// EdgeSource holds the string denoting the source edge name in mutations.
 	EdgeSource = "source"
 	// EdgePackageVersion holds the string denoting the package_version edge name in mutations.
@@ -83,6 +85,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldKnownSince,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -167,6 +170,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByKnownSince orders the results by the known_since field.
+func ByKnownSince(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKnownSince, opts...).ToFunc()
 }
 
 // BySourceField orders the results by source field.

--- a/pkg/assembler/backends/ent/certification/where.go
+++ b/pkg/assembler/backends/ent/certification/where.go
@@ -3,6 +3,8 @@
 package certification
 
 import (
+	"time"
+
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
@@ -86,6 +88,11 @@ func Origin(v string) predicate.Certification {
 // Collector applies equality check predicate on the "collector" field. It's identical to CollectorEQ.
 func Collector(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldEQ(FieldCollector, v))
+}
+
+// KnownSince applies equality check predicate on the "known_since" field. It's identical to KnownSinceEQ.
+func KnownSince(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
 }
 
 // SourceIDEQ applies the EQ predicate on the "source_id" field.
@@ -421,6 +428,46 @@ func CollectorEqualFold(v string) predicate.Certification {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// KnownSinceEQ applies the EQ predicate on the "known_since" field.
+func KnownSinceEQ(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
+}
+
+// KnownSinceNEQ applies the NEQ predicate on the "known_since" field.
+func KnownSinceNEQ(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldNEQ(FieldKnownSince, v))
+}
+
+// KnownSinceIn applies the In predicate on the "known_since" field.
+func KnownSinceIn(vs ...time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceNotIn applies the NotIn predicate on the "known_since" field.
+func KnownSinceNotIn(vs ...time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldNotIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceGT applies the GT predicate on the "known_since" field.
+func KnownSinceGT(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldGT(FieldKnownSince, v))
+}
+
+// KnownSinceGTE applies the GTE predicate on the "known_since" field.
+func KnownSinceGTE(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldGTE(FieldKnownSince, v))
+}
+
+// KnownSinceLT applies the LT predicate on the "known_since" field.
+func KnownSinceLT(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldLT(FieldKnownSince, v))
+}
+
+// KnownSinceLTE applies the LTE predicate on the "known_since" field.
+func KnownSinceLTE(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldLTE(FieldKnownSince, v))
 }
 
 // HasSource applies the HasEdge predicate on the "source" edge.

--- a/pkg/assembler/backends/ent/certification_create.go
+++ b/pkg/assembler/backends/ent/certification_create.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -113,6 +114,12 @@ func (cc *CertificationCreate) SetCollector(s string) *CertificationCreate {
 	return cc
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cc *CertificationCreate) SetKnownSince(t time.Time) *CertificationCreate {
+	cc.mutation.SetKnownSince(t)
+	return cc
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (cc *CertificationCreate) SetSource(s *SourceName) *CertificationCreate {
 	return cc.SetSourceID(s.ID)
@@ -207,6 +214,9 @@ func (cc *CertificationCreate) check() error {
 	if _, ok := cc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "Certification.collector"`)}
 	}
+	if _, ok := cc.mutation.KnownSince(); !ok {
+		return &ValidationError{Name: "known_since", err: errors.New(`ent: missing required field "Certification.known_since"`)}
+	}
 	return nil
 }
 
@@ -249,6 +259,10 @@ func (cc *CertificationCreate) createSpec() (*Certification, *sqlgraph.CreateSpe
 	if value, ok := cc.mutation.Collector(); ok {
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := cc.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+		_node.KnownSince = value
 	}
 	if nodes := cc.mutation.SourceIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -490,6 +504,18 @@ func (u *CertificationUpsert) UpdateCollector() *CertificationUpsert {
 	return u
 }
 
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsert) SetKnownSince(v time.Time) *CertificationUpsert {
+	u.Set(certification.FieldKnownSince, v)
+	return u
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsert) UpdateKnownSince() *CertificationUpsert {
+	u.SetExcluded(certification.FieldKnownSince)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -667,6 +693,20 @@ func (u *CertificationUpsertOne) SetCollector(v string) *CertificationUpsertOne 
 func (u *CertificationUpsertOne) UpdateCollector() *CertificationUpsertOne {
 	return u.Update(func(s *CertificationUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsertOne) SetKnownSince(v time.Time) *CertificationUpsertOne {
+	return u.Update(func(s *CertificationUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsertOne) UpdateKnownSince() *CertificationUpsertOne {
+	return u.Update(func(s *CertificationUpsert) {
+		s.UpdateKnownSince()
 	})
 }
 
@@ -1011,6 +1051,20 @@ func (u *CertificationUpsertBulk) SetCollector(v string) *CertificationUpsertBul
 func (u *CertificationUpsertBulk) UpdateCollector() *CertificationUpsertBulk {
 	return u.Update(func(s *CertificationUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsertBulk) SetKnownSince(v time.Time) *CertificationUpsertBulk {
+	return u.Update(func(s *CertificationUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsertBulk) UpdateKnownSince() *CertificationUpsertBulk {
+	return u.Update(func(s *CertificationUpsert) {
+		s.UpdateKnownSince()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certification_update.go
+++ b/pkg/assembler/backends/ent/certification_update.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -143,6 +144,12 @@ func (cu *CertificationUpdate) SetCollector(s string) *CertificationUpdate {
 	return cu
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cu *CertificationUpdate) SetKnownSince(t time.Time) *CertificationUpdate {
+	cu.mutation.SetKnownSince(t)
+	return cu
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (cu *CertificationUpdate) SetSource(s *SourceName) *CertificationUpdate {
 	return cu.SetSourceID(s.ID)
@@ -266,6 +273,9 @@ func (cu *CertificationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := cu.mutation.Collector(); ok {
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cu.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
 	}
 	if cu.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -515,6 +525,12 @@ func (cuo *CertificationUpdateOne) SetCollector(s string) *CertificationUpdateOn
 	return cuo
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cuo *CertificationUpdateOne) SetKnownSince(t time.Time) *CertificationUpdateOne {
+	cuo.mutation.SetKnownSince(t)
+	return cuo
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (cuo *CertificationUpdateOne) SetSource(s *SourceName) *CertificationUpdateOne {
 	return cuo.SetSourceID(s.ID)
@@ -668,6 +684,9 @@ func (cuo *CertificationUpdateOne) sqlSave(ctx context.Context) (_node *Certific
 	}
 	if value, ok := cuo.mutation.Collector(); ok {
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cuo.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
 	}
 	if cuo.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -480,6 +480,11 @@ func (c *CertificationQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, certification.FieldCollector)
 				fieldSeen[certification.FieldCollector] = struct{}{}
 			}
+		case "knownSince":
+			if _, ok := fieldSeen[certification.FieldKnownSince]; !ok {
+				selectedFields = append(selectedFields, certification.FieldKnownSince)
+				fieldSeen[certification.FieldKnownSince] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -244,6 +244,11 @@ func (bom *BillOfMaterialsQuery) collectField(ctx context.Context, opCtx *graphq
 				selectedFields = append(selectedFields, billofmaterials.FieldCollector)
 				fieldSeen[billofmaterials.FieldCollector] = struct{}{}
 			}
+		case "knownSince":
+			if _, ok := fieldSeen[billofmaterials.FieldKnownSince]; !ok {
+				selectedFields = append(selectedFields, billofmaterials.FieldKnownSince)
+				fieldSeen[billofmaterials.FieldKnownSince] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -42,6 +42,7 @@ var (
 		{Name: "download_location", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "known_since", Type: field.TypeTime},
 		{Name: "package_id", Type: field.TypeInt, Nullable: true},
 		{Name: "artifact_id", Type: field.TypeInt, Nullable: true},
 	}
@@ -53,13 +54,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "bill_of_materials_package_versions_package",
-				Columns:    []*schema.Column{BillOfMaterialsColumns[7]},
+				Columns:    []*schema.Column{BillOfMaterialsColumns[8]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "bill_of_materials_artifacts_artifact",
-				Columns:    []*schema.Column{BillOfMaterialsColumns[8]},
+				Columns:    []*schema.Column{BillOfMaterialsColumns[9]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -68,7 +69,7 @@ var (
 			{
 				Name:    "sbom_unique_package",
 				Unique:  true,
-				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[7]},
+				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[7], BillOfMaterialsColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND artifact_id IS NULL",
 				},
@@ -76,7 +77,7 @@ var (
 			{
 				Name:    "sbom_unique_artifact",
 				Unique:  true,
-				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[8]},
+				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[7], BillOfMaterialsColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND artifact_id IS NOT NULL",
 				},

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -109,6 +109,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "known_since", Type: field.TypeTime},
 		{Name: "source_id", Type: field.TypeInt, Nullable: true},
 		{Name: "package_version_id", Type: field.TypeInt, Nullable: true},
 		{Name: "package_name_id", Type: field.TypeInt, Nullable: true},
@@ -122,58 +123,58 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certifications_source_names_source",
-				Columns:    []*schema.Column{CertificationsColumns[5]},
+				Columns:    []*schema.Column{CertificationsColumns[6]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_package_versions_package_version",
-				Columns:    []*schema.Column{CertificationsColumns[6]},
+				Columns:    []*schema.Column{CertificationsColumns[7]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_package_names_all_versions",
-				Columns:    []*schema.Column{CertificationsColumns[7]},
+				Columns:    []*schema.Column{CertificationsColumns[8]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_artifacts_artifact",
-				Columns:    []*schema.Column{CertificationsColumns[8]},
+				Columns:    []*schema.Column{CertificationsColumns[9]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certification_type_justification_origin_collector_source_id",
+				Name:    "certification_type_justification_origin_collector_source_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[5]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[6], CertificationsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_package_version_id",
+				Name:    "certification_type_justification_origin_collector_package_version_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[6]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[7], CertificationsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_package_name_id",
+				Name:    "certification_type_justification_origin_collector_package_name_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[7]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[8], CertificationsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_artifact_id",
+				Name:    "certification_type_justification_origin_collector_artifact_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[8]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[9], CertificationsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},

--- a/pkg/assembler/backends/ent/mutation.go
+++ b/pkg/assembler/backends/ent/mutation.go
@@ -2137,6 +2137,7 @@ type CertificationMutation struct {
 	justification          *string
 	origin                 *string
 	collector              *string
+	known_since            *time.Time
 	clearedFields          map[string]struct{}
 	source                 *int
 	clearedsource          bool
@@ -2589,6 +2590,42 @@ func (m *CertificationMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetKnownSince sets the "known_since" field.
+func (m *CertificationMutation) SetKnownSince(t time.Time) {
+	m.known_since = &t
+}
+
+// KnownSince returns the value of the "known_since" field in the mutation.
+func (m *CertificationMutation) KnownSince() (r time.Time, exists bool) {
+	v := m.known_since
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKnownSince returns the old "known_since" field's value of the Certification entity.
+// If the Certification object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertificationMutation) OldKnownSince(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKnownSince is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKnownSince requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKnownSince: %w", err)
+	}
+	return oldValue.KnownSince, nil
+}
+
+// ResetKnownSince resets all changes to the "known_since" field.
+func (m *CertificationMutation) ResetKnownSince() {
+	m.known_since = nil
+}
+
 // ClearSource clears the "source" edge to the SourceName entity.
 func (m *CertificationMutation) ClearSource() {
 	m.clearedsource = true
@@ -2744,7 +2781,7 @@ func (m *CertificationMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertificationMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m.source != nil {
 		fields = append(fields, certification.FieldSourceID)
 	}
@@ -2768,6 +2805,9 @@ func (m *CertificationMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, certification.FieldCollector)
+	}
+	if m.known_since != nil {
+		fields = append(fields, certification.FieldKnownSince)
 	}
 	return fields
 }
@@ -2793,6 +2833,8 @@ func (m *CertificationMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case certification.FieldCollector:
 		return m.Collector()
+	case certification.FieldKnownSince:
+		return m.KnownSince()
 	}
 	return nil, false
 }
@@ -2818,6 +2860,8 @@ func (m *CertificationMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldOrigin(ctx)
 	case certification.FieldCollector:
 		return m.OldCollector(ctx)
+	case certification.FieldKnownSince:
+		return m.OldKnownSince(ctx)
 	}
 	return nil, fmt.Errorf("unknown Certification field %s", name)
 }
@@ -2882,6 +2926,13 @@ func (m *CertificationMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case certification.FieldKnownSince:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKnownSince(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Certification field %s", name)
@@ -2985,6 +3036,9 @@ func (m *CertificationMutation) ResetField(name string) error {
 		return nil
 	case certification.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case certification.FieldKnownSince:
+		m.ResetKnownSince()
 		return nil
 	}
 	return fmt.Errorf("unknown Certification field %s", name)

--- a/pkg/assembler/backends/ent/mutation.go
+++ b/pkg/assembler/backends/ent/mutation.go
@@ -818,6 +818,7 @@ type BillOfMaterialsMutation struct {
 	download_location *string
 	origin            *string
 	collector         *string
+	known_since       *time.Time
 	clearedFields     map[string]struct{}
 	_package          *int
 	cleared_package   bool
@@ -1240,6 +1241,42 @@ func (m *BillOfMaterialsMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetKnownSince sets the "known_since" field.
+func (m *BillOfMaterialsMutation) SetKnownSince(t time.Time) {
+	m.known_since = &t
+}
+
+// KnownSince returns the value of the "known_since" field in the mutation.
+func (m *BillOfMaterialsMutation) KnownSince() (r time.Time, exists bool) {
+	v := m.known_since
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKnownSince returns the old "known_since" field's value of the BillOfMaterials entity.
+// If the BillOfMaterials object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillOfMaterialsMutation) OldKnownSince(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKnownSince is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKnownSince requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKnownSince: %w", err)
+	}
+	return oldValue.KnownSince, nil
+}
+
+// ResetKnownSince resets all changes to the "known_since" field.
+func (m *BillOfMaterialsMutation) ResetKnownSince() {
+	m.known_since = nil
+}
+
 // ClearPackage clears the "package" edge to the PackageVersion entity.
 func (m *BillOfMaterialsMutation) ClearPackage() {
 	m.cleared_package = true
@@ -1328,7 +1365,7 @@ func (m *BillOfMaterialsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BillOfMaterialsMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m._package != nil {
 		fields = append(fields, billofmaterials.FieldPackageID)
 	}
@@ -1352,6 +1389,9 @@ func (m *BillOfMaterialsMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, billofmaterials.FieldCollector)
+	}
+	if m.known_since != nil {
+		fields = append(fields, billofmaterials.FieldKnownSince)
 	}
 	return fields
 }
@@ -1377,6 +1417,8 @@ func (m *BillOfMaterialsMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case billofmaterials.FieldCollector:
 		return m.Collector()
+	case billofmaterials.FieldKnownSince:
+		return m.KnownSince()
 	}
 	return nil, false
 }
@@ -1402,6 +1444,8 @@ func (m *BillOfMaterialsMutation) OldField(ctx context.Context, name string) (en
 		return m.OldOrigin(ctx)
 	case billofmaterials.FieldCollector:
 		return m.OldCollector(ctx)
+	case billofmaterials.FieldKnownSince:
+		return m.OldKnownSince(ctx)
 	}
 	return nil, fmt.Errorf("unknown BillOfMaterials field %s", name)
 }
@@ -1466,6 +1510,13 @@ func (m *BillOfMaterialsMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case billofmaterials.FieldKnownSince:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKnownSince(v)
 		return nil
 	}
 	return fmt.Errorf("unknown BillOfMaterials field %s", name)
@@ -1557,6 +1608,9 @@ func (m *BillOfMaterialsMutation) ResetField(name string) error {
 		return nil
 	case billofmaterials.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case billofmaterials.FieldKnownSince:
+		m.ResetKnownSince()
 		return nil
 	}
 	return fmt.Errorf("unknown BillOfMaterials field %s", name)

--- a/pkg/assembler/backends/ent/schema/billofmaterials.go
+++ b/pkg/assembler/backends/ent/schema/billofmaterials.go
@@ -39,6 +39,7 @@ func (BillOfMaterials) Fields() []ent.Field {
 		field.String("download_location"),
 		field.String("origin"),
 		field.String("collector").Comment("GUAC collector for the document"),
+		field.Time("known_since"),
 	}
 }
 
@@ -53,9 +54,9 @@ func (BillOfMaterials) Edges() []ent.Edge {
 // Indexes of the Material.
 func (BillOfMaterials) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("algorithm", "digest", "uri", "download_location").Edges("package").Unique().
+		index.Fields("algorithm", "digest", "uri", "download_location", "known_since").Edges("package").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND artifact_id IS NULL")).StorageKey("sbom_unique_package"),
-		index.Fields("algorithm", "digest", "uri", "download_location").Edges("artifact").Unique().
+		index.Fields("algorithm", "digest", "uri", "download_location", "known_since").Edges("artifact").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND artifact_id IS NOT NULL")).StorageKey("sbom_unique_artifact"),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certification.go
+++ b/pkg/assembler/backends/ent/schema/certification.go
@@ -40,6 +40,7 @@ func (Certification) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.Time("known_since"),
 	}
 }
 
@@ -55,9 +56,9 @@ func (Certification) Edges() []ent.Edge {
 
 func (Certification) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("type", "justification", "origin", "collector", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("type", "justification", "origin", "collector", "source_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "package_version_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "package_name_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "artifact_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }


### PR DESCRIPTION
# Description of the PR

* Updating `sbom`, `certifyGood` and `certifyBad` with `KnownSince`
* Fixes https://github.com/guacsec/guac/issues/1030.
* And is based on https://github.com/guacsec/guac/pull/1338#discussion_r1343080326.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
