### PR TITLE
Included version information which the CLI starts up

### DIFF
--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/deps_dev"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,6 +53,8 @@ var depsDevCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
+
+		version.DumpVersion()
 
 		opts, err := validateDepsDevFlags(
 			viper.GetString("nats-addr"),
@@ -109,7 +112,6 @@ func validateDepsDevFlags(natsAddr string, csubAddr string, csubTls bool, csubTl
 	sources := []datasource.Source{}
 	for _, arg := range args {
 		sources = append(sources, datasource.Source{Value: arg})
-
 	}
 
 	var err error

--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/collector/file"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -46,7 +47,6 @@ var filesCmd = &cobra.Command{
 	Use:   "files [flags] file_path",
 	Short: "take a folder of files and create a GUAC graph utilizing Nats pubsub",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		opts, err := validateFilesFlags(
 			viper.GetString("nats-addr"),
 			viper.GetBool("service-poll"),
@@ -59,6 +59,8 @@ var filesCmd = &cobra.Command{
 
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
+
+		version.DumpVersion()
 
 		// Register collector
 		fileCollector := file.NewFileCollector(ctx, opts.path, opts.poll, 30*time.Second)

--- a/cmd/guaccollect/cmd/github.go
+++ b/cmd/guaccollect/cmd/github.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/github"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -50,6 +51,7 @@ var githubCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
+		version.DumpVersion()
 
 		opts, err := validateGithubFlags(
 			viper.GetString("nats-addr"),

--- a/cmd/guaccollect/cmd/oci.go
+++ b/cmd/guaccollect/cmd/oci.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/oci"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -50,6 +51,7 @@ var ociCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
+		version.DumpVersion()
 
 		opts, err := validateOCIFlags(
 			viper.GetString("nats-addr"),

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -22,14 +22,12 @@ import (
 
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/version"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
-
 	set, err := cli.BuildFlags([]string{"nats-addr", "csub-addr", "use-csub", "service-poll"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)

--- a/cmd/guaccsub/cmd/root.go
+++ b/cmd/guaccsub/cmd/root.go
@@ -27,7 +27,6 @@ import (
 	"github.com/guacsec/guac/pkg/collectsub/server"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/guacsec/guac/pkg/version"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -43,13 +42,11 @@ var rootCmd = &cobra.Command{
 	Short:   "GUAC collect subscriber service for GUAC collectors",
 	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		var opts, err = validateCsubFlags(
+		opts, err := validateCsubFlags(
 			viper.GetInt("csub-listen-port"),
 			viper.GetString("csub-tls-cert-file"),
 			viper.GetString("csub-tls-key-file"),
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
@@ -59,6 +56,7 @@ var rootCmd = &cobra.Command{
 		ctx, cf := context.WithCancel(logging.WithLogger(context.Background()))
 		logger := logging.FromContext(ctx)
 
+		version.DumpVersion()
 		// Start csub listening server
 		csubServer, err := server.NewServer(opts.port, opts.tlsCertFile, opts.tlsKeyFile)
 		if err != nil {

--- a/cmd/guacgql/cmd/root.go
+++ b/cmd/guacgql/cmd/root.go
@@ -92,6 +92,7 @@ var rootCmd = &cobra.Command{
 		flags.neptuneRegion = viper.GetString("neptune-region")
 		flags.neptuneUser = viper.GetString("neptune-user")
 		flags.neptuneRealm = viper.GetString("neptune-realm")
+		version.DumpVersion()
 
 		startServer(cmd)
 	},

--- a/cmd/guacgql/cmd/server.go
+++ b/cmd/guacgql/cmd/server.go
@@ -71,7 +71,6 @@ func startServer(cmd *cobra.Command) {
 		_ = cmd.Help()
 		os.Exit(1)
 	}
-
 	srv, err := getGraphqlServer(ctx)
 	if err != nil {
 		logger.Errorf("unable to initialize graphql server: %v", err)

--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor/process"
 	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -41,7 +42,6 @@ type options struct {
 }
 
 func ingest(cmd *cobra.Command, args []string) {
-
 	opts, err := validateFlags(
 		viper.GetString("nats-addr"),
 		viper.GetString("csub-addr"),
@@ -57,7 +57,7 @@ func ingest(cmd *cobra.Command, args []string) {
 
 	ctx, cf := context.WithCancel(logging.WithLogger(context.Background()))
 	logger := logging.FromContext(ctx)
-
+	version.DumpVersion()
 	// initialize jetstream
 	// TODO: pass in credentials file for NATS secure login
 	jetStream := emitter.NewJetStream(opts.natsAddr, "", "")

--- a/cmd/guacone/cmd/bad.go
+++ b/cmd/guacone/cmd/bad.go
@@ -27,6 +27,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,12 +45,11 @@ var queryBadCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateQueryBadFlags(
 			viper.GetString("gql-addr"),
 			viper.GetInt("search-depth"),
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
@@ -139,10 +139,12 @@ var queryBadCmd = &cobra.Command{
 
 				var fullCertifyBadPath []string
 				for _, version := range pkgVersions {
-					fullCertifyBadPath = append([]string{selectedCertifyBad.Id,
+					fullCertifyBadPath = append([]string{
+						selectedCertifyBad.Id,
 						version.Id,
 						subject.Namespaces[0].Names[0].Id, subject.Namespaces[0].Id,
-						subject.Id}, pkgPath...)
+						subject.Id,
+					}, pkgPath...)
 				}
 				if len(pkgPath) > 0 {
 					path = append(path, fullCertifyBadPath...)
@@ -187,9 +189,11 @@ var queryBadCmd = &cobra.Command{
 				}
 
 				if len(path) > 0 {
-					fullCertifyBadPath := append([]string{selectedCertifyBad.Id,
+					fullCertifyBadPath := append([]string{
+						selectedCertifyBad.Id,
 						subject.Namespaces[0].Names[0].Id,
-						subject.Namespaces[0].Id, subject.Id}, path...)
+						subject.Namespaces[0].Id, subject.Id,
+					}, path...)
 					path = append(path, fullCertifyBadPath...)
 					fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
 				} else {
@@ -230,8 +234,10 @@ var queryBadCmd = &cobra.Command{
 					}
 				}
 				if len(path) > 0 {
-					fullCertifyBadPath := append([]string{selectedCertifyBad.Id,
-						subject.Id}, path...)
+					fullCertifyBadPath := append([]string{
+						selectedCertifyBad.Id,
+						subject.Id,
+					}, path...)
 					path = append(path, fullCertifyBadPath...)
 					fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
 				} else {

--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -28,6 +28,7 @@ import (
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -55,14 +56,13 @@ var certifyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateCertifyFlags(
 			viper.GetString("gql-addr"),
 			viper.GetBool("cert-good"),
 			viper.GetBool("package-name"),
 			args,
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()

--- a/cmd/guacone/cmd/collectsub_client.go
+++ b/cmd/guacone/cmd/collectsub_client.go
@@ -21,13 +21,13 @@ import (
 	"io"
 	"os"
 
-	jsoniter "github.com/json-iterator/go"
-
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/collectsub"
 	"github.com/guacsec/guac/pkg/collectsub/collectsub/input"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -48,7 +48,7 @@ var csubClientCmd = &cobra.Command{
 func setupCsubClient(cmd *cobra.Command, args []string) (context.Context, client.Client) {
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)
-
+	version.DumpVersion()
 	opts, err := client.ValidateCsubClientFlags(
 		viper.GetString("csub-addr"),
 		viper.GetBool("csub-tls"),

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -36,6 +36,7 @@ import (
 	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/guacsec/guac/pkg/ingestor/verifier/sigstore_verifier"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
@@ -76,7 +77,7 @@ var filesCmd = &cobra.Command{
 			_ = cmd.Help()
 			os.Exit(1)
 		}
-
+		version.DumpVersion()
 		// Register Keystore
 		inmemory := inmemory.NewInmemoryProvider()
 		err = key.RegisterKeyProvider(inmemory, inmemory.Type())
@@ -143,7 +144,6 @@ var filesCmd = &cobra.Command{
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 			err := ingestor.Ingest(filesCtx, d, opts.graphqlEndpoint, csubClient)
-
 			if err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)

--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -51,7 +51,7 @@ var gcsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateGCSFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
@@ -106,7 +106,6 @@ var gcsCmd = &cobra.Command{
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
-
 			if err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)

--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -27,6 +27,7 @@ import (
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -88,12 +89,11 @@ var queryKnownCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateQueryKnownFlags(
 			viper.GetString("gql-addr"),
 			args,
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
@@ -152,9 +152,11 @@ var queryKnownCmd = &cobra.Command{
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, goodLinkStr, packageSubjectType))
 			t.AppendSeparator()
 
-			path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Id,
+			path = append([]string{
+				pkgResponse.Packages[0].Namespaces[0].Names[0].Id,
 				pkgResponse.Packages[0].Namespaces[0].Id,
-				pkgResponse.Packages[0].Id}, neighborsPath...)
+				pkgResponse.Packages[0].Id,
+			}, neighborsPath...)
 
 			fmt.Println(t.Render())
 			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
@@ -188,9 +190,11 @@ var queryKnownCmd = &cobra.Command{
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, badLinkStr, packageSubjectType))
 			t.AppendSeparator()
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, goodLinkStr, packageSubjectType))
-			path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
+			path = append([]string{
+				pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
 				pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
-				pkgResponse.Packages[0].Id}, neighborsPath...)
+				pkgResponse.Packages[0].Id,
+			}, neighborsPath...)
 
 			fmt.Println(t.Render())
 			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
@@ -228,8 +232,10 @@ var queryKnownCmd = &cobra.Command{
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, badLinkStr, sourceSubjectType))
 			t.AppendSeparator()
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, goodLinkStr, sourceSubjectType))
-			path = append([]string{srcResponse.Sources[0].Namespaces[0].Names[0].Id,
-				srcResponse.Sources[0].Namespaces[0].Id, srcResponse.Sources[0].Id}, neighborsPath...)
+			path = append([]string{
+				srcResponse.Sources[0].Namespaces[0].Names[0].Id,
+				srcResponse.Sources[0].Namespaces[0].Id, srcResponse.Sources[0].Id,
+			}, neighborsPath...)
 
 			fmt.Println(t.Render())
 			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -48,7 +49,7 @@ var ociCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateOCIFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
@@ -83,7 +84,6 @@ var ociCmd = &cobra.Command{
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
-
 			if err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -36,6 +36,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -53,7 +54,7 @@ var osvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateOSVFlags(
 			viper.GetString("gql-addr"),
 			viper.GetBool("poll"),
@@ -62,7 +63,6 @@ var osvCmd = &cobra.Command{
 			viper.GetBool("csub-tls"),
 			viper.GetBool("csub-tls-skip-verify"),
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()

--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -28,6 +28,7 @@ import (
 	"github.com/guacsec/guac/pkg/cli"
 	analysis "github.com/guacsec/guac/pkg/guacanalytics"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -47,7 +48,7 @@ var queryPatchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateQueryPatchFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("start-purl"),
@@ -57,7 +58,6 @@ var queryPatchCmd = &cobra.Command{
 			viper.GetBool("is-pkg-version-stop"),
 			args,
 		)
-
 		if err != nil {
 			logger.Fatalf("unable to validate flags: %s\n", err)
 		}
@@ -77,7 +77,6 @@ var queryPatchCmd = &cobra.Command{
 
 		if opts.stopPurl != "" {
 			stopPkg, err := getPkgID(ctx, gqlClient, opts.stopPurl, opts.isPackageVersionStop)
-
 			if err != nil {
 				logger.Fatalf("error getting stop pkg from purl inputted: %s\n", err)
 			}
@@ -87,13 +86,11 @@ var queryPatchCmd = &cobra.Command{
 		}
 
 		bfsMap, path, err := analysis.SearchDependentsFromStartPackage(ctx, gqlClient, startID, stopID, opts.depth)
-
 		if err != nil {
 			logger.Fatalf("error searching dependents-- %s\n", err)
 		}
 
 		frontiers, infoNodes, err := analysis.TopoSortFromBfsNodeMap(ctx, gqlClient, bfsMap)
-
 		if err != nil {
 			fmt.Printf("WARNING: There was cycle detected in the toposort so the results are incomplete: %s\n", err)
 		}
@@ -109,7 +106,6 @@ var queryPatchCmd = &cobra.Command{
 			fmt.Printf("\n---FRONTIER LEVEL %d---\n", level)
 
 			nodesInfo, err := printNodesInfo(ctx, gqlClient, bfsMap, allNodes)
-
 			if err != nil {
 				logger.Fatalf("%s", err)
 			}
@@ -122,7 +118,6 @@ var queryPatchCmd = &cobra.Command{
 			fmt.Printf("no info nodes found\n")
 		} else {
 			nodesInfo, err := printNodesInfo(ctx, gqlClient, bfsMap, infoNodes)
-
 			if err != nil {
 				logger.Fatalf("%s", err)
 			}
@@ -147,7 +142,6 @@ func printNodesInfo(ctx context.Context, gqlClient graphql.Client, bfsMap map[st
 	poc := []string{}
 	for _, id := range nodes {
 		node, err := model.Node(ctx, gqlClient, id)
-
 		if err != nil {
 			fmt.Printf("error: %s \n", err)
 		}
@@ -212,7 +206,6 @@ func makeArtifactPretty(artifact model.NodeNodeArtifact) string {
 
 func getPkgID(ctx context.Context, gqlClient graphql.Client, purl string, isPackageVersion bool) (string, error) {
 	pkgInput, err := helpers.PurlToPkg(purl)
-
 	if err != nil {
 		return "", fmt.Errorf("error getting pkg ID: %s", err)
 	}

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -26,17 +26,16 @@ import (
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
 	sc "github.com/guacsec/guac/pkg/certifier/components/source"
+	"github.com/guacsec/guac/pkg/certifier/scorecard"
 	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
-	"github.com/guacsec/guac/pkg/ingestor"
-
-	"github.com/guacsec/guac/pkg/certifier"
-	"github.com/guacsec/guac/pkg/certifier/scorecard"
-
-	"github.com/guacsec/guac/pkg/certifier/certify"
 	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,7 +53,7 @@ var scorecardCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateScorecardFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
@@ -63,7 +62,6 @@ var scorecardCmd = &cobra.Command{
 			viper.GetBool("poll"),
 			viper.GetString("interval"),
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
@@ -71,7 +69,6 @@ var scorecardCmd = &cobra.Command{
 		}
 		// scorecard runner is the scorecard library that runs the scorecard checks
 		scorecardRunner, err := scorecard.NewScorecardRunner(ctx)
-
 		if err != nil {
 			fmt.Printf("unable to create scorecard runner: %v\n", err)
 			_ = cmd.Help()
@@ -92,7 +89,6 @@ var scorecardCmd = &cobra.Command{
 
 		// running and getting the scorecard checks
 		scorecardCertifier, err := scorecard.NewScorecardCertifier(scorecardRunner)
-
 		if err != nil {
 			fmt.Printf("unable to create scorecard certifier: %v\n", err)
 			_ = cmd.Help()
@@ -102,7 +98,6 @@ var scorecardCmd = &cobra.Command{
 		// scorecard certifier is the certifier that gets the scorecard data graphQL
 		// setting "daysSinceLastScan" to 0 does not check the timestamp on the scorecard that exist
 		query, err := sc.NewCertifier(gqlclient, 0)
-
 		if err != nil {
 			fmt.Printf("unable to create scorecard certifier: %v\n", err)
 			_ = cmd.Help()
@@ -122,7 +117,6 @@ var scorecardCmd = &cobra.Command{
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
-
 			if err != nil {
 				return fmt.Errorf("unable to ingest document: %v", err)
 			}

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -28,6 +28,7 @@ import (
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/guacsec/guac/pkg/misc/depversion"
+	"github.com/guacsec/guac/pkg/version"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,7 +55,7 @@ var queryVulnCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-
+		version.DumpVersion()
 		opts, err := validateQueryVulnFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("vuln-id"),
@@ -62,7 +63,6 @@ var queryVulnCmd = &cobra.Command{
 			viper.GetInt("num-path"),
 			args,
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
@@ -152,9 +152,11 @@ var queryVulnCmd = &cobra.Command{
 			tableRows = append(tableRows, depVulnTableRows...)
 
 			if len(path) > 0 {
-				path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
+				path = append([]string{
+					pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
 					pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
-					pkgResponse.Packages[0].Id}, path...)
+					pkgResponse.Packages[0].Id,
+				}, path...)
 				t.AppendRows(tableRows)
 
 				fmt.Println(t.Render())
@@ -180,10 +182,12 @@ func queryVulnsViaPackageNeighbors(ctx context.Context, gqlclient graphql.Client
 			if certifyVuln.Vulnerability.Type != noVulnType {
 				for _, vuln := range certifyVuln.Vulnerability.VulnerabilityIDs {
 					tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
-					path = append(path, []string{vuln.Id, certifyVuln.Id,
+					path = append(path, []string{
+						vuln.Id, certifyVuln.Id,
 						certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 						certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
-						certifyVuln.Package.Id}...)
+						certifyVuln.Package.Id,
+					}...)
 				}
 			}
 		}
@@ -218,6 +222,7 @@ func vexSubjectString(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) st
 		return "unknown subject"
 	}
 }
+
 func vexSubjectIds(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) []string {
 	switch v := s.(type) {
 	case *model.AllCertifyVEXStatementSubjectArtifact:
@@ -227,7 +232,8 @@ func vexSubjectIds(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) []str
 			v.Id,
 			v.Namespaces[0].Id,
 			v.Namespaces[0].Names[0].Id,
-			v.Namespaces[0].Names[0].Versions[0].Id}
+			v.Namespaces[0].Names[0].Versions[0].Id,
+		}
 	default:
 		return []string{}
 	}
@@ -290,7 +296,7 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 					// version ranges from deps.dev. Continue here to report possible
 					// vulns even if some paths cannot be followed.
 					matchingDepPkgVersions = nil
-					//return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
+					// return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
 				}
 
 				for matchingDepPkgVersion := range matchingDepPkgVersions {
@@ -345,10 +351,12 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 				return nil, fmt.Errorf("error searching dependency packages match: %w", err)
 			}
 			if len(pkgPath) > 0 {
-				fullVulnPath := append([]string{vulnerabilityNodeID, certifyVuln.Id,
+				fullVulnPath := append([]string{
+					vulnerabilityNodeID, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
-					certifyVuln.Package.Id}, pkgPath...)
+					certifyVuln.Package.Id,
+				}, pkgPath...)
 				path = append(path, fullVulnPath...)
 				numberOfPaths += 1
 			}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,8 +16,14 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 var (
@@ -39,4 +45,24 @@ func init() {
 func (u uat) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Set("User-Agent", UserAgent)
 	return u.tr.RoundTrip(r)
+}
+
+// DumpVersion dumps the version information to the log.
+func DumpVersion() {
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+	if Commit == "" {
+		commit, _ := exec.Command("git", "rev-parse", "HEAD").Output()
+		Commit = strings.TrimRight(string(commit), "\n")
+		logger.Infof("Commit: dev-%s", Commit)
+	} else {
+		logger.Infof("Commit: %s", Commit)
+	}
+
+	if Date == "" {
+		Date = time.Now().Format("2006-01-02")
+		logger.Infof("Date: %s", Date)
+	} else {
+		logger.Infof("Date: %s", Date)
+	}
 }


### PR DESCRIPTION


# Description of the PR

- Included the version information when the CLI starts up.

```
{"level":"info","ts":1697396471.853624,"caller":"version/version.go:57","msg":"Commit: dev-7c3b1b9188e868c1ce2c8c21793cd7e6894aa244\n"}
{"level":"info","ts":1697396471.853778,"caller":"version/version.go:64","msg":"Date: 2023-10-15"}
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
