### PR TITLE
Add log level configuration

### DIFF
--- a/guac.yaml
+++ b/guac.yaml
@@ -34,4 +34,4 @@ gql-addr: http://localhost:8080/query
 service-poll: true
 use-csub: true
 
-log-level: 0
+log-level: Info

--- a/guac.yaml
+++ b/guac.yaml
@@ -33,3 +33,5 @@ gql-addr: http://localhost:8080/query
 # Collector behavior
 service-poll: true
 use-csub: true
+
+log-level: 0

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -28,8 +28,6 @@ import (
 )
 
 func InitConfig() {
-	ctx := logging.WithLogger(context.Background())
-	logger := logging.FromContext(ctx)
 
 	home, err := homedir.Dir()
 	if err != nil {
@@ -49,7 +47,15 @@ func InitConfig() {
 	// The POSIX standard does not allow - in env variables
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	if err := viper.ReadInConfig(); err == nil {
+	err = viper.ReadInConfig()
+
+	// init after reading in config to account for log level
+	logging.InitLogger(viper.GetInt(ConfigLogLevelVar))
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	if err == nil {
 		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
+
 }

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -50,7 +50,7 @@ func InitConfig() {
 	err = viper.ReadInConfig()
 
 	// init after reading in config to account for log level
-	logging.InitLogger(viper.GetInt(ConfigLogLevelVar))
+	logging.InitLogger(viper.GetString(ConfigLogLevelVar))
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)
 

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -49,7 +49,8 @@ func InitConfig() {
 
 	err = viper.ReadInConfig()
 
-	// init after reading in config to account for log level
+	// initialize logging after reading in the config
+	viper.SetDefault("log-level", logging.InfoLevel)
 	logging.InitLogger(viper.GetString(ConfigLogLevelVar))
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -49,14 +49,21 @@ func InitConfig() {
 
 	err = viper.ReadInConfig()
 
+	viper.SetDefault("log-level", string(logging.Info))
+
 	// initialize logging after reading in the config
-	viper.SetDefault("log-level", logging.InfoLevel)
-	logging.InitLogger(viper.GetString(ConfigLogLevelVar))
+	level, logErr := logging.ParseLevel(viper.GetString(ConfigLogLevelVar))
+	if logErr != nil {
+		level = logging.Info
+	}
+	logging.InitLogger(level)
+
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)
-
+	if logErr != nil {
+		logger.Infof("Error setting up logging: %v", logErr)
+	}
 	if err == nil {
 		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
-
 }

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli_test
 
 import (

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -1,0 +1,43 @@
+package cli_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/guacsec/guac/pkg/cli"
+	"github.com/guacsec/guac/pkg/logging"
+	"go.uber.org/zap/zapcore"
+)
+
+var envVar string = "GUAC_LOG_LEVEL"
+
+// tests that InitConfig sets up logging correctly with configuration from an env var
+func Test_InitConfig_EnvVarSet(t *testing.T) {
+	prevVal := os.Getenv(envVar)
+	defer func() { os.Setenv(envVar, prevVal) }()
+	os.Setenv(envVar, "-1")
+
+	cli.InitConfig()
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	if logger.Level() != zapcore.DebugLevel {
+		t.Errorf("Expected %s, got %s", zapcore.DebugLevel, logger.Level())
+	}
+}
+
+// tests that InitConfig sets up logging correctly when no env var is set
+func Test_InitConfig_EnvVarNotSet(t *testing.T) {
+	prevVal := os.Getenv(envVar)
+	defer func() { os.Setenv(envVar, prevVal) }()
+	os.Unsetenv(envVar)
+
+	cli.InitConfig()
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	if logger.Level() != zapcore.InfoLevel {
+		t.Errorf("Expected %s, got %s", zapcore.InfoLevel, logger.Level())
+	}
+}

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -31,7 +31,7 @@ func Test_InitConfig_EnvVarSet(t *testing.T) {
 	prevVal := os.Getenv(envVar)
 	defer func() { os.Setenv(envVar, prevVal) }()
 
-	envVarValue := 2
+	envVarValue := "warn"
 
 	err := os.Setenv(envVar, fmt.Sprintf("%v", envVarValue))
 	if err != nil {
@@ -39,12 +39,12 @@ func Test_InitConfig_EnvVarSet(t *testing.T) {
 	}
 
 	cli.InitConfig()
-	if actual := viper.GetInt(cli.ConfigLogLevelVar); actual != envVarValue {
-		t.Errorf("unexpected viper.GetInt result: Expected %v, got %v", envVarValue, actual)
+	if actual := viper.GetString(cli.ConfigLogLevelVar); actual != envVarValue {
+		t.Errorf("unexpected viper.GetString result: Expected %v, got %v", envVarValue, actual)
 	}
 }
 
-// tests that the default for the log level env var is 0
+// tests that the default for the log level env var is info
 func Test_InitConfig_EnvVarNotSet(t *testing.T) {
 	prevVal := os.Getenv(envVar)
 	defer func() { os.Setenv(envVar, prevVal) }()
@@ -55,8 +55,8 @@ func Test_InitConfig_EnvVarNotSet(t *testing.T) {
 	}
 
 	cli.InitConfig()
-	envVarValue := 0
-	if actual := viper.GetInt(cli.ConfigLogLevelVar); actual != envVarValue {
-		t.Errorf("unexpected viper.GetInt result: Expected %v, got %v", envVarValue, actual)
+	envVarValue := "info"
+	if actual := viper.GetString(cli.ConfigLogLevelVar); actual != envVarValue {
+		t.Errorf("unexpected viper.GetString result: Expected %v, got %v", envVarValue, actual)
 	}
 }

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -24,7 +24,7 @@ import (
 
 var flagStore = make(map[string]*pflag.Flag)
 
-var (
+const (
 	ConfigLogLevelVar = "log-level"
 )
 

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -24,6 +24,10 @@ import (
 
 var flagStore = make(map[string]*pflag.Flag)
 
+var (
+	ConfigLogLevelVar = "log-level"
+)
+
 var NotFound = errors.New("Flag not found")
 
 func init() {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -54,6 +54,9 @@ func InitLogger(level int) {
 }
 
 func WithLogger(ctx context.Context) context.Context {
+	if logger == nil {
+		InitLogger(-1)
+	}
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -55,7 +55,9 @@ func InitLogger(level int) {
 
 func WithLogger(ctx context.Context) context.Context {
 	if logger == nil {
+		// defaults to Debug if InitLogger has not been called
 		InitLogger(-1)
+		logger.Debugf("InitLogger has not been called. Defaulting to debug log level")
 	}
 	return context.WithValue(ctx, loggerKey{}, logger)
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logging_test
 
 import (

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -23,62 +23,77 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func Test_InitLogger(t *testing.T) {
+func Test_ParseLevel(t *testing.T) {
 	tests := []struct {
-		name     string
-		inLevel  string
-		outLevel zapcore.Level
+		name        string
+		inLevel     string
+		expected    logging.LogLevel
+		expectedErr bool
 	}{
 		{
-			name:     "invalid level leads to info level",
-			inLevel:  "1",
-			outLevel: zapcore.InfoLevel,
+			name:        "invalid level",
+			inLevel:     "1",
+			expectedErr: true,
 		},
 		{
-			name:     "empty level leads to info level",
-			inLevel:  "",
-			outLevel: zapcore.InfoLevel,
+			name:        "empty level leads to invalid",
+			inLevel:     "",
+			expectedErr: true,
 		},
 		{
 			name:     "debug level",
 			inLevel:  "Debug",
-			outLevel: zapcore.DebugLevel,
+			expected: logging.Debug,
 		},
 		{
 			name:     "warn level",
-			inLevel:  "warn",
-			outLevel: zapcore.WarnLevel,
+			inLevel:  "WARN",
+			expected: logging.Warn,
 		},
 		{
 			name:     "error level",
 			inLevel:  "error",
-			outLevel: zapcore.ErrorLevel,
+			expected: logging.Error,
 		},
 		{
 			name:     "DPanic level",
-			inLevel:  "DPanic",
-			outLevel: zapcore.DPanicLevel,
+			inLevel:  "dpanic",
+			expected: logging.DPanic,
 		},
 		{
 			name:     "PanicLevel level",
-			inLevel:  "panic",
-			outLevel: zapcore.PanicLevel,
+			inLevel:  "Panic",
+			expected: logging.Panic,
 		},
 		{
 			name:     "Fatal level",
 			inLevel:  "fatal",
-			outLevel: zapcore.FatalLevel,
+			expected: logging.Fatal,
 		},
 	}
 
 	for _, test := range tests {
-		logging.InitLogger(test.inLevel)
 
-		ctx := logging.WithLogger(context.Background())
-		logger := logging.FromContext(ctx)
+		res, err := logging.ParseLevel(test.inLevel)
+		if test.expectedErr {
+			if err == nil {
+				t.Error("Expected error but did not get one")
+			}
+		} else if res != test.expected {
+			t.Errorf("Expected %v, got %v", test.expected, res)
 
-		if logger.Level() != test.outLevel {
-			t.Errorf("Expected %v, got %v", test.outLevel, logger.Level())
 		}
+	}
+}
+
+func Test_InitLogger(t *testing.T) {
+
+	logging.InitLogger(logging.Warn)
+
+	ctx := logging.WithLogger(context.Background())
+	logger := logging.FromContext(ctx)
+
+	if logger.Level() != zapcore.WarnLevel {
+		t.Errorf("Expected %v, got %v", zapcore.WarnLevel, logger.Level())
 	}
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,64 @@
+package logging_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/guacsec/guac/pkg/logging"
+	"go.uber.org/zap/zapcore"
+)
+
+func Test_InitLogger(t *testing.T) {
+	tests := []struct {
+		name     string
+		inLevel  int
+		outLevel zapcore.Level
+	}{
+		{
+			name:     "invalid level leads to info level",
+			inLevel:  -2,
+			outLevel: zapcore.InfoLevel,
+		},
+		{
+			name:     "debug level",
+			inLevel:  -1,
+			outLevel: zapcore.DebugLevel,
+		},
+		{
+			name:     "warn level",
+			inLevel:  1,
+			outLevel: zapcore.WarnLevel,
+		},
+		{
+			name:     "error level",
+			inLevel:  2,
+			outLevel: zapcore.ErrorLevel,
+		},
+		{
+			name:     "DPanic level",
+			inLevel:  3,
+			outLevel: zapcore.DPanicLevel,
+		},
+		{
+			name:     "PanicLevel level",
+			inLevel:  4,
+			outLevel: zapcore.PanicLevel,
+		},
+		{
+			name:     "Fatal level",
+			inLevel:  5,
+			outLevel: zapcore.FatalLevel,
+		},
+	}
+
+	for _, test := range tests {
+		logging.InitLogger(test.inLevel)
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		if logger.Level() != test.outLevel {
+			t.Errorf("Expected %v, got %v", test.outLevel, logger.Level())
+		}
+	}
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -26,42 +26,47 @@ import (
 func Test_InitLogger(t *testing.T) {
 	tests := []struct {
 		name     string
-		inLevel  int
+		inLevel  string
 		outLevel zapcore.Level
 	}{
 		{
 			name:     "invalid level leads to info level",
-			inLevel:  -2,
+			inLevel:  "1",
+			outLevel: zapcore.InfoLevel,
+		},
+		{
+			name:     "empty level leads to info level",
+			inLevel:  "",
 			outLevel: zapcore.InfoLevel,
 		},
 		{
 			name:     "debug level",
-			inLevel:  -1,
+			inLevel:  "Debug",
 			outLevel: zapcore.DebugLevel,
 		},
 		{
 			name:     "warn level",
-			inLevel:  1,
+			inLevel:  "warn",
 			outLevel: zapcore.WarnLevel,
 		},
 		{
 			name:     "error level",
-			inLevel:  2,
+			inLevel:  "error",
 			outLevel: zapcore.ErrorLevel,
 		},
 		{
 			name:     "DPanic level",
-			inLevel:  3,
+			inLevel:  "DPanic",
 			outLevel: zapcore.DPanicLevel,
 		},
 		{
 			name:     "PanicLevel level",
-			inLevel:  4,
+			inLevel:  "panic",
 			outLevel: zapcore.PanicLevel,
 		},
 		{
 			name:     "Fatal level",
-			inLevel:  5,
+			inLevel:  "fatal",
 			outLevel: zapcore.FatalLevel,
 		},
 	}


### PR DESCRIPTION
# Description of the PR

Adds the ability to configure log level with a `GUAC_LOG_LEVEL` env variable or with `log-level` in the guac.yaml. 

Fixes #832. 

Since there are two sources of configuration, ideally we test the expected behavior of Viper, which involves writing and reading env vars and `guac.yaml` files. This requires more support for integration tests, such as doing the tests in a container. For this reason I didn't write tests for configuring the logger via `guac.yaml`, but I did decide to test the configuration via env var because setting an env var is a relatively small side effect. 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
