### PR TITLE
[bug] docker-compose.yaml starts postgres but does not use it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,18 @@ services:
   #     - "7687:7687"
   #   restart: on-failure
 
-  postgres:
-    image: postgres:15
-    environment:
-      POSTGRES_USER: guac
-      POSTGRES_PASSWORD: guac
-      POSTGRES_HOST_AUTH_METHOD: trust
-    networks: [frontend]
-    ports:
-      - "5432:5432"
-    volumes:
-      - ./container_files/pg:/var/lib/postgresql/data
+  # Ent on postgres is turned down for now since we are currently only using the in memory backend
+  # postgres:
+  #  image: docker.io/library/postgres:16
+  #  environment:
+  #    POSTGRES_USER: guac
+  #    POSTGRES_PASSWORD: guac
+  #    POSTGRES_HOST_AUTH_METHOD: trust
+  #  networks: [frontend]
+  #  ports:
+  #    - "5432:5432"
+  #  volumes:
+  #    - ./container_files/pg:/var/lib/postgresql/data
 
   nats:
     networks: [frontend]


### PR DESCRIPTION
# Description of the PR
docker-compose.yaml starts postgres but does not use it.
see : https://github.com/guacsec/guac/issues/1386

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
