### PR TITLE
1434-docker-compose - backend selection on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ start-service: check-docker-compose-tool-check
 	# not handle that well.
 	#
 	# if container images are missing, run `make container` first
-	$(CONTAINER) compose up --force-recreate
+	$(CONTAINER) compose -f docker-compose.yml -f container_files/mem.yaml up --force-recreate
 
 # to flush state, service-stop must be used else state is taken from old containers
 .PHONY: stop-service

--- a/container_files/arango.yaml
+++ b/container_files/arango.yaml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 volumes:
   arangodb_data_container:
@@ -19,7 +19,7 @@ services:
     ports:
       - "$GUAC_API_PORT:8080"
     volumes:
-      - ./container_files/guac:/guac
+      - ./container_files/arango:/guac
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:8080"]
       interval: 10s

--- a/container_files/arango/guac.yaml
+++ b/container_files/arango/guac.yaml
@@ -6,9 +6,10 @@ csub-addr: guac-collectsub:2782
 csub-listen-port: 2782
 
 # graphql
-gql-backend: inmem
+gql-backend: arango
 gql-listen-port: 8080
 gql-debug: true
+gql-test-data: false
 gql-addr: http://guac-graphql:8080/query
 
 # collector polling
@@ -18,3 +19,8 @@ use-csub: true
 # certifier polling
 poll: true
 interval: 5m
+
+# arangodb
+arango-user: root
+arango-pass: test123
+arango-addr: http://arangodb:8529

--- a/container_files/ent.yaml
+++ b/container_files/ent.yaml
@@ -1,0 +1,36 @@
+version: "3.9"
+
+services:
+
+  postgres:
+    image: docker.io/library/postgres:16
+    environment:
+      POSTGRES_USER: guac
+      POSTGRES_PASSWORD: guac
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks: [frontend]
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./container_files/pg:/var/lib/postgresql/data
+
+
+  guac-graphql:
+    networks: [frontend]
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacgql"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      nats:
+        condition: service_healthy
+    ports:
+      - "$GUAC_API_PORT:8080"
+    volumes:
+      - ./container_files/ent:/guac:z
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s    

--- a/container_files/ent/guac.yaml
+++ b/container_files/ent/guac.yaml
@@ -6,9 +6,10 @@ csub-addr: guac-collectsub:2782
 csub-listen-port: 2782
 
 # graphql
-gql-backend: inmem
+gql-backend: ent
 gql-listen-port: 8080
 gql-debug: true
+gql-test-data: false
 gql-addr: http://guac-graphql:8080/query
 
 # collector polling
@@ -18,3 +19,8 @@ use-csub: true
 # certifier polling
 poll: true
 interval: 5m
+
+# Ent config
+db-driver: postgres
+db-address: postgres://guac:guac@postgres:5432/guac?sslmode=disable
+db-migrate: true

--- a/container_files/mem.yaml
+++ b/container_files/mem.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+
+  guac-graphql:
+    networks: [frontend]
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacgql"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      nats:
+        condition: service_healthy
+    ports:
+      - "$GUAC_API_PORT:8080"
+    volumes:
+      - ./container_files/guac:/guac:z
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s

--- a/container_files/neo4j.yaml
+++ b/container_files/neo4j.yaml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+
+  neo4j:
+    image: "neo4j:4.4.9-community"
+    environment:
+      NEO4J_AUTH: "neo4j/s3cr3t"
+      NEO4J_apoc_export_file_enabled: true
+      NEO4J_apoc_import_file_enabled: true
+      NEO4J_apoc_import_file_use__neo4j__config: true
+      NEO4JLABS_PLUGINS: '["apoc"]'
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    restart: on-failure
+
+
+  guac-graphql:
+    networks: [frontend]
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacgql"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      nats:
+        condition: service_healthy
+    ports:
+      - "$GUAC_API_PORT:8080"
+    volumes:
+      - ./container_files/neo4j:/guac:z
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s

--- a/container_files/neo4j/guac.yaml
+++ b/container_files/neo4j/guac.yaml
@@ -6,9 +6,10 @@ csub-addr: guac-collectsub:2782
 csub-listen-port: 2782
 
 # graphql
-gql-backend: inmem
+gql-backend: neo4j
 gql-listen-port: 8080
 gql-debug: true
+gql-test-data: false
 gql-addr: http://guac-graphql:8080/query
 
 # collector polling
@@ -18,3 +19,9 @@ use-csub: true
 # certifier polling
 poll: true
 interval: 5m
+
+# Neo4j details
+neo4j-user: neo4j
+neo4j-pass: s3cr3t
+neo4j-addr: neo4j://localhost:7687
+neo4j-realm: neo4j

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,6 @@
 version: "3.9"
 
 services:
-  # Neo4j is turned down for now since we are currently only using the in memory backend
-  # neo4j:
-  #   image: "neo4j:4.4.9-community"
-  #   environment:
-  #     NEO4J_AUTH: "neo4j/s3cr3t"
-  #     NEO4J_apoc_export_file_enabled: true
-  #     NEO4J_apoc_import_file_enabled: true
-  #     NEO4J_apoc_import_file_use__neo4j__config: true
-  #     NEO4JLABS_PLUGINS: '["apoc"]'
-  #   ports:
-  #     - "7474:7474"
-  #     - "7687:7687"
-  #   restart: on-failure
-
-  # Ent on postgres is turned down for now since we are currently only using the in memory backend
-  # postgres:
-  #  image: docker.io/library/postgres:16
-  #  environment:
-  #    POSTGRES_USER: guac
-  #    POSTGRES_PASSWORD: guac
-  #    POSTGRES_HOST_AUTH_METHOD: trust
-  #  networks: [frontend]
-  #  ports:
-  #    - "5432:5432"
-  #  volumes:
-  #    - ./container_files/pg:/var/lib/postgresql/data
 
   nats:
     networks: [frontend]
@@ -61,26 +35,6 @@ services:
       - ./container_files/guac:/guac:z
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:2782"]
-      interval: 10s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
-
-  guac-graphql:
-    networks: [frontend]
-    image: $GUAC_IMAGE
-    command: "/opt/guac/guacgql"
-    working_dir: /guac
-    restart: on-failure
-    depends_on:
-      nats:
-        condition: service_healthy
-    ports:
-      - "$GUAC_API_PORT:8080"
-    volumes:
-      - ./container_files/guac:/guac:z
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
# Description of the PR
See: https://github.com/guacsec/guac/issues/1434

This PR enable the startup of guac with docker compose choosing the backend


- In memory **docker compose -f docker-compose.yml -f container_files/mem.yaml up** 

- Arango **docker compose -f docker-compose.yml -f container_files/arango.yaml up**

- Ent **docker compose -f docker-compose.yml -f container_files/ent.yaml up**

- Neo4j **docker compose -f docker-compose.yml -f container_files/neo4j.yaml up**

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
