### PR TITLE
fix: use unique sbom identifier for the uri field

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -750,7 +750,7 @@ var (
 		{
 			Pkg: topLevelPack,
 			HasSBOM: &model.HasSBOMInputSpec{
-				Uri:              "TestSource",
+				Uri:              "https://anchore.com/syft/image/alpine-latest-e78eca08-d9f4-49c7-97e0-6d4b9bfa99c2",
 				Algorithm:        "sha256",
 				Digest:           "8b5e8212cae084f92ff91f8625a50ea1070738cfc68ecca08bf04d64f64b9feb",
 				DownloadLocation: "TestSource",
@@ -972,7 +972,7 @@ var (
 		{
 			Pkg: cdxTopLevelPack,
 			HasSBOM: &model.HasSBOMInputSpec{
-				Uri:              "TestSource",
+				Uri:              "urn:uuid:6a44e622-2983-4566-bf90-f87b6103ebaf",
 				Algorithm:        "sha256",
 				Digest:           "01942b5eefd3c15b50318c66d8d16627be573197c877e8a286a8cb12de7939cb",
 				DownloadLocation: "TestSource",
@@ -1066,7 +1066,7 @@ var (
 		{
 			Pkg: cdxTopQuarkusPack,
 			HasSBOM: &model.HasSBOMInputSpec{
-				Uri:              "TestSource",
+				Uri:              "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
 				Algorithm:        "sha256",
 				Digest:           "036a9f51468f5ce6eec7c310583164ed0ab9f58d7c03380a3fe19d420609e3de",
 				DownloadLocation: "TestSource",
@@ -1104,7 +1104,7 @@ var (
 		{
 			Pkg: cdxWebAppPackage,
 			HasSBOM: &model.HasSBOMInputSpec{
-				Uri:              "TestSource",
+				Uri:              "",
 				Algorithm:        "sha256",
 				Digest:           "35363f03c80f26a88db6f2400771bdcc6624bb7b61b96da8503be0f757605fde",
 				DownloadLocation: "TestSource",
@@ -1125,7 +1125,7 @@ var (
 		{
 			Pkg: quarkusParentPackage,
 			HasSBOM: &model.HasSBOMInputSpec{
-				Uri:              "TestSource",
+				Uri:              "urn:uuid:8a689387-e9b4-4ba2-835c-a2c3dde6181d",
 				Algorithm:        "sha256",
 				Digest:           "fcd4d1f9c83c274fbc2dabdca4e7de749b23fab1aa15dc2854880a13479fa74e",
 				DownloadLocation: "TestSource",

--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -101,13 +101,13 @@ func CreateTopLevelIsDeps(topLevel *model.PkgInputSpec, packages map[string][]*m
 	return isDeps
 }
 
-func CreateTopLevelHasSBOM(topLevel *model.PkgInputSpec, sbomDoc *processor.Document, timeStamp time.Time) assembler.HasSBOMIngest {
+func CreateTopLevelHasSBOM(topLevel *model.PkgInputSpec, sbomDoc *processor.Document, uri string, timeStamp time.Time) assembler.HasSBOMIngest {
 	sha256sum := sha256.Sum256(sbomDoc.Blob)
 	hash := hex.EncodeToString(sha256sum[:])
 	return assembler.HasSBOMIngest{
 		Pkg: topLevel,
 		HasSBOM: &model.HasSBOMInputSpec{
-			Uri:              sbomDoc.SourceInformation.Source,
+			Uri:              uri,
 			Algorithm:        "sha256",
 			Digest:           hash,
 			DownloadLocation: sbomDoc.SourceInformation.Source,

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -260,7 +260,7 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 		}
 
 		preds.IsDependency = append(preds.IsDependency, common.CreateTopLevelIsDeps(toplevel[0], c.packagePackages, nil, "top-level package GUAC heuristic connecting to each file/package")...)
-		preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOM(toplevel[0], c.doc, timestamp))
+		preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOM(toplevel[0], c.doc, c.cdxBom.SerialNumber, timestamp))
 	}
 
 	for id := range c.packagePackages {

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -249,7 +249,7 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 			return nil
 		}
 		for _, topLevelPkg := range topLevel {
-			preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOM(topLevelPkg, s.doc, timestamp))
+			preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOM(topLevelPkg, s.doc, s.spdxDoc.DocumentNamespace, timestamp))
 		}
 
 		if s.topLevelIsHeuristic {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -146,7 +146,7 @@ func Test_spdxParser(t *testing.T) {
 							Subpath:   &packageOfEmptyString,
 						},
 						HasSBOM: &generated.HasSBOMInputSpec{
-							Uri:              "TestSource",
+							Uri:              "https://anchore.com/syft/image/alpine-latest-e78eca08-d9f4-49c7-97e0-6d4b9bfa99c2",
 							Algorithm:        "sha256",
 							Digest:           "ba096464061993bbbdfc30a26b42cd8beb1bfff301726fe6c58cb45d468c7648",
 							DownloadLocation: "TestSource",


### PR DESCRIPTION
# Description of the PR

`HasSBOM` has a `uri` field that is currently set to the source information. Both SPDX and CyclonDX provide an unique uri that can be used to identify the SBOM document. By storing this information in `HasSBOM` we are making it easier for folks to find "sbom-uri"->"top-level-package" relation.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
