### PR TITLE
Fixed incorrect depsdev getporject

### DIFF
--- a/pkg/assembler/helpers/vcs.go
+++ b/pkg/assembler/helpers/vcs.go
@@ -48,7 +48,6 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 		} else {
 			return nil, fmt.Errorf("scheme has unknown source type: %s", u.Host)
 		}
-
 	} else {
 		// Should be <vcs_tool>+<transport>
 		schemeSp := strings.Split(u.Scheme, "+")
@@ -66,6 +65,10 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 	} else {
 		m.Name = strings.TrimPrefix(u.Path, "/")
 	}
+	// Based on the issue https://github.com/guacsec/guac/issues/1413, we need to ensure
+	// that the .git suffix is removed from the repository name. This is because some
+	// repository URLs might include the .git suffix which is not expected by certain endpoints.
+	m.Name = strings.TrimSuffix(m.Name, ".git")
 
 	sp := strings.Split(m.Name, "@")
 	if len(sp) > 2 {

--- a/pkg/assembler/helpers/vcs_test.go
+++ b/pkg/assembler/helpers/vcs_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestVcsUriToSrc(t *testing.T) {
-
 	testCases := []struct {
 		uri      string
 		wantErr  bool
@@ -49,7 +48,8 @@ func TestVcsUriToSrc(t *testing.T) {
 			uri:      "git+https://github.com/kubernetes@main",
 			wantErr:  false,
 			expected: src("git", "github.com", "kubernetes", nil, strP("main")),
-		}, {
+		},
+		{
 			uri:      "https://github.com/sfackler/rust-openssl",
 			wantErr:  false,
 			expected: src("git", "github.com/sfackler", "rust-openssl", nil, nil),
@@ -80,10 +80,14 @@ func TestVcsUriToSrc(t *testing.T) {
 			uri:     "github.com/kubernetes@@main",
 			wantErr: true,
 		},
+		{
+			uri:      "git+https://github.com/kubernetes/kubernetes.git",
+			wantErr:  false,
+			expected: src("git", "github.com/kubernetes", "kubernetes", nil, nil),
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("parsing %s", tt.uri), func(t *testing.T) {
-
 			// err == nil should be equivalent to IsVcs
 			if IsVcs(tt.uri) == tt.wantErr {
 				t.Errorf("expected err but IsVcs returned valid vcs uri")

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -23,9 +23,6 @@ import (
 	"sync"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
-	"golang.org/x/exp/maps"
-
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
@@ -33,6 +30,8 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/guacsec/guac/pkg/version"
+	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -568,7 +567,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 				logger.Debugf("The project key was not found in the map: %v", projectReq.ProjectKey)
 				project, err = d.client.GetProject(ctx, projectReq)
 				if err != nil {
-					logger.Debugf("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
+					logger.Infof("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
 					continue
 				}
 			}


### PR DESCRIPTION
# Description of the PR

- Fixed the issue of incorrect GetProject issue
- Fixes https://github.com/guacsec/guac/issues/1413
# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
