### PR TITLE
Ent - PackageVersion: added index for improving IsDependency ingestion

### DIFF
--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -806,6 +806,11 @@ var (
 					},
 				},
 			},
+			{
+				Name:    "packageversion_version_subpath_qualifiers_name_id",
+				Unique:  true,
+				Columns: []*schema.Column{PackageVersionsColumns[1], PackageVersionsColumns[2], PackageVersionsColumns[3], PackageVersionsColumns[5]},
+			},
 		},
 	}
 	// PkgEqualsColumns holds the columns for the "pkg_equals" table.

--- a/pkg/assembler/backends/ent/schema/packageversion.go
+++ b/pkg/assembler/backends/ent/schema/packageversion.go
@@ -61,5 +61,6 @@ func (PackageVersion) Indexes() []ent.Index {
 		index.Fields("qualifiers").Annotations(
 			entsql.IndexTypes(map[string]string{dialect.Postgres: "GIN"}),
 		),
+		index.Fields("version", "subpath", "qualifiers").Edges("name").Unique(),
 	}
 }


### PR DESCRIPTION
# Description of the PR

While testing Ent backend with a real SBOM, I've analyzed the SQL statement executed and it turned out the retrieving the `PackageVersion` during the  `IsDependency` ingestion was missing a DB index that I've added.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
