### PR TITLE
Fixed docker-compose down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
     depends_on:
       guac-collectsub:
         condition: service_healthy
-      guac-graphql:
-        condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
 
@@ -62,8 +60,6 @@ services:
     restart: on-failure
     depends_on:
       guac-collectsub:
-        condition: service_healthy
-      guac-graphql:
         condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
@@ -79,8 +75,6 @@ services:
     depends_on:
       guac-collectsub:
         condition: service_healthy
-      guac-graphql:
-        condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
 
@@ -92,8 +86,6 @@ services:
     restart: on-failure
     depends_on:
       guac-collectsub:
-        condition: service_healthy
-      guac-graphql:
         condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z


### PR DESCRIPTION
# Description of the PR

When running `make stop-service` I was getting:

```
make stop-service
docker compose down
service "oci-collector" depends on undefined service guac-graphql: invalid compose project
make: *** [stop-service] Error 15
```

This is because the guac-graphql was removed from, 8336525f9e8ed9b7c34de0dd60cc66b9c300925a.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
