### PR TITLE
fix check for ingested packages and source IDs

### DIFF
--- a/pkg/assembler/graphql/helpers/package.go
+++ b/pkg/assembler/graphql/helpers/package.go
@@ -19,7 +19,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-// Return a package structure containing only IDs
+// Flattens the trie and returns a flat package structure containing only IDs
 func GetPackageAsIds(packages []*model.Package) []*model.PackageIDs {
 	results := []*model.PackageIDs{}
 	for _, pkg := range packages {
@@ -41,7 +41,7 @@ func GetPackageAsIds(packages []*model.Package) []*model.PackageIDs {
 	return results
 }
 
-// Return a source structure containing only IDs
+// Flattens the trie and returns a flat source structure containing only IDs
 func GetSourceAsIds(sources []*model.Source) []*model.SourceIDs {
 	results := []*model.SourceIDs{}
 	for _, src := range sources {

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -32,7 +32,7 @@ func (r *mutationResolver) IngestPackages(ctx context.Context, pkgs []*model.Pkg
 	ingestedPackages, err := r.Backend.IngestPackages(ctx, pkgs)
 	if err == nil {
 		results := helpers.GetPackageAsIds(ingestedPackages)
-		if len(results) != len(ingestedPackages) {
+		if len(results) != len(pkgs) {
 			return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return %d but have %d", len(ingestedPackages), len(results))
 		}
 		return results, nil

--- a/pkg/assembler/graphql/resolvers/package.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/package.resolvers.go
@@ -33,7 +33,7 @@ func (r *mutationResolver) IngestPackages(ctx context.Context, pkgs []*model.Pkg
 	if err == nil {
 		results := helpers.GetPackageAsIds(ingestedPackages)
 		if len(results) != len(pkgs) {
-			return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return %d but have %d", len(ingestedPackages), len(results))
+			return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return %d but have %d", len(pkgs), len(results))
 		}
 		return results, nil
 	}

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -31,7 +31,7 @@ func (r *mutationResolver) IngestSources(ctx context.Context, sources []*model.S
 	ingestedSources, err := r.Backend.IngestSources(ctx, sources)
 	if err == nil {
 		results := helpers.GetSourceAsIds(ingestedSources)
-		if len(results) != len(ingestedSources) {
+		if len(results) != len(sources) {
 			return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return 1 but have %d", len(results))
 		}
 		return results, nil

--- a/pkg/assembler/graphql/resolvers/source.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/source.resolvers.go
@@ -21,7 +21,7 @@ func (r *mutationResolver) IngestSource(ctx context.Context, source model.Source
 	}
 	results := helpers.GetSourceAsIds([]*model.Source{ingestedSource})
 	if len(results) != 1 {
-		return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return 1 but have %d", len(results))
+		return nil, fmt.Errorf("could no derive correct source ID information for ingested sources, expected to return 1 but have %d", len(results))
 	}
 	return results[0], nil
 }
@@ -32,7 +32,7 @@ func (r *mutationResolver) IngestSources(ctx context.Context, sources []*model.S
 	if err == nil {
 		results := helpers.GetSourceAsIds(ingestedSources)
 		if len(results) != len(sources) {
-			return nil, fmt.Errorf("could no derive correct package ID information for ingested packages, expected to return 1 but have %d", len(results))
+			return nil, fmt.Errorf("could no derive correct source ID information for ingested sources, expected to return %d but have %d", len(sources), len(results))
 		}
 		return results, nil
 	}


### PR DESCRIPTION
# Description of the PR

check input and results for the IDs as arango and inmem return in different formats which causes an unneeded error. This will change in the future to just return IDs but currently causes errors in arango ingestion 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
