### PR TITLE
Ent - HasMetadata: applied concurrent approach

### DIFF
--- a/pkg/assembler/backends/ent/backend/hasMetadata_test.go
+++ b/pkg/assembler/backends/ent/backend/hasMetadata_test.go
@@ -992,7 +992,7 @@ func (s *Suite) TestIngestBulkHasMetadata() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpHM, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpHM, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -468,33 +468,33 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hasmetadata_timestamp_key_value_justification_origin_collector_source_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_source_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[1], HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[7]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[7]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_timestamp_key_value_justification_origin_collector_package_version_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_package_version_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[1], HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[8]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_timestamp_key_value_justification_origin_collector_package_name_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_package_name_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[1], HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[9]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_timestamp_key_value_justification_origin_collector_artifact_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_artifact_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[1], HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[10]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},

--- a/pkg/assembler/backends/ent/schema/hasmetadata.go
+++ b/pkg/assembler/backends/ent/schema/hasmetadata.go
@@ -56,9 +56,9 @@ func (HasMetadata) Edges() []ent.Edge {
 
 func (HasMetadata) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("timestamp", "key", "value", "justification", "origin", "collector", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("timestamp", "key", "value", "justification", "origin", "collector", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("timestamp", "key", "value", "justification", "origin", "collector", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("timestamp", "key", "value", "justification", "origin", "collector", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }


### PR DESCRIPTION
# Description of the PR

Ent:

- Applied the concurrent approach (ref https://github.com/guacsec/guac/pull/1440) to  `IngestBulkHasMetadata` endpoint
- removed `Timestamp` field from the table's unique indexes based on the consideration that ingesting twice the same SBOM will generate exactly the same input to HasMetadata but the `Timestamp` field

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
