### PR TITLE
Ent - Vulnerability endpoints: applied concurrent approach

### DIFF
--- a/pkg/assembler/backends/ent/backend/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/ent/backend/certifyVEXStatement_test.go
@@ -1063,7 +1063,7 @@ func (s *Suite) TestVEXBulkIngest() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpVEX, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpVEX, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/ent/backend/helpers_test.go
+++ b/pkg/assembler/backends/ent/backend/helpers_test.go
@@ -49,6 +49,8 @@ var IngestPredicatesCmpOpts = []cmp.Option{
 	cmpopts.SortSlices(isDependencyLess),
 	cmpopts.SortSlices(packageLess),
 	cmpopts.SortSlices(certifyVulnLess),
+	cmpopts.SortSlices(certifyVexLess),
+	cmpopts.SortSlices(vulnerabilityLess),
 }
 
 func isDependencyLess(e1, e2 *model.IsDependency) bool {
@@ -63,4 +65,20 @@ func packageLess(e1, e2 *model.Package) bool {
 
 func certifyVulnLess(e1, e2 *model.CertifyVuln) bool {
 	return packageLess(e1.Package, e2.Package)
+}
+
+func certifyVexLess(e1, e2 *model.CertifyVEXStatement) bool {
+	return e1.Vulnerability.VulnerabilityIDs[0].VulnerabilityID < e2.Vulnerability.VulnerabilityIDs[0].VulnerabilityID
+}
+
+func vulnerabilityLess(e1, e2 *model.Vulnerability) bool {
+	e1String := e1.Type
+	if len(e1.VulnerabilityIDs) > 0 {
+		e1String += e1.VulnerabilityIDs[0].VulnerabilityID
+	}
+	e2String := e1.Type
+	if len(e2.VulnerabilityIDs) > 0 {
+		e2String += e2.VulnerabilityIDs[0].VulnerabilityID
+	}
+	return e1String < e2String
 }

--- a/pkg/assembler/backends/ent/backend/vulnEqual_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnEqual_test.go
@@ -622,9 +622,6 @@ func (s *Suite) TestIngestVulnEquals() {
 			},
 		},
 	}
-	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-	}, cmp.Ignore())
 	ctx := context.Background()
 	for _, test := range tests {
 		s.Run(test.Name, func() {
@@ -653,7 +650,7 @@ func (s *Suite) TestIngestVulnEquals() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpVulnEqual, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpVulnEqual, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -26,18 +26,29 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/vulnerabilitytype"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 const NoVuln = "novuln"
 
 func (b *EntBackend) IngestVulnerabilities(ctx context.Context, vulns []*model.VulnerabilityInputSpec) ([]*model.Vulnerability, error) {
-	var modelVulnerabilities []*model.Vulnerability
-	for _, vuln := range vulns {
-		modelVuln, err := b.IngestVulnerability(ctx, *vuln)
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestVulnerability failed with err: %v", err)
-		}
-		modelVulnerabilities = append(modelVulnerabilities, modelVuln)
+	var modelVulnerabilities = make([]*model.Vulnerability, len(vulns))
+	eg, ctx := errgroup.WithContext(ctx)
+	for i := range vulns {
+		index := i
+		vuln := vulns[index]
+		concurrently(eg, func() error {
+			modelVuln, err := b.IngestVulnerability(ctx, *vuln)
+			if err == nil {
+				modelVulnerabilities[index] = modelVuln
+				return err
+			} else {
+				return gqlerror.Errorf("IngestVulnerability failed with err: %v", err)
+			}
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return modelVulnerabilities, nil
 }

--- a/pkg/assembler/backends/ent/backend/vulnerability_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability_test.go
@@ -352,9 +352,6 @@ func (s *Suite) TestIngestVulnerabilities() {
 		ingests: []*model.VulnerabilityInputSpec{c1, c2, c3},
 		exp:     []*model.Vulnerability{{}, {}, {}},
 	}}
-	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-	}, cmp.Ignore())
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			ctx := s.Ctx
@@ -368,7 +365,7 @@ func (s *Suite) TestIngestVulnerabilities() {
 				t.Fatalf("ingest error: %v", err)
 				return
 			}
-			if diff := cmp.Diff(test.exp, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.exp, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
# Description of the PR

Ent backend, implemented concurrent approach [1] for:

- `IngestVulnerabilities`
- `IngestVEXStatements`
- `IngestCertifyVulns`

[1] from https://github.com/guacsec/guac/pull/1440

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
