### PR TITLE
fix/update ingestor with errGroups to ingest documents concurrently based on a limit

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -77,7 +77,7 @@ func ingest(cmd *cobra.Command, args []string) {
 	defer csubClient.Close()
 
 	emit := func(d *processor.Document) error {
-		return ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+		return ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient, nil)
 	}
 
 	// Assuming that publisher and consumer are different processes.

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/guacsec/guac/pkg/cli"
-	"github.com/guacsec/guac/pkg/collectsub/client"
+
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/file"
@@ -53,7 +53,7 @@ type fileOptions struct {
 	// gql endpoint
 	graphqlEndpoint string
 	// csub client options for identifier strings
-	csubClientOptions client.CsubClientOptions
+	csubClientOptions csub_client.CsubClientOptions
 }
 
 var filesCmd = &cobra.Command{
@@ -142,7 +142,7 @@ var filesCmd = &cobra.Command{
 
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(filesCtx, d, opts.graphqlEndpoint, csubClient)
+			err := ingestor.Ingest(filesCtx, d, opts.graphqlEndpoint, csubClient, files)
 
 			if err != nil {
 				gotErr = true
@@ -198,7 +198,7 @@ func validateFilesFlags(keyPath string, keyID string, graphqlEndpoint string, cs
 		return opts, fmt.Errorf("expected positional argument for file_path")
 	}
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {
 		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
 	}

--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -22,7 +22,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/guacsec/guac/pkg/cli"
-	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/collector/gcs"
@@ -37,7 +36,7 @@ import (
 
 type gcsOptions struct {
 	graphqlEndpoint   string
-	csubClientOptions client.CsubClientOptions
+	csubClientOptions csub_client.CsubClientOptions
 	bucket            string
 }
 
@@ -105,7 +104,7 @@ var gcsCmd = &cobra.Command{
 
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient, nil)
 
 			if err != nil {
 				gotErr = true
@@ -139,7 +138,7 @@ func validateGCSFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTls
 	var opts gcsOptions
 	opts.graphqlEndpoint = gqlEndpoint
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {
 		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
 	}

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
@@ -38,7 +37,7 @@ import (
 type ociOptions struct {
 	graphqlEndpoint   string
 	dataSource        datasource.CollectSource
-	csubClientOptions client.CsubClientOptions
+	csubClientOptions csub_client.CsubClientOptions
 }
 
 var ociCmd = &cobra.Command{
@@ -82,7 +81,7 @@ var ociCmd = &cobra.Command{
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient, nil)
 
 			if err != nil {
 				gotErr = true
@@ -116,7 +115,7 @@ func validateOCIFlags(gqlEndpoint string, csubAddr string, csubTls bool, csubTls
 	var opts ociOptions
 	opts.graphqlEndpoint = gqlEndpoint
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {
 		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
 	}

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -31,7 +31,6 @@ import (
 	"github.com/guacsec/guac/pkg/certifier/certify"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/certifier/osv"
-	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor"
@@ -43,7 +42,7 @@ import (
 type osvOptions struct {
 	graphqlEndpoint   string
 	poll              bool
-	csubClientOptions client.CsubClientOptions
+	csubClientOptions csub_client.CsubClientOptions
 	interval          time.Duration
 }
 
@@ -213,7 +212,7 @@ func validateOSVFlags(graphqlEndpoint string, poll bool, interval string, csubAd
 	}
 	opts.interval = i
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {
 		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
 	}

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -105,7 +105,7 @@ var s3Cmd = &cobra.Command{
 		errFound := false
 
 		emit := func(d *processor.Document) error {
-			err := ingestor.Ingest(ctx, d, s3Opts.graphqlEndpoint, csubClient)
+			err := ingestor.Ingest(ctx, d, s3Opts.graphqlEndpoint, csubClient, nil)
 
 			if err != nil {
 				errFound = true

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	sc "github.com/guacsec/guac/pkg/certifier/components/source"
-	"github.com/guacsec/guac/pkg/collectsub/client"
 	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
 	"github.com/guacsec/guac/pkg/ingestor"
 
@@ -45,7 +44,7 @@ type scorecardOptions struct {
 	graphqlEndpoint   string
 	poll              bool
 	interval          time.Duration
-	csubClientOptions client.CsubClientOptions
+	csubClientOptions csub_client.CsubClientOptions
 }
 
 var scorecardCmd = &cobra.Command{
@@ -121,7 +120,7 @@ var scorecardCmd = &cobra.Command{
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient, nil)
 
 			if err != nil {
 				return fmt.Errorf("unable to ingest document: %v", err)
@@ -174,7 +173,7 @@ func validateScorecardFlags(graphqlEndpoint string, csubAddr string, csubTls boo
 	var opts scorecardOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {
 		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
 	}


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/1433

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
