### PR TITLE
Ent - ScorecardID IngestScorecardID

### DIFF
--- a/pkg/assembler/backends/ent/backend/scorecard_test.go
+++ b/pkg/assembler/backends/ent/backend/scorecard_test.go
@@ -428,7 +428,7 @@ func (s *Suite) TestCertifyScorecard() {
 				}
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestScorecard(ctx, *o.Src, *o.SC)
+				_, err := b.IngestScorecardID(ctx, *o.Src, *o.SC)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}


### PR DESCRIPTION
# Description of the PR
Ent backend

- `IngestScorecardID` (with bulk) implementations
-  `IngestScorecard`, removed
-   changes consistently all of the tests involved


Refers to https://github.com/guacsec/guac/issues/1198

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
