### PR TITLE
Ent - IngestHasSbomID

### DIFF
--- a/pkg/assembler/backends/ent/backend/sbom.go
+++ b/pkg/assembler/backends/ent/backend/sbom.go
@@ -17,6 +17,8 @@ package backend
 
 import (
 	"context"
+	stdsql "database/sql"
+	"strconv"
 	"strings"
 
 	"entgo.io/ent/dialect/sql"
@@ -68,7 +70,7 @@ func (b *EntBackend) HasSBOM(ctx context.Context, spec *model.HasSBOMSpec) ([]*m
 	return collect(records, toModelHasSBOM), nil
 }
 
-func (b *EntBackend) IngestHasSbom(ctx context.Context, subject model.PackageOrArtifactInput, spec model.HasSBOMInputSpec) (*model.HasSbom, error) {
+func (b *EntBackend) IngestHasSbomID(ctx context.Context, subject model.PackageOrArtifactInput, spec model.HasSBOMInputSpec) (string, error) {
 	funcName := "IngestHasSbom"
 
 	sbomId, err := WithinTX(ctx, b.client, func(ctx context.Context) (*int, error) {
@@ -126,36 +128,31 @@ func (b *EntBackend) IngestHasSbom(ctx context.Context, subject model.PackageOrA
 				sql.ConflictColumns(conflictColumns...),
 				sql.ConflictWhere(conflictWhere),
 			).
-			Ignore().
+			DoNothing().
 			ID(ctx)
 		if err != nil {
-			return nil, Errorf("%v ::  %s", funcName, err)
+			if err != stdsql.ErrNoRows {
+				return nil, errors.Wrap(err, "IngestHasSbomID")
+			}
+			id, err = client.BillOfMaterials.Query().
+				Where(billofmaterials.URIEQ(spec.URI)).
+				OnlyID(ctx)
+			if err != nil {
+				return nil, Errorf("%v ::  %s", funcName, err)
+			}
+
 		}
 		return &id, nil
 	})
 	if err != nil {
-		return nil, Errorf("%v :: %s", funcName, err)
+		return "", Errorf("%v :: %s", funcName, err)
 	}
 
-	sbom, err := b.client.BillOfMaterials.Query().
-		Where(billofmaterials.ID(*sbomId)).
-		WithPackage(func(q *ent.PackageVersionQuery) {
-			q.WithName(func(q *ent.PackageNameQuery) {
-				q.WithNamespace(func(q *ent.PackageNamespaceQuery) {
-					q.WithPackage()
-				})
-			})
-		}).
-		WithArtifact().
-		Only(ctx)
-	if err != nil {
-		return nil, Errorf("%v :: %s", funcName, err)
-	}
-	return toModelHasSBOM(sbom), nil
+	return strconv.Itoa(*sbomId), nil
 }
 
-func (b *EntBackend) IngestHasSBOMs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]*model.HasSbom, error) {
-	var modelHasSboms []*model.HasSbom
+func (b *EntBackend) IngestHasSBOMIDs(ctx context.Context, subjects model.PackageOrArtifactInputs, hasSBOMs []*model.HasSBOMInputSpec) ([]string, error) {
+	var modelHasSboms []string
 	for i, hasSbom := range hasSBOMs {
 		var subject model.PackageOrArtifactInput
 		if len(subjects.Artifacts) > 0 {
@@ -163,7 +160,7 @@ func (b *EntBackend) IngestHasSBOMs(ctx context.Context, subjects model.PackageO
 		} else {
 			subject = model.PackageOrArtifactInput{Package: subjects.Packages[i]}
 		}
-		modelHasSbom, err := b.IngestHasSbom(ctx, subject, *hasSbom)
+		modelHasSbom, err := b.IngestHasSbomID(ctx, subject, *hasSbom)
 		if err != nil {
 			return nil, gqlerror.Errorf("IngestHasSBOMs failed with err: %v", err)
 		}

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -481,14 +481,14 @@ func (s *Suite) Test_HasSBOM() {
 
 			recordIDs := make([]string, len(test.Calls))
 			for i, o := range test.Calls {
-				dep, err := b.IngestHasSbom(ctx, o.Sub, *o.Spec)
+				id, err := b.IngestHasSbomID(ctx, o.Sub, *o.Spec)
 				if (err != nil) != test.ExpIngestErr {
 					s.T().Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
 				if err != nil {
 					return
 				}
-				recordIDs[i] = dep.ID
+				recordIDs[i] = id
 			}
 
 			if test.Query.ID != nil {
@@ -719,7 +719,7 @@ func (s *Suite) TestIngestHasSBOMs() {
 				}
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestHasSBOMs(ctx, o.Sub, o.HS)
+				_, err := b.IngestHasSBOMIDs(ctx, o.Sub, o.HS)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}


### PR DESCRIPTION
# Description of the PR

Ent backend

- `IngestHasSbomID` (with bulk) implementations
-  `IngestHasSbom`, removed
-   changes consistently all of the tests involved


Refers to https://github.com/guacsec/guac/issues/1198

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
