### PR TITLE
Ent - PkgEqualsID

### DIFF
--- a/pkg/assembler/backends/ent/backend/pkgequal_test.go
+++ b/pkg/assembler/backends/ent/backend/pkgequal_test.go
@@ -509,7 +509,7 @@ func (s *Suite) TestPkgEqual() {
 
 			ids := make([]string, len(test.Calls))
 			for i, o := range test.Calls {
-				v, err := b.IngestPkgEqual(ctx, *o.P1, *o.P2, *o.PkgEqual)
+				id, err := b.IngestPkgEqualID(ctx, *o.P1, *o.P2, *o.PkgEqual)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
@@ -517,7 +517,7 @@ func (s *Suite) TestPkgEqual() {
 					return
 				}
 
-				ids[i] = v.ID
+				ids[i] = id
 			}
 			afterCount := s.Client.PkgEqual.Query().CountX(ctx)
 
@@ -829,7 +829,7 @@ func (s *Suite) TestPkgEqualNeighbors() {
 				}
 			}
 			for _, o := range test.Calls {
-				if _, err := b.IngestPkgEqual(ctx, *o.P1, *o.P2, *o.HE); err != nil {
+				if _, err := b.IngestPkgEqualID(ctx, *o.P1, *o.P2, *o.HE); err != nil {
 					t.Fatalf("Could not ingest PkgEqual: %v", err)
 				}
 			}


### PR DESCRIPTION
# Description of the PR
Ent backend

- `IngestPkgEqualID` (with bulk) implementations
-  `IngestPkgEqual`, removed
-   changes consistently all of the tests involved


Refers to https://github.com/guacsec/guac/issues/1198

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
