### PR TITLE
Ent: error management when closing Ent client during tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,6 @@ require (
 	entgo.io/ent v0.12.4
 	github.com/99designs/gqlgen v0.17.39
 	github.com/CycloneDX/cyclonedx-go v0.7.2
-	github.com/DATA-DOG/go-txdb v0.1.7
 	github.com/Khan/genqlient v0.6.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/arangodb/go-driver v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/CycloneDX/cyclonedx-go v0.7.2 h1:kKQ0t1dPOlugSIYVOMiMtFqeXI2wp/f5DBId
 github.com/CycloneDX/cyclonedx-go v0.7.2/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DATA-DOG/go-txdb v0.1.7 h1:ibr3YvD3SKI4oBPbXbmzsn7eCPlg9oFdDdFtsWCvy7Q=
-github.com/DATA-DOG/go-txdb v0.1.7/go.mod h1:l06JaBQdV+y4aWAmDmWj4NwfnJknEXBxg8d4B8sJzXA=
 github.com/Khan/genqlient v0.6.0 h1:Bwb1170ekuNIVIwTJEqvO8y7RxBxXu639VJOkKSrwAk=
 github.com/Khan/genqlient v0.6.0/go.mod h1:rvChwWVTqXhiapdhLDV4bp9tz/Xvtewwkon4DpWWCRM=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -266,8 +264,6 @@ github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
-github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
-github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=

--- a/pkg/assembler/backends/ent/backend/hashequal_test.go
+++ b/pkg/assembler/backends/ent/backend/hashequal_test.go
@@ -643,7 +643,7 @@ func (s *Suite) TestIngestHashEquals() {
 			},
 			Query: &model.HashEqualSpec{
 				Artifacts: []*model.ArtifactSpec{{
-					ID: ptrfrom.String("9"),
+					ID: ptrfrom.String("3"),
 				}},
 			},
 			ExpHE: []*model.HashEqual{
@@ -667,7 +667,7 @@ func (s *Suite) TestIngestHashEquals() {
 			},
 			Query: &model.HashEqualSpec{
 				Artifacts: []*model.ArtifactSpec{{
-					ID: ptrfrom.String("10"),
+					ID: ptrfrom.String("1"),
 				}},
 			},
 			ExpHE: []*model.HashEqual{
@@ -748,7 +748,7 @@ func (s *Suite) TestIngestHashEquals() {
 						Digest:    ptrfrom.String("7A8F47318E4676DACB0142AFA0B83029CD7BEFD9"),
 					},
 					{
-						ID: ptrfrom.String("21"),
+						ID: ptrfrom.String("3"),
 					},
 				},
 			},

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -109,24 +109,26 @@ func (s *Suite) TestNode() {
 }
 
 func (s *Suite) TestNodes() {
-	be, err := GetBackend(s.Client)
-	s.Require().NoError(err)
+	s.Run("HappyPath", func() {
+		be, err := GetBackend(s.Client)
+		s.Require().NoError(err)
 
-	v, err := be.IngestArtifact(s.Ctx, a1)
-	s.Require().NoError(err)
+		v, err := be.IngestArtifact(s.Ctx, a1)
+		s.Require().NoError(err)
 
-	p, err := be.IngestPackage(s.Ctx, *p4)
-	s.Require().NoError(err)
+		p, err := be.IngestPackage(s.Ctx, *p4)
+		s.Require().NoError(err)
 
-	nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
-	s.Require().NoError(err)
-	if diff := cmp.Diff(a1out, nodes[0], ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-	if diff := cmp.Diff(p4outNamespace, nodes[1], ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-	if diff := cmp.Diff(p4out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
+		nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
+		s.Require().NoError(err)
+		if diff := cmp.Diff(a1out, nodes[0], ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(p4outNamespace, nodes[1], ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(p4out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -210,35 +210,37 @@ var s2out = &model.Source{
 }
 
 func (s *Suite) TestOccurrenceHappyPath() {
-	be, err := GetBackend(s.Client)
-	s.Require().NoError(err)
+	s.Run("HappyPath", func() {
+		be, err := GetBackend(s.Client)
+		s.Require().NoError(err)
 
-	_, err = be.IngestPackage(s.Ctx, *p1)
-	s.Require().NoError(err)
+		_, err = be.IngestPackage(s.Ctx, *p1)
+		s.Require().NoError(err)
 
-	_, err = be.IngestArtifact(s.Ctx, a1)
-	s.Require().NoError(err)
+		_, err = be.IngestArtifact(s.Ctx, a1)
+		s.Require().NoError(err)
 
-	occ, err := be.IngestOccurrence(s.Ctx,
-		model.PackageOrSourceInput{
-			Package: p1,
-		},
-		*a1,
-		model.IsOccurrenceInputSpec{
-			Justification: "test justification",
-		},
-	)
-	s.Require().NoError(err)
-	s.Require().NotNil(occ)
-	s.Equal("test justification", occ.Justification)
-	s.Equal(a1.Digest, occ.Artifact.Digest)
+		occ, err := be.IngestOccurrence(s.Ctx,
+			model.PackageOrSourceInput{
+				Package: p1,
+			},
+			*a1,
+			model.IsOccurrenceInputSpec{
+				Justification: "test justification",
+			},
+		)
+		s.Require().NoError(err)
+		s.Require().NotNil(occ)
+		s.Equal("test justification", occ.Justification)
+		s.Equal(a1.Digest, occ.Artifact.Digest)
 
-	if pkgSrc, ok := occ.Subject.(*model.Package); ok && pkgSrc != nil {
-		s.Equal(p1.Type, pkgSrc.Type)
-		s.NotEmpty(pkgSrc.Namespaces[0].Names[0].Versions[0].ID)
-	} else {
-		s.Failf("fail", "subject is not a package, got %T", occ.Subject)
-	}
+		if pkgSrc, ok := occ.Subject.(*model.Package); ok && pkgSrc != nil {
+			s.Equal(p1.Type, pkgSrc.Type)
+			s.NotEmpty(pkgSrc.Namespaces[0].Names[0].Versions[0].ID)
+		} else {
+			s.Failf("fail", "subject is not a package, got %T", occ.Subject)
+		}
+	})
 }
 
 func (s *Suite) TestOccurrence() {

--- a/pkg/assembler/backends/ent/backend/search_test.go
+++ b/pkg/assembler/backends/ent/backend/search_test.go
@@ -23,56 +23,58 @@ import (
 )
 
 func (s *Suite) Test_FindSoftware() {
-	b, err := GetBackend(s.Client)
-	s.NoError(err)
+	s.Run("HappyPath", func() {
+		b, err := GetBackend(s.Client)
+		s.NoError(err)
 
-	for _, p := range []*model.PkgInputSpec{p1, p2, p3} {
-		if _, err := b.IngestPackage(s.Ctx, *p); err != nil {
-			s.NoError(err)
+		for _, p := range []*model.PkgInputSpec{p1, p2, p3} {
+			if _, err := b.IngestPackage(s.Ctx, *p); err != nil {
+				s.NoError(err)
+			}
 		}
-	}
 
-	for _, src := range []*model.SourceInputSpec{s1, s2} {
-		if _, err := b.IngestSource(s.Ctx, *src); err != nil {
-			s.NoError(err)
+		for _, src := range []*model.SourceInputSpec{s1, s2} {
+			if _, err := b.IngestSource(s.Ctx, *src); err != nil {
+				s.NoError(err)
+			}
 		}
-	}
 
-	for _, art := range []*model.ArtifactInputSpec{a1} {
-		if _, err := b.IngestArtifact(s.Ctx, art); err != nil {
-			s.NoError(err)
+		for _, art := range []*model.ArtifactInputSpec{a1} {
+			if _, err := b.IngestArtifact(s.Ctx, art); err != nil {
+				s.NoError(err)
+			}
 		}
-	}
 
-	// Find a package
-	results, err := b.FindSoftware(s.Ctx, "tensor")
-	s.NoError(err)
+		// Find a package
+		results, err := b.FindSoftware(s.Ctx, "tensor")
+		s.NoError(err)
 
-	if diff := cmp.Diff([]model.PackageSourceOrArtifact{p1out, p2out, p3out}, results, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
+		if diff := cmp.Diff([]model.PackageSourceOrArtifact{p1out, p2out, p3out}, results, ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
 
-	// Find a source
-	results, err = b.FindSoftware(s.Ctx, "bobs")
-	s.NoError(err)
+		// Find a source
+		results, err = b.FindSoftware(s.Ctx, "bobs")
+		s.NoError(err)
 
-	if diff := cmp.Diff([]model.PackageSourceOrArtifact{s2out}, results, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
+		if diff := cmp.Diff([]model.PackageSourceOrArtifact{s2out}, results, ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
 
-	// Find an artifact
-	results, err = b.FindSoftware(s.Ctx, "6bbb0da")
-	s.NoError(err)
+		// Find an artifact
+		results, err = b.FindSoftware(s.Ctx, "6bbb0da")
+		s.NoError(err)
 
-	if diff := cmp.Diff([]model.PackageSourceOrArtifact{a1out}, results, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
+		if diff := cmp.Diff([]model.PackageSourceOrArtifact{a1out}, results, ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
 
-	// Find with empty query
-	results, err = b.FindSoftware(s.Ctx, "")
-	s.NoError(err)
+		// Find with empty query
+		results, err = b.FindSoftware(s.Ctx, "")
+		s.NoError(err)
 
-	if diff := cmp.Diff([]model.PackageSourceOrArtifact{}, results, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
+		if diff := cmp.Diff([]model.PackageSourceOrArtifact{}, results, ignoreID, ignoreEmptySlices); diff != "" {
+			s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/pkg/assembler/backends/ent/backend/software_test.go
+++ b/pkg/assembler/backends/ent/backend/software_test.go
@@ -36,122 +36,128 @@ func TestEntBackendSuite(t *testing.T) {
 }
 
 func (s *Suite) TestCreateSoftwareTree() {
-	be, err := GetBackend(s.Client)
-	s.NoError(err)
+	s.Run("HappyPath", func() {
+		be, err := GetBackend(s.Client)
+		s.NoError(err)
 
-	// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
-	pkg, err := be.IngestPackage(s.Ctx, model.PkgInputSpec{
-		Type:      "apk",
-		Namespace: ptr("alpine"),
-		Name:      "apk",
-		Version:   ptr("2.12.9-r3"),
-		Subpath:   nil,
-		Qualifiers: []*model.PackageQualifierInputSpec{
-			{Key: "arch", Value: "x86"},
-		},
-	})
-	s.NoError(err)
-	s.NotNil(pkg)
-	s.Equal("apk", pkg.Type)
+		// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
+		pkg, err := be.IngestPackage(s.Ctx, model.PkgInputSpec{
+			Type:      "apk",
+			Namespace: ptr("alpine"),
+			Name:      "apk",
+			Version:   ptr("2.12.9-r3"),
+			Subpath:   nil,
+			Qualifiers: []*model.PackageQualifierInputSpec{
+				{Key: "arch", Value: "x86"},
+			},
+		})
+		s.NoError(err)
+		s.NotNil(pkg)
+		s.Equal("apk", pkg.Type)
 
-	if s.Len(pkg.Namespaces, 1) {
-		s.Equal("alpine", pkg.Namespaces[0].Namespace)
+		if s.Len(pkg.Namespaces, 1) {
+			s.Equal("alpine", pkg.Namespaces[0].Namespace)
 
-		if s.Len(pkg.Namespaces[0].Names, 1) {
-			s.Equal("apk", pkg.Namespaces[0].Names[0].Name)
+			if s.Len(pkg.Namespaces[0].Names, 1) {
+				s.Equal("apk", pkg.Namespaces[0].Names[0].Name)
 
-			if s.Len(pkg.Namespaces[0].Names[0].Versions, 1) {
-				s.Equal("2.12.9-r3", pkg.Namespaces[0].Names[0].Versions[0].Version)
+				if s.Len(pkg.Namespaces[0].Names[0].Versions, 1) {
+					s.Equal("2.12.9-r3", pkg.Namespaces[0].Names[0].Versions[0].Version)
+				}
 			}
 		}
-	}
 
-	// Ingest a second time should only create a new version
-	pkg, err = be.IngestPackage(s.Ctx, model.PkgInputSpec{
-		Type:      "apk",
-		Namespace: ptr("alpine"),
-		Name:      "apk",
-		Version:   ptr("2.12.10"),
-		Subpath:   nil,
-		Qualifiers: []*model.PackageQualifierInputSpec{
-			{Key: "arch", Value: "x86"},
-		},
-	})
-	// Ensure that we don't get a duplicate row error
-	s.NoError(err)
-	s.NotNil(pkg)
+		// Ingest a second time should only create a new version
+		pkg, err = be.IngestPackage(s.Ctx, model.PkgInputSpec{
+			Type:      "apk",
+			Namespace: ptr("alpine"),
+			Name:      "apk",
+			Version:   ptr("2.12.10"),
+			Subpath:   nil,
+			Qualifiers: []*model.PackageQualifierInputSpec{
+				{Key: "arch", Value: "x86"},
+			},
+		})
+		// Ensure that we don't get a duplicate row error
+		s.NoError(err)
+		s.NotNil(pkg)
 
-	if s.Len(pkg.Namespaces, 1) {
-		s.Equal("alpine", pkg.Namespaces[0].Namespace)
+		if s.Len(pkg.Namespaces, 1) {
+			s.Equal("alpine", pkg.Namespaces[0].Namespace)
 
-		if s.Len(pkg.Namespaces[0].Names, 1) {
-			s.Equal("apk", pkg.Namespaces[0].Names[0].Name)
+			if s.Len(pkg.Namespaces[0].Names, 1) {
+				s.Equal("apk", pkg.Namespaces[0].Names[0].Name)
 
-			if s.Len(pkg.Namespaces[0].Names[0].Versions, 1) {
-				s.Equal("2.12.10", pkg.Namespaces[0].Names[0].Versions[0].Version)
+				if s.Len(pkg.Namespaces[0].Names[0].Versions, 1) {
+					s.Equal("2.12.10", pkg.Namespaces[0].Names[0].Versions[0].Version)
+				}
 			}
 		}
-	}
+	})
 }
 
 func (s *Suite) TestVersionUpsertsWithQualifiers() {
-	be, err := GetBackend(s.Client)
-	s.NoError(err)
+	s.Run("HappyPath", func() {
+		be, err := GetBackend(s.Client)
+		s.NoError(err)
 
-	// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
-	pkg1, err := be.IngestPackage(s.Ctx, model.PkgInputSpec{
-		Type:       "apk",
-		Namespace:  ptr("alpine"),
-		Name:       "apk",
-		Version:    ptr("2.12.9-r3"),
-		Subpath:    nil,
-		Qualifiers: []*model.PackageQualifierInputSpec{{Key: "arch", Value: "x86"}},
+		// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
+		pkg1, err := be.IngestPackage(s.Ctx, model.PkgInputSpec{
+			Type:       "apk",
+			Namespace:  ptr("alpine"),
+			Name:       "apk",
+			Version:    ptr("2.12.9-r3"),
+			Subpath:    nil,
+			Qualifiers: []*model.PackageQualifierInputSpec{{Key: "arch", Value: "x86"}},
+		})
+		s.NoError(err)
+		s.NotNil(pkg1)
+		s.Equal("", pkg1.Namespaces[0].Names[0].Versions[0].Subpath)
+
+		// pkg:apk/alpine/apk@2.12.9-r3?arch=arm64
+		spec2 := model.PkgInputSpec{
+			Type:       "apk",
+			Namespace:  ptr("alpine"),
+			Name:       "apk",
+			Version:    ptr("2.12.9-r3"),
+			Subpath:    nil,
+			Qualifiers: []*model.PackageQualifierInputSpec{{Key: "arch", Value: "arm64"}},
+		}
+
+		pkg2, err := be.IngestPackage(s.Ctx, spec2)
+		s.NoError(err)
+		s.NotNil(pkg2)
 	})
-	s.NoError(err)
-	s.NotNil(pkg1)
-	s.Equal("", pkg1.Namespaces[0].Names[0].Versions[0].Subpath)
-
-	// pkg:apk/alpine/apk@2.12.9-r3?arch=arm64
-	spec2 := model.PkgInputSpec{
-		Type:       "apk",
-		Namespace:  ptr("alpine"),
-		Name:       "apk",
-		Version:    ptr("2.12.9-r3"),
-		Subpath:    nil,
-		Qualifiers: []*model.PackageQualifierInputSpec{{Key: "arch", Value: "arm64"}},
-	}
-
-	pkg2, err := be.IngestPackage(s.Ctx, spec2)
-	s.NoError(err)
-	s.NotNil(pkg2)
 }
 
 func (s *Suite) TestIngestOccurrence_Package() {
-	be, err := GetBackend(s.Client)
-	s.NoError(err)
+	s.Run("HappyPath", func() {
+		be, err := GetBackend(s.Client)
+		s.NoError(err)
 
-	_, err = be.IngestPackage(s.Ctx, *p1)
-	s.NoError(err)
+		_, err = be.IngestPackage(s.Ctx, *p1)
+		s.NoError(err)
 
-	_, err = be.IngestArtifact(s.Ctx, &model.ArtifactInputSpec{
-		Algorithm: "sha256", Digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
-	})
-	s.NoError(err)
-
-	// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
-	oc, err := be.IngestOccurrence(s.Ctx,
-		model.PackageOrSourceInput{
-			Package: p1,
-		},
-		model.ArtifactInputSpec{
+		_, err = be.IngestArtifact(s.Ctx, &model.ArtifactInputSpec{
 			Algorithm: "sha256", Digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
-		},
-		model.IsOccurrenceInputSpec{
-			Justification: "this artifact is an occurrence of this openssl",
-			Origin:        "Demo ingestion",
-			Collector:     "Demo ingestion",
-		},
-	)
-	s.NoError(err)
-	s.NotNil(oc)
+		})
+		s.NoError(err)
+
+		// pkg:apk/alpine/apk@2.12.9-r3?arch=x86
+		oc, err := be.IngestOccurrence(s.Ctx,
+			model.PackageOrSourceInput{
+				Package: p1,
+			},
+			model.ArtifactInputSpec{
+				Algorithm: "sha256", Digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf",
+			},
+			model.IsOccurrenceInputSpec{
+				Justification: "this artifact is an occurrence of this openssl",
+				Origin:        "Demo ingestion",
+				Collector:     "Demo ingestion",
+			},
+		)
+		s.NoError(err)
+		s.NotNil(oc)
+	})
 }

--- a/pkg/assembler/backends/ent/testutils/suite.go
+++ b/pkg/assembler/backends/ent/testutils/suite.go
@@ -18,6 +18,7 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
 
@@ -110,7 +111,11 @@ func (s *Suite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *Suite) AfterTest(suiteName, testName string) {
-	s.Client.Close()
+	err := s.Client.Close()
+	if err != nil {
+		fmt.Printf("WARN: %v/%v error while closing the Ent client :: %s", suiteName, testName, err)
+		return
+	}
 }
 
 var _ suite.BeforeTest = (*Suite)(nil)

--- a/pkg/assembler/backends/ent/testutils/suite.go
+++ b/pkg/assembler/backends/ent/testutils/suite.go
@@ -20,9 +20,9 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
-	"github.com/DATA-DOG/go-txdb"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/enttest"
 	"github.com/segmentio/ksuid"
@@ -35,17 +35,24 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func init() {
-	db := os.Getenv("ENT_TEST_DATABASE_URL")
-	if db == "" {
-		db = "postgresql://localhost/guac_test?sslmode=disable"
-	}
+var psqlDb *sql.DB
+var dbUrl *url.URL
 
-	txdb.Register("txdb", "postgres", db)
-	err := os.Setenv("MAX_CONCURRENT_BULK_INGESTION", "1")
+func init() {
+	dbUrlString := os.Getenv("ENT_TEST_DATABASE_URL")
+	if dbUrlString == "" {
+		dbUrlString = "postgresql://localhost/guac_test?sslmode=disable"
+	}
+	db, err := sql.Open("postgres", dbUrlString)
 	if err != nil {
 		log.Fatal(err)
 	}
+	psqlDb = db
+	u, err := url.Parse(dbUrlString)
+	if err != nil {
+		log.Fatal(err)
+	}
+	dbUrl = u
 }
 
 type Suite struct {
@@ -62,16 +69,6 @@ func TestSuite() *Suite {
 }
 
 func (s *Suite) Run(testName string, tf func()) {
-	_, err := s.db.Exec("SAVEPOINT savepoint1")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func(db *sql.DB, query string, args ...any) {
-		_, err := db.Exec(query, args...)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(s.db, "ROLLBACK TO SAVEPOINT savepoint1")
 	s.Suite.Run(testName, tf)
 }
 
@@ -84,9 +81,18 @@ func (s *Suite) AfterEach(fn func()) {
 }
 
 func (s *Suite) BeforeTest(suiteName, testName string) {
-	ctx := context.Background()
+	s.Ctx = context.Background()
+}
+func (s *Suite) SetupSubTest() {
+	ctx := s.Ctx
 	ident := ksuid.New().String()
-	db, err := sql.Open("txdb", ident)
+	_, err := psqlDb.ExecContext(s.Ctx, fmt.Sprintf("CREATE DATABASE \"%v\"", ident))
+	if err != nil {
+		log.Fatal(err)
+	}
+	u := *dbUrl
+	u.Path = ident
+	db, err := sql.Open("postgres", u.String())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -104,19 +110,16 @@ func (s *Suite) BeforeTest(suiteName, testName string) {
 	// Populate context with ent client so that transactions work
 	ctx = ent.NewContext(ctx, s.Client)
 	s.Ctx = ctx
-
-	for _, fn := range s.beforeHooks {
-		fn(suiteName, testName)
-	}
 }
 
-func (s *Suite) AfterTest(suiteName, testName string) {
+func (s *Suite) TearDownSubTest() {
 	err := s.Client.Close()
 	if err != nil {
-		fmt.Printf("WARN: %v/%v error while closing the Ent client :: %s", suiteName, testName, err)
+		fmt.Printf("WARN: error while closing the Ent client :: %s", err)
 		return
 	}
 }
 
 var _ suite.BeforeTest = (*Suite)(nil)
-var _ suite.AfterTest = (*Suite)(nil)
+var _ suite.SetupSubTest = (*Suite)(nil)
+var _ suite.TearDownSubTest = (*Suite)(nil)


### PR DESCRIPTION
# Description of the PR

Removed `DATA-DOG/go-txdb` for tests

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
