### PR TITLE
Ent - DependencyID

### DIFF
--- a/pkg/assembler/backends/ent/backend/dependency_test.go
+++ b/pkg/assembler/backends/ent/backend/dependency_test.go
@@ -628,14 +628,14 @@ func (s *Suite) TestIsDependency() {
 			depIDs := make([]string, len(test.Calls))
 			for i, o := range test.Calls {
 
-				dep, err := b.IngestDependency(ctx, *o.P1, *o.P2, o.MF, *o.ID)
+				id, err := b.IngestDependencyID(ctx, *o.P1, *o.P2, o.MF, *o.ID)
 				if (err != nil) != test.ExpIngestErr {
 					s.T().Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
 				if err != nil {
 					return
 				}
-				depIDs[i] = dep.ID
+				depIDs[i] = id
 			}
 
 			if test.Query.ID != nil {
@@ -744,7 +744,7 @@ func (s *Suite) TestIngestDependencies() {
 				}
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestDependencies(ctx, o.P1s, o.P2s, o.MF, o.IDs)
+				_, err := b.IngestDependencyIDs(ctx, o.P1s, o.P2s, o.MF, o.IDs)
 				if (err != nil) != test.ExpIngestErr {
 					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}


### PR DESCRIPTION
# Description of the PR
Ent backend

- `IngestDependencyID` (with bulk) implementations
-  `IngestDependency`, removed
-   changes consistently all of the tests involved


Refers to https://github.com/guacsec/guac/issues/1198

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
