### PR TITLE
(feat) add support for attestations stored as image manifest

### DIFF
--- a/pkg/handler/processor/guesser/type_ite6.go
+++ b/pkg/handler/processor/guesser/type_ite6.go
@@ -40,6 +40,8 @@ func (_ *ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.Format
 				return processor.DocumentITE6Generic
 			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vuln/v0.1") {
 				return processor.DocumentITE6Vul
+			} else if strings.HasPrefix(statement.PredicateType, "https://spdx.dev/Document") {
+				return processor.DocumentITE6SPDX
 			}
 			return processor.DocumentITE6Generic
 		}

--- a/pkg/handler/processor/ite6/ite6.go
+++ b/pkg/handler/processor/ite6/ite6.go
@@ -31,7 +31,7 @@ type ITE6Processor struct {
 
 // ValidateSchema ensures that the document blob can be parsed into a valid data structure
 func (e *ITE6Processor) ValidateSchema(i *processor.Document) error {
-	if i.Type != processor.DocumentITE6Generic && i.Type != processor.DocumentITE6SLSA && i.Type != processor.DocumentITE6Vul {
+	if i.Type != processor.DocumentITE6Generic && i.Type != processor.DocumentITE6SLSA && i.Type != processor.DocumentITE6Vul && i.Type != processor.DocumentITE6SPDX {
 		return fmt.Errorf("expected ITE6 document type, actual document type: %v", i.Type)
 	}
 

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -52,6 +52,7 @@ func init() {
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Generic)
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6SLSA)
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Vul)
+	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6SPDX)
 	_ = RegisterDocumentProcessor(&dsse.DSSEProcessor{}, processor.DocumentDSSE)
 	_ = RegisterDocumentProcessor(&spdx.SPDXProcessor{}, processor.DocumentSPDX)
 	_ = RegisterDocumentProcessor(&csaf.CSAFProcessor{}, processor.DocumentCsaf)

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -58,6 +58,7 @@ const (
 	DocumentITE6Vul          DocumentType = "ITE6VUL"
 	DocumentDSSE             DocumentType = "DSSE"
 	DocumentSPDX             DocumentType = "SPDX"
+	DocumentITE6SPDX         DocumentType = "ITE6SPDX"
 	DocumentJsonLines        DocumentType = "JSON_LINES"
 	DocumentScorecard        DocumentType = "SCORECARD"
 	DocumentCycloneDX        DocumentType = "CycloneDX"

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -44,6 +44,7 @@ func init() {
 	_ = RegisterDocumentParser(dsse.NewDSSEParser, processor.DocumentDSSE)
 	_ = RegisterDocumentParser(slsa.NewSLSAParser, processor.DocumentITE6SLSA)
 	_ = RegisterDocumentParser(vuln.NewVulnCertificationParser, processor.DocumentITE6Vul)
+	_ = RegisterDocumentParser(spdx.NewSpdxParser, processor.DocumentITE6SPDX)
 	_ = RegisterDocumentParser(spdx.NewSpdxParser, processor.DocumentSPDX)
 	_ = RegisterDocumentParser(cyclonedx.NewCycloneDXParser, processor.DocumentCycloneDX)
 	_ = RegisterDocumentParser(scorecard.NewScorecardParser, processor.DocumentScorecard)


### PR DESCRIPTION
# Description of the PR
Currently, guac only works with certain OCI images. Build tools store attestations in a variety of ways as of now and it might take them a while to adopt to using referrers. As of now, Docker stores the attestation in an image manifest and it would be wonderful for GUAC to support that as docker is a popular tool for building containers.  I'm not entirely sure if this is the right way to implement this,  I'd appreciate any feedback to make this change a reality. 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
