### PR TITLE
OCI purl: fix repository URL management

### DIFF
--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -136,7 +136,7 @@ func purlConvert(p purl.PackageURL) (*model.PkgInputSpec, error) {
 		}
 
 		delete(qs, "repository_url")
-		ns = strings.TrimRight(ns, "/"+p.Name)
+		ns = strings.TrimSuffix(ns, "/"+p.Name)
 		r := pkg(p.Type, ns, p.Name, p.Version, p.Subpath, qs)
 		return r, nil
 	case purl.TypeDocker:

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -200,6 +200,11 @@ func TestPurlConvert(t *testing.T) {
 		}, {
 			purlUri:  "pkg:swift/github.com/RxSwiftCommunity/RxFlow@2.12.4",
 			expected: pkg("swift", "github.com/RxSwiftCommunity", "RxFlow", "2.12.4", "", map[string]string{}),
+		}, {
+			purlUri: "pkg:oci/ubi9-container@sha256:8614ce95268b970880a1eca97dddfce5154fab35418d839c5f75012cccaca0d9?repository_url=registry.redhat.io/ubi9&tag=9.2-489",
+			expected: pkg("oci", "registry.redhat.io/ubi9", "ubi9-container", "sha256:8614ce95268b970880a1eca97dddfce5154fab35418d839c5f75012cccaca0d9", "", map[string]string{
+				"tag": "9.2-489",
+			}),
 		},
 	}
 


### PR DESCRIPTION
# Description of the PR

Fixes #1484 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
