### PR TITLE
CSAF Parser: fix double ingestion

### DIFF
--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -274,7 +274,6 @@ func (c *csafParser) generateVexIngest(ctx context.Context, vulnInput *generated
 func (c *csafParser) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
 	rv := &assembler.IngestPredicates{}
 	var vis []assembler.VexIngest
-	var cvs []assembler.CertifyVulnIngest
 
 	for _, v := range c.csaf.Vulnerabilities {
 		vuln, err := helpers.CreateVulnInput(v.CVE)
@@ -290,36 +289,10 @@ func (c *csafParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 				if vi == nil {
 					continue
 				}
-
-				if status == "known_affected" || status == "under_investigation" {
-					vulnData := generated.ScanMetadataInput{
-						TimeScanned: c.csaf.Document.Tracking.CurrentReleaseDate,
-					}
-					cv := assembler.CertifyVulnIngest{
-						Pkg:           vi.Pkg,
-						Vulnerability: vuln,
-						VulnData:      &vulnData,
-					}
-					cvs = append(cvs, cv)
-				} else if status == "known_not_affected" || status == "fixed" {
-					vulnData := generated.ScanMetadataInput{
-						TimeScanned: c.csaf.Document.Tracking.CurrentReleaseDate,
-					}
-					noVuln := generated.VulnerabilityInputSpec{
-						Type: "NoVuln",
-					}
-					cv := assembler.CertifyVulnIngest{
-						Pkg:           vi.Pkg,
-						Vulnerability: &noVuln,
-						VulnData:      &vulnData,
-					}
-					cvs = append(cvs, cv)
-				}
 				vis = append(vis, *vi)
 			}
 		}
 	}
 	rv.Vex = vis
-	rv.CertifyVuln = cvs
 	return rv
 }

--- a/pkg/ingestor/parser/csaf/parser_csaf_test.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_test.go
@@ -50,8 +50,7 @@ func Test_csafParser(t *testing.T) {
 			},
 		},
 		wantPredicates: &assembler.IngestPredicates{
-			Vex:         testdata.CsafVexIngest,
-			CertifyVuln: testdata.CsafCertifyVulnIngest,
+			Vex: testdata.CsafVexIngest,
 		},
 		wantErr: false,
 	}}


### PR DESCRIPTION
# Description of the PR

Fixes #1496 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
