### PR TITLE
add openssf scorecard badge for guac

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <img src="https://user-images.githubusercontent.com/3060102/204297133-9bf702c6-b4e2-46df-a029-42b5060b19a4.png">
 </p>
 
+[![build](https://github.com/guacsec/guac/workflows/release/badge.svg)](https://github.com/guacsec/guac/actions?query=workflow%3Arelease) [![PkgGoDev](https://pkg.go.dev/badge/github.com/guacsec/guac)](https://pkg.go.dev/github.com/guacsec/guac) [![Go Report Card](https://goreportcard.com/badge/github.com/guacsec/guac)](https://goreportcard.com/report/github.com/guacsec/guac)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/guacsec/guac/badge)](https://api.securityscorecards.dev/projects/github.com/guacsec/guac)
+
 **Note:** GUAC is under active development - if you are interested in
 contributing, please look at [contributor guide](CONTRIBUTING.md).
 


### PR DESCRIPTION
# Description of the PR

quick PR to add in missing badges (most importantly openssf scorecard)

![Screenshot 2023-11-14 at 1 10 06 PM](https://github.com/guacsec/guac/assets/88045217/f9be3da2-b6d4-48f3-919e-9e5537813048)


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
