### PR TITLE
Inlcuded a faster fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ cover: test
 .PHONY: fmt
 fmt:
 	@echo "Testing formatting and imports"
-	test -z "$(shell find . -name '*.go' -not -path './.git/*' -not -wholename './vendor/*' -not -name '*.pb.go' -exec goimports -l -e {} \;)"
+	test -z "$(shell git diff --name-status $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') -- '*.go' | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 goimports -l -e)"
 	@echo "Testing copyright notice"
-	test -z "$(shell find . -name '*.go' -not -path './.git/*' -not -wholename './vendor/*' -not -name '*.pb.go' -exec .github/scripts/copyright.sh {} \;)"
+	test -z "$(shell git diff --name-status $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') -- '*.go' | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 .github/scripts/copyright.sh)"
 
 
 # Check that generated files are up to date
@@ -263,10 +263,3 @@ check-goreleaser-tool-check:
 # Check that all the tools are installed.
 .PHONY: check-tools
 check-tools: check-docker-tool-check check-docker-buildx-tool-check check-docker-compose-tool-check check-protoc-tool-check check-golangci-lint-tool-check check-mockgen-tool-check check-goreleaser-tool-check
-
-.PHONY: fmt-local
-fmt-local:
-	@echo "Testing formatting and imports"
-	test -z "$(shell git diff --name-status main | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 goimports -l -e)"
-	@echo "Testing copyright notice"
-	test -z "$(shell git diff --name-status main | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 .github/scripts/copyright.sh)"

--- a/Makefile
+++ b/Makefile
@@ -263,3 +263,10 @@ check-goreleaser-tool-check:
 # Check that all the tools are installed.
 .PHONY: check-tools
 check-tools: check-docker-tool-check check-docker-buildx-tool-check check-docker-compose-tool-check check-protoc-tool-check check-golangci-lint-tool-check check-mockgen-tool-check check-goreleaser-tool-check
+
+.PHONY: fmt-local
+fmt-local:
+	@echo "Testing formatting and imports"
+	test -z "$(shell git diff --name-status main | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 goimports -l -e)"
+	@echo "Testing copyright notice"
+	test -z "$(shell git diff --name-status main | grep '.go$$' | grep -v '^D' | grep -v '*.pb.go' | grep -v 'vendor/*' | cut -f 2- | xargs -n 1 -P 4 .github/scripts/copyright.sh)"


### PR DESCRIPTION
# Description of the PR

* `make fmt` takes an extremely long time so I created `fmt-local`.
* `fmt-local` doesn't break the CI.
* `fmt-local` works by only running on files that are changed.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
