### PR TITLE
Iterating Over all IDs in QueryVulnsViaVulnNodeNeighbors

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -336,7 +336,7 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 	}
 
 	var path []string
-	vulnNodeNeighborResponses := []vulnNeighbor{}
+	var vulnNodeNeighborResponses []vulnNeighbor
 
 	for _, vulnerabilitiesResponse := range vulnerabilitiesResponses {
 		for _, vulnerabilityNodeID := range vulnerabilitiesResponse.VulnerabilityIDs {

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -118,7 +118,7 @@ var queryVulnCmd = &cobra.Command{
 
 				tableRows = append(tableRows, table.Row{vulnResponse.Vulnerabilities[0].Type, vulnResponse.Vulnerabilities[0].Id, "vulnerability ID: " + vulnResponse.Vulnerabilities[0].VulnerabilityIDs[0].VulnerabilityID})
 
-				path, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, vulnResponse.Vulnerabilities[0].VulnerabilityIDs[0].Id, model.EdgeVulnerabilityCertifyVuln, opts.depth, opts.pathsToReturn)
+				path, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, vulnResponse.Vulnerabilities, model.EdgeVulnerabilityCertifyVuln, opts.depth, opts.pathsToReturn)
 				if err != nil {
 					logger.Fatalf("error querying neighbor: %v", err)
 				}
@@ -329,23 +329,40 @@ func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, top
 	return path, tableRows, nil
 }
 
-func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilityNodeID string, edgeType model.Edge, depth, pathsToReturn int) ([]string, error) {
-	var path []string
-	vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID, []model.Edge{edgeType})
-	if err != nil {
-		return nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
+func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilitiesResponses []model.VulnerabilitiesVulnerabilitiesVulnerability, edgeType model.Edge, depth, pathsToReturn int) ([]string, error) {
+	type vulnNeighbor struct {
+		node model.NeighborsNeighborsNode
+		id   string
 	}
+
+	var path []string
+	vulnNodeNeighborResponses := []vulnNeighbor{}
+
+	for _, vulnerabilitiesResponse := range vulnerabilitiesResponses {
+		for _, vulnerabilityNodeID := range vulnerabilitiesResponse.VulnerabilityIDs {
+			vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID.Id, []model.Edge{edgeType})
+
+			if err != nil {
+				return nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
+			}
+
+			for _, neighbor := range vulnNodeNeighborResponse.Neighbors {
+				vulnNodeNeighborResponses = append(vulnNodeNeighborResponses, vulnNeighbor{neighbor, vulnerabilityNodeID.Id})
+			}
+		}
+	}
+
 	certifyVulnFound := false
 	numberOfPaths := 0
-	for _, neighbor := range vulnNodeNeighborResponse.Neighbors {
-		if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
+	for _, neighbor := range vulnNodeNeighborResponses {
+		if certifyVuln, ok := neighbor.node.(*model.NeighborsNeighborsCertifyVuln); ok {
 			certifyVulnFound = true
 			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
 			if err != nil {
 				return nil, fmt.Errorf("error searching dependency packages match: %w", err)
 			}
 			if len(pkgPath) > 0 {
-				fullVulnPath := append([]string{vulnerabilityNodeID, certifyVuln.Id,
+				fullVulnPath := append([]string{neighbor.id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}, pkgPath...)


### PR DESCRIPTION
# Description of the PR

* Fixes https://github.com/guacsec/guac/issues/1441
* Now the function `QueryVulnsViaVulnNodeNeighbors` iterates over each ID in `vulnResponse.Vulnerabilities` instead of just using the ID `vulnResponse.Vulnerabilities[0].VulnerabilityIDs`

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
