### PR TITLE
Use filename as qualifier for SBOM file references

### DIFF
--- a/internal/testing/testdata/exampledata/ingest_predicates.json
+++ b/internal/testing/testdata/exampledata/ingest_predicates.json
@@ -147,8 +147,13 @@
         "namespace": "files",
         "name": "sha256:713e3907167dce202d7c16034831af3d670191382a3e9026e0ac0a4023013201",
         "version": "",
-        "qualifiers": null,
-        "subpath": "etc/apk/world"
+        "qualifiers": [
+          {
+            "key": "filename",
+            "value": "/etc/apk/world"
+          }
+        ],
+        "subpath": ""
       },
       "artifact": {
         "algorithm": "sha256",
@@ -166,8 +171,13 @@
         "namespace": "files",
         "name": "sha256:575d810a9fae5f2f0671c9b2c0ce973e46c7207fbe5cb8d1b0d1836a6a0470e3",
         "version": "",
-        "qualifiers": null,
-        "subpath": "etc/crontabs/root"
+        "qualifiers": [
+          {
+            "key": "filename",
+            "value": "/etc/crontabs/root"
+          }
+        ],
+        "subpath": ""
       },
       "artifact": {
         "algorithm": "sha256",

--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -245,7 +245,7 @@ func GuacPkgPurl(pkgName string, pkgVersion *string) string {
 func GuacFilePurl(alg string, digest string, filename *string) string {
 	s := fmt.Sprintf(PurlFilesGuac+"%s:%s", strings.ToLower(alg), digest)
 	if filename != nil {
-		s += fmt.Sprintf("#%s", SanitizeString(*filename))
+		s += fmt.Sprintf("?filename=%s", SanitizeString(*filename))
 	}
 	return s
 }

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -953,7 +953,7 @@ func TestGuacFilePurl(t *testing.T) {
 			alg:      "sha256",
 			digest:   "cf194aa4315da360a262ff73ce63e2ff68a128c3a9ee7d97163c998fd1690cec",
 			filename: strP("/test/path"),
-			expected: "pkg:guac/files/sha256:cf194aa4315da360a262ff73ce63e2ff68a128c3a9ee7d97163c998fd1690cec#/test/path",
+			expected: "pkg:guac/files/sha256:cf194aa4315da360a262ff73ce63e2ff68a128c3a9ee7d97163c998fd1690cec?filename=/test/path",
 		},
 		{
 			alg:      "sha256",

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -468,7 +468,7 @@ func guacCDXFilePurl(fileName string, version string, topLevel bool) string {
 			splitVersion := strings.Split(version, ":")
 			if len(splitVersion) == 2 {
 				s := fmt.Sprintf("pkg:guac/cdx/"+"%s:%s", strings.ToLower(splitVersion[0]), splitVersion[1])
-				s += fmt.Sprintf("#%s", escapedName)
+				s += fmt.Sprintf("?filename=%s", escapedName)
 				return s
 			}
 		}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -275,7 +275,7 @@ func Test_cyclonedxParser_addRootPackage(t *testing.T) {
 				},
 			},
 		},
-		wantPurl: "pkg:guac/cdx/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870#/home/work/test/build/webserver",
+		wantPurl: "pkg:guac/cdx/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?filename=/home/work/test/build/webserver",
 	}, {
 		name: "file type - purl nor provided, version not provided",
 		cdxBom: &cdx.BOM{
@@ -434,7 +434,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/files/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870#/home/work/test/build/webserver",
+		wantPurl: "pkg:guac/files/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?filename=/home/work/test/build/webserver",
 	}, {
 		name: "file type - purl nor provided, version not provided",
 		cdxBom: &cdx.BOM{

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -483,7 +483,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [
 					"TEXT"

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -512,7 +512,7 @@ func Test_spdxParser(t *testing.T) {
 				IsDependency: []assembler.IsDependencyIngest{
 					{
 						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
-						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
 						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
 						IsDependency: &generated.IsDependencyInputSpec{
 							DependencyType: generated.DependencyTypeUnknown,
@@ -522,7 +522,7 @@ func Test_spdxParser(t *testing.T) {
 				},
 				IsOccurrence: []assembler.IsOccurrenceIngest{
 					{
-						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
 						Artifact: &generated.ArtifactInputSpec{
 							Algorithm: "sha1",
 							Digest:    "ba1c68d88439599dcca7594d610030a19eda4f63",
@@ -596,7 +596,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [
 					"TEXT"
@@ -611,7 +611,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [
 					"TEXT"
@@ -626,7 +626,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [
 					"TEXT"
@@ -641,7 +641,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e36",
 				  "fileTypes": [
 					"TEXT"
@@ -656,7 +656,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 								{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e37",
 				  "fileTypes": [
 					"TEXT"
@@ -672,7 +672,7 @@ func Test_spdxParser(t *testing.T) {
 				}
 				,
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e38",
 				  "fileTypes": [
 					"TEXT"
@@ -687,7 +687,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e39",
 				  "fileTypes": [
 					"TEXT"
@@ -702,7 +702,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e39",
 				  "fileTypes": [
 					"TEXT"
@@ -717,7 +717,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e39",
 				  "fileTypes": [
 					"TEXT"
@@ -732,7 +732,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e39",
 				  "fileTypes": [
 					"TEXT"
@@ -747,7 +747,7 @@ func Test_spdxParser(t *testing.T) {
 				  "copyrightText": ""
 				},
 				{
-				  "fileName": "include-file",
+				  "fileName": "./include-file",
 				  "SPDXID": "SPDXRef-aef1c9f4f2277e39",
 				  "fileTypes": [
 					"TEXT"
@@ -775,7 +775,7 @@ func Test_spdxParser(t *testing.T) {
 				IsDependency: []assembler.IsDependencyIngest{
 					{
 						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
-						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
 						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
 						IsDependency: &generated.IsDependencyInputSpec{
 							DependencyType: generated.DependencyTypeUnknown,
@@ -785,7 +785,7 @@ func Test_spdxParser(t *testing.T) {
 				},
 				IsOccurrence: []assembler.IsOccurrenceIngest{
 					{
-						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63#include-file"),
+						Pkg: pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
 						Artifact: &generated.ArtifactInputSpec{
 							Algorithm: "sha1",
 							Digest:    "ba1c68d88439599dcca7594d610030a19eda4f63",


### PR DESCRIPTION
# Description of the PR
As per #1545, there is a bug with how SPDX relative filenames are handled. Fix this by changing the SPDX/CycloneDX parser to use filename in qualifier instead of subpath.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
