### PR TITLE
Change Keys method in kv interface to Scan

### DIFF
--- a/pkg/assembler/backends/keyvalue/artifact.go
+++ b/pkg/assembler/backends/keyvalue/artifact.go
@@ -239,28 +239,33 @@ func (c *demoClient) Artifacts(ctx context.Context, artifactSpec *model.Artifact
 	algorithm := strings.ToLower(nilToEmpty(artifactSpec.Algorithm))
 	digest := strings.ToLower(nilToEmpty(artifactSpec.Digest))
 	var rv []*model.Artifact
-	artKeys, err := c.kv.Keys(ctx, artCol)
-	if err != nil {
-		return nil, err
-	}
-	for _, ak := range artKeys {
-		a, err := byKeykv[*artStruct](ctx, artCol, ak, c)
+	var done bool
+	scn := c.kv.Keys(artCol)
+	for !done {
+		var artKeys []string
+		artKeys, done, err = scn.Scan(ctx)
 		if err != nil {
 			return nil, err
 		}
+		for _, ak := range artKeys {
+			a, err := byKeykv[*artStruct](ctx, artCol, ak, c)
+			if err != nil {
+				return nil, err
+			}
 
-		matchAlgorithm := false
-		if algorithm == "" || algorithm == a.Algorithm {
-			matchAlgorithm = true
-		}
+			matchAlgorithm := false
+			if algorithm == "" || algorithm == a.Algorithm {
+				matchAlgorithm = true
+			}
 
-		matchDigest := false
-		if digest == "" || digest == a.Digest {
-			matchDigest = true
-		}
+			matchDigest := false
+			if digest == "" || digest == a.Digest {
+				matchDigest = true
+			}
 
-		if matchDigest && matchAlgorithm {
-			rv = append(rv, c.convArtifact(a))
+			if matchDigest && matchAlgorithm {
+				rv = append(rv, c.convArtifact(a))
+			}
 		}
 	}
 	return rv, nil

--- a/pkg/assembler/backends/keyvalue/builder.go
+++ b/pkg/assembler/backends/keyvalue/builder.go
@@ -124,16 +124,21 @@ func (c *demoClient) Builders(ctx context.Context, builderSpec *model.BuilderSpe
 		return []*model.Builder{c.convBuilder(b)}, nil
 	}
 	var builders []*model.Builder
-	bKeys, err := c.kv.Keys(ctx, builderCol)
-	if err != nil {
-		return nil, err
-	}
-	for _, bk := range bKeys {
-		b, err := byKeykv[*builderStruct](ctx, builderCol, bk, c)
+	var done bool
+	scn := c.kv.Keys(builderCol)
+	for !done {
+		var bKeys []string
+		bKeys, done, err = scn.Scan(ctx)
 		if err != nil {
 			return nil, err
 		}
-		builders = append(builders, c.convBuilder(b))
+		for _, bk := range bKeys {
+			b, err := byKeykv[*builderStruct](ctx, builderCol, bk, c)
+			if err != nil {
+				return nil, err
+			}
+			builders = append(builders, c.convBuilder(b))
+		}
 	}
 	return builders, nil
 }

--- a/pkg/assembler/backends/keyvalue/hasSLSA.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA.go
@@ -151,18 +151,24 @@ func (c *demoClient) HasSlsa(ctx context.Context, filter *model.HasSLSASpec) ([]
 			}
 		}
 	} else {
-		slsaKeys, err := c.kv.Keys(ctx, slsaCol)
-		if err != nil {
-			return nil, err
-		}
-		for _, slsak := range slsaKeys {
-			link, err := byKeykv[*hasSLSAStruct](ctx, slsaCol, slsak, c)
+		var done bool
+		scn := c.kv.Keys(slsaCol)
+		for !done {
+			var slsaKeys []string
+			var err error
+			slsaKeys, done, err = scn.Scan(ctx)
 			if err != nil {
 				return nil, err
 			}
-			out, err = c.addSLSAIfMatch(ctx, out, filter, link)
-			if err != nil {
-				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			for _, slsak := range slsaKeys {
+				link, err := byKeykv[*hasSLSAStruct](ctx, slsaCol, slsak, c)
+				if err != nil {
+					return nil, err
+				}
+				out, err = c.addSLSAIfMatch(ctx, out, filter, link)
+				if err != nil {
+					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+				}
 			}
 		}
 	}

--- a/pkg/assembler/backends/keyvalue/isDependency.go
+++ b/pkg/assembler/backends/keyvalue/isDependency.go
@@ -211,18 +211,24 @@ func (c *demoClient) IsDependency(ctx context.Context, filter *model.IsDependenc
 			}
 		}
 	} else {
-		depKeys, err := c.kv.Keys(ctx, isDepCol)
-		if err != nil {
-			return nil, err
-		}
-		for _, depKey := range depKeys {
-			link, err := byKeykv[*isDependencyLink](ctx, isDepCol, depKey, c)
+		var done bool
+		scn := c.kv.Keys(isDepCol)
+		for !done {
+			var depKeys []string
+			var err error
+			depKeys, done, err = scn.Scan(ctx)
 			if err != nil {
 				return nil, err
 			}
-			out, err = c.addDepIfMatch(ctx, out, filter, link)
-			if err != nil {
-				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			for _, depKey := range depKeys {
+				link, err := byKeykv[*isDependencyLink](ctx, isDepCol, depKey, c)
+				if err != nil {
+					return nil, err
+				}
+				out, err = c.addDepIfMatch(ctx, out, filter, link)
+				if err != nil {
+					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+				}
 			}
 		}
 	}

--- a/pkg/assembler/backends/keyvalue/isOccurrence.go
+++ b/pkg/assembler/backends/keyvalue/isOccurrence.go
@@ -293,18 +293,24 @@ func (c *demoClient) IsOccurrence(ctx context.Context, filter *model.IsOccurrenc
 			}
 		}
 	} else {
-		occKeys, err := c.kv.Keys(ctx, occCol)
-		if err != nil {
-			return nil, err
-		}
-		for _, ok := range occKeys {
-			link, err := byKeykv[*isOccurrenceStruct](ctx, occCol, ok, c)
+		var done bool
+		scn := c.kv.Keys(occCol)
+		for !done {
+			var occKeys []string
+			var err error
+			occKeys, done, err = scn.Scan(ctx)
 			if err != nil {
 				return nil, err
 			}
-			out, err = c.addOccIfMatch(ctx, out, filter, link)
-			if err != nil {
-				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			for _, ok := range occKeys {
+				link, err := byKeykv[*isOccurrenceStruct](ctx, occCol, ok, c)
+				if err != nil {
+					return nil, err
+				}
+				out, err = c.addOccIfMatch(ctx, out, filter, link)
+				if err != nil {
+					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+				}
 			}
 		}
 	}

--- a/pkg/assembler/backends/keyvalue/license.go
+++ b/pkg/assembler/backends/keyvalue/license.go
@@ -169,21 +169,26 @@ func (c *demoClient) Licenses(ctx context.Context, licenseSpec *model.LicenseSpe
 	}
 
 	var rv []*model.License
-	lKeys, err := c.kv.Keys(ctx, licenseCol)
-	if err != nil {
-		return nil, err
-	}
-	for _, lk := range lKeys {
-		l, err := byKeykv[*licStruct](ctx, licenseCol, lk, c)
+	var done bool
+	scn := c.kv.Keys(licenseCol)
+	for !done {
+		var lKeys []string
+		lKeys, done, err = scn.Scan(ctx)
 		if err != nil {
 			return nil, err
 		}
-		if noMatch(licenseSpec.Name, l.Name) ||
-			noMatch(licenseSpec.ListVersion, l.ListVersion) ||
-			noMatch(licenseSpec.Inline, l.Inline) {
-			continue
+		for _, lk := range lKeys {
+			l, err := byKeykv[*licStruct](ctx, licenseCol, lk, c)
+			if err != nil {
+				return nil, err
+			}
+			if noMatch(licenseSpec.Name, l.Name) ||
+				noMatch(licenseSpec.ListVersion, l.ListVersion) ||
+				noMatch(licenseSpec.Inline, l.Inline) {
+				continue
+			}
+			rv = append(rv, c.convLicense(l))
 		}
-		rv = append(rv, c.convLicense(l))
 	}
 	return rv, nil
 }

--- a/pkg/assembler/backends/keyvalue/vulnEqual.go
+++ b/pkg/assembler/backends/keyvalue/vulnEqual.go
@@ -196,18 +196,24 @@ func (c *demoClient) VulnEqual(ctx context.Context, filter *model.VulnEqualSpec)
 			}
 		}
 	} else {
-		veKeys, err := c.kv.Keys(ctx, vulnEqCol)
-		if err != nil {
-			return nil, err
-		}
-		for _, vek := range veKeys {
-			link, err := byKeykv[*vulnerabilityEqualLink](ctx, vulnEqCol, vek, c)
+		var done bool
+		scn := c.kv.Keys(vulnEqCol)
+		for !done {
+			var veKeys []string
+			var err error
+			veKeys, done, err = scn.Scan(ctx)
 			if err != nil {
 				return nil, err
 			}
-			out, err = c.addVulnIfMatch(ctx, out, filter, link)
-			if err != nil {
-				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+			for _, vek := range veKeys {
+				link, err := byKeykv[*vulnerabilityEqualLink](ctx, vulnEqCol, vek, c)
+				if err != nil {
+					return nil, err
+				}
+				out, err = c.addVulnIfMatch(ctx, out, filter, link)
+				if err != nil {
+					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
+				}
 			}
 		}
 	}

--- a/pkg/assembler/backends/keyvalue/vulnerability.go
+++ b/pkg/assembler/backends/keyvalue/vulnerability.go
@@ -250,22 +250,28 @@ func (c *demoClient) Vulnerabilities(ctx context.Context, filter *model.Vulnerab
 			}
 		}
 	} else {
-		typeKeys, err := c.kv.Keys(ctx, vulnTypeCol)
-		if err != nil {
-			return nil, err
-		}
-		for _, tk := range typeKeys {
-			typeStruct, err := byKeykv[*vulnTypeStruct](ctx, vulnTypeCol, tk, c)
+		var done bool
+		scn := c.kv.Keys(vulnTypeCol)
+		for !done {
+			var typeKeys []string
+			var err error
+			typeKeys, done, err = scn.Scan(ctx)
 			if err != nil {
 				return nil, err
 			}
-			vulnIDs := c.buildVulnID(ctx, typeStruct, filter)
-			if len(vulnIDs) > 0 {
-				out = append(out, &model.Vulnerability{
-					ID:               typeStruct.ThisID,
-					Type:             typeStruct.Type,
-					VulnerabilityIDs: vulnIDs,
-				})
+			for _, tk := range typeKeys {
+				typeStruct, err := byKeykv[*vulnTypeStruct](ctx, vulnTypeCol, tk, c)
+				if err != nil {
+					return nil, err
+				}
+				vulnIDs := c.buildVulnID(ctx, typeStruct, filter)
+				if len(vulnIDs) > 0 {
+					out = append(out, &model.Vulnerability{
+						ID:               typeStruct.ThisID,
+						Type:             typeStruct.Type,
+						VulnerabilityIDs: vulnIDs,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/assembler/kv/kv.go
+++ b/pkg/assembler/kv/kv.go
@@ -31,10 +31,8 @@ type Store interface {
 	// Sets a value, creates collection if necessary
 	Set(ctx context.Context, collection, key string, value any) error
 
-	// Returns a slice of all keys for a collection. If collection does not
-	// exist, return a nil slice.
-	// TODO(jeffmendoza) implement scanning in kv interface
-	Keys(ctx context.Context, collection string) ([]string, error)
+	// Create a scanner that will be used to get all the keys in a collection.
+	Keys(collection string) Scanner
 }
 
 // Error to return (wrap) on Get if value not found
@@ -43,3 +41,14 @@ var NotFoundError = errors.New("Not found")
 // Error to return (wrap) on Get if Ptr is not a pointer, or not the right
 // type.
 var BadPtrError = errors.New("Bad pointer")
+
+// Scanner is used to get all the keys for a collection. The concrete
+// implementation will store any intermediate cursors or last key data so that
+// the next call to Scan will pick up where the last one left off. Each
+// instance will only be used once.
+type Scanner interface {
+
+	// Scan returns some number of keys. If the collection does not exist, return
+	// a nil slice. If there are no more keys, return true as end signal.
+	Scan(ctx context.Context) ([]string, bool, error)
+}


### PR DESCRIPTION
Keys was a placeholder, as an external keyvalue may have more keys than we want to read at once. Additionally we don't want to overload the external store with an operation that will block for a long time. Now the Scan interface will only get some number of keys at a time. Implementations for Redis and TiKV have been added.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
