### PR TITLE
Update key methods to use a non-cryptographic hash function.

### DIFF
--- a/pkg/assembler/backends/keyvalue/artifact.go
+++ b/pkg/assembler/backends/keyvalue/artifact.go
@@ -120,7 +120,7 @@ func (n *artStruct) setPointOfContactLinks(ctx context.Context, ID string, c *de
 }
 
 func (n *artStruct) Key() string {
-	return strings.Join([]string{n.Algorithm, n.Digest}, ":")
+	return hashKey(strings.Join([]string{n.Algorithm, n.Digest}, ":"))
 }
 
 func (c *demoClient) artifactByInput(ctx context.Context, a *model.ArtifactInputSpec) (*artStruct, error) {

--- a/pkg/assembler/backends/keyvalue/backend.go
+++ b/pkg/assembler/backends/keyvalue/backend.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"reflect"
 	"slices"
@@ -328,4 +329,19 @@ func (c *demoClient) getPackageVersionAndArtifacts(ctx context.Context, pkgOrArt
 	}
 
 	return pkgs, arts, nil
+}
+
+func hashKey(in string) string {
+	h := fnv.New128a()
+	h.Write([]byte(in))
+	bts := h.Sum(nil)
+	return fmtBytes(bts)
+}
+
+func fmtBytes(s []byte) string {
+	strs := make([]string, len(s))
+	for i, v := range s {
+		strs[i] = fmt.Sprintf("%x", v)
+	}
+	return strings.Join(strs, "")
 }

--- a/pkg/assembler/backends/keyvalue/builder.go
+++ b/pkg/assembler/backends/keyvalue/builder.go
@@ -32,7 +32,7 @@ type builderStruct struct {
 }
 
 func (n *builderStruct) Key() string {
-	return n.URI
+	return hashKey(n.URI)
 }
 
 func (b *builderStruct) ID() string { return b.ThisID }

--- a/pkg/assembler/backends/keyvalue/certifyBad.go
+++ b/pkg/assembler/backends/keyvalue/certifyBad.go
@@ -44,7 +44,7 @@ type badLink struct {
 func (n *badLink) ID() string { return n.ThisID }
 
 func (n *badLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.ArtifactID,
 		n.SourceID,
@@ -52,7 +52,7 @@ func (n *badLink) Key() string {
 		n.Origin,
 		n.Collector,
 		timeKey(n.KnownSince),
-	}, ":")
+	}, ":"))
 }
 
 func (n *badLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyBad_test.go
+++ b/pkg/assembler/backends/keyvalue/certifyBad_test.go
@@ -408,11 +408,11 @@ func TestCertifyBad(t *testing.T) {
 			},
 			ExpCB: []*model.CertifyBad{
 				{
-					Subject:       s1out,
+					Subject:       s2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       s2out,
+					Subject:       s1out,
 					Justification: "test justification",
 				},
 			},
@@ -464,11 +464,11 @@ func TestCertifyBad(t *testing.T) {
 			},
 			ExpCB: []*model.CertifyBad{
 				{
-					Subject:       p1outName,
+					Subject:       p2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       p2out,
+					Subject:       p1outName,
 					Justification: "test justification",
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/certifyGood.go
+++ b/pkg/assembler/backends/keyvalue/certifyGood.go
@@ -42,7 +42,7 @@ type goodLink struct {
 func (n *goodLink) ID() string { return n.ThisID }
 
 func (n *goodLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.ArtifactID,
 		n.SourceID,
@@ -50,7 +50,7 @@ func (n *goodLink) Key() string {
 		n.Origin,
 		n.Collector,
 		timeKey(n.KnownSince),
-	}, ":")
+	}, ":"))
 }
 
 func (n *goodLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyGood_test.go
+++ b/pkg/assembler/backends/keyvalue/certifyGood_test.go
@@ -408,11 +408,11 @@ func TestCertifyGood(t *testing.T) {
 			},
 			ExpCG: []*model.CertifyGood{
 				{
-					Subject:       s1out,
+					Subject:       s2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       s2out,
+					Subject:       s1out,
 					Justification: "test justification",
 				},
 			},
@@ -464,11 +464,11 @@ func TestCertifyGood(t *testing.T) {
 			},
 			ExpCG: []*model.CertifyGood{
 				{
-					Subject:       p1outName,
+					Subject:       p2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       p2out,
+					Subject:       p1outName,
 					Justification: "test justification",
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/certifyLegal.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal.go
@@ -47,7 +47,7 @@ type certifyLegalStruct struct {
 
 func (n *certifyLegalStruct) ID() string { return n.ThisID }
 func (n *certifyLegalStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Pkg,
 		n.Source,
 		n.DeclaredLicense,
@@ -59,7 +59,7 @@ func (n *certifyLegalStruct) Key() string {
 		timeKey(n.TimeScanned),
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *certifyLegalStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyLegal_test.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal_test.go
@@ -431,12 +431,12 @@ func TestLegal(t *testing.T) {
 			},
 			ExpLegal: []*model.CertifyLegal{
 				{
-					Subject:          p1out,
+					Subject:          p2out,
 					DeclaredLicenses: []*model.License{l1out},
 					Justification:    "test justification",
 				},
 				{
-					Subject:          p2out,
+					Subject:          p1out,
 					DeclaredLicenses: []*model.License{l1out},
 					Justification:    "test justification",
 				},
@@ -570,12 +570,12 @@ func TestLegals(t *testing.T) {
 			},
 			ExpLegal: []*model.CertifyLegal{
 				{
-					Subject:          p1out,
+					Subject:          p2out,
 					DeclaredLicenses: []*model.License{l1out},
 					Justification:    "test justification",
 				},
 				{
-					Subject:          p2out,
+					Subject:          p1out,
 					DeclaredLicenses: []*model.License{l1out},
 					Justification:    "test justification",
 				},

--- a/pkg/assembler/backends/keyvalue/certifyScorecard.go
+++ b/pkg/assembler/backends/keyvalue/certifyScorecard.go
@@ -44,7 +44,7 @@ type scorecardLink struct {
 
 func (n *scorecardLink) ID() string { return n.ThisID }
 func (n *scorecardLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.SourceID,
 		timeKey(n.TimeScanned),
 		fmt.Sprint(n.AggregateScore),
@@ -53,7 +53,7 @@ func (n *scorecardLink) Key() string {
 		n.ScorecardCommit,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *scorecardLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyVEXStatement.go
+++ b/pkg/assembler/backends/keyvalue/certifyVEXStatement.go
@@ -46,7 +46,7 @@ type vexLink struct {
 func (n *vexLink) ID() string { return n.ThisID }
 
 func (n *vexLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.ArtifactID,
 		n.VulnerabilityID,
@@ -57,7 +57,7 @@ func (n *vexLink) Key() string {
 		string(n.Justification),
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *vexLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -45,7 +45,7 @@ type certifyVulnerabilityLink struct {
 
 func (n *certifyVulnerabilityLink) ID() string { return n.ThisID }
 func (n *certifyVulnerabilityLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.VulnerabilityID,
 		timeKey(n.TimeScanned),
@@ -55,7 +55,7 @@ func (n *certifyVulnerabilityLink) Key() string {
 		n.ScannerVersion,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *certifyVulnerabilityLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/certifyVuln_test.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln_test.go
@@ -502,14 +502,6 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 			},
 			ExpVuln: []*model.CertifyVuln{
 				{
-					Package: p2out,
-					Vulnerability: &model.Vulnerability{
-						Type:             "novuln",
-						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
-					},
-					Metadata: vmd1,
-				},
-				{
 					Package: p1out,
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
@@ -522,6 +514,14 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 					Vulnerability: &model.Vulnerability{
 						Type:             "ghsa",
 						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "novuln",
+						VulnerabilityIDs: []*model.VulnerabilityID{noVulnOut},
 					},
 					Metadata: vmd1,
 				},
@@ -701,18 +701,18 @@ func TestIngestCertifyVulns(t *testing.T) {
 			},
 			ExpVuln: []*model.CertifyVuln{
 				{
-					Package: p1out,
-					Vulnerability: &model.Vulnerability{
-						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
-					},
-					Metadata: vmd1,
-				},
-				{
 					Package: p2out,
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
 						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+					},
+					Metadata: vmd1,
+				},
+				{
+					Package: p1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
 					},
 					Metadata: vmd1,
 				},

--- a/pkg/assembler/backends/keyvalue/hasMetadata.go
+++ b/pkg/assembler/backends/keyvalue/hasMetadata.go
@@ -42,7 +42,7 @@ type hasMetadataLink struct {
 
 func (n *hasMetadataLink) ID() string { return n.ThisID }
 func (n *hasMetadataLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.ArtifactID,
 		n.SourceID,
@@ -52,7 +52,7 @@ func (n *hasMetadataLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *hasMetadataLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/hasMetadata_test.go
+++ b/pkg/assembler/backends/keyvalue/hasMetadata_test.go
@@ -243,14 +243,14 @@ func TestHasMetadata(t *testing.T) {
 			ExpHM: []*model.HasMetadata{
 				{
 					Subject:       p1out,
-					Key:           "key1",
-					Value:         "value1",
+					Key:           "key2",
+					Value:         "value2",
 					Justification: "test justification",
 				},
 				{
 					Subject:       p1out,
-					Key:           "key2",
-					Value:         "value2",
+					Key:           "key1",
+					Value:         "value1",
 					Justification: "test justification",
 				},
 			},
@@ -546,11 +546,11 @@ func TestHasMetadata(t *testing.T) {
 			},
 			ExpHM: []*model.HasMetadata{
 				{
-					Subject:       p1outName,
+					Subject:       p2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       p2out,
+					Subject:       p1outName,
 					Justification: "test justification",
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/hasSBOM.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM.go
@@ -46,7 +46,7 @@ type hasSBOMStruct struct {
 
 func (n *hasSBOMStruct) ID() string { return n.ThisID }
 func (n *hasSBOMStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Pkg,
 		n.Artifact,
 		n.URI,
@@ -59,7 +59,7 @@ func (n *hasSBOMStruct) Key() string {
 		fmt.Sprint(n.IncludedSoftware),
 		fmt.Sprint(n.IncludedDependencies),
 		fmt.Sprint(n.IncludedOccurrences),
-	}, ":")
+	}, ":"))
 }
 
 func (n *hasSBOMStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/hasSBOM_test.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM_test.go
@@ -798,11 +798,11 @@ func TestHasSBOM(t *testing.T) {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject:          p1out,
+					Subject:          p2out,
 					DownloadLocation: "location two",
 				},
 				{
-					Subject:          p2out,
+					Subject:          p1out,
 					DownloadLocation: "location two",
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/hasSLSA.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA.go
@@ -55,7 +55,7 @@ func (n *hasSLSAStruct) Key() string {
 	if n.Finish != nil {
 		fn = timeKey(*n.Finish)
 	}
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Subject,
 		fmt.Sprint(n.BuiltFrom),
 		n.BuiltBy,
@@ -66,7 +66,7 @@ func (n *hasSLSAStruct) Key() string {
 		fn,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *hasSLSAStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/hasSLSA_test.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA_test.go
@@ -299,14 +299,14 @@ func TestHasSLSA(t *testing.T) {
 					Subject: a1out,
 					Slsa: &model.Slsa{
 						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out, a3out},
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
 						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltFrom: []*model.Artifact{a2out, a3out},
 					},
 				},
 			},
@@ -683,14 +683,14 @@ func TestIngestHasSLSAs(t *testing.T) {
 					Subject: a1out,
 					Slsa: &model.Slsa{
 						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out, a3out},
+						BuiltFrom: []*model.Artifact{a2out},
 					},
 				},
 				{
 					Subject: a1out,
 					Slsa: &model.Slsa{
 						BuiltBy:   b1out,
-						BuiltFrom: []*model.Artifact{a2out},
+						BuiltFrom: []*model.Artifact{a2out, a3out},
 					},
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/hasSourceAt.go
+++ b/pkg/assembler/backends/keyvalue/hasSourceAt.go
@@ -40,14 +40,14 @@ type srcMapLink struct {
 
 func (n *srcMapLink) ID() string { return n.ThisID }
 func (n *srcMapLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.SourceID,
 		n.PackageID,
 		timeKey(n.KnownSince),
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *srcMapLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/hasSourceAt_test.go
+++ b/pkg/assembler/backends/keyvalue/hasSourceAt_test.go
@@ -437,11 +437,11 @@ func TestHasSourceAt(t *testing.T) {
 			},
 			ExpHSA: []*model.HasSourceAt{
 				{
-					Package: p1outName,
+					Package: p1out,
 					Source:  s1out,
 				},
 				{
-					Package: p1out,
+					Package: p1outName,
 					Source:  s1out,
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/hashEqual.go
+++ b/pkg/assembler/backends/keyvalue/hashEqual.go
@@ -39,12 +39,12 @@ type hashEqualStruct struct {
 
 func (n *hashEqualStruct) ID() string { return n.ThisID }
 func (n *hashEqualStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		fmt.Sprint(n.Artifacts),
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *hashEqualStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/isDependency.go
+++ b/pkg/assembler/backends/keyvalue/isDependency.go
@@ -40,7 +40,7 @@ type isDependencyLink struct {
 
 func (n *isDependencyLink) ID() string { return n.ThisID }
 func (n *isDependencyLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.DepPackageID,
 		n.VersionRange,
@@ -48,7 +48,7 @@ func (n *isDependencyLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *isDependencyLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/isOccurrence.go
+++ b/pkg/assembler/backends/keyvalue/isOccurrence.go
@@ -59,14 +59,14 @@ func (n *isOccurrenceStruct) BuildModelNode(ctx context.Context, c *demoClient) 
 }
 
 func (n *isOccurrenceStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Pkg,
 		n.Source,
 		n.Artifact,
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 // Ingest IngestOccurrences

--- a/pkg/assembler/backends/keyvalue/license.go
+++ b/pkg/assembler/backends/keyvalue/license.go
@@ -37,10 +37,10 @@ type licStruct struct {
 
 func (n *licStruct) ID() string { return n.ThisID }
 func (n *licStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Name,
 		n.ListVersion,
-	}, ":")
+	}, ":"))
 }
 
 func (n *licStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/pkg.go
+++ b/pkg/assembler/backends/keyvalue/pkg.go
@@ -310,7 +310,7 @@ func (p *pkgVersion) setCertifyLegals(ctx context.Context, id string, c *demoCli
 }
 
 func (n *pkgType) Key() string {
-	return n.Type
+	return hashKey(n.Type)
 }
 
 func (n *pkgType) addNamespace(ctx context.Context, ns string, c *demoClient) error {
@@ -319,10 +319,10 @@ func (n *pkgType) addNamespace(ctx context.Context, ns string, c *demoClient) er
 }
 
 func (n *pkgNamespace) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		n.Namespace,
-	}, ":")
+	}, ":"))
 }
 
 func (n *pkgNamespace) addName(ctx context.Context, name string, c *demoClient) error {
@@ -331,10 +331,10 @@ func (n *pkgNamespace) addName(ctx context.Context, name string, c *demoClient) 
 }
 
 func (n *pkgName) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		n.Name,
-	}, ":")
+	}, ":"))
 }
 
 func (n *pkgName) addVersion(ctx context.Context, ver string, c *demoClient) error {
@@ -343,10 +343,10 @@ func (n *pkgName) addVersion(ctx context.Context, ver string, c *demoClient) err
 }
 
 func (n *pkgVersion) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		hashVersionHelper(n.Version, n.Subpath, n.Qualifiers),
-	}, ":")
+	}, ":"))
 }
 
 // Ingest Package

--- a/pkg/assembler/backends/keyvalue/pkgEqual.go
+++ b/pkg/assembler/backends/keyvalue/pkgEqual.go
@@ -37,12 +37,12 @@ type pkgEqualStruct struct {
 
 func (n *pkgEqualStruct) ID() string { return n.ThisID }
 func (n *pkgEqualStruct) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		fmt.Sprint(n.Pkgs),
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *pkgEqualStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/pointOfContact.go
+++ b/pkg/assembler/backends/keyvalue/pointOfContact.go
@@ -43,7 +43,7 @@ type pointOfContactLink struct {
 
 func (n *pointOfContactLink) ID() string { return n.ThisID }
 func (n *pointOfContactLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.ArtifactID,
 		n.SourceID,
@@ -53,7 +53,7 @@ func (n *pointOfContactLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *pointOfContactLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/pointOfContact_test.go
+++ b/pkg/assembler/backends/keyvalue/pointOfContact_test.go
@@ -243,14 +243,14 @@ func TestPointOfContact(t *testing.T) {
 			ExpHM: []*model.PointOfContact{
 				{
 					Subject:       p1out,
-					Email:         "a@b.com",
-					Info:          "info1",
+					Email:         "x@y.com",
+					Info:          "info2",
 					Justification: "test justification",
 				},
 				{
 					Subject:       p1out,
-					Email:         "x@y.com",
-					Info:          "info2",
+					Email:         "a@b.com",
+					Info:          "info1",
 					Justification: "test justification",
 				},
 			},
@@ -490,11 +490,11 @@ func TestPointOfContact(t *testing.T) {
 			},
 			ExpHM: []*model.PointOfContact{
 				{
-					Subject:       s1out,
+					Subject:       s2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       s2out,
+					Subject:       s1out,
 					Justification: "test justification",
 				},
 			},
@@ -546,11 +546,11 @@ func TestPointOfContact(t *testing.T) {
 			},
 			ExpHM: []*model.PointOfContact{
 				{
-					Subject:       p1outName,
+					Subject:       p2out,
 					Justification: "test justification",
 				},
 				{
-					Subject:       p2out,
+					Subject:       p1outName,
 					Justification: "test justification",
 				},
 			},

--- a/pkg/assembler/backends/keyvalue/src.go
+++ b/pkg/assembler/backends/keyvalue/src.go
@@ -60,23 +60,23 @@ func (n *srcNamespace) ID() string { return n.ThisID }
 func (n *srcNameNode) ID() string  { return n.ThisID }
 
 func (n *srcType) Key() string {
-	return n.Type
+	return hashKey(n.Type)
 }
 
 func (n *srcNamespace) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		n.Namespace,
-	}, ":")
+	}, ":"))
 }
 
 func (n *srcNameNode) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		n.Name,
 		n.Tag,
 		n.Commit,
-	}, ":")
+	}, ":"))
 }
 
 func (n *srcType) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/vulnEqual.go
+++ b/pkg/assembler/backends/keyvalue/vulnEqual.go
@@ -38,12 +38,12 @@ type vulnerabilityEqualLink struct {
 
 func (n *vulnerabilityEqualLink) ID() string { return n.ThisID }
 func (n *vulnerabilityEqualLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		fmt.Sprint(n.Vulnerabilities),
 		n.Justification,
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *vulnerabilityEqualLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/vulnMetadata.go
+++ b/pkg/assembler/backends/keyvalue/vulnMetadata.go
@@ -40,14 +40,14 @@ type vulnerabilityMetadataLink struct {
 
 func (n *vulnerabilityMetadataLink) ID() string { return n.ThisID }
 func (n *vulnerabilityMetadataLink) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.VulnerabilityID,
 		string(n.ScoreType),
 		fmt.Sprint(n.ScoreValue), // TODO check that fmt.Sprint(float64) is stable for small diffs (epsilon) fmt.Sprintf("%.2f", f)
 		timeKey(n.Timestamp),
 		n.Origin,
 		n.Collector,
-	}, ":")
+	}, ":"))
 }
 
 func (n *vulnerabilityMetadataLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/vulnMetadata_test.go
+++ b/pkg/assembler/backends/keyvalue/vulnMetadata_test.go
@@ -347,10 +347,10 @@ func TestIngestVulnMetadata(t *testing.T) {
 				{
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
 					},
-					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
-					ScoreValue: 8.9,
+					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+					ScoreValue: 7.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
@@ -358,10 +358,10 @@ func TestIngestVulnMetadata(t *testing.T) {
 				{
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
 					},
-					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
-					ScoreValue: 7.9,
+					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+					ScoreValue: 8.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
@@ -455,10 +455,10 @@ func TestIngestVulnMetadata(t *testing.T) {
 				{
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
 					},
-					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
-					ScoreValue: 8.9,
+					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+					ScoreValue: 7.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
@@ -466,10 +466,10 @@ func TestIngestVulnMetadata(t *testing.T) {
 				{
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
 					},
-					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
-					ScoreValue: 7.9,
+					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+					ScoreValue: 8.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
@@ -571,22 +571,22 @@ func TestIngestVulnMetadata(t *testing.T) {
 			ExpVuln: []*model.VulnerabilityMetadata{
 				{
 					Vulnerability: &model.Vulnerability{
-						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
+						Type:             "ghsa",
+						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
 					},
 					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
-					ScoreValue: 7.9,
+					ScoreValue: 6.3,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
 				},
 				{
 					Vulnerability: &model.Vulnerability{
-						Type:             "ghsa",
-						VulnerabilityIDs: []*model.VulnerabilityID{g1out},
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
 					},
 					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
-					ScoreValue: 6.3,
+					ScoreValue: 7.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",
@@ -740,17 +740,6 @@ func TestIngestVulnMetadata(t *testing.T) {
 				{
 					Vulnerability: &model.Vulnerability{
 						Type:             "cve",
-						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
-					},
-					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
-					ScoreValue: 8.9,
-					Timestamp:  t1,
-					Collector:  "test collector",
-					Origin:     "test origin",
-				},
-				{
-					Vulnerability: &model.Vulnerability{
-						Type:             "cve",
 						VulnerabilityIDs: []*model.VulnerabilityID{c1out},
 					},
 					ScoreType:  model.VulnerabilityScoreTypeEPSSv2,
@@ -766,6 +755,17 @@ func TestIngestVulnMetadata(t *testing.T) {
 					},
 					ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
 					ScoreValue: 2.9,
+					Timestamp:  t1,
+					Collector:  "test collector",
+					Origin:     "test origin",
+				},
+				{
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{c2out},
+					},
+					ScoreType:  model.VulnerabilityScoreTypeCVSSv2,
+					ScoreValue: 8.9,
 					Timestamp:  t1,
 					Collector:  "test collector",
 					Origin:     "test origin",

--- a/pkg/assembler/backends/keyvalue/vulnerability.go
+++ b/pkg/assembler/backends/keyvalue/vulnerability.go
@@ -50,14 +50,14 @@ func (n *vulnTypeStruct) ID() string { return n.ThisID }
 func (n *vulnIDNode) ID() string     { return n.ThisID }
 
 func (n *vulnTypeStruct) Key() string {
-	return n.Type
+	return hashKey(n.Type)
 }
 
 func (n *vulnIDNode) Key() string {
-	return strings.Join([]string{
+	return hashKey(strings.Join([]string{
 		n.Parent,
 		n.VulnID,
-	}, ":")
+	}, ":"))
 }
 
 func (n *vulnTypeStruct) Neighbors(allowedEdges edgeMap) []string {


### PR DESCRIPTION
Some key-value stores (TiKV) have a size limit on keys. So just concatenating all the fields for each node will overflow it. Use a NCHF to hash the key.

The stable memmap used for test sorts on keys. Since the keys changed the expected order in some unit tests were rearranged.


# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
