### PR TITLE
nix.shell: Bump go to 1.21

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ mkShell {
     docker-compose
     jq  
     gcc
-    go_1_19
+    go_1_21
     gopls
     gotests
     goreleaser


### PR DESCRIPTION
Bumping the nix shell was missed from 7e52b359.