### PR TITLE
Remove extra read locking that will cause deadlock.

### DIFF
--- a/pkg/assembler/backends/keyvalue/path.go
+++ b/pkg/assembler/backends/keyvalue/path.go
@@ -54,8 +54,6 @@ func (c *demoClient) Neighbors(ctx context.Context, source string, usingOnly []m
 	}
 	c.m.RUnlock()
 
-	c.m.RLock()
-	defer c.m.RUnlock()
 	return c.Nodes(ctx, neighbors)
 }
 


### PR DESCRIPTION
# Description of the PR

Fixes #1561

The issue is that `Neighbors()` was wrapping its call to `Nodes()` with the read lock. `Nodes()` then calls `Node()` which does its own read lock.  This is not ok, due to:

>If a goroutine holds a RWMutex for reading and another goroutine might call Lock, no goroutine should expect to be able to acquire a read lock until the initial read lock is released. In particular, this prohibits recursive read locking. This is to ensure that the lock eventually becomes available; a blocked Lock call excludes new readers from acquiring the lock.

https://pkg.go.dev/sync#RWMutex

So any time ingestion was happening at the same time as any Neighbors queries, there was a possibility of deadlock.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
