### PR TITLE
Fix some error returns without unlocks.

### DIFF
--- a/pkg/assembler/backends/keyvalue/pkg.go
+++ b/pkg/assembler/backends/keyvalue/pkg.go
@@ -379,13 +379,16 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 		outType, err = byKeykv[*pkgType](ctx, pkgTypeCol, inType.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inType.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, pkgTypeCol, inType); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, pkgTypeCol, inType, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outType = inType
@@ -404,14 +407,21 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 		c.m.Lock()
 		outNamespace, err = byKeykv[*pkgNamespace](ctx, pkgNSCol, inNamespace.Key(), c)
 		if err != nil {
+			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
+				return nil, err
+			}
 			inNamespace.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, pkgNSCol, inNamespace); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, pkgNSCol, inNamespace, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outType.addNamespace(ctx, inNamespace.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outNamespace = inNamespace
@@ -430,14 +440,21 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 		c.m.Lock()
 		outName, err = byKeykv[*pkgName](ctx, pkgNameCol, inName.Key(), c)
 		if err != nil {
+			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
+				return nil, err
+			}
 			inName.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, pkgNameCol, inName); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, pkgNameCol, inName, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outNamespace.addName(ctx, inName.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outName = inName
@@ -458,14 +475,21 @@ func (c *demoClient) IngestPackage(ctx context.Context, input model.PkgInputSpec
 		c.m.Lock()
 		outVersion, err = byKeykv[*pkgVersion](ctx, pkgVerCol, inVersion.Key(), c)
 		if err != nil {
+			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
+				return nil, err
+			}
 			inVersion.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, pkgVerCol, inVersion); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, pkgVerCol, inVersion, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outName.addVersion(ctx, inVersion.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outVersion = inVersion

--- a/pkg/assembler/backends/keyvalue/src.go
+++ b/pkg/assembler/backends/keyvalue/src.go
@@ -211,13 +211,16 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 		outType, err = byKeykv[*srcType](ctx, srcTypeCol, inType.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inType.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, srcTypeCol, inType); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, srcTypeCol, inType, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outType = inType
@@ -240,16 +243,20 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 		outNamespace, err = byKeykv[*srcNamespace](ctx, srcNSCol, inNamespace.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inNamespace.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, srcNSCol, inNamespace); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, srcNSCol, inNamespace, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outType.addNamespace(ctx, inNamespace.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outNamespace = inNamespace
@@ -274,16 +281,20 @@ func (c *demoClient) IngestSource(ctx context.Context, input model.SourceInputSp
 		outName, err = byKeykv[*srcNameNode](ctx, srcNameCol, inName.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inName.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, srcNameCol, inName); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, srcNameCol, inName, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outNamespace.addName(ctx, inName.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outName = inName

--- a/pkg/assembler/backends/keyvalue/vulnerability.go
+++ b/pkg/assembler/backends/keyvalue/vulnerability.go
@@ -153,13 +153,16 @@ func (c *demoClient) IngestVulnerability(ctx context.Context, input model.Vulner
 		outType, err = byKeykv[*vulnTypeStruct](ctx, vulnTypeCol, inType.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inType.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, vulnTypeCol, inType); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, vulnTypeCol, inType, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outType = inType
@@ -182,16 +185,20 @@ func (c *demoClient) IngestVulnerability(ctx context.Context, input model.Vulner
 		outVulnID, err = byKeykv[*vulnIDNode](ctx, vulnIDCol, inVulnID.Key(), c)
 		if err != nil {
 			if !errors.Is(err, kv.NotFoundError) {
+				c.m.Unlock()
 				return nil, err
 			}
 			inVulnID.ThisID = c.getNextID()
 			if err := c.addToIndex(ctx, vulnIDCol, inVulnID); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := setkv(ctx, vulnIDCol, inVulnID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			if err := outType.addVulnID(ctx, inVulnID.ThisID, c); err != nil {
+				c.m.Unlock()
 				return nil, err
 			}
 			outVulnID = inVulnID


### PR DESCRIPTION
When looking at the last lock issues, I noticed some returns missing unlocks.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
