### PR TITLE
Ent: hasSBOM 'included' implementation

### DIFF
--- a/pkg/assembler/backends/ent/artifact/where.go
+++ b/pkg/assembler/backends/ent/artifact/where.go
@@ -285,6 +285,29 @@ func HasSameWith(preds ...predicate.HashEqual) predicate.Artifact {
 	})
 }
 
+// HasIncludedInSboms applies the HasEdge predicate on the "included_in_sboms" edge.
+func HasIncludedInSboms() predicate.Artifact {
+	return predicate.Artifact(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, IncludedInSbomsTable, IncludedInSbomsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedInSbomsWith applies the HasEdge predicate on the "included_in_sboms" edge with a given conditions (other predicates).
+func HasIncludedInSbomsWith(preds ...predicate.BillOfMaterials) predicate.Artifact {
+	return predicate.Artifact(func(s *sql.Selector) {
+		step := newIncludedInSbomsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Artifact) predicate.Artifact {
 	return predicate.Artifact(sql.AndPredicates(predicates...))

--- a/pkg/assembler/backends/ent/artifact_create.go
+++ b/pkg/assembler/backends/ent/artifact_create.go
@@ -97,6 +97,21 @@ func (ac *ArtifactCreate) AddSame(h ...*HashEqual) *ArtifactCreate {
 	return ac.AddSameIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (ac *ArtifactCreate) AddIncludedInSbomIDs(ids ...int) *ArtifactCreate {
+	ac.mutation.AddIncludedInSbomIDs(ids...)
+	return ac
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (ac *ArtifactCreate) AddIncludedInSboms(b ...*BillOfMaterials) *ArtifactCreate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return ac.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the ArtifactMutation object of the builder.
 func (ac *ArtifactCreate) Mutation() *ArtifactMutation {
 	return ac.mutation
@@ -229,6 +244,22 @@ func (ac *ArtifactCreate) createSpec() (*Artifact, *sqlgraph.CreateSpec) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hashequal.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := ac.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/artifact_update.go
+++ b/pkg/assembler/backends/ent/artifact_update.go
@@ -119,6 +119,21 @@ func (au *ArtifactUpdate) AddSame(h ...*HashEqual) *ArtifactUpdate {
 	return au.AddSameIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (au *ArtifactUpdate) AddIncludedInSbomIDs(ids ...int) *ArtifactUpdate {
+	au.mutation.AddIncludedInSbomIDs(ids...)
+	return au
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (au *ArtifactUpdate) AddIncludedInSboms(b ...*BillOfMaterials) *ArtifactUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return au.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the ArtifactMutation object of the builder.
 func (au *ArtifactUpdate) Mutation() *ArtifactMutation {
 	return au.mutation
@@ -206,6 +221,27 @@ func (au *ArtifactUpdate) RemoveSame(h ...*HashEqual) *ArtifactUpdate {
 		ids[i] = h[i].ID
 	}
 	return au.RemoveSameIDs(ids...)
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (au *ArtifactUpdate) ClearIncludedInSboms() *ArtifactUpdate {
+	au.mutation.ClearIncludedInSboms()
+	return au
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (au *ArtifactUpdate) RemoveIncludedInSbomIDs(ids ...int) *ArtifactUpdate {
+	au.mutation.RemoveIncludedInSbomIDs(ids...)
+	return au
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (au *ArtifactUpdate) RemoveIncludedInSboms(b ...*BillOfMaterials) *ArtifactUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return au.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -430,6 +466,51 @@ func (au *ArtifactUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if au.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := au.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !au.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := au.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, au.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{artifact.Label}
@@ -538,6 +619,21 @@ func (auo *ArtifactUpdateOne) AddSame(h ...*HashEqual) *ArtifactUpdateOne {
 	return auo.AddSameIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (auo *ArtifactUpdateOne) AddIncludedInSbomIDs(ids ...int) *ArtifactUpdateOne {
+	auo.mutation.AddIncludedInSbomIDs(ids...)
+	return auo
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (auo *ArtifactUpdateOne) AddIncludedInSboms(b ...*BillOfMaterials) *ArtifactUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return auo.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the ArtifactMutation object of the builder.
 func (auo *ArtifactUpdateOne) Mutation() *ArtifactMutation {
 	return auo.mutation
@@ -625,6 +721,27 @@ func (auo *ArtifactUpdateOne) RemoveSame(h ...*HashEqual) *ArtifactUpdateOne {
 		ids[i] = h[i].ID
 	}
 	return auo.RemoveSameIDs(ids...)
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (auo *ArtifactUpdateOne) ClearIncludedInSboms() *ArtifactUpdateOne {
+	auo.mutation.ClearIncludedInSboms()
+	return auo
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (auo *ArtifactUpdateOne) RemoveIncludedInSbomIDs(ids ...int) *ArtifactUpdateOne {
+	auo.mutation.RemoveIncludedInSbomIDs(ids...)
+	return auo
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (auo *ArtifactUpdateOne) RemoveIncludedInSboms(b ...*BillOfMaterials) *ArtifactUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return auo.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Where appends a list predicates to the ArtifactUpdate builder.
@@ -872,6 +989,51 @@ func (auo *ArtifactUpdateOne) sqlSave(ctx context.Context) (_node *Artifact, err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hashequal.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if auo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := auo.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !auo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := auo.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   artifact.IncludedInSbomsTable,
+			Columns: artifact.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -26,32 +26,301 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-func (s *Suite) Test_HasSBOM() {
+type testDependency struct {
+	pkg       *model.PkgInputSpec
+	depPkg    *model.PkgInputSpec
+	matchType model.MatchFlags
+	isDep     *model.IsDependencyInputSpec
+}
+
+type testOccurrence struct {
+	Subj  *model.PackageOrSourceInput
+	Art   *model.ArtifactInputSpec
+	isOcc *model.IsOccurrenceInputSpec
+}
+
+// Test resources
+
+var includedPackage1QualifierKey = "p1_key"
+var includedPackage1QualifierValue = "p1_value"
+
+var includedPackage1 = &model.PkgInputSpec{
+	Type:      "p1_type",
+	Namespace: ptrfrom.String("p1_namespace"),
+	Name:      "p1_name",
+	Version:   ptrfrom.String("v1.0.0-p1version"),
+	Qualifiers: []*model.PackageQualifierInputSpec{{
+		Key:   includedPackage1QualifierKey,
+		Value: includedPackage1QualifierValue,
+	}},
+	Subpath: ptrfrom.String("p1_subpath"),
+}
+
+var includedPackage2QualifierKey = "p2_key"
+var includedPackage2QualifierValue = "p2_value"
+
+var includedPackage2 = &model.PkgInputSpec{
+	Type:      "p2_type",
+	Namespace: ptrfrom.String("p2_namespace"),
+	Name:      "p2_name",
+	Version:   ptrfrom.String("v1.0.0-p2version"),
+	Qualifiers: []*model.PackageQualifierInputSpec{{
+		Key:   includedPackage2QualifierKey,
+		Value: includedPackage2QualifierValue,
+	}},
+	Subpath: ptrfrom.String("p2_subpath"),
+}
+
+var includedPackage3 = &model.PkgInputSpec{
+	Type:       "p3_type",
+	Namespace:  ptrfrom.String("p3_namespace"),
+	Name:       "p3_name",
+	Version:    ptrfrom.String("v1.0.0-p3version"),
+	Qualifiers: []*model.PackageQualifierInputSpec{},
+	Subpath:    ptrfrom.String("p3_subpath"),
+}
+
+var includedPackages = []*model.PkgInputSpec{includedPackage1, includedPackage2, includedPackage3}
+
+var includedArtifact1 = &model.ArtifactInputSpec{
+	Algorithm: "a1_algorithm",
+	Digest:    "a1_digest",
+}
+
+var includedArtifact2 = &model.ArtifactInputSpec{
+	Algorithm: "a2_algorithm",
+	Digest:    "a2_digest",
+}
+
+var includedArtifacts = []*model.ArtifactInputSpec{includedArtifact1, includedArtifact2}
+
+var includedPackageArtifacts = &model.PackageOrArtifactInputs{
+	Packages:  includedPackages,
+	Artifacts: includedArtifacts,
+}
+
+var includedDependency1 = &model.IsDependencyInputSpec{
+	VersionRange:   "dep1_range",
+	DependencyType: model.DependencyTypeDirect,
+	Justification:  "dep1_justification",
+	Origin:         "dep1_origin",
+	Collector:      "dep1_collector",
+}
+
+var includedDependency2 = &model.IsDependencyInputSpec{
+	VersionRange:   "dep2_range",
+	DependencyType: model.DependencyTypeIndirect,
+	Justification:  "dep2_justification",
+	Origin:         "dep2_origin",
+	Collector:      "dep2_collector",
+}
+
+var includedTestDependency1 = &testDependency{
+	pkg:       includedPackage1,
+	depPkg:    includedPackage2,
+	matchType: mSpecific,
+	isDep:     includedDependency1,
+}
+
+var includedTestDependency2 = &testDependency{
+	pkg:       includedPackage1,
+	depPkg:    includedPackage3,
+	matchType: mSpecific,
+	isDep:     includedDependency2,
+}
+
+var includedTestDependencies = []testDependency{*includedTestDependency1, *includedTestDependency2}
+
+var includedSource = &model.SourceInputSpec{
+	Type:      "src_type",
+	Namespace: "src_namespace",
+	Name:      "src_name",
+	Tag:       ptrfrom.String("src_tag"),
+	Commit:    ptrfrom.String("src_commit"),
+}
+
+var includedSources = []*model.SourceInputSpec{includedSource}
+
+var includedOccurrence = &model.IsOccurrenceInputSpec{
+	Justification: "occ_justification",
+	Origin:        "occ_origin",
+	Collector:     "occ_collector",
+}
+
+var includedTestOccurrences = []testOccurrence{{
+	Subj:  &model.PackageOrSourceInput{Package: includedPackage1},
+	Art:   includedArtifact1,
+	isOcc: includedOccurrence,
+}, {
+	Subj:  &model.PackageOrSourceInput{Source: includedSource},
+	Art:   includedArtifact1,
+	isOcc: includedOccurrence,
+}}
+
+var includedHasSBOM = &model.HasSBOMInputSpec{
+	URI:              "sbom_URI",
+	Algorithm:        "sbom_algorithm",
+	Digest:           "sbom_digest",
+	DownloadLocation: "sbom_download_location",
+	Origin:           "sbom_origin",
+	Collector:        "sbom_collector",
+}
+
+var includedTestExpectedPackage1 = &model.Package{
+	Type: "p1_type",
+	Namespaces: []*model.PackageNamespace{{
+		Namespace: "p1_namespace",
+		Names: []*model.PackageName{{
+			Name: "p1_name",
+			Versions: []*model.PackageVersion{{
+				Version: "v1.0.0-p1version",
+				Qualifiers: []*model.PackageQualifier{{
+					Key:   includedPackage1QualifierKey,
+					Value: includedPackage1QualifierValue,
+				}},
+				Subpath: "p1_subpath",
+			}},
+		}},
+	}},
+}
+
+var includedTestExpectedPackage2 = &model.Package{
+	Type: "p2_type",
+	Namespaces: []*model.PackageNamespace{{
+		Namespace: "p2_namespace",
+		Names: []*model.PackageName{{
+			Name: "p2_name",
+			Versions: []*model.PackageVersion{{
+				Version: "v1.0.0-p2version",
+				Qualifiers: []*model.PackageQualifier{{
+					Key:   includedPackage2QualifierKey,
+					Value: includedPackage2QualifierValue,
+				}},
+				Subpath: "p2_subpath",
+			}},
+		}},
+	}},
+}
+
+var includedTestExpectedPackage3 = &model.Package{
+	Type: "p3_type",
+	Namespaces: []*model.PackageNamespace{{
+		Namespace: "p3_namespace",
+		Names: []*model.PackageName{{
+			Name: "p3_name",
+			Versions: []*model.PackageVersion{{
+				Version:    "v1.0.0-p3version",
+				Qualifiers: []*model.PackageQualifier{},
+				Subpath:    "p3_subpath",
+			}},
+		}},
+	}},
+}
+
+var includedTestExpectedArtifact1 = &model.Artifact{
+	Algorithm: "a1_algorithm",
+	Digest:    "a1_digest",
+}
+
+var includedTestExpectedArtifact2 = &model.Artifact{
+	Algorithm: "a2_algorithm",
+	Digest:    "a2_digest",
+}
+
+var includedTestExpectedSource = &model.Source{
+	Type: "src_type",
+	Namespaces: []*model.SourceNamespace{{
+		Namespace: "src_namespace",
+		Names: []*model.SourceName{{
+			Name:   "src_name",
+			Tag:    ptrfrom.String("src_tag"),
+			Commit: ptrfrom.String("src_commit"),
+		}},
+	}},
+}
+
+var includedTestExpectedSBOM = &model.HasSbom{
+	Subject:          includedTestExpectedPackage1,
+	URI:              "sbom_URI",
+	Algorithm:        "sbom_algorithm",
+	Digest:           "sbom_digest",
+	DownloadLocation: "sbom_download_location",
+	Origin:           "sbom_origin",
+	Collector:        "sbom_collector",
+	IncludedSoftware: []model.PackageOrArtifact{
+		includedTestExpectedPackage3,
+		includedTestExpectedArtifact1,
+		includedTestExpectedArtifact2,
+		includedTestExpectedPackage1,
+		includedTestExpectedPackage2,
+	},
+	IncludedDependencies: []*model.IsDependency{{
+		Package:           includedTestExpectedPackage1,
+		DependencyPackage: includedTestExpectedPackage2,
+		VersionRange:      "dep1_range",
+		DependencyType:    model.DependencyTypeDirect,
+		Justification:     "dep1_justification",
+		Origin:            "dep1_origin",
+		Collector:         "dep1_collector",
+	}, {
+		Package:           includedTestExpectedPackage1,
+		DependencyPackage: includedTestExpectedPackage3,
+		VersionRange:      "dep2_range",
+		DependencyType:    model.DependencyTypeIndirect,
+		Justification:     "dep2_justification",
+		Origin:            "dep2_origin",
+		Collector:         "dep2_collector",
+	}},
+	IncludedOccurrences: []*model.IsOccurrence{{
+		Subject:       includedTestExpectedPackage1,
+		Artifact:      includedTestExpectedArtifact1,
+		Justification: "occ_justification",
+		Origin:        "occ_origin",
+		Collector:     "occ_collector",
+	}, {
+		Subject:       includedTestExpectedSource,
+		Artifact:      includedTestExpectedArtifact1,
+		Justification: "occ_justification",
+		Origin:        "occ_origin",
+		Collector:     "occ_collector",
+	}},
+}
+
+// End of Test resources
+
+func (s *Suite) TestHasSBOM() {
+	curTime := time.Now().UTC()
+	timeAfterOneSecond := time.UnixMicro(curTime.UnixMicro()).Add(time.Second)
 	type call struct {
-		Sub  model.PackageOrArtifactInput
-		Spec *model.HasSBOMInputSpec
-		Inc  *model.HasSBOMIncludesInputSpec
+		Sub model.PackageOrArtifactInput
+		HS  *model.HasSBOMInputSpec
 	}
 	tests := []struct {
 		Name         string
 		InPkg        []*model.PkgInputSpec
 		InArt        []*model.ArtifactInputSpec
+		PkgArt       *model.PackageOrArtifactInputs
+		InSrc        []*model.SourceInputSpec
+		IsDeps       []testDependency
+		IsOccs       []testOccurrence
 		Calls        []call
 		Query        *model.HasSBOMSpec
-		Expected     []*model.HasSbom
+		ExpHS        []*model.HasSbom
 		ExpIngestErr bool
 		ExpQueryErr  bool
-		Only         bool
 	}{
 		{
 			Name:  "HappyPath",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -59,22 +328,26 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				URI: ptrfrom.String("test uri"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri",
+					Subject:          p1out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Ingest same twice",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -82,7 +355,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -90,22 +363,26 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				URI: ptrfrom.String("test uri"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri",
+					Subject:          p1out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Query on URI",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri one",
 					},
 				},
@@ -113,7 +390,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri two",
 					},
 				},
@@ -121,10 +398,11 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				URI: ptrfrom.String("test uri one"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri one",
+					Subject:          p1out,
+					URI:              "test uri one",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
@@ -136,39 +414,64 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
-						KnownSince: time.Unix(1e9, 0),
+					HS: &model.HasSBOMInputSpec{
+						KnownSince: timeAfterOneSecond,
+					},
+				},
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: p1,
+					},
+					HS: &model.HasSBOMInputSpec{
+						KnownSince: curTime,
 					},
 				},
 			},
 			Query: &model.HasSBOMSpec{
-				KnownSince: ptrfrom.Time(time.Unix(1e9, 0)),
+				KnownSince: &timeAfterOneSecond,
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
 					Subject:    p1out,
-					KnownSince: time.Unix(1e9, 0),
+					KnownSince: timeAfterOneSecond,
 				},
 			},
 		},
 		{
 			Name:  "Query on Package",
-			InPkg: []*model.PkgInputSpec{p1, p2},
+			InPkg: []*model.PkgInputSpec{p2, p4},
 			InArt: []*model.ArtifactInputSpec{a1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages:  []*model.PkgInputSpec{p2, p4},
+				Artifacts: []*model.ArtifactInputSpec{a1},
+			},
+			IsDeps: []testDependency{{
+				pkg:       p2,
+				depPkg:    p4,
+				matchType: mSpecific,
+				isDep: &model.IsDependencyInputSpec{
+					Justification: "test justification",
+				},
+			}},
+			IsOccs: []testOccurrence{{
+				Subj:  &model.PackageOrSourceInput{Package: p4},
+				Art:   a1,
+				isOcc: &model.IsOccurrenceInputSpec{Justification: "test justification"},
+			}},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
-						Package: p1,
+						Package: p2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
 				{
 					Sub: model.PackageOrArtifactInput{
-						Package: p2,
+						Package: p4,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -176,7 +479,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Artifact: a1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -188,23 +491,39 @@ func (s *Suite) Test_HasSBOM() {
 					},
 				},
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: p2out,
-					URI:     "test uri",
+					Subject:          p2out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p2out, p4out, a1out},
+					IncludedDependencies: []*model.IsDependency{{
+						Package:           p2out,
+						DependencyPackage: p4out,
+						Justification:     "test justification",
+						DependencyType:    model.DependencyTypeUnknown,
+					}},
+					IncludedOccurrences: []*model.IsOccurrence{{
+						Subject:       p4out,
+						Artifact:      a1out,
+						Justification: "test justification",
+					}},
 				},
 			},
 		},
 		{
 			Name:  "Query on Artifact",
-			InPkg: []*model.PkgInputSpec{p1},
+			InPkg: []*model.PkgInputSpec{p2},
 			InArt: []*model.ArtifactInputSpec{a1, a2},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages:  []*model.PkgInputSpec{p2},
+				Artifacts: []*model.ArtifactInputSpec{a1, a2},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
-						Package: p1,
+						Package: p2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -212,7 +531,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Artifact: a1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -220,7 +539,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Artifact: a2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						URI: "test uri",
 					},
 				},
@@ -232,22 +551,26 @@ func (s *Suite) Test_HasSBOM() {
 					},
 				},
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: a2out,
-					URI:     "test uri",
+					Subject:          a2out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p2out, a1out, a2out},
 				},
 			},
 		},
 		{
 			Name:  "Query on Algorithm",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						Algorithm: "QWERasdf",
 					},
 				},
@@ -255,7 +578,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						Algorithm: "QWERasdf two",
 					},
 				},
@@ -263,30 +586,48 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				Algorithm: ptrfrom.String("QWERASDF"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject:   p1out,
-					Algorithm: "qwerasdf",
+					Subject:          p1out,
+					Algorithm:        "qwerasdf",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Query on Digest",
-			InPkg: []*model.PkgInputSpec{p1},
+			InPkg: []*model.PkgInputSpec{p2, p4},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages:  []*model.PkgInputSpec{p2, p4},
+				Artifacts: []*model.ArtifactInputSpec{a1},
+			},
+			IsDeps: []testDependency{{
+				pkg:       p2,
+				depPkg:    p4,
+				matchType: mSpecific,
+				isDep: &model.IsDependencyInputSpec{
+					Justification: "test justification",
+				},
+			}},
+			IsOccs: []testOccurrence{{
+				Subj:  &model.PackageOrSourceInput{Package: p4},
+				Art:   a1,
+				isOcc: &model.IsOccurrenceInputSpec{Justification: "test justification"},
+			}},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
-						Package: p1,
+						Package: p2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						Digest: "QWERasdf",
 					},
 				},
 				{
 					Sub: model.PackageOrArtifactInput{
-						Package: p1,
+						Package: p2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						Digest: "QWERasdf two",
 					},
 				},
@@ -294,22 +635,37 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				Digest: ptrfrom.String("QWERASDF"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					Digest:  "qwerasdf",
+					Subject:          p2out,
+					Digest:           "qwerasdf",
+					IncludedSoftware: []model.PackageOrArtifact{p2out, p4out, a1out},
+					IncludedDependencies: []*model.IsDependency{{
+						Package:           p2out,
+						DependencyPackage: p4out,
+						Justification:     "test justification",
+						DependencyType:    model.DependencyTypeUnknown,
+					}},
+					IncludedOccurrences: []*model.IsOccurrence{{
+						Subject:       p4out,
+						Artifact:      a1out,
+						Justification: "test justification",
+					}},
 				},
 			},
 		},
 		{
 			Name:  "Query on DownloadLocation",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
@@ -317,7 +673,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location two",
 					},
 				},
@@ -325,22 +681,26 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				DownloadLocation: ptrfrom.String("location two"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
 					Subject:          p1out,
 					DownloadLocation: "location two",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Query none",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
@@ -348,7 +708,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location two",
 					},
 				},
@@ -356,7 +716,7 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				DownloadLocation: ptrfrom.String("location three"),
 			},
-			Expected: nil,
+			ExpHS: nil,
 		},
 		{
 			Name:  "Query multiple",
@@ -366,7 +726,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
@@ -374,7 +734,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location two",
 					},
 				},
@@ -382,7 +742,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p2,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location two",
 					},
 				},
@@ -390,13 +750,13 @@ func (s *Suite) Test_HasSBOM() {
 			Query: &model.HasSBOMSpec{
 				DownloadLocation: ptrfrom.String("location two"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
-					Subject:          p1out,
+					Subject:          p2out,
 					DownloadLocation: "location two",
 				},
 				{
-					Subject:          p2out,
+					Subject:          p1out,
 					DownloadLocation: "location two",
 				},
 			},
@@ -404,12 +764,15 @@ func (s *Suite) Test_HasSBOM() {
 		{
 			Name:  "Query on ID",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
@@ -417,18 +780,19 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location two",
 					},
 				},
 			},
 			Query: &model.HasSBOMSpec{
-				ID: ptrfrom.String("1"), // 1 = p1
+				ID: ptrfrom.String("1"),
 			},
-			Expected: []*model.HasSbom{
+			ExpHS: []*model.HasSbom{
 				{
 					Subject:          p1out,
 					DownloadLocation: "location two",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
@@ -439,7 +803,7 @@ func (s *Suite) Test_HasSBOM() {
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
@@ -447,84 +811,1876 @@ func (s *Suite) Test_HasSBOM() {
 			ExpIngestErr: true,
 		},
 		{
-			Name:  "Query bad ID",
+			Name:  "Query without hasSBOMSpec",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInput{
 						Package: p1,
 					},
-					Spec: &model.HasSBOMInputSpec{
+					HS: &model.HasSBOMInputSpec{
 						DownloadLocation: "location one",
 					},
 				},
+			},
+			Query: &model.HasSBOMSpec{},
+			ExpHS: []*model.HasSbom{
 				{
-					Sub: model.PackageOrArtifactInput{
-						Package: p1,
-					},
-					Spec: &model.HasSBOMInputSpec{
-						DownloadLocation: "location two",
-					},
+					Subject:          p1out,
+					DownloadLocation: "location one",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
-			Query: &model.HasSBOMSpec{
-				ID: ptrfrom.String("badID"),
-			},
-			ExpQueryErr: true,
+		},
+		{
+			Name:   "Includeds - include without filters",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{ID: ptrfrom.String("0")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Namespace: includedPackage2.Namespace}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Namespace: ptrfrom.String("invalid_namespace")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Name: &includedPackage2.Name}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Version: includedPackage2.Version}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Version: ptrfrom.String("v1.0.0-invalid-version")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package Qualifier",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage2QualifierKey, Value: ptrfrom.String(includedPackage2QualifierValue)}}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package Qualifier Key",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: "invalid_qualifier_key", Value: ptrfrom.String(includedPackage2QualifierValue)}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Subject Package Qualifier Value",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage2QualifierKey, Value: ptrfrom.String("invalid_qualifier_value")}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Subpath: includedPackage2.Subpath}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Package: &model.PkgSpec{Subpath: ptrfrom.String("invalid_subpath")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Artifact ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{ID: ptrfrom.String("0")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Artifact ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Artifact Algorithm",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{Algorithm: &includedArtifact1.Algorithm}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Artifact Algorithm",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{Algorithm: ptrfrom.String("invalid_algorithm")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedSoftware - Valid Included Artifact Digest",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{Digest: &includedArtifact1.Digest}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedSoftware - Invalid Included Artifact Digest",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedSoftware: []*model.PackageOrArtifactSpec{{Artifact: &model.ArtifactSpec{Digest: ptrfrom.String("invalid_digest")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{ID: ptrfrom.String("0")}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{ID: ptrfrom.String("10000")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{ID: ptrfrom.String("0")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Namespace: includedPackage1.Namespace}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Namespace: ptrfrom.String("invalid_namespace")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Name: &includedPackage1.Name}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Version: includedPackage1.Version}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Version: ptrfrom.String("v1.0.0-invalid-version")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Qualifier",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage1QualifierKey, Value: ptrfrom.String(includedPackage1QualifierValue)}}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Qualifier Key",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: "invalid_qualifier_key", Value: ptrfrom.String(includedPackage1QualifierValue)}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Subject Package Qualifier Value",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage1QualifierKey, Value: ptrfrom.String("invalid_qualifier_value")}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Subpath: includedPackage1.Subpath}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Subpath: ptrfrom.String("invalid_subpath")}}}},
+			ExpHS: nil,
+		},
+
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{ID: ptrfrom.String("1")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Namespace: includedPackage2.Namespace}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Namespace: ptrfrom.String("invalid_namespace")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Name: &includedPackage2.Name}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Version: includedPackage2.Version}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Version: ptrfrom.String("v1.0.0-invalid-version")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage Qualifier",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage2QualifierKey, Value: ptrfrom.String(includedPackage2QualifierValue)}}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage Qualifier Key",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: "invalid_qualifier_key", Value: ptrfrom.String(includedPackage2QualifierValue)}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Subject DependencyPackage Qualifier Value",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage2QualifierKey, Value: ptrfrom.String("invalid_qualifier_value")}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyPackage Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Subpath: includedPackage2.Subpath}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyPackage Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyPackage: &model.PkgSpec{Subpath: ptrfrom.String("invalid_subpath")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package ID and DependencyPackage ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{ID: ptrfrom.String("0")}, DependencyPackage: &model.PkgSpec{ID: ptrfrom.String("1")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package ID and Invalid DependencyPackage ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{ID: ptrfrom.String("4")}, DependencyPackage: &model.PkgSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package ID and Valid DependencyPackage ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{ID: ptrfrom.String("10000")}, DependencyPackage: &model.PkgSpec{ID: ptrfrom.String("8")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Name and DependencyPackage Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Name: &includedPackage1.Name}, DependencyPackage: &model.PkgSpec{Name: &includedPackage2.Name}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Package Name and Invalid DependencyPackage Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Name: &includedPackage1.Name}, DependencyPackage: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Package Name and Valid DependencyPackage Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Package: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}, DependencyPackage: &model.PkgSpec{Name: &includedPackage2.Name}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included VersionRange",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{VersionRange: &includedDependency1.VersionRange}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included VersionRange",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{VersionRange: ptrfrom.String("invalid_range")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included DependencyType",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyType: &includedDependency1.DependencyType}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included DependencyType",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{DependencyType: (*model.DependencyType)(ptrfrom.String(string(model.DependencyTypeUnknown)))}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Justification",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Justification: &includedDependency1.Justification}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Justification",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Justification: ptrfrom.String("invalid_justification")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Origin",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Origin: &includedDependency1.Origin}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Origin",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Origin: ptrfrom.String("invalid_origin")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedDependencies - Valid Included Collector",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Collector: &includedDependency1.Collector}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedDependencies - Invalid Included Collector",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedDependencies: []*model.IsDependencySpec{{Collector: ptrfrom.String("invalid_collector")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{ID: ptrfrom.String("0")}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{ID: ptrfrom.String("10000")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{ID: ptrfrom.String("0")}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{ID: ptrfrom.String("10000")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Namespace: includedPackage1.Namespace}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Namespace: ptrfrom.String("invalid_namespace")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Name: ptrfrom.String("p1_name")}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Name: ptrfrom.String("invalid_name")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Version: includedPackage1.Version}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package Version",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Version: ptrfrom.String("v1.0.0-invalid-version")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package Qualifier",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage1QualifierKey, Value: ptrfrom.String(includedPackage1QualifierValue)}}}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package Qualifier Key",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: "invalid_qualifier_key", Value: ptrfrom.String(includedPackage1QualifierValue)}}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Subject Package Qualifier Value",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Qualifiers: []*model.PackageQualifierSpec{{Key: includedPackage1QualifierKey, Value: ptrfrom.String("invalid_qualifier_value")}}}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Subpath: includedPackage1.Subpath}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Package Subpath",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{Subpath: ptrfrom.String("invalid_subpath")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Source ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{ID: ptrfrom.String("0")}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{ID: ptrfrom.String("10000")}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Source",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			// TODO (knrc) - source currently needs to be an exact match, does this need to change?
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      &includedSource.Type,
+				Namespace: &includedSource.Namespace,
+				Name:      &includedSource.Name,
+				Tag:       includedSource.Tag,
+				Commit:    includedSource.Commit,
+			}}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source Type",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      ptrfrom.String("invalid_type"),
+				Namespace: &includedSource.Namespace,
+				Name:      &includedSource.Name,
+				Tag:       includedSource.Tag,
+				Commit:    includedSource.Commit,
+			}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source Namespace",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      &includedSource.Type,
+				Namespace: ptrfrom.String("invalid_namespace"),
+				Name:      &includedSource.Name,
+				Tag:       includedSource.Tag,
+				Commit:    includedSource.Commit,
+			}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source Name",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      &includedSource.Type,
+				Namespace: &includedSource.Namespace,
+				Name:      ptrfrom.String("invalid_name"),
+				Tag:       includedSource.Tag,
+				Commit:    includedSource.Commit,
+			}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source Tag",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      &includedSource.Type,
+				Namespace: &includedSource.Namespace,
+				Name:      &includedSource.Name,
+				Tag:       ptrfrom.String("invalid_tag"),
+				Commit:    includedSource.Commit,
+			}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Source Commit",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Subject: &model.PackageOrSourceSpec{Source: &model.SourceSpec{
+				Type:      &includedSource.Type,
+				Namespace: &includedSource.Namespace,
+				Name:      &includedSource.Name,
+				Tag:       includedSource.Tag,
+				Commit:    ptrfrom.String("invalid_commit"),
+			}}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Artifact ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{ID: ptrfrom.String("0")}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Artifact ID",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{ID: ptrfrom.String("10000")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Artifact Algorithm",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{Algorithm: &includedArtifact1.Algorithm}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Artifact Algorithm",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{Algorithm: ptrfrom.String("invalid_algorithm")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Artifact Digest",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{Digest: &includedArtifact1.Digest}}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Artifact Digest",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Artifact: &model.ArtifactSpec{Digest: ptrfrom.String("invalid_digest")}}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Justification",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Justification: &includedOccurrence.Justification}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Justification",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Justification: ptrfrom.String("invalid_justification")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Origin",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Origin: &includedOccurrence.Origin}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Origin",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Origin: ptrfrom.String("invalid_origin")}}},
+			ExpHS: nil,
+		},
+		{
+			Name:   "IncludedOccurrences - Valid Included Collector",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Collector: &includedOccurrence.Collector}}},
+			ExpHS: []*model.HasSbom{includedTestExpectedSBOM},
+		},
+		{
+			Name:   "IncludedOccurrences - Invalid Included Collector",
+			InPkg:  includedPackages,
+			InArt:  includedArtifacts,
+			InSrc:  includedSources,
+			PkgArt: includedPackageArtifacts,
+			IsDeps: includedTestDependencies,
+			IsOccs: includedTestOccurrences,
+			Calls: []call{{
+				Sub: model.PackageOrArtifactInput{
+					Package: includedPackage1,
+				},
+				HS: includedHasSBOM,
+			}},
+			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Collector: ptrfrom.String("invalid_collector")}}},
+			ExpHS: nil,
 		},
 	}
-
 	ctx := s.Ctx
-	hasOnly := false
-	for _, t := range tests {
-		if t.Only {
-			hasOnly = true
-			break
-		}
-	}
-
 	for _, test := range tests {
-		if hasOnly && !test.Only {
-			continue
-		}
-
 		s.Run(test.Name, func() {
 			b, err := GetBackend(s.Client)
 			if err != nil {
 				s.T().Fatalf("Could not instantiate testing backend: %v", err)
 			}
+			var pkgIDs []string
 			for _, p := range test.InPkg {
-				if _, err := b.IngestPackage(ctx, *p); err != nil {
+				if pkg, err := b.IngestPackage(ctx, *p); err != nil {
 					s.T().Fatalf("Could not ingest package: %v", err)
+				} else {
+					pkgIDs = append(pkgIDs, pkg.PackageVersionID)
 				}
 			}
+			var artifactIDs []string
 			for _, a := range test.InArt {
-				if _, err := b.IngestArtifact(ctx, a); err != nil {
+				if art, err := b.IngestArtifact(ctx, a); err != nil {
 					s.T().Fatalf("Could not ingest artifact: %v", err)
+				} else {
+					artifactIDs = append(artifactIDs, art)
+				}
+			}
+			var srcIDs []string
+			for _, src := range test.InSrc {
+				if source, err := b.IngestSource(ctx, *src); err != nil {
+					s.T().Fatalf("Could not ingest source: %v", err)
+				} else {
+					srcIDs = append(srcIDs, source.SourceNameID)
 				}
 			}
 
-			recordIDs := make([]string, len(test.Calls))
+			includes := model.HasSBOMIncludesInputSpec{}
+
+			if test.PkgArt != nil {
+				if pkgs, err := b.IngestPackages(ctx, test.PkgArt.Packages); err != nil {
+					s.T().Fatalf("Could not ingest package: %v", err)
+				} else {
+					for _, pkg := range pkgs {
+						includes.Software = append(includes.Software, pkg.PackageVersionID)
+					}
+				}
+				if arts, err := b.IngestArtifacts(ctx, test.PkgArt.Artifacts); err != nil {
+					s.T().Fatalf("Could not ingest artifact: %v", err)
+				} else {
+					includes.Software = append(includes.Software, arts...)
+				}
+			}
+
+			var depIDs []string
+			for _, dep := range test.IsDeps {
+				if isDep, err := b.IngestDependency(ctx, *dep.pkg, *dep.depPkg, dep.matchType, *dep.isDep); err != nil {
+					s.T().Fatalf("Could not ingest dependency: %v", err)
+				} else {
+					includes.Dependencies = append(includes.Dependencies, isDep)
+					depIDs = append(depIDs, isDep)
+				}
+			}
+
+			var occIDs []string
+			for _, occ := range test.IsOccs {
+				if isOcc, err := b.IngestOccurrence(ctx, *occ.Subj, *occ.Art, *occ.isOcc); err != nil {
+					s.T().Fatalf("Could not ingest occurrence: %v", err)
+				} else {
+					includes.Occurrences = append(includes.Occurrences, isOcc)
+					occIDs = append(occIDs, isOcc)
+				}
+			}
+
+			hasSbomIDs := make([]string, len(test.Calls))
 			for i, o := range test.Calls {
-				id, err := b.IngestHasSbom(ctx, o.Sub, *o.Spec, model.HasSBOMIncludesInputSpec{})
+				id, err := b.IngestHasSbom(ctx, o.Sub, *o.HS, includes)
 				if (err != nil) != test.ExpIngestErr {
 					s.T().Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
 				if err != nil {
 					return
 				}
-				recordIDs[i] = id
+				hasSbomIDs[i] = id
 			}
 
+			// Queries IDs translation into real ones
 			if test.Query.ID != nil {
 				idIdx, err := strconv.Atoi(*test.Query.ID)
 				if err == nil {
-					if idIdx >= len(recordIDs) {
-						s.T().Fatalf("ID index out of range, want: %d, got: %d", len(recordIDs), idIdx)
+					if idIdx >= len(hasSbomIDs) {
+						s.T().Fatalf("ID index out of range, want: %d, got: %d", len(hasSbomIDs), idIdx)
 					}
 
-					realID := recordIDs[idIdx]
+					realID := hasSbomIDs[idIdx]
 					test.Query.ID = &realID
+				}
+			}
+			for _, includedSw := range test.Query.IncludedSoftware {
+				if includedSw.Package != nil && includedSw.Package.ID != nil {
+					rewriteID(s.T(), includedSw.Package.ID, pkgIDs)
+				} else if includedSw.Artifact != nil && includedSw.Artifact.ID != nil {
+					rewriteID(s.T(), includedSw.Artifact.ID, artifactIDs)
+				}
+			}
+			for _, includedDep := range test.Query.IncludedDependencies {
+				if includedDep.ID != nil {
+					rewriteID(s.T(), includedDep.ID, depIDs)
+				}
+				if includedDep.Package != nil && includedDep.Package.ID != nil {
+					rewriteID(s.T(), includedDep.Package.ID, pkgIDs)
+				}
+				if includedDep.DependencyPackage != nil && includedDep.DependencyPackage.ID != nil {
+					rewriteID(s.T(), includedDep.DependencyPackage.ID, pkgIDs)
+				}
+			}
+			for _, includedOcc := range test.Query.IncludedOccurrences {
+				if includedOcc.ID != nil {
+					rewriteID(s.T(), includedOcc.ID, occIDs)
+				}
+				if includedOcc.Subject != nil {
+					if includedOcc.Subject.Package != nil && includedOcc.Subject.Package.ID != nil {
+						rewriteID(s.T(), includedOcc.Subject.Package.ID, pkgIDs)
+					} else if includedOcc.Subject.Source != nil && includedOcc.Subject.Source.ID != nil {
+						rewriteID(s.T(), includedOcc.Subject.Source.ID, srcIDs)
+					}
+				}
+				if includedOcc.Artifact != nil && includedOcc.Artifact.ID != nil {
+					rewriteID(s.T(), includedOcc.Artifact.ID, artifactIDs)
 				}
 			}
 
@@ -535,7 +2691,7 @@ func (s *Suite) Test_HasSBOM() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.Expected, got, ignoreID, ignoreEmptySlices); diff != "" {
+			if diff := cmp.Diff(test.ExpHS, got, IngestPredicatesCmpOpts...); diff != "" {
 				s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
@@ -546,12 +2702,14 @@ func (s *Suite) TestIngestHasSBOMs() {
 	type call struct {
 		Sub model.PackageOrArtifactInputs
 		HS  []*model.HasSBOMInputSpec
-		Inc []*model.HasSBOMIncludesInputSpec
 	}
 	tests := []struct {
 		Name         string
 		InPkg        []*model.PkgInputSpec
 		InArt        []*model.ArtifactInputSpec
+		PkgArt       *model.PackageOrArtifactInputs
+		IsDeps       []testDependency
+		IsOccs       []testOccurrence
 		Calls        []call
 		Query        *model.HasSBOMSpec
 		ExpHS        []*model.HasSbom
@@ -561,6 +2719,9 @@ func (s *Suite) TestIngestHasSBOMs() {
 		{
 			Name:  "HappyPath",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInputs{
@@ -578,14 +2739,18 @@ func (s *Suite) TestIngestHasSBOMs() {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri",
+					Subject:          p1out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Ingest same twice",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInputs{
@@ -606,14 +2771,18 @@ func (s *Suite) TestIngestHasSBOMs() {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri",
+					Subject:          p1out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Query on URI",
 			InPkg: []*model.PkgInputSpec{p1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.PkgInputSpec{p1},
+			},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInputs{
@@ -634,44 +2803,37 @@ func (s *Suite) TestIngestHasSBOMs() {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject: p1out,
-					URI:     "test uri one",
-				},
-			},
-		},
-		{
-			Name:  "Query on KnownSince",
-			InPkg: []*model.PkgInputSpec{p1},
-			Calls: []call{
-				{
-					Sub: model.PackageOrArtifactInputs{
-						Packages: []*model.PkgInputSpec{p1, p1},
-					},
-					HS: []*model.HasSBOMInputSpec{
-						{
-							KnownSince: time.Unix(1e9, 0),
-						},
-					},
-				},
-			},
-			Query: &model.HasSBOMSpec{
-				KnownSince: ptrfrom.Time(time.Unix(1e9, 0)),
-			},
-			ExpHS: []*model.HasSbom{
-				{
-					Subject:    p1out,
-					KnownSince: time.Unix(1e9, 0),
+					Subject:          p1out,
+					URI:              "test uri one",
+					IncludedSoftware: []model.PackageOrArtifact{p1out},
 				},
 			},
 		},
 		{
 			Name:  "Query on Package",
-			InPkg: []*model.PkgInputSpec{p1, p2},
+			InPkg: []*model.PkgInputSpec{p2, p4},
 			InArt: []*model.ArtifactInputSpec{a1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages:  []*model.PkgInputSpec{p2, p4},
+				Artifacts: []*model.ArtifactInputSpec{a1},
+			},
+			IsDeps: []testDependency{{
+				pkg:       p2,
+				depPkg:    p4,
+				matchType: mSpecific,
+				isDep: &model.IsDependencyInputSpec{
+					Justification: "test justification",
+				},
+			}},
+			IsOccs: []testOccurrence{{
+				Subj:  &model.PackageOrSourceInput{Package: p4},
+				Art:   a1,
+				isOcc: &model.IsOccurrenceInputSpec{Justification: "test justification"},
+			}},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInputs{
-						Packages: []*model.PkgInputSpec{p1, p2},
+						Packages: []*model.PkgInputSpec{p2, p4},
 					},
 					HS: []*model.HasSBOMInputSpec{
 						{
@@ -702,8 +2864,20 @@ func (s *Suite) TestIngestHasSBOMs() {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject: p2out,
-					URI:     "test uri",
+					Subject:          p2out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p2out, p4out, a1out},
+					IncludedDependencies: []*model.IsDependency{{
+						Package:           p2out,
+						DependencyPackage: p4out,
+						Justification:     "test justification",
+						DependencyType:    model.DependencyTypeUnknown,
+					}},
+					IncludedOccurrences: []*model.IsOccurrence{{
+						Subject:       p4out,
+						Artifact:      a1out,
+						Justification: "test justification",
+					}},
 				},
 			},
 		},
@@ -711,6 +2885,15 @@ func (s *Suite) TestIngestHasSBOMs() {
 			Name:  "Query on Artifact",
 			InPkg: []*model.PkgInputSpec{p1},
 			InArt: []*model.ArtifactInputSpec{a1, a2},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages:  []*model.PkgInputSpec{p1},
+				Artifacts: []*model.ArtifactInputSpec{a1, a2},
+			},
+			IsOccs: []testOccurrence{{
+				Subj:  &model.PackageOrSourceInput{Package: p1},
+				Art:   a2,
+				isOcc: &model.IsOccurrenceInputSpec{Justification: "test justification"},
+			}},
 			Calls: []call{
 				{
 					Sub: model.PackageOrArtifactInputs{
@@ -745,8 +2928,14 @@ func (s *Suite) TestIngestHasSBOMs() {
 			},
 			ExpHS: []*model.HasSbom{
 				{
-					Subject: a2out,
-					URI:     "test uri",
+					Subject:          a2out,
+					URI:              "test uri",
+					IncludedSoftware: []model.PackageOrArtifact{p1out, a1out, a2out},
+					IncludedOccurrences: []*model.IsOccurrence{{
+						Subject:       p1out,
+						Artifact:      a2out,
+						Justification: "test justification",
+					}},
 				},
 			},
 		},
@@ -754,25 +2943,59 @@ func (s *Suite) TestIngestHasSBOMs() {
 	ctx := s.Ctx
 	for _, test := range tests {
 		s.Run(test.Name, func() {
-			t := s.T()
 			b, err := GetBackend(s.Client)
 			if err != nil {
 				s.T().Fatalf("Could not instantiate testing backend: %v", err)
 			}
 			for _, p := range test.InPkg {
 				if _, err := b.IngestPackage(ctx, *p); err != nil {
-					t.Fatalf("Could not ingest package: %v", err)
+					s.T().Fatalf("Could not ingest package: %v", err)
 				}
 			}
 			for _, a := range test.InArt {
 				if _, err := b.IngestArtifact(ctx, a); err != nil {
-					t.Fatalf("Could not ingest artifact: %v", err)
+					s.T().Fatalf("Could not ingest artifact: %v", err)
+				}
+			}
+			includes := model.HasSBOMIncludesInputSpec{}
+			if test.PkgArt != nil {
+				if pkgs, err := b.IngestPackages(ctx, test.PkgArt.Packages); err != nil {
+					s.T().Fatalf("Could not ingest package: %v", err)
+				} else {
+					for _, pkg := range pkgs {
+						includes.Software = append(includes.Software, pkg.PackageVersionID)
+					}
+				}
+				if arts, err := b.IngestArtifacts(ctx, test.PkgArt.Artifacts); err != nil {
+					s.T().Fatalf("Could not ingest artifact: %v", err)
+				} else {
+					includes.Software = append(includes.Software, arts...)
+				}
+			}
+
+			for _, dep := range test.IsDeps {
+				if isDep, err := b.IngestDependency(ctx, *dep.pkg, *dep.depPkg, dep.matchType, *dep.isDep); err != nil {
+					s.T().Fatalf("Could not ingest dependency: %v", err)
+				} else {
+					includes.Dependencies = append(includes.Dependencies, isDep)
+				}
+			}
+
+			for _, occ := range test.IsOccs {
+				if isOcc, err := b.IngestOccurrence(ctx, *occ.Subj, *occ.Art, *occ.isOcc); err != nil {
+					s.T().Fatalf("Could not ingest occurrence: %v", err)
+				} else {
+					includes.Occurrences = append(includes.Occurrences, isOcc)
 				}
 			}
 			for _, o := range test.Calls {
-				_, err := b.IngestHasSBOMs(ctx, o.Sub, o.HS, nil)
+				var sbomIncludes []*model.HasSBOMIncludesInputSpec
+				for count := 0; count < len(o.HS); count++ {
+					sbomIncludes = append(sbomIncludes, &includes)
+				}
+				_, err := b.IngestHasSBOMs(ctx, o.Sub, o.HS, sbomIncludes)
 				if (err != nil) != test.ExpIngestErr {
-					t.Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
+					s.T().Fatalf("did not get expected ingest error, want: %v, got: %v", test.ExpIngestErr, err)
 				}
 				if err != nil {
 					return
@@ -780,13 +3003,13 @@ func (s *Suite) TestIngestHasSBOMs() {
 			}
 			got, err := b.HasSBOM(ctx, test.Query)
 			if (err != nil) != test.ExpQueryErr {
-				t.Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
+				s.T().Fatalf("did not get expected query error, want: %v, got: %v", test.ExpQueryErr, err)
 			}
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpHS, got, ignoreID); diff != "" {
-				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			if diff := cmp.Diff(test.ExpHS, got, IngestPredicatesCmpOpts...); diff != "" {
+				s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/assembler/backends/ent/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials.go
@@ -49,11 +49,24 @@ type BillOfMaterialsEdges struct {
 	Package *PackageVersion `json:"package,omitempty"`
 	// Artifact holds the value of the artifact edge.
 	Artifact *Artifact `json:"artifact,omitempty"`
+	// IncludedSoftwarePackages holds the value of the included_software_packages edge.
+	IncludedSoftwarePackages []*PackageVersion `json:"included_software_packages,omitempty"`
+	// IncludedSoftwareArtifacts holds the value of the included_software_artifacts edge.
+	IncludedSoftwareArtifacts []*Artifact `json:"included_software_artifacts,omitempty"`
+	// IncludedDependencies holds the value of the included_dependencies edge.
+	IncludedDependencies []*Dependency `json:"included_dependencies,omitempty"`
+	// IncludedOccurrences holds the value of the included_occurrences edge.
+	IncludedOccurrences []*Occurrence `json:"included_occurrences,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [6]bool
 	// totalCount holds the count of the edges above.
-	totalCount [2]map[string]int
+	totalCount [6]map[string]int
+
+	namedIncludedSoftwarePackages  map[string][]*PackageVersion
+	namedIncludedSoftwareArtifacts map[string][]*Artifact
+	namedIncludedDependencies      map[string][]*Dependency
+	namedIncludedOccurrences       map[string][]*Occurrence
 }
 
 // PackageOrErr returns the Package value or an error if the edge
@@ -80,6 +93,42 @@ func (e BillOfMaterialsEdges) ArtifactOrErr() (*Artifact, error) {
 		return e.Artifact, nil
 	}
 	return nil, &NotLoadedError{edge: "artifact"}
+}
+
+// IncludedSoftwarePackagesOrErr returns the IncludedSoftwarePackages value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillOfMaterialsEdges) IncludedSoftwarePackagesOrErr() ([]*PackageVersion, error) {
+	if e.loadedTypes[2] {
+		return e.IncludedSoftwarePackages, nil
+	}
+	return nil, &NotLoadedError{edge: "included_software_packages"}
+}
+
+// IncludedSoftwareArtifactsOrErr returns the IncludedSoftwareArtifacts value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillOfMaterialsEdges) IncludedSoftwareArtifactsOrErr() ([]*Artifact, error) {
+	if e.loadedTypes[3] {
+		return e.IncludedSoftwareArtifacts, nil
+	}
+	return nil, &NotLoadedError{edge: "included_software_artifacts"}
+}
+
+// IncludedDependenciesOrErr returns the IncludedDependencies value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillOfMaterialsEdges) IncludedDependenciesOrErr() ([]*Dependency, error) {
+	if e.loadedTypes[4] {
+		return e.IncludedDependencies, nil
+	}
+	return nil, &NotLoadedError{edge: "included_dependencies"}
+}
+
+// IncludedOccurrencesOrErr returns the IncludedOccurrences value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillOfMaterialsEdges) IncludedOccurrencesOrErr() ([]*Occurrence, error) {
+	if e.loadedTypes[5] {
+		return e.IncludedOccurrences, nil
+	}
+	return nil, &NotLoadedError{edge: "included_occurrences"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -193,6 +242,26 @@ func (bom *BillOfMaterials) QueryArtifact() *ArtifactQuery {
 	return NewBillOfMaterialsClient(bom.config).QueryArtifact(bom)
 }
 
+// QueryIncludedSoftwarePackages queries the "included_software_packages" edge of the BillOfMaterials entity.
+func (bom *BillOfMaterials) QueryIncludedSoftwarePackages() *PackageVersionQuery {
+	return NewBillOfMaterialsClient(bom.config).QueryIncludedSoftwarePackages(bom)
+}
+
+// QueryIncludedSoftwareArtifacts queries the "included_software_artifacts" edge of the BillOfMaterials entity.
+func (bom *BillOfMaterials) QueryIncludedSoftwareArtifacts() *ArtifactQuery {
+	return NewBillOfMaterialsClient(bom.config).QueryIncludedSoftwareArtifacts(bom)
+}
+
+// QueryIncludedDependencies queries the "included_dependencies" edge of the BillOfMaterials entity.
+func (bom *BillOfMaterials) QueryIncludedDependencies() *DependencyQuery {
+	return NewBillOfMaterialsClient(bom.config).QueryIncludedDependencies(bom)
+}
+
+// QueryIncludedOccurrences queries the "included_occurrences" edge of the BillOfMaterials entity.
+func (bom *BillOfMaterials) QueryIncludedOccurrences() *OccurrenceQuery {
+	return NewBillOfMaterialsClient(bom.config).QueryIncludedOccurrences(bom)
+}
+
 // Update returns a builder for updating this BillOfMaterials.
 // Note that you need to call BillOfMaterials.Unwrap() before calling this method if this BillOfMaterials
 // was returned from a transaction, and the transaction was committed or rolled back.
@@ -248,6 +317,102 @@ func (bom *BillOfMaterials) String() string {
 	builder.WriteString(bom.KnownSince.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// NamedIncludedSoftwarePackages returns the IncludedSoftwarePackages named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (bom *BillOfMaterials) NamedIncludedSoftwarePackages(name string) ([]*PackageVersion, error) {
+	if bom.Edges.namedIncludedSoftwarePackages == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := bom.Edges.namedIncludedSoftwarePackages[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (bom *BillOfMaterials) appendNamedIncludedSoftwarePackages(name string, edges ...*PackageVersion) {
+	if bom.Edges.namedIncludedSoftwarePackages == nil {
+		bom.Edges.namedIncludedSoftwarePackages = make(map[string][]*PackageVersion)
+	}
+	if len(edges) == 0 {
+		bom.Edges.namedIncludedSoftwarePackages[name] = []*PackageVersion{}
+	} else {
+		bom.Edges.namedIncludedSoftwarePackages[name] = append(bom.Edges.namedIncludedSoftwarePackages[name], edges...)
+	}
+}
+
+// NamedIncludedSoftwareArtifacts returns the IncludedSoftwareArtifacts named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (bom *BillOfMaterials) NamedIncludedSoftwareArtifacts(name string) ([]*Artifact, error) {
+	if bom.Edges.namedIncludedSoftwareArtifacts == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := bom.Edges.namedIncludedSoftwareArtifacts[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (bom *BillOfMaterials) appendNamedIncludedSoftwareArtifacts(name string, edges ...*Artifact) {
+	if bom.Edges.namedIncludedSoftwareArtifacts == nil {
+		bom.Edges.namedIncludedSoftwareArtifacts = make(map[string][]*Artifact)
+	}
+	if len(edges) == 0 {
+		bom.Edges.namedIncludedSoftwareArtifacts[name] = []*Artifact{}
+	} else {
+		bom.Edges.namedIncludedSoftwareArtifacts[name] = append(bom.Edges.namedIncludedSoftwareArtifacts[name], edges...)
+	}
+}
+
+// NamedIncludedDependencies returns the IncludedDependencies named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (bom *BillOfMaterials) NamedIncludedDependencies(name string) ([]*Dependency, error) {
+	if bom.Edges.namedIncludedDependencies == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := bom.Edges.namedIncludedDependencies[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (bom *BillOfMaterials) appendNamedIncludedDependencies(name string, edges ...*Dependency) {
+	if bom.Edges.namedIncludedDependencies == nil {
+		bom.Edges.namedIncludedDependencies = make(map[string][]*Dependency)
+	}
+	if len(edges) == 0 {
+		bom.Edges.namedIncludedDependencies[name] = []*Dependency{}
+	} else {
+		bom.Edges.namedIncludedDependencies[name] = append(bom.Edges.namedIncludedDependencies[name], edges...)
+	}
+}
+
+// NamedIncludedOccurrences returns the IncludedOccurrences named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (bom *BillOfMaterials) NamedIncludedOccurrences(name string) ([]*Occurrence, error) {
+	if bom.Edges.namedIncludedOccurrences == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := bom.Edges.namedIncludedOccurrences[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (bom *BillOfMaterials) appendNamedIncludedOccurrences(name string, edges ...*Occurrence) {
+	if bom.Edges.namedIncludedOccurrences == nil {
+		bom.Edges.namedIncludedOccurrences = make(map[string][]*Occurrence)
+	}
+	if len(edges) == 0 {
+		bom.Edges.namedIncludedOccurrences[name] = []*Occurrence{}
+	} else {
+		bom.Edges.namedIncludedOccurrences[name] = append(bom.Edges.namedIncludedOccurrences[name], edges...)
+	}
 }
 
 // BillOfMaterialsSlice is a parsable slice of BillOfMaterials.

--- a/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
@@ -34,6 +34,14 @@ const (
 	EdgePackage = "package"
 	// EdgeArtifact holds the string denoting the artifact edge name in mutations.
 	EdgeArtifact = "artifact"
+	// EdgeIncludedSoftwarePackages holds the string denoting the included_software_packages edge name in mutations.
+	EdgeIncludedSoftwarePackages = "included_software_packages"
+	// EdgeIncludedSoftwareArtifacts holds the string denoting the included_software_artifacts edge name in mutations.
+	EdgeIncludedSoftwareArtifacts = "included_software_artifacts"
+	// EdgeIncludedDependencies holds the string denoting the included_dependencies edge name in mutations.
+	EdgeIncludedDependencies = "included_dependencies"
+	// EdgeIncludedOccurrences holds the string denoting the included_occurrences edge name in mutations.
+	EdgeIncludedOccurrences = "included_occurrences"
 	// Table holds the table name of the billofmaterials in the database.
 	Table = "bill_of_materials"
 	// PackageTable is the table that holds the package relation/edge.
@@ -50,6 +58,26 @@ const (
 	ArtifactInverseTable = "artifacts"
 	// ArtifactColumn is the table column denoting the artifact relation/edge.
 	ArtifactColumn = "artifact_id"
+	// IncludedSoftwarePackagesTable is the table that holds the included_software_packages relation/edge. The primary key declared below.
+	IncludedSoftwarePackagesTable = "bill_of_materials_included_software_packages"
+	// IncludedSoftwarePackagesInverseTable is the table name for the PackageVersion entity.
+	// It exists in this package in order to avoid circular dependency with the "packageversion" package.
+	IncludedSoftwarePackagesInverseTable = "package_versions"
+	// IncludedSoftwareArtifactsTable is the table that holds the included_software_artifacts relation/edge. The primary key declared below.
+	IncludedSoftwareArtifactsTable = "bill_of_materials_included_software_artifacts"
+	// IncludedSoftwareArtifactsInverseTable is the table name for the Artifact entity.
+	// It exists in this package in order to avoid circular dependency with the "artifact" package.
+	IncludedSoftwareArtifactsInverseTable = "artifacts"
+	// IncludedDependenciesTable is the table that holds the included_dependencies relation/edge. The primary key declared below.
+	IncludedDependenciesTable = "bill_of_materials_included_dependencies"
+	// IncludedDependenciesInverseTable is the table name for the Dependency entity.
+	// It exists in this package in order to avoid circular dependency with the "dependency" package.
+	IncludedDependenciesInverseTable = "dependencies"
+	// IncludedOccurrencesTable is the table that holds the included_occurrences relation/edge. The primary key declared below.
+	IncludedOccurrencesTable = "bill_of_materials_included_occurrences"
+	// IncludedOccurrencesInverseTable is the table name for the Occurrence entity.
+	// It exists in this package in order to avoid circular dependency with the "occurrence" package.
+	IncludedOccurrencesInverseTable = "occurrences"
 )
 
 // Columns holds all SQL columns for billofmaterials fields.
@@ -65,6 +93,21 @@ var Columns = []string{
 	FieldCollector,
 	FieldKnownSince,
 }
+
+var (
+	// IncludedSoftwarePackagesPrimaryKey and IncludedSoftwarePackagesColumn2 are the table columns denoting the
+	// primary key for the included_software_packages relation (M2M).
+	IncludedSoftwarePackagesPrimaryKey = []string{"bill_of_materials_id", "package_version_id"}
+	// IncludedSoftwareArtifactsPrimaryKey and IncludedSoftwareArtifactsColumn2 are the table columns denoting the
+	// primary key for the included_software_artifacts relation (M2M).
+	IncludedSoftwareArtifactsPrimaryKey = []string{"bill_of_materials_id", "artifact_id"}
+	// IncludedDependenciesPrimaryKey and IncludedDependenciesColumn2 are the table columns denoting the
+	// primary key for the included_dependencies relation (M2M).
+	IncludedDependenciesPrimaryKey = []string{"bill_of_materials_id", "dependency_id"}
+	// IncludedOccurrencesPrimaryKey and IncludedOccurrencesColumn2 are the table columns denoting the
+	// primary key for the included_occurrences relation (M2M).
+	IncludedOccurrencesPrimaryKey = []string{"bill_of_materials_id", "occurrence_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -142,6 +185,62 @@ func ByArtifactField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newArtifactStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByIncludedSoftwarePackagesCount orders the results by included_software_packages count.
+func ByIncludedSoftwarePackagesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIncludedSoftwarePackagesStep(), opts...)
+	}
+}
+
+// ByIncludedSoftwarePackages orders the results by included_software_packages terms.
+func ByIncludedSoftwarePackages(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIncludedSoftwarePackagesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByIncludedSoftwareArtifactsCount orders the results by included_software_artifacts count.
+func ByIncludedSoftwareArtifactsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIncludedSoftwareArtifactsStep(), opts...)
+	}
+}
+
+// ByIncludedSoftwareArtifacts orders the results by included_software_artifacts terms.
+func ByIncludedSoftwareArtifacts(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIncludedSoftwareArtifactsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByIncludedDependenciesCount orders the results by included_dependencies count.
+func ByIncludedDependenciesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIncludedDependenciesStep(), opts...)
+	}
+}
+
+// ByIncludedDependencies orders the results by included_dependencies terms.
+func ByIncludedDependencies(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIncludedDependenciesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByIncludedOccurrencesCount orders the results by included_occurrences count.
+func ByIncludedOccurrencesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIncludedOccurrencesStep(), opts...)
+	}
+}
+
+// ByIncludedOccurrences orders the results by included_occurrences terms.
+func ByIncludedOccurrences(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIncludedOccurrencesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newPackageStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -154,5 +253,33 @@ func newArtifactStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(ArtifactInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, false, ArtifactTable, ArtifactColumn),
+	)
+}
+func newIncludedSoftwarePackagesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IncludedSoftwarePackagesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, IncludedSoftwarePackagesTable, IncludedSoftwarePackagesPrimaryKey...),
+	)
+}
+func newIncludedSoftwareArtifactsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IncludedSoftwareArtifactsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, IncludedSoftwareArtifactsTable, IncludedSoftwareArtifactsPrimaryKey...),
+	)
+}
+func newIncludedDependenciesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IncludedDependenciesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, IncludedDependenciesTable, IncludedDependenciesPrimaryKey...),
+	)
+}
+func newIncludedOccurrencesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IncludedOccurrencesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, IncludedOccurrencesTable, IncludedOccurrencesPrimaryKey...),
 	)
 }

--- a/pkg/assembler/backends/ent/billofmaterials/where.go
+++ b/pkg/assembler/backends/ent/billofmaterials/where.go
@@ -636,6 +636,98 @@ func HasArtifactWith(preds ...predicate.Artifact) predicate.BillOfMaterials {
 	})
 }
 
+// HasIncludedSoftwarePackages applies the HasEdge predicate on the "included_software_packages" edge.
+func HasIncludedSoftwarePackages() predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, IncludedSoftwarePackagesTable, IncludedSoftwarePackagesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedSoftwarePackagesWith applies the HasEdge predicate on the "included_software_packages" edge with a given conditions (other predicates).
+func HasIncludedSoftwarePackagesWith(preds ...predicate.PackageVersion) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := newIncludedSoftwarePackagesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasIncludedSoftwareArtifacts applies the HasEdge predicate on the "included_software_artifacts" edge.
+func HasIncludedSoftwareArtifacts() predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, IncludedSoftwareArtifactsTable, IncludedSoftwareArtifactsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedSoftwareArtifactsWith applies the HasEdge predicate on the "included_software_artifacts" edge with a given conditions (other predicates).
+func HasIncludedSoftwareArtifactsWith(preds ...predicate.Artifact) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := newIncludedSoftwareArtifactsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasIncludedDependencies applies the HasEdge predicate on the "included_dependencies" edge.
+func HasIncludedDependencies() predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, IncludedDependenciesTable, IncludedDependenciesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedDependenciesWith applies the HasEdge predicate on the "included_dependencies" edge with a given conditions (other predicates).
+func HasIncludedDependenciesWith(preds ...predicate.Dependency) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := newIncludedDependenciesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasIncludedOccurrences applies the HasEdge predicate on the "included_occurrences" edge.
+func HasIncludedOccurrences() predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, IncludedOccurrencesTable, IncludedOccurrencesPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedOccurrencesWith applies the HasEdge predicate on the "included_occurrences" edge with a given conditions (other predicates).
+func HasIncludedOccurrencesWith(preds ...predicate.Occurrence) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(func(s *sql.Selector) {
+		step := newIncludedOccurrencesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.BillOfMaterials) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.AndPredicates(predicates...))

--- a/pkg/assembler/backends/ent/billofmaterials_create.go
+++ b/pkg/assembler/backends/ent/billofmaterials_create.go
@@ -13,6 +13,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/billofmaterials"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/dependency"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/occurrence"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 )
 
@@ -102,6 +104,66 @@ func (bomc *BillOfMaterialsCreate) SetPackage(p *PackageVersion) *BillOfMaterial
 // SetArtifact sets the "artifact" edge to the Artifact entity.
 func (bomc *BillOfMaterialsCreate) SetArtifact(a *Artifact) *BillOfMaterialsCreate {
 	return bomc.SetArtifactID(a.ID)
+}
+
+// AddIncludedSoftwarePackageIDs adds the "included_software_packages" edge to the PackageVersion entity by IDs.
+func (bomc *BillOfMaterialsCreate) AddIncludedSoftwarePackageIDs(ids ...int) *BillOfMaterialsCreate {
+	bomc.mutation.AddIncludedSoftwarePackageIDs(ids...)
+	return bomc
+}
+
+// AddIncludedSoftwarePackages adds the "included_software_packages" edges to the PackageVersion entity.
+func (bomc *BillOfMaterialsCreate) AddIncludedSoftwarePackages(p ...*PackageVersion) *BillOfMaterialsCreate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return bomc.AddIncludedSoftwarePackageIDs(ids...)
+}
+
+// AddIncludedSoftwareArtifactIDs adds the "included_software_artifacts" edge to the Artifact entity by IDs.
+func (bomc *BillOfMaterialsCreate) AddIncludedSoftwareArtifactIDs(ids ...int) *BillOfMaterialsCreate {
+	bomc.mutation.AddIncludedSoftwareArtifactIDs(ids...)
+	return bomc
+}
+
+// AddIncludedSoftwareArtifacts adds the "included_software_artifacts" edges to the Artifact entity.
+func (bomc *BillOfMaterialsCreate) AddIncludedSoftwareArtifacts(a ...*Artifact) *BillOfMaterialsCreate {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return bomc.AddIncludedSoftwareArtifactIDs(ids...)
+}
+
+// AddIncludedDependencyIDs adds the "included_dependencies" edge to the Dependency entity by IDs.
+func (bomc *BillOfMaterialsCreate) AddIncludedDependencyIDs(ids ...int) *BillOfMaterialsCreate {
+	bomc.mutation.AddIncludedDependencyIDs(ids...)
+	return bomc
+}
+
+// AddIncludedDependencies adds the "included_dependencies" edges to the Dependency entity.
+func (bomc *BillOfMaterialsCreate) AddIncludedDependencies(d ...*Dependency) *BillOfMaterialsCreate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return bomc.AddIncludedDependencyIDs(ids...)
+}
+
+// AddIncludedOccurrenceIDs adds the "included_occurrences" edge to the Occurrence entity by IDs.
+func (bomc *BillOfMaterialsCreate) AddIncludedOccurrenceIDs(ids ...int) *BillOfMaterialsCreate {
+	bomc.mutation.AddIncludedOccurrenceIDs(ids...)
+	return bomc
+}
+
+// AddIncludedOccurrences adds the "included_occurrences" edges to the Occurrence entity.
+func (bomc *BillOfMaterialsCreate) AddIncludedOccurrences(o ...*Occurrence) *BillOfMaterialsCreate {
+	ids := make([]int, len(o))
+	for i := range o {
+		ids[i] = o[i].ID
+	}
+	return bomc.AddIncludedOccurrenceIDs(ids...)
 }
 
 // Mutation returns the BillOfMaterialsMutation object of the builder.
@@ -246,6 +308,70 @@ func (bomc *BillOfMaterialsCreate) createSpec() (*BillOfMaterials, *sqlgraph.Cre
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.ArtifactID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := bomc.mutation.IncludedSoftwarePackagesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := bomc.mutation.IncludedSoftwareArtifactsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := bomc.mutation.IncludedDependenciesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := bomc.mutation.IncludedOccurrencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/assembler/backends/ent/billofmaterials_update.go
+++ b/pkg/assembler/backends/ent/billofmaterials_update.go
@@ -13,6 +13,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/billofmaterials"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/dependency"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/occurrence"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 )
@@ -178,6 +180,66 @@ func (bomu *BillOfMaterialsUpdate) SetArtifact(a *Artifact) *BillOfMaterialsUpda
 	return bomu.SetArtifactID(a.ID)
 }
 
+// AddIncludedSoftwarePackageIDs adds the "included_software_packages" edge to the PackageVersion entity by IDs.
+func (bomu *BillOfMaterialsUpdate) AddIncludedSoftwarePackageIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.AddIncludedSoftwarePackageIDs(ids...)
+	return bomu
+}
+
+// AddIncludedSoftwarePackages adds the "included_software_packages" edges to the PackageVersion entity.
+func (bomu *BillOfMaterialsUpdate) AddIncludedSoftwarePackages(p ...*PackageVersion) *BillOfMaterialsUpdate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return bomu.AddIncludedSoftwarePackageIDs(ids...)
+}
+
+// AddIncludedSoftwareArtifactIDs adds the "included_software_artifacts" edge to the Artifact entity by IDs.
+func (bomu *BillOfMaterialsUpdate) AddIncludedSoftwareArtifactIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.AddIncludedSoftwareArtifactIDs(ids...)
+	return bomu
+}
+
+// AddIncludedSoftwareArtifacts adds the "included_software_artifacts" edges to the Artifact entity.
+func (bomu *BillOfMaterialsUpdate) AddIncludedSoftwareArtifacts(a ...*Artifact) *BillOfMaterialsUpdate {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return bomu.AddIncludedSoftwareArtifactIDs(ids...)
+}
+
+// AddIncludedDependencyIDs adds the "included_dependencies" edge to the Dependency entity by IDs.
+func (bomu *BillOfMaterialsUpdate) AddIncludedDependencyIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.AddIncludedDependencyIDs(ids...)
+	return bomu
+}
+
+// AddIncludedDependencies adds the "included_dependencies" edges to the Dependency entity.
+func (bomu *BillOfMaterialsUpdate) AddIncludedDependencies(d ...*Dependency) *BillOfMaterialsUpdate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return bomu.AddIncludedDependencyIDs(ids...)
+}
+
+// AddIncludedOccurrenceIDs adds the "included_occurrences" edge to the Occurrence entity by IDs.
+func (bomu *BillOfMaterialsUpdate) AddIncludedOccurrenceIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.AddIncludedOccurrenceIDs(ids...)
+	return bomu
+}
+
+// AddIncludedOccurrences adds the "included_occurrences" edges to the Occurrence entity.
+func (bomu *BillOfMaterialsUpdate) AddIncludedOccurrences(o ...*Occurrence) *BillOfMaterialsUpdate {
+	ids := make([]int, len(o))
+	for i := range o {
+		ids[i] = o[i].ID
+	}
+	return bomu.AddIncludedOccurrenceIDs(ids...)
+}
+
 // Mutation returns the BillOfMaterialsMutation object of the builder.
 func (bomu *BillOfMaterialsUpdate) Mutation() *BillOfMaterialsMutation {
 	return bomu.mutation
@@ -193,6 +255,90 @@ func (bomu *BillOfMaterialsUpdate) ClearPackage() *BillOfMaterialsUpdate {
 func (bomu *BillOfMaterialsUpdate) ClearArtifact() *BillOfMaterialsUpdate {
 	bomu.mutation.ClearArtifact()
 	return bomu
+}
+
+// ClearIncludedSoftwarePackages clears all "included_software_packages" edges to the PackageVersion entity.
+func (bomu *BillOfMaterialsUpdate) ClearIncludedSoftwarePackages() *BillOfMaterialsUpdate {
+	bomu.mutation.ClearIncludedSoftwarePackages()
+	return bomu
+}
+
+// RemoveIncludedSoftwarePackageIDs removes the "included_software_packages" edge to PackageVersion entities by IDs.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedSoftwarePackageIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.RemoveIncludedSoftwarePackageIDs(ids...)
+	return bomu
+}
+
+// RemoveIncludedSoftwarePackages removes "included_software_packages" edges to PackageVersion entities.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedSoftwarePackages(p ...*PackageVersion) *BillOfMaterialsUpdate {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return bomu.RemoveIncludedSoftwarePackageIDs(ids...)
+}
+
+// ClearIncludedSoftwareArtifacts clears all "included_software_artifacts" edges to the Artifact entity.
+func (bomu *BillOfMaterialsUpdate) ClearIncludedSoftwareArtifacts() *BillOfMaterialsUpdate {
+	bomu.mutation.ClearIncludedSoftwareArtifacts()
+	return bomu
+}
+
+// RemoveIncludedSoftwareArtifactIDs removes the "included_software_artifacts" edge to Artifact entities by IDs.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedSoftwareArtifactIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.RemoveIncludedSoftwareArtifactIDs(ids...)
+	return bomu
+}
+
+// RemoveIncludedSoftwareArtifacts removes "included_software_artifacts" edges to Artifact entities.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedSoftwareArtifacts(a ...*Artifact) *BillOfMaterialsUpdate {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return bomu.RemoveIncludedSoftwareArtifactIDs(ids...)
+}
+
+// ClearIncludedDependencies clears all "included_dependencies" edges to the Dependency entity.
+func (bomu *BillOfMaterialsUpdate) ClearIncludedDependencies() *BillOfMaterialsUpdate {
+	bomu.mutation.ClearIncludedDependencies()
+	return bomu
+}
+
+// RemoveIncludedDependencyIDs removes the "included_dependencies" edge to Dependency entities by IDs.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedDependencyIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.RemoveIncludedDependencyIDs(ids...)
+	return bomu
+}
+
+// RemoveIncludedDependencies removes "included_dependencies" edges to Dependency entities.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedDependencies(d ...*Dependency) *BillOfMaterialsUpdate {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return bomu.RemoveIncludedDependencyIDs(ids...)
+}
+
+// ClearIncludedOccurrences clears all "included_occurrences" edges to the Occurrence entity.
+func (bomu *BillOfMaterialsUpdate) ClearIncludedOccurrences() *BillOfMaterialsUpdate {
+	bomu.mutation.ClearIncludedOccurrences()
+	return bomu
+}
+
+// RemoveIncludedOccurrenceIDs removes the "included_occurrences" edge to Occurrence entities by IDs.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedOccurrenceIDs(ids ...int) *BillOfMaterialsUpdate {
+	bomu.mutation.RemoveIncludedOccurrenceIDs(ids...)
+	return bomu
+}
+
+// RemoveIncludedOccurrences removes "included_occurrences" edges to Occurrence entities.
+func (bomu *BillOfMaterialsUpdate) RemoveIncludedOccurrences(o ...*Occurrence) *BillOfMaterialsUpdate {
+	ids := make([]int, len(o))
+	for i := range o {
+		ids[i] = o[i].ID
+	}
+	return bomu.RemoveIncludedOccurrenceIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -303,6 +449,186 @@ func (bomu *BillOfMaterialsUpdate) sqlSave(ctx context.Context) (n int, err erro
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomu.mutation.IncludedSoftwarePackagesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.RemovedIncludedSoftwarePackagesIDs(); len(nodes) > 0 && !bomu.mutation.IncludedSoftwarePackagesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.IncludedSoftwarePackagesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomu.mutation.IncludedSoftwareArtifactsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.RemovedIncludedSoftwareArtifactsIDs(); len(nodes) > 0 && !bomu.mutation.IncludedSoftwareArtifactsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.IncludedSoftwareArtifactsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomu.mutation.IncludedDependenciesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.RemovedIncludedDependenciesIDs(); len(nodes) > 0 && !bomu.mutation.IncludedDependenciesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.IncludedDependenciesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomu.mutation.IncludedOccurrencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.RemovedIncludedOccurrencesIDs(); len(nodes) > 0 && !bomu.mutation.IncludedOccurrencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomu.mutation.IncludedOccurrencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {
@@ -478,6 +804,66 @@ func (bomuo *BillOfMaterialsUpdateOne) SetArtifact(a *Artifact) *BillOfMaterials
 	return bomuo.SetArtifactID(a.ID)
 }
 
+// AddIncludedSoftwarePackageIDs adds the "included_software_packages" edge to the PackageVersion entity by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedSoftwarePackageIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.AddIncludedSoftwarePackageIDs(ids...)
+	return bomuo
+}
+
+// AddIncludedSoftwarePackages adds the "included_software_packages" edges to the PackageVersion entity.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedSoftwarePackages(p ...*PackageVersion) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return bomuo.AddIncludedSoftwarePackageIDs(ids...)
+}
+
+// AddIncludedSoftwareArtifactIDs adds the "included_software_artifacts" edge to the Artifact entity by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedSoftwareArtifactIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.AddIncludedSoftwareArtifactIDs(ids...)
+	return bomuo
+}
+
+// AddIncludedSoftwareArtifacts adds the "included_software_artifacts" edges to the Artifact entity.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedSoftwareArtifacts(a ...*Artifact) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return bomuo.AddIncludedSoftwareArtifactIDs(ids...)
+}
+
+// AddIncludedDependencyIDs adds the "included_dependencies" edge to the Dependency entity by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedDependencyIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.AddIncludedDependencyIDs(ids...)
+	return bomuo
+}
+
+// AddIncludedDependencies adds the "included_dependencies" edges to the Dependency entity.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedDependencies(d ...*Dependency) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return bomuo.AddIncludedDependencyIDs(ids...)
+}
+
+// AddIncludedOccurrenceIDs adds the "included_occurrences" edge to the Occurrence entity by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedOccurrenceIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.AddIncludedOccurrenceIDs(ids...)
+	return bomuo
+}
+
+// AddIncludedOccurrences adds the "included_occurrences" edges to the Occurrence entity.
+func (bomuo *BillOfMaterialsUpdateOne) AddIncludedOccurrences(o ...*Occurrence) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(o))
+	for i := range o {
+		ids[i] = o[i].ID
+	}
+	return bomuo.AddIncludedOccurrenceIDs(ids...)
+}
+
 // Mutation returns the BillOfMaterialsMutation object of the builder.
 func (bomuo *BillOfMaterialsUpdateOne) Mutation() *BillOfMaterialsMutation {
 	return bomuo.mutation
@@ -493,6 +879,90 @@ func (bomuo *BillOfMaterialsUpdateOne) ClearPackage() *BillOfMaterialsUpdateOne 
 func (bomuo *BillOfMaterialsUpdateOne) ClearArtifact() *BillOfMaterialsUpdateOne {
 	bomuo.mutation.ClearArtifact()
 	return bomuo
+}
+
+// ClearIncludedSoftwarePackages clears all "included_software_packages" edges to the PackageVersion entity.
+func (bomuo *BillOfMaterialsUpdateOne) ClearIncludedSoftwarePackages() *BillOfMaterialsUpdateOne {
+	bomuo.mutation.ClearIncludedSoftwarePackages()
+	return bomuo
+}
+
+// RemoveIncludedSoftwarePackageIDs removes the "included_software_packages" edge to PackageVersion entities by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedSoftwarePackageIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.RemoveIncludedSoftwarePackageIDs(ids...)
+	return bomuo
+}
+
+// RemoveIncludedSoftwarePackages removes "included_software_packages" edges to PackageVersion entities.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedSoftwarePackages(p ...*PackageVersion) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(p))
+	for i := range p {
+		ids[i] = p[i].ID
+	}
+	return bomuo.RemoveIncludedSoftwarePackageIDs(ids...)
+}
+
+// ClearIncludedSoftwareArtifacts clears all "included_software_artifacts" edges to the Artifact entity.
+func (bomuo *BillOfMaterialsUpdateOne) ClearIncludedSoftwareArtifacts() *BillOfMaterialsUpdateOne {
+	bomuo.mutation.ClearIncludedSoftwareArtifacts()
+	return bomuo
+}
+
+// RemoveIncludedSoftwareArtifactIDs removes the "included_software_artifacts" edge to Artifact entities by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedSoftwareArtifactIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.RemoveIncludedSoftwareArtifactIDs(ids...)
+	return bomuo
+}
+
+// RemoveIncludedSoftwareArtifacts removes "included_software_artifacts" edges to Artifact entities.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedSoftwareArtifacts(a ...*Artifact) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(a))
+	for i := range a {
+		ids[i] = a[i].ID
+	}
+	return bomuo.RemoveIncludedSoftwareArtifactIDs(ids...)
+}
+
+// ClearIncludedDependencies clears all "included_dependencies" edges to the Dependency entity.
+func (bomuo *BillOfMaterialsUpdateOne) ClearIncludedDependencies() *BillOfMaterialsUpdateOne {
+	bomuo.mutation.ClearIncludedDependencies()
+	return bomuo
+}
+
+// RemoveIncludedDependencyIDs removes the "included_dependencies" edge to Dependency entities by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedDependencyIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.RemoveIncludedDependencyIDs(ids...)
+	return bomuo
+}
+
+// RemoveIncludedDependencies removes "included_dependencies" edges to Dependency entities.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedDependencies(d ...*Dependency) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(d))
+	for i := range d {
+		ids[i] = d[i].ID
+	}
+	return bomuo.RemoveIncludedDependencyIDs(ids...)
+}
+
+// ClearIncludedOccurrences clears all "included_occurrences" edges to the Occurrence entity.
+func (bomuo *BillOfMaterialsUpdateOne) ClearIncludedOccurrences() *BillOfMaterialsUpdateOne {
+	bomuo.mutation.ClearIncludedOccurrences()
+	return bomuo
+}
+
+// RemoveIncludedOccurrenceIDs removes the "included_occurrences" edge to Occurrence entities by IDs.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedOccurrenceIDs(ids ...int) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.RemoveIncludedOccurrenceIDs(ids...)
+	return bomuo
+}
+
+// RemoveIncludedOccurrences removes "included_occurrences" edges to Occurrence entities.
+func (bomuo *BillOfMaterialsUpdateOne) RemoveIncludedOccurrences(o ...*Occurrence) *BillOfMaterialsUpdateOne {
+	ids := make([]int, len(o))
+	for i := range o {
+		ids[i] = o[i].ID
+	}
+	return bomuo.RemoveIncludedOccurrenceIDs(ids...)
 }
 
 // Where appends a list predicates to the BillOfMaterialsUpdate builder.
@@ -633,6 +1103,186 @@ func (bomuo *BillOfMaterialsUpdateOne) sqlSave(ctx context.Context) (_node *Bill
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomuo.mutation.IncludedSoftwarePackagesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.RemovedIncludedSoftwarePackagesIDs(); len(nodes) > 0 && !bomuo.mutation.IncludedSoftwarePackagesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.IncludedSoftwarePackagesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwarePackagesTable,
+			Columns: billofmaterials.IncludedSoftwarePackagesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomuo.mutation.IncludedSoftwareArtifactsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.RemovedIncludedSoftwareArtifactsIDs(); len(nodes) > 0 && !bomuo.mutation.IncludedSoftwareArtifactsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.IncludedSoftwareArtifactsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedSoftwareArtifactsTable,
+			Columns: billofmaterials.IncludedSoftwareArtifactsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(artifact.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomuo.mutation.IncludedDependenciesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.RemovedIncludedDependenciesIDs(); len(nodes) > 0 && !bomuo.mutation.IncludedDependenciesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.IncludedDependenciesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedDependenciesTable,
+			Columns: billofmaterials.IncludedDependenciesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(dependency.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if bomuo.mutation.IncludedOccurrencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.RemovedIncludedOccurrencesIDs(); len(nodes) > 0 && !bomuo.mutation.IncludedOccurrencesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := bomuo.mutation.IncludedOccurrencesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   billofmaterials.IncludedOccurrencesTable,
+			Columns: billofmaterials.IncludedOccurrencesPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(occurrence.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/client.go
+++ b/pkg/assembler/backends/ent/client.go
@@ -623,6 +623,22 @@ func (c *ArtifactClient) QuerySame(a *Artifact) *HashEqualQuery {
 	return query
 }
 
+// QueryIncludedInSboms queries the included_in_sboms edge of a Artifact.
+func (c *ArtifactClient) QueryIncludedInSboms(a *Artifact) *BillOfMaterialsQuery {
+	query := (&BillOfMaterialsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := a.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(artifact.Table, artifact.FieldID, id),
+			sqlgraph.To(billofmaterials.Table, billofmaterials.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, artifact.IncludedInSbomsTable, artifact.IncludedInSbomsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(a.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *ArtifactClient) Hooks() []Hook {
 	return c.hooks.Artifact
@@ -781,6 +797,70 @@ func (c *BillOfMaterialsClient) QueryArtifact(bom *BillOfMaterials) *ArtifactQue
 			sqlgraph.From(billofmaterials.Table, billofmaterials.FieldID, id),
 			sqlgraph.To(artifact.Table, artifact.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, billofmaterials.ArtifactTable, billofmaterials.ArtifactColumn),
+		)
+		fromV = sqlgraph.Neighbors(bom.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIncludedSoftwarePackages queries the included_software_packages edge of a BillOfMaterials.
+func (c *BillOfMaterialsClient) QueryIncludedSoftwarePackages(bom *BillOfMaterials) *PackageVersionQuery {
+	query := (&PackageVersionClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := bom.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billofmaterials.Table, billofmaterials.FieldID, id),
+			sqlgraph.To(packageversion.Table, packageversion.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, billofmaterials.IncludedSoftwarePackagesTable, billofmaterials.IncludedSoftwarePackagesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(bom.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIncludedSoftwareArtifacts queries the included_software_artifacts edge of a BillOfMaterials.
+func (c *BillOfMaterialsClient) QueryIncludedSoftwareArtifacts(bom *BillOfMaterials) *ArtifactQuery {
+	query := (&ArtifactClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := bom.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billofmaterials.Table, billofmaterials.FieldID, id),
+			sqlgraph.To(artifact.Table, artifact.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, billofmaterials.IncludedSoftwareArtifactsTable, billofmaterials.IncludedSoftwareArtifactsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(bom.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIncludedDependencies queries the included_dependencies edge of a BillOfMaterials.
+func (c *BillOfMaterialsClient) QueryIncludedDependencies(bom *BillOfMaterials) *DependencyQuery {
+	query := (&DependencyClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := bom.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billofmaterials.Table, billofmaterials.FieldID, id),
+			sqlgraph.To(dependency.Table, dependency.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, billofmaterials.IncludedDependenciesTable, billofmaterials.IncludedDependenciesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(bom.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIncludedOccurrences queries the included_occurrences edge of a BillOfMaterials.
+func (c *BillOfMaterialsClient) QueryIncludedOccurrences(bom *BillOfMaterials) *OccurrenceQuery {
+	query := (&OccurrenceClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := bom.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billofmaterials.Table, billofmaterials.FieldID, id),
+			sqlgraph.To(occurrence.Table, occurrence.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, billofmaterials.IncludedOccurrencesTable, billofmaterials.IncludedOccurrencesPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(bom.driver.Dialect(), step)
 		return fromV, nil
@@ -2023,6 +2103,22 @@ func (c *DependencyClient) QueryDependentPackageVersion(d *Dependency) *PackageV
 	return query
 }
 
+// QueryIncludedInSboms queries the included_in_sboms edge of a Dependency.
+func (c *DependencyClient) QueryIncludedInSboms(d *Dependency) *BillOfMaterialsQuery {
+	query := (&BillOfMaterialsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := d.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(dependency.Table, dependency.FieldID, id),
+			sqlgraph.To(billofmaterials.Table, billofmaterials.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, dependency.IncludedInSbomsTable, dependency.IncludedInSbomsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(d.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *DependencyClient) Hooks() []Hook {
 	return c.hooks.Dependency
@@ -3061,6 +3157,22 @@ func (c *OccurrenceClient) QuerySource(o *Occurrence) *SourceNameQuery {
 	return query
 }
 
+// QueryIncludedInSboms queries the included_in_sboms edge of a Occurrence.
+func (c *OccurrenceClient) QueryIncludedInSboms(o *Occurrence) *BillOfMaterialsQuery {
+	query := (&BillOfMaterialsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := o.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(occurrence.Table, occurrence.FieldID, id),
+			sqlgraph.To(billofmaterials.Table, billofmaterials.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, occurrence.IncludedInSbomsTable, occurrence.IncludedInSbomsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(o.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *OccurrenceClient) Hooks() []Hook {
 	return c.hooks.Occurrence
@@ -3730,6 +3842,22 @@ func (c *PackageVersionClient) QueryEqualPackages(pv *PackageVersion) *PkgEqualQ
 			sqlgraph.From(packageversion.Table, packageversion.FieldID, id),
 			sqlgraph.To(pkgequal.Table, pkgequal.FieldID),
 			sqlgraph.Edge(sqlgraph.M2M, true, packageversion.EqualPackagesTable, packageversion.EqualPackagesPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(pv.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryIncludedInSboms queries the included_in_sboms edge of a PackageVersion.
+func (c *PackageVersionClient) QueryIncludedInSboms(pv *PackageVersion) *BillOfMaterialsQuery {
+	query := (&BillOfMaterialsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pv.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(packageversion.Table, packageversion.FieldID, id),
+			sqlgraph.To(billofmaterials.Table, billofmaterials.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, packageversion.IncludedInSbomsTable, packageversion.IncludedInSbomsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(pv.driver.Dialect(), step)
 		return fromV, nil

--- a/pkg/assembler/backends/ent/dependency/where.go
+++ b/pkg/assembler/backends/ent/dependency/where.go
@@ -517,6 +517,29 @@ func HasDependentPackageVersionWith(preds ...predicate.PackageVersion) predicate
 	})
 }
 
+// HasIncludedInSboms applies the HasEdge predicate on the "included_in_sboms" edge.
+func HasIncludedInSboms() predicate.Dependency {
+	return predicate.Dependency(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, IncludedInSbomsTable, IncludedInSbomsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedInSbomsWith applies the HasEdge predicate on the "included_in_sboms" edge with a given conditions (other predicates).
+func HasIncludedInSbomsWith(preds ...predicate.BillOfMaterials) predicate.Dependency {
+	return predicate.Dependency(func(s *sql.Selector) {
+		step := newIncludedInSbomsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Dependency) predicate.Dependency {
 	return predicate.Dependency(sql.AndPredicates(predicates...))

--- a/pkg/assembler/backends/ent/dependency_update.go
+++ b/pkg/assembler/backends/ent/dependency_update.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/billofmaterials"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/dependency"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagename"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
@@ -168,6 +169,21 @@ func (du *DependencyUpdate) SetDependentPackageVersion(p *PackageVersion) *Depen
 	return du.SetDependentPackageVersionID(p.ID)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (du *DependencyUpdate) AddIncludedInSbomIDs(ids ...int) *DependencyUpdate {
+	du.mutation.AddIncludedInSbomIDs(ids...)
+	return du
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (du *DependencyUpdate) AddIncludedInSboms(b ...*BillOfMaterials) *DependencyUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return du.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the DependencyMutation object of the builder.
 func (du *DependencyUpdate) Mutation() *DependencyMutation {
 	return du.mutation
@@ -189,6 +205,27 @@ func (du *DependencyUpdate) ClearDependentPackageName() *DependencyUpdate {
 func (du *DependencyUpdate) ClearDependentPackageVersion() *DependencyUpdate {
 	du.mutation.ClearDependentPackageVersion()
 	return du
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (du *DependencyUpdate) ClearIncludedInSboms() *DependencyUpdate {
+	du.mutation.ClearIncludedInSboms()
+	return du
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (du *DependencyUpdate) RemoveIncludedInSbomIDs(ids ...int) *DependencyUpdate {
+	du.mutation.RemoveIncludedInSbomIDs(ids...)
+	return du
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (du *DependencyUpdate) RemoveIncludedInSboms(b ...*BillOfMaterials) *DependencyUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return du.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -338,6 +375,51 @@ func (du *DependencyUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if du.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !du.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := du.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {
@@ -504,6 +586,21 @@ func (duo *DependencyUpdateOne) SetDependentPackageVersion(p *PackageVersion) *D
 	return duo.SetDependentPackageVersionID(p.ID)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (duo *DependencyUpdateOne) AddIncludedInSbomIDs(ids ...int) *DependencyUpdateOne {
+	duo.mutation.AddIncludedInSbomIDs(ids...)
+	return duo
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (duo *DependencyUpdateOne) AddIncludedInSboms(b ...*BillOfMaterials) *DependencyUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return duo.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the DependencyMutation object of the builder.
 func (duo *DependencyUpdateOne) Mutation() *DependencyMutation {
 	return duo.mutation
@@ -525,6 +622,27 @@ func (duo *DependencyUpdateOne) ClearDependentPackageName() *DependencyUpdateOne
 func (duo *DependencyUpdateOne) ClearDependentPackageVersion() *DependencyUpdateOne {
 	duo.mutation.ClearDependentPackageVersion()
 	return duo
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (duo *DependencyUpdateOne) ClearIncludedInSboms() *DependencyUpdateOne {
+	duo.mutation.ClearIncludedInSboms()
+	return duo
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (duo *DependencyUpdateOne) RemoveIncludedInSbomIDs(ids ...int) *DependencyUpdateOne {
+	duo.mutation.RemoveIncludedInSbomIDs(ids...)
+	return duo
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (duo *DependencyUpdateOne) RemoveIncludedInSboms(b ...*BillOfMaterials) *DependencyUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return duo.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Where appends a list predicates to the DependencyUpdate builder.
@@ -704,6 +822,51 @@ func (duo *DependencyUpdateOne) sqlSave(ctx context.Context) (_node *Dependency,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(packageversion.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if duo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !duo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := duo.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   dependency.IncludedInSbomsTable,
+			Columns: dependency.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -108,6 +108,18 @@ func (a *ArtifactQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			a.WithNamedSame(alias, func(wq *HashEqualQuery) {
 				*wq = *query
 			})
+		case "includedInSboms":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&BillOfMaterialsClient{config: a.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			a.WithNamedIncludedInSboms(alias, func(wq *BillOfMaterialsQuery) {
+				*wq = *query
+			})
 		case "algorithm":
 			if _, ok := fieldSeen[artifact.FieldAlgorithm]; !ok {
 				selectedFields = append(selectedFields, artifact.FieldAlgorithm)
@@ -205,6 +217,54 @@ func (bom *BillOfMaterialsQuery) collectField(ctx context.Context, opCtx *graphq
 				selectedFields = append(selectedFields, billofmaterials.FieldArtifactID)
 				fieldSeen[billofmaterials.FieldArtifactID] = struct{}{}
 			}
+		case "includedSoftwarePackages":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&PackageVersionClient{config: bom.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			bom.WithNamedIncludedSoftwarePackages(alias, func(wq *PackageVersionQuery) {
+				*wq = *query
+			})
+		case "includedSoftwareArtifacts":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ArtifactClient{config: bom.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			bom.WithNamedIncludedSoftwareArtifacts(alias, func(wq *ArtifactQuery) {
+				*wq = *query
+			})
+		case "includedDependencies":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&DependencyClient{config: bom.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			bom.WithNamedIncludedDependencies(alias, func(wq *DependencyQuery) {
+				*wq = *query
+			})
+		case "includedOccurrences":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&OccurrenceClient{config: bom.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			bom.WithNamedIncludedOccurrences(alias, func(wq *OccurrenceQuery) {
+				*wq = *query
+			})
 		case "packageID":
 			if _, ok := fieldSeen[billofmaterials.FieldPackageID]; !ok {
 				selectedFields = append(selectedFields, billofmaterials.FieldPackageID)
@@ -1133,6 +1193,18 @@ func (d *DependencyQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				selectedFields = append(selectedFields, dependency.FieldDependentPackageVersionID)
 				fieldSeen[dependency.FieldDependentPackageVersionID] = struct{}{}
 			}
+		case "includedInSboms":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&BillOfMaterialsClient{config: d.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			d.WithNamedIncludedInSboms(alias, func(wq *BillOfMaterialsQuery) {
+				*wq = *query
+			})
 		case "packageID":
 			if _, ok := fieldSeen[dependency.FieldPackageID]; !ok {
 				selectedFields = append(selectedFields, dependency.FieldPackageID)
@@ -1871,6 +1943,18 @@ func (o *OccurrenceQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				selectedFields = append(selectedFields, occurrence.FieldSourceID)
 				fieldSeen[occurrence.FieldSourceID] = struct{}{}
 			}
+		case "includedInSboms":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&BillOfMaterialsClient{config: o.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			o.WithNamedIncludedInSboms(alias, func(wq *BillOfMaterialsQuery) {
+				*wq = *query
+			})
 		case "artifactID":
 			if _, ok := fieldSeen[occurrence.FieldArtifactID]; !ok {
 				selectedFields = append(selectedFields, occurrence.FieldArtifactID)
@@ -2274,6 +2358,18 @@ func (pv *PackageVersionQuery) collectField(ctx context.Context, opCtx *graphql.
 				return err
 			}
 			pv.WithNamedEqualPackages(alias, func(wq *PkgEqualQuery) {
+				*wq = *query
+			})
+		case "includedInSboms":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&BillOfMaterialsClient{config: pv.config}).Query()
+			)
+			if err := query.collectField(ctx, opCtx, field, path, satisfies...); err != nil {
+				return err
+			}
+			pv.WithNamedIncludedInSboms(alias, func(wq *BillOfMaterialsQuery) {
 				*wq = *query
 			})
 		case "nameID":

--- a/pkg/assembler/backends/ent/gql_edge.go
+++ b/pkg/assembler/backends/ent/gql_edge.go
@@ -56,6 +56,18 @@ func (a *Artifact) Same(ctx context.Context) (result []*HashEqual, err error) {
 	return result, err
 }
 
+func (a *Artifact) IncludedInSboms(ctx context.Context) (result []*BillOfMaterials, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = a.NamedIncludedInSboms(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = a.Edges.IncludedInSbomsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = a.QueryIncludedInSboms().All(ctx)
+	}
+	return result, err
+}
+
 func (bom *BillOfMaterials) Package(ctx context.Context) (*PackageVersion, error) {
 	result, err := bom.Edges.PackageOrErr()
 	if IsNotLoaded(err) {
@@ -70,6 +82,54 @@ func (bom *BillOfMaterials) Artifact(ctx context.Context) (*Artifact, error) {
 		result, err = bom.QueryArtifact().Only(ctx)
 	}
 	return result, MaskNotFound(err)
+}
+
+func (bom *BillOfMaterials) IncludedSoftwarePackages(ctx context.Context) (result []*PackageVersion, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = bom.NamedIncludedSoftwarePackages(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = bom.Edges.IncludedSoftwarePackagesOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = bom.QueryIncludedSoftwarePackages().All(ctx)
+	}
+	return result, err
+}
+
+func (bom *BillOfMaterials) IncludedSoftwareArtifacts(ctx context.Context) (result []*Artifact, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = bom.NamedIncludedSoftwareArtifacts(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = bom.Edges.IncludedSoftwareArtifactsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = bom.QueryIncludedSoftwareArtifacts().All(ctx)
+	}
+	return result, err
+}
+
+func (bom *BillOfMaterials) IncludedDependencies(ctx context.Context) (result []*Dependency, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = bom.NamedIncludedDependencies(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = bom.Edges.IncludedDependenciesOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = bom.QueryIncludedDependencies().All(ctx)
+	}
+	return result, err
+}
+
+func (bom *BillOfMaterials) IncludedOccurrences(ctx context.Context) (result []*Occurrence, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = bom.NamedIncludedOccurrences(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = bom.Edges.IncludedOccurrencesOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = bom.QueryIncludedOccurrences().All(ctx)
+	}
+	return result, err
 }
 
 func (b *Builder) SlsaAttestations(ctx context.Context) (result []*SLSAAttestation, err error) {
@@ -236,6 +296,18 @@ func (d *Dependency) DependentPackageVersion(ctx context.Context) (*PackageVersi
 	return result, MaskNotFound(err)
 }
 
+func (d *Dependency) IncludedInSboms(ctx context.Context) (result []*BillOfMaterials, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = d.NamedIncludedInSboms(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = d.Edges.IncludedInSbomsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = d.QueryIncludedInSboms().All(ctx)
+	}
+	return result, err
+}
+
 func (hm *HasMetadata) Source(ctx context.Context) (*SourceName, error) {
 	result, err := hm.Edges.SourceOrErr()
 	if IsNotLoaded(err) {
@@ -368,6 +440,18 @@ func (o *Occurrence) Source(ctx context.Context) (*SourceName, error) {
 	return result, MaskNotFound(err)
 }
 
+func (o *Occurrence) IncludedInSboms(ctx context.Context) (result []*BillOfMaterials, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = o.NamedIncludedInSboms(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = o.Edges.IncludedInSbomsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = o.QueryIncludedInSboms().All(ctx)
+	}
+	return result, err
+}
+
 func (pn *PackageName) Namespace(ctx context.Context) (*PackageNamespace, error) {
 	result, err := pn.Edges.NamespaceOrErr()
 	if IsNotLoaded(err) {
@@ -460,6 +544,18 @@ func (pv *PackageVersion) EqualPackages(ctx context.Context) (result []*PkgEqual
 	}
 	if IsNotLoaded(err) {
 		result, err = pv.QueryEqualPackages().All(ctx)
+	}
+	return result, err
+}
+
+func (pv *PackageVersion) IncludedInSboms(ctx context.Context) (result []*BillOfMaterials, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = pv.NamedIncludedInSboms(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = pv.Edges.IncludedInSbomsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = pv.QueryIncludedInSboms().All(ctx)
 	}
 	return result, err
 }

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -1145,6 +1145,106 @@ var (
 			},
 		},
 	}
+	// BillOfMaterialsIncludedSoftwarePackagesColumns holds the columns for the "bill_of_materials_included_software_packages" table.
+	BillOfMaterialsIncludedSoftwarePackagesColumns = []*schema.Column{
+		{Name: "bill_of_materials_id", Type: field.TypeInt},
+		{Name: "package_version_id", Type: field.TypeInt},
+	}
+	// BillOfMaterialsIncludedSoftwarePackagesTable holds the schema information for the "bill_of_materials_included_software_packages" table.
+	BillOfMaterialsIncludedSoftwarePackagesTable = &schema.Table{
+		Name:       "bill_of_materials_included_software_packages",
+		Columns:    BillOfMaterialsIncludedSoftwarePackagesColumns,
+		PrimaryKey: []*schema.Column{BillOfMaterialsIncludedSoftwarePackagesColumns[0], BillOfMaterialsIncludedSoftwarePackagesColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "bill_of_materials_included_software_packages_bill_of_materials_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedSoftwarePackagesColumns[0]},
+				RefColumns: []*schema.Column{BillOfMaterialsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "bill_of_materials_included_software_packages_package_version_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedSoftwarePackagesColumns[1]},
+				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// BillOfMaterialsIncludedSoftwareArtifactsColumns holds the columns for the "bill_of_materials_included_software_artifacts" table.
+	BillOfMaterialsIncludedSoftwareArtifactsColumns = []*schema.Column{
+		{Name: "bill_of_materials_id", Type: field.TypeInt},
+		{Name: "artifact_id", Type: field.TypeInt},
+	}
+	// BillOfMaterialsIncludedSoftwareArtifactsTable holds the schema information for the "bill_of_materials_included_software_artifacts" table.
+	BillOfMaterialsIncludedSoftwareArtifactsTable = &schema.Table{
+		Name:       "bill_of_materials_included_software_artifacts",
+		Columns:    BillOfMaterialsIncludedSoftwareArtifactsColumns,
+		PrimaryKey: []*schema.Column{BillOfMaterialsIncludedSoftwareArtifactsColumns[0], BillOfMaterialsIncludedSoftwareArtifactsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "bill_of_materials_included_software_artifacts_bill_of_materials_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedSoftwareArtifactsColumns[0]},
+				RefColumns: []*schema.Column{BillOfMaterialsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "bill_of_materials_included_software_artifacts_artifact_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedSoftwareArtifactsColumns[1]},
+				RefColumns: []*schema.Column{ArtifactsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// BillOfMaterialsIncludedDependenciesColumns holds the columns for the "bill_of_materials_included_dependencies" table.
+	BillOfMaterialsIncludedDependenciesColumns = []*schema.Column{
+		{Name: "bill_of_materials_id", Type: field.TypeInt},
+		{Name: "dependency_id", Type: field.TypeInt},
+	}
+	// BillOfMaterialsIncludedDependenciesTable holds the schema information for the "bill_of_materials_included_dependencies" table.
+	BillOfMaterialsIncludedDependenciesTable = &schema.Table{
+		Name:       "bill_of_materials_included_dependencies",
+		Columns:    BillOfMaterialsIncludedDependenciesColumns,
+		PrimaryKey: []*schema.Column{BillOfMaterialsIncludedDependenciesColumns[0], BillOfMaterialsIncludedDependenciesColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "bill_of_materials_included_dependencies_bill_of_materials_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedDependenciesColumns[0]},
+				RefColumns: []*schema.Column{BillOfMaterialsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "bill_of_materials_included_dependencies_dependency_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedDependenciesColumns[1]},
+				RefColumns: []*schema.Column{DependenciesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// BillOfMaterialsIncludedOccurrencesColumns holds the columns for the "bill_of_materials_included_occurrences" table.
+	BillOfMaterialsIncludedOccurrencesColumns = []*schema.Column{
+		{Name: "bill_of_materials_id", Type: field.TypeInt},
+		{Name: "occurrence_id", Type: field.TypeInt},
+	}
+	// BillOfMaterialsIncludedOccurrencesTable holds the schema information for the "bill_of_materials_included_occurrences" table.
+	BillOfMaterialsIncludedOccurrencesTable = &schema.Table{
+		Name:       "bill_of_materials_included_occurrences",
+		Columns:    BillOfMaterialsIncludedOccurrencesColumns,
+		PrimaryKey: []*schema.Column{BillOfMaterialsIncludedOccurrencesColumns[0], BillOfMaterialsIncludedOccurrencesColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "bill_of_materials_included_occurrences_bill_of_materials_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedOccurrencesColumns[0]},
+				RefColumns: []*schema.Column{BillOfMaterialsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "bill_of_materials_included_occurrences_occurrence_id",
+				Columns:    []*schema.Column{BillOfMaterialsIncludedOccurrencesColumns[1]},
+				RefColumns: []*schema.Column{OccurrencesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// CertifyLegalDeclaredLicensesColumns holds the columns for the "certify_legal_declared_licenses" table.
 	CertifyLegalDeclaredLicensesColumns = []*schema.Column{
 		{Name: "certify_legal_id", Type: field.TypeInt},
@@ -1327,6 +1427,10 @@ var (
 		VulnerabilityIdsTable,
 		VulnerabilityMetadataTable,
 		VulnerabilityTypesTable,
+		BillOfMaterialsIncludedSoftwarePackagesTable,
+		BillOfMaterialsIncludedSoftwareArtifactsTable,
+		BillOfMaterialsIncludedDependenciesTable,
+		BillOfMaterialsIncludedOccurrencesTable,
 		CertifyLegalDeclaredLicensesTable,
 		CertifyLegalDiscoveredLicensesTable,
 		HashEqualArtifactsTable,
@@ -1383,6 +1487,14 @@ func init() {
 	SourceNamespacesTable.ForeignKeys[0].RefTable = SourceTypesTable
 	VulnerabilityIdsTable.ForeignKeys[0].RefTable = VulnerabilityTypesTable
 	VulnerabilityMetadataTable.ForeignKeys[0].RefTable = VulnerabilityIdsTable
+	BillOfMaterialsIncludedSoftwarePackagesTable.ForeignKeys[0].RefTable = BillOfMaterialsTable
+	BillOfMaterialsIncludedSoftwarePackagesTable.ForeignKeys[1].RefTable = PackageVersionsTable
+	BillOfMaterialsIncludedSoftwareArtifactsTable.ForeignKeys[0].RefTable = BillOfMaterialsTable
+	BillOfMaterialsIncludedSoftwareArtifactsTable.ForeignKeys[1].RefTable = ArtifactsTable
+	BillOfMaterialsIncludedDependenciesTable.ForeignKeys[0].RefTable = BillOfMaterialsTable
+	BillOfMaterialsIncludedDependenciesTable.ForeignKeys[1].RefTable = DependenciesTable
+	BillOfMaterialsIncludedOccurrencesTable.ForeignKeys[0].RefTable = BillOfMaterialsTable
+	BillOfMaterialsIncludedOccurrencesTable.ForeignKeys[1].RefTable = OccurrencesTable
 	CertifyLegalDeclaredLicensesTable.ForeignKeys[0].RefTable = CertifyLegalsTable
 	CertifyLegalDeclaredLicensesTable.ForeignKeys[1].RefTable = LicensesTable
 	CertifyLegalDiscoveredLicensesTable.ForeignKeys[0].RefTable = CertifyLegalsTable

--- a/pkg/assembler/backends/ent/occurrence/where.go
+++ b/pkg/assembler/backends/ent/occurrence/where.go
@@ -427,6 +427,29 @@ func HasSourceWith(preds ...predicate.SourceName) predicate.Occurrence {
 	})
 }
 
+// HasIncludedInSboms applies the HasEdge predicate on the "included_in_sboms" edge.
+func HasIncludedInSboms() predicate.Occurrence {
+	return predicate.Occurrence(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, IncludedInSbomsTable, IncludedInSbomsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedInSbomsWith applies the HasEdge predicate on the "included_in_sboms" edge with a given conditions (other predicates).
+func HasIncludedInSbomsWith(preds ...predicate.BillOfMaterials) predicate.Occurrence {
+	return predicate.Occurrence(func(s *sql.Selector) {
+		step := newIncludedInSbomsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Occurrence) predicate.Occurrence {
 	return predicate.Occurrence(sql.AndPredicates(predicates...))

--- a/pkg/assembler/backends/ent/occurrence_update.go
+++ b/pkg/assembler/backends/ent/occurrence_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/billofmaterials"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/occurrence"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
@@ -141,6 +142,21 @@ func (ou *OccurrenceUpdate) SetSource(s *SourceName) *OccurrenceUpdate {
 	return ou.SetSourceID(s.ID)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (ou *OccurrenceUpdate) AddIncludedInSbomIDs(ids ...int) *OccurrenceUpdate {
+	ou.mutation.AddIncludedInSbomIDs(ids...)
+	return ou
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (ou *OccurrenceUpdate) AddIncludedInSboms(b ...*BillOfMaterials) *OccurrenceUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return ou.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the OccurrenceMutation object of the builder.
 func (ou *OccurrenceUpdate) Mutation() *OccurrenceMutation {
 	return ou.mutation
@@ -162,6 +178,27 @@ func (ou *OccurrenceUpdate) ClearPackage() *OccurrenceUpdate {
 func (ou *OccurrenceUpdate) ClearSource() *OccurrenceUpdate {
 	ou.mutation.ClearSource()
 	return ou
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (ou *OccurrenceUpdate) ClearIncludedInSboms() *OccurrenceUpdate {
+	ou.mutation.ClearIncludedInSboms()
+	return ou
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (ou *OccurrenceUpdate) RemoveIncludedInSbomIDs(ids ...int) *OccurrenceUpdate {
+	ou.mutation.RemoveIncludedInSbomIDs(ids...)
+	return ou
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (ou *OccurrenceUpdate) RemoveIncludedInSboms(b ...*BillOfMaterials) *OccurrenceUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return ou.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -307,6 +344,51 @@ func (ou *OccurrenceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if ou.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ou.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !ou.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ou.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, ou.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{occurrence.Label}
@@ -438,6 +520,21 @@ func (ouo *OccurrenceUpdateOne) SetSource(s *SourceName) *OccurrenceUpdateOne {
 	return ouo.SetSourceID(s.ID)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (ouo *OccurrenceUpdateOne) AddIncludedInSbomIDs(ids ...int) *OccurrenceUpdateOne {
+	ouo.mutation.AddIncludedInSbomIDs(ids...)
+	return ouo
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (ouo *OccurrenceUpdateOne) AddIncludedInSboms(b ...*BillOfMaterials) *OccurrenceUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return ouo.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the OccurrenceMutation object of the builder.
 func (ouo *OccurrenceUpdateOne) Mutation() *OccurrenceMutation {
 	return ouo.mutation
@@ -459,6 +556,27 @@ func (ouo *OccurrenceUpdateOne) ClearPackage() *OccurrenceUpdateOne {
 func (ouo *OccurrenceUpdateOne) ClearSource() *OccurrenceUpdateOne {
 	ouo.mutation.ClearSource()
 	return ouo
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (ouo *OccurrenceUpdateOne) ClearIncludedInSboms() *OccurrenceUpdateOne {
+	ouo.mutation.ClearIncludedInSboms()
+	return ouo
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (ouo *OccurrenceUpdateOne) RemoveIncludedInSbomIDs(ids ...int) *OccurrenceUpdateOne {
+	ouo.mutation.RemoveIncludedInSbomIDs(ids...)
+	return ouo
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (ouo *OccurrenceUpdateOne) RemoveIncludedInSboms(b ...*BillOfMaterials) *OccurrenceUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return ouo.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Where appends a list predicates to the OccurrenceUpdate builder.
@@ -627,6 +745,51 @@ func (ouo *OccurrenceUpdateOne) sqlSave(ctx context.Context) (_node *Occurrence,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(sourcename.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ouo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ouo.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !ouo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ouo.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   occurrence.IncludedInSbomsTable,
+			Columns: occurrence.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/packageversion/packageversion.go
+++ b/pkg/assembler/backends/ent/packageversion/packageversion.go
@@ -30,6 +30,8 @@ const (
 	EdgeSbom = "sbom"
 	// EdgeEqualPackages holds the string denoting the equal_packages edge name in mutations.
 	EdgeEqualPackages = "equal_packages"
+	// EdgeIncludedInSboms holds the string denoting the included_in_sboms edge name in mutations.
+	EdgeIncludedInSboms = "included_in_sboms"
 	// Table holds the table name of the packageversion in the database.
 	Table = "package_versions"
 	// NameTable is the table that holds the name relation/edge.
@@ -58,6 +60,11 @@ const (
 	// EqualPackagesInverseTable is the table name for the PkgEqual entity.
 	// It exists in this package in order to avoid circular dependency with the "pkgequal" package.
 	EqualPackagesInverseTable = "pkg_equals"
+	// IncludedInSbomsTable is the table that holds the included_in_sboms relation/edge. The primary key declared below.
+	IncludedInSbomsTable = "bill_of_materials_included_software_packages"
+	// IncludedInSbomsInverseTable is the table name for the BillOfMaterials entity.
+	// It exists in this package in order to avoid circular dependency with the "billofmaterials" package.
+	IncludedInSbomsInverseTable = "bill_of_materials"
 )
 
 // Columns holds all SQL columns for packageversion fields.
@@ -74,6 +81,9 @@ var (
 	// EqualPackagesPrimaryKey and EqualPackagesColumn2 are the table columns denoting the
 	// primary key for the equal_packages relation (M2M).
 	EqualPackagesPrimaryKey = []string{"pkg_equal_id", "package_version_id"}
+	// IncludedInSbomsPrimaryKey and IncludedInSbomsColumn2 are the table columns denoting the
+	// primary key for the included_in_sboms relation (M2M).
+	IncludedInSbomsPrimaryKey = []string{"bill_of_materials_id", "package_version_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -169,6 +179,20 @@ func ByEqualPackages(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newEqualPackagesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
+
+// ByIncludedInSbomsCount orders the results by included_in_sboms count.
+func ByIncludedInSbomsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newIncludedInSbomsStep(), opts...)
+	}
+}
+
+// ByIncludedInSboms orders the results by included_in_sboms terms.
+func ByIncludedInSboms(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newIncludedInSbomsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newNameStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -195,5 +219,12 @@ func newEqualPackagesStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(EqualPackagesInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2M, true, EqualPackagesTable, EqualPackagesPrimaryKey...),
+	)
+}
+func newIncludedInSbomsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(IncludedInSbomsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, IncludedInSbomsTable, IncludedInSbomsPrimaryKey...),
 	)
 }

--- a/pkg/assembler/backends/ent/packageversion/where.go
+++ b/pkg/assembler/backends/ent/packageversion/where.go
@@ -390,6 +390,29 @@ func HasEqualPackagesWith(preds ...predicate.PkgEqual) predicate.PackageVersion 
 	})
 }
 
+// HasIncludedInSboms applies the HasEdge predicate on the "included_in_sboms" edge.
+func HasIncludedInSboms() predicate.PackageVersion {
+	return predicate.PackageVersion(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, IncludedInSbomsTable, IncludedInSbomsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasIncludedInSbomsWith applies the HasEdge predicate on the "included_in_sboms" edge with a given conditions (other predicates).
+func HasIncludedInSbomsWith(preds ...predicate.BillOfMaterials) predicate.PackageVersion {
+	return predicate.PackageVersion(func(s *sql.Selector) {
+		step := newIncludedInSbomsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.PackageVersion) predicate.PackageVersion {
 	return predicate.PackageVersion(sql.AndPredicates(predicates...))

--- a/pkg/assembler/backends/ent/packageversion_create.go
+++ b/pkg/assembler/backends/ent/packageversion_create.go
@@ -122,6 +122,21 @@ func (pvc *PackageVersionCreate) AddEqualPackages(p ...*PkgEqual) *PackageVersio
 	return pvc.AddEqualPackageIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (pvc *PackageVersionCreate) AddIncludedInSbomIDs(ids ...int) *PackageVersionCreate {
+	pvc.mutation.AddIncludedInSbomIDs(ids...)
+	return pvc
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (pvc *PackageVersionCreate) AddIncludedInSboms(b ...*BillOfMaterials) *PackageVersionCreate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return pvc.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the PackageVersionMutation object of the builder.
 func (pvc *PackageVersionCreate) Mutation() *PackageVersionMutation {
 	return pvc.mutation
@@ -285,6 +300,22 @@ func (pvc *PackageVersionCreate) createSpec() (*PackageVersion, *sqlgraph.Create
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(pkgequal.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pvc.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/packageversion_update.go
+++ b/pkg/assembler/backends/ent/packageversion_update.go
@@ -157,6 +157,21 @@ func (pvu *PackageVersionUpdate) AddEqualPackages(p ...*PkgEqual) *PackageVersio
 	return pvu.AddEqualPackageIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (pvu *PackageVersionUpdate) AddIncludedInSbomIDs(ids ...int) *PackageVersionUpdate {
+	pvu.mutation.AddIncludedInSbomIDs(ids...)
+	return pvu
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (pvu *PackageVersionUpdate) AddIncludedInSboms(b ...*BillOfMaterials) *PackageVersionUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return pvu.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the PackageVersionMutation object of the builder.
 func (pvu *PackageVersionUpdate) Mutation() *PackageVersionMutation {
 	return pvu.mutation
@@ -229,6 +244,27 @@ func (pvu *PackageVersionUpdate) RemoveEqualPackages(p ...*PkgEqual) *PackageVer
 		ids[i] = p[i].ID
 	}
 	return pvu.RemoveEqualPackageIDs(ids...)
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (pvu *PackageVersionUpdate) ClearIncludedInSboms() *PackageVersionUpdate {
+	pvu.mutation.ClearIncludedInSboms()
+	return pvu
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (pvu *PackageVersionUpdate) RemoveIncludedInSbomIDs(ids ...int) *PackageVersionUpdate {
+	pvu.mutation.RemoveIncludedInSbomIDs(ids...)
+	return pvu
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (pvu *PackageVersionUpdate) RemoveIncludedInSboms(b ...*BillOfMaterials) *PackageVersionUpdate {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return pvu.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -462,6 +498,51 @@ func (pvu *PackageVersionUpdate) sqlSave(ctx context.Context) (n int, err error)
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if pvu.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pvu.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !pvu.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pvu.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, pvu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{packageversion.Label}
@@ -606,6 +687,21 @@ func (pvuo *PackageVersionUpdateOne) AddEqualPackages(p ...*PkgEqual) *PackageVe
 	return pvuo.AddEqualPackageIDs(ids...)
 }
 
+// AddIncludedInSbomIDs adds the "included_in_sboms" edge to the BillOfMaterials entity by IDs.
+func (pvuo *PackageVersionUpdateOne) AddIncludedInSbomIDs(ids ...int) *PackageVersionUpdateOne {
+	pvuo.mutation.AddIncludedInSbomIDs(ids...)
+	return pvuo
+}
+
+// AddIncludedInSboms adds the "included_in_sboms" edges to the BillOfMaterials entity.
+func (pvuo *PackageVersionUpdateOne) AddIncludedInSboms(b ...*BillOfMaterials) *PackageVersionUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return pvuo.AddIncludedInSbomIDs(ids...)
+}
+
 // Mutation returns the PackageVersionMutation object of the builder.
 func (pvuo *PackageVersionUpdateOne) Mutation() *PackageVersionMutation {
 	return pvuo.mutation
@@ -678,6 +774,27 @@ func (pvuo *PackageVersionUpdateOne) RemoveEqualPackages(p ...*PkgEqual) *Packag
 		ids[i] = p[i].ID
 	}
 	return pvuo.RemoveEqualPackageIDs(ids...)
+}
+
+// ClearIncludedInSboms clears all "included_in_sboms" edges to the BillOfMaterials entity.
+func (pvuo *PackageVersionUpdateOne) ClearIncludedInSboms() *PackageVersionUpdateOne {
+	pvuo.mutation.ClearIncludedInSboms()
+	return pvuo
+}
+
+// RemoveIncludedInSbomIDs removes the "included_in_sboms" edge to BillOfMaterials entities by IDs.
+func (pvuo *PackageVersionUpdateOne) RemoveIncludedInSbomIDs(ids ...int) *PackageVersionUpdateOne {
+	pvuo.mutation.RemoveIncludedInSbomIDs(ids...)
+	return pvuo
+}
+
+// RemoveIncludedInSboms removes "included_in_sboms" edges to BillOfMaterials entities.
+func (pvuo *PackageVersionUpdateOne) RemoveIncludedInSboms(b ...*BillOfMaterials) *PackageVersionUpdateOne {
+	ids := make([]int, len(b))
+	for i := range b {
+		ids[i] = b[i].ID
+	}
+	return pvuo.RemoveIncludedInSbomIDs(ids...)
 }
 
 // Where appends a list predicates to the PackageVersionUpdate builder.
@@ -934,6 +1051,51 @@ func (pvuo *PackageVersionUpdateOne) sqlSave(ctx context.Context) (_node *Packag
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(pkgequal.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pvuo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pvuo.mutation.RemovedIncludedInSbomsIDs(); len(nodes) > 0 && !pvuo.mutation.IncludedInSbomsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pvuo.mutation.IncludedInSbomsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   packageversion.IncludedInSbomsTable,
+			Columns: packageversion.IncludedInSbomsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billofmaterials.FieldID, field.TypeInt),
 			},
 		}
 		for _, k := range nodes {

--- a/pkg/assembler/backends/ent/schema/artifact.go
+++ b/pkg/assembler/backends/ent/schema/artifact.go
@@ -46,6 +46,7 @@ func (Artifact) Edges() []ent.Edge {
 		// edge.To("dependency", Artifact.Type).Annotations(entsql.OnDelete(entsql.Cascade)).From("dependents"),
 		// edge.From("source_occurrences", SourceOccurrence.Type).Ref("artifact"),
 		// edge.To("sources", Source.Type).Through("source_occurrences", SourceOccurrence.Type),
+		edge.From("included_in_sboms", BillOfMaterials.Type).Ref("included_software_artifacts"),
 	}
 }
 

--- a/pkg/assembler/backends/ent/schema/billofmaterials.go
+++ b/pkg/assembler/backends/ent/schema/billofmaterials.go
@@ -48,6 +48,10 @@ func (BillOfMaterials) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("package", PackageVersion.Type).Field("package_id").Unique(),
 		edge.To("artifact", Artifact.Type).Field("artifact_id").Unique(),
+		edge.To("included_software_packages", PackageVersion.Type),
+		edge.To("included_software_artifacts", Artifact.Type),
+		edge.To("included_dependencies", Dependency.Type),
+		edge.To("included_occurrences", Occurrence.Type),
 	}
 }
 

--- a/pkg/assembler/backends/ent/schema/dependency.go
+++ b/pkg/assembler/backends/ent/schema/dependency.go
@@ -64,6 +64,7 @@ func (Dependency) Edges() []ent.Edge {
 		edge.To("dependent_package_version", PackageVersion.Type).
 			Field("dependent_package_version_id").
 			Unique(),
+		edge.From("included_in_sboms", BillOfMaterials.Type).Ref("included_dependencies"),
 	}
 }
 

--- a/pkg/assembler/backends/ent/schema/occurrence.go
+++ b/pkg/assembler/backends/ent/schema/occurrence.go
@@ -52,6 +52,7 @@ func (Occurrence) Edges() []ent.Edge {
 		edge.To("artifact", Artifact.Type).Field("artifact_id").Unique().Required(),
 		edge.To("package", PackageVersion.Type).Unique().Field("package_id"),
 		edge.To("source", SourceName.Type).Unique().Field("source_id"),
+		edge.From("included_in_sboms", BillOfMaterials.Type).Ref("included_occurrences"),
 	}
 }
 

--- a/pkg/assembler/backends/ent/schema/packageversion.go
+++ b/pkg/assembler/backends/ent/schema/packageversion.go
@@ -51,6 +51,7 @@ func (PackageVersion) Edges() []ent.Edge {
 		// edge.To("equal_packages", PackageVersion.Type).Through("equals", PkgEqual.Type),
 		edge.From("equal_packages", PkgEqual.Type).Ref("packages"),
 		// edge.From("pkg_equal_dependant", PkgEqual.Type).Ref("dependant_package"),
+		edge.From("included_in_sboms", BillOfMaterials.Type).Ref("included_software_packages"),
 	}
 }
 


### PR DESCRIPTION
# Description of the PR

Provides the Ent implemenation for managing the multiple `Included` resources within `hasSBOM`.

Fixes #1550 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
