### PR TITLE
update deps.dev parser to output hasSBOM

### DIFF
--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -35,7 +35,7 @@ func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputS
 			return &assembler.IsDependencyIngest{
 				Pkg:             foundNode,
 				DepPkg:          rfileNode,
-				DepPkgMatchFlag: getMatchFlagsFromPkgInput(rfileNode),
+				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(rfileNode),
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -48,7 +48,7 @@ func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputS
 			return &assembler.IsDependencyIngest{
 				Pkg:             foundNode,
 				DepPkg:          rpackNode,
-				DepPkgMatchFlag: getMatchFlagsFromPkgInput(rpackNode),
+				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(rpackNode),
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -70,7 +70,7 @@ func CreateTopLevelIsDeps(topLevel *model.PkgInputSpec, packages map[string][]*m
 				p := assembler.IsDependencyIngest{
 					Pkg:             topLevel,
 					DepPkg:          packNode,
-					DepPkgMatchFlag: getMatchFlagsFromPkgInput(packNode),
+					DepPkgMatchFlag: GetMatchFlagsFromPkgInput(packNode),
 					IsDependency: &model.IsDependencyInputSpec{
 						DependencyType: model.DependencyTypeUnknown,
 						Justification:  justification,
@@ -87,7 +87,7 @@ func CreateTopLevelIsDeps(topLevel *model.PkgInputSpec, packages map[string][]*m
 			p := assembler.IsDependencyIngest{
 				Pkg:             topLevel,
 				DepPkg:          fileNode,
-				DepPkgMatchFlag: getMatchFlagsFromPkgInput(fileNode),
+				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(fileNode),
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -116,7 +116,7 @@ func CreateTopLevelHasSBOM(topLevel *model.PkgInputSpec, sbomDoc *processor.Docu
 	}
 }
 
-func getMatchFlagsFromPkgInput(p *model.PkgInputSpec) model.MatchFlags {
+func GetMatchFlagsFromPkgInput(p *model.PkgInputSpec) model.MatchFlags {
 	matchFlags := model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions}
 	if p.Version != nil && *p.Version != "" {
 		matchFlags = model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion}

--- a/pkg/ingestor/parser/deps_dev/deps_dev.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev.go
@@ -72,10 +72,11 @@ func (d *depsDevParser) GetPredicates(ctx context.Context) *assembler.IngestPred
 		preds.IsDependency = append(preds.IsDependency, assembler.IsDependencyIngest{
 			Pkg:             isDepComp.CurrentPackageInput,
 			DepPkg:          isDepComp.DepPackageInput,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: common.GetMatchFlagsFromPkgInput(isDepComp.DepPackageInput),
 			IsDependency:    isDepComp.IsDependency,
 		})
 	}
+	preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOM(d.packComponent.CurrentPackage, d.doc, helpers.PkgInputSpecToPurl(d.packComponent.CurrentPackage), d.packComponent.UpdateTime))
 
 	return preds
 }

--- a/pkg/ingestor/parser/deps_dev/deps_dev_test.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev_test.go
@@ -17,6 +17,8 @@ package deps_dev
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"reflect"
 	"testing"
 	"time"
@@ -26,6 +28,7 @@ import (
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/assembler"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/assembler/helpers"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/logging"
@@ -51,7 +54,9 @@ func TestNewDepsDevParser(t *testing.T) {
 func Test_depsDevParser_Parse(t *testing.T) {
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
 	ctx := logging.WithLogger(context.Background())
-
+	sha256sumNPMReact := sha256.Sum256([]byte(testdata.CollectedNPMReact))
+	sha256sumForeignTypes := sha256.Sum256([]byte(testdata.CollectedForeignTypes))
+	sha256sumYargsParser := sha256.Sum256([]byte(testdata.CollectedYargsParser))
 	tests := []struct {
 		name           string
 		doc            *processor.Document
@@ -75,7 +80,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Version:   ptrfrom.String("1.4.0"),
 						Subpath:   ptrfrom.String(""),
 					},
-					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					DepPkg: &model.PkgInputSpec{
 						Type:      "npm",
 						Namespace: ptrfrom.String(""),
@@ -98,7 +103,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Version:   ptrfrom.String("17.0.0"),
 						Subpath:   ptrfrom.String(""),
 					},
-					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					DepPkg: &model.PkgInputSpec{
 						Type:      "npm",
 						Namespace: ptrfrom.String(""),
@@ -128,7 +133,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Version:   ptrfrom.String("4.1.1"),
 						Subpath:   ptrfrom.String(""),
 					},
-					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					IsDependency: &model.IsDependencyInputSpec{
 						DependencyType: model.DependencyTypeDirect,
 						VersionRange:   "^4.1.1",
@@ -204,6 +209,31 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Justification: "collected via deps.dev",
 						Origin:        "",
 						Collector:     "",
+					},
+				},
+			},
+			HasSBOM: []assembler.HasSBOMIngest{
+				{
+					Pkg: &model.PkgInputSpec{
+						Type:      "npm",
+						Namespace: ptrfrom.String(""),
+						Name:      "react",
+						Version:   ptrfrom.String("17.0.0"),
+						Subpath:   ptrfrom.String(""),
+					},
+					HasSBOM: &model.HasSBOMInputSpec{
+						Uri: helpers.PkgInputSpecToPurl(&model.PkgInputSpec{
+							Type:      "npm",
+							Namespace: ptrfrom.String(""),
+							Name:      "react",
+							Version:   ptrfrom.String("17.0.0"),
+							Subpath:   ptrfrom.String(""),
+						}),
+						Algorithm:  "sha256",
+						Digest:     hex.EncodeToString(sha256sumNPMReact[:]),
+						KnownSince: tm.UTC(),
+						Origin:     "",
+						Collector:  "",
 					},
 				},
 			},
@@ -295,7 +325,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Version:   ptrfrom.String("0.1.1"),
 						Subpath:   ptrfrom.String(""),
 					},
-					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					IsDependency: &model.IsDependencyInputSpec{
 						DependencyType: model.DependencyTypeDirect,
 						VersionRange:   "^0.1",
@@ -352,6 +382,31 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					},
 				},
 			},
+			HasSBOM: []assembler.HasSBOMIngest{
+				{
+					Pkg: &model.PkgInputSpec{
+						Type:      "cargo",
+						Namespace: ptrfrom.String(""),
+						Name:      "foreign-types",
+						Version:   ptrfrom.String("0.3.2"),
+						Subpath:   ptrfrom.String(""),
+					},
+					HasSBOM: &model.HasSBOMInputSpec{
+						Uri: helpers.PkgInputSpecToPurl(&model.PkgInputSpec{
+							Type:      "cargo",
+							Namespace: ptrfrom.String(""),
+							Name:      "foreign-types",
+							Version:   ptrfrom.String("0.3.2"),
+							Subpath:   ptrfrom.String(""),
+						}),
+						Algorithm:  "sha256",
+						Digest:     hex.EncodeToString(sha256sumForeignTypes[:]),
+						KnownSince: tm.UTC(),
+						Origin:     "",
+						Collector:  "",
+					},
+				},
+			},
 		},
 		wantErr: false,
 	}, {
@@ -372,7 +427,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Version:   ptrfrom.String("4.2.1"),
 						Subpath:   ptrfrom.String(""),
 					},
-					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					DepPkg: &model.PkgInputSpec{
 						Type:      "npm",
 						Namespace: ptrfrom.String(""),
@@ -434,6 +489,31 @@ func Test_depsDevParser_Parse(t *testing.T) {
 						Justification: "collected via deps.dev",
 						Origin:        "",
 						Collector:     "",
+					},
+				},
+			},
+			HasSBOM: []assembler.HasSBOMIngest{
+				{
+					Pkg: &model.PkgInputSpec{
+						Type:      "npm",
+						Namespace: ptrfrom.String(""),
+						Name:      "yargs-parser",
+						Version:   ptrfrom.String("4.2.1"),
+						Subpath:   ptrfrom.String(""),
+					},
+					HasSBOM: &model.HasSBOMInputSpec{
+						Uri: helpers.PkgInputSpecToPurl(&model.PkgInputSpec{
+							Type:      "npm",
+							Namespace: ptrfrom.String(""),
+							Name:      "yargs-parser",
+							Version:   ptrfrom.String("4.2.1"),
+							Subpath:   ptrfrom.String(""),
+						}),
+						Algorithm:  "sha256",
+						Digest:     hex.EncodeToString(sha256sumYargsParser[:]),
+						KnownSince: tm.UTC(),
+						Origin:     "",
+						Collector:  "",
 					},
 				},
 			},


### PR DESCRIPTION
# Description of the PR

Update deps.dev parser to output `hasSBOM` for collected packages and dependencies.

closes https://github.com/guacsec/guac/issues/1357

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
