### PR TITLE
Enable query on benchmark, fix some Scan() issues in keyvalue

### DIFF
--- a/.github/workflows/db-performance-test.yaml
+++ b/.github/workflows/db-performance-test.yaml
@@ -30,8 +30,8 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-local-build.yaml
     with:
-      repository: 'guacsec/guac'
-      ref: 'main'
+      repository: ${{ github.repository}}
+      ref: ${{ github.ref }}
 
   db-performance:
     needs: [build]
@@ -115,30 +115,28 @@ jobs:
           matrix-key: ${{ matrix.database }}
           outputs: |-
             elapsed_time: ${{ steps.run_test.outputs.elapsed_time }}
-      # - name: Run query tests with ${{ matrix.database }}
-      #   id: query_test
-      #   run: |
-      #     if [ ${{ matrix.database }} == "inmem" ]; then
-      #       #!/usr/bin/env bash
-      #       set -euo pipefail
-      #       echo "Running query tests..."
-      #       start=$(date -u +%s)
-      #       ./bin/guacone certifier osv --poll=false > output 2>&1
-      #       ./bin/guacone query vuln "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest" > output 2>&1
-      #       #grep "Visualizer url" output
-      #       end=$(date -u +%s)
-      #       query_time=$((end - start))
-      #       printf "%-15s%-20s%-15s%s seconds\n" "Query" "${{ matrix.database }}" "$query_time"
-      #       echo "query_time=$query_time" >> $GITHUB_OUTPUT
-      #     fi
-      # ## Write for matrix outputs workaround
-      # - uses: cloudposse/github-action-matrix-outputs-write@main
-      #   id: out-query
-      #   with:
-      #     matrix-step-name: query_test
-      #     matrix-key: ${{ matrix.database }}
-      #     outputs: |-
-      #       query_time: ${{ steps.query_test.outputs.query_time }}
+      - name: Run query tests with ${{ matrix.database }}
+        id: query_test
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          echo "Running query tests..."
+          start=$(date -u +%s)
+          ./bin/guacone certifier osv --poll=false > output 2>&1
+          ./bin/guacone query vuln "pkg:guac/spdx/ghcr.io/guacsec/vul-image-latest" > output 2>&1
+          grep "Visualizer url" output
+          end=$(date -u +%s)
+          query_time=$((end - start))
+          printf "%-15s%-20s%-15s%s seconds\n" "Query" "${{ matrix.database }}" "$query_time"
+          echo "query_time=$query_time" >> $GITHUB_OUTPUT
+      ## Write for matrix outputs workaround
+      - uses: cloudposse/github-action-matrix-outputs-write@main
+        id: out-query
+        with:
+          matrix-step-name: query_test
+          matrix-key: ${{ matrix.database }}
+          outputs: |-
+            query_time: ${{ steps.query_test.outputs.query_time }}
   ## Read matrix outputs
   read:
     runs-on: ubuntu-latest

--- a/pkg/assembler/kv/redis/redis.go
+++ b/pkg/assembler/kv/redis/redis.go
@@ -87,13 +87,20 @@ func (s *scanner) Scan(ctx context.Context) ([]string, bool, error) {
 	if s.done {
 		return nil, true, nil
 	}
-	rv, newCur, err := s.c.HScan(ctx, s.collection, s.cursor, "", count).Result()
+	res, newCur, err := s.c.HScan(ctx, s.collection, s.cursor, "", count).Result()
 	if err != nil {
 		return nil, false, err
 	}
 	s.cursor = newCur
 	if newCur == 0 {
 		s.done = true
+	}
+	// HSCAN returns keys and values, need just keys.
+	rv := make([]string, len(res)/2)
+	for i, v := range res {
+		if i%2 == 0 {
+			rv[i/2] = v
+		}
 	}
 	return rv, s.done, nil
 }

--- a/pkg/assembler/kv/tikv/tikv.go
+++ b/pkg/assembler/kv/tikv/tikv.go
@@ -18,6 +18,7 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/guacsec/guac/pkg/assembler/kv"
@@ -105,7 +106,11 @@ func (s *scanner) Scan(ctx context.Context) ([]string, bool, error) {
 		if bytes.Compare(k, largest) > 0 {
 			largest = k
 		}
-		rv[i] = string(k)
+		parts := strings.SplitN(string(k), ":", 2)
+		if len(parts) != 2 {
+			return nil, false, fmt.Errorf("Invalid key found in TiKV: %q", string(k))
+		}
+		rv[i] = string(parts[1])
 	}
 	s.curKey = kvti.NextKey(largest)
 	return rv, s.done, nil


### PR DESCRIPTION
Scan() had issues on Redis and TiKV, fixed those. Also changed the benchmark to use guac from the PR/branch that it is running instead of guacsec/guac main.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
