### PR TITLE
Ent - Restore IngestPackages concurrently

### DIFF
--- a/pkg/assembler/backends/ent/backend/helpers_test.go
+++ b/pkg/assembler/backends/ent/backend/helpers_test.go
@@ -54,7 +54,6 @@ var IngestPredicatesCmpOpts = []cmp.Option{
 	cmpopts.SortSlices(certifyVexLess),
 	cmpopts.SortSlices(vulnerabilityLess),
 	cmpopts.SortSlices(hasSbomLess),
-	cmpopts.SortSlices(packageOrArtifactLess),
 }
 
 func isDependencyLess(e1, e2 *model.IsDependency) bool {
@@ -88,20 +87,16 @@ func vulnerabilityLess(e1, e2 *model.Vulnerability) bool {
 }
 
 func hasSbomLess(e1, e2 *model.HasSbom) bool {
-	return packageOrArtifactLess(e1.Subject, e2.Subject)
-}
-
-func packageOrArtifactLess(e1, e2 model.PackageOrArtifact) bool {
-	switch subject1 := e1.(type) {
+	switch subject1 := e1.Subject.(type) {
 	case *model.Package:
-		switch subject2 := e2.(type) {
+		switch subject2 := e2.Subject.(type) {
 		case *model.Package:
 			return packageLess(subject1, subject2)
 		case *model.Artifact:
 			return false
 		}
 	case *model.Artifact:
-		switch subject2 := e2.(type) {
+		switch subject2 := e2.Subject.(type) {
 		case *model.Package:
 			return true
 		case *model.Artifact:

--- a/pkg/assembler/backends/ent/backend/sbom_test.go
+++ b/pkg/assembler/backends/ent/backend/sbom_test.go
@@ -248,11 +248,11 @@ var includedTestExpectedSBOM = &model.HasSbom{
 	Origin:           "sbom_origin",
 	Collector:        "sbom_collector",
 	IncludedSoftware: []model.PackageOrArtifact{
+		includedTestExpectedPackage1,
+		includedTestExpectedPackage2,
 		includedTestExpectedPackage3,
 		includedTestExpectedArtifact1,
 		includedTestExpectedArtifact2,
-		includedTestExpectedPackage1,
-		includedTestExpectedPackage2,
 	},
 	IncludedDependencies: []*model.IsDependency{{
 		Package:           includedTestExpectedPackage1,


### PR DESCRIPTION
# Description of the PR
This changes were

- introduced in https://github.com/guacsec/guac/commit/a20dbc722743302c29176881c4125f76a937f64d#diff-ab2364612c30bc9846841e0f336814fe799a540783af0e390dbb59ad928de8efR107-R120 
- then reverted (unintentionally) with in https://github.com/guacsec/guac/commit/32697ae2b5def8e49b3039e105a109d7d158cac3#diff-ab2364612c30bc9846841e0f336814fe799a540783af0e390dbb59ad928de8efL106-L120

So this PR restores them to optimize `IngestPackages` Ent implementation.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
