### PR TITLE
Update ent and arango source model generation.

### DIFF
--- a/internal/testing/testdata/models.go
+++ b/internal/testing/testdata/models.go
@@ -93,9 +93,7 @@ var S1out = &model.Source{
 	Namespaces: []*model.SourceNamespace{{
 		Namespace: "github.com/jeff",
 		Names: []*model.SourceName{{
-			Name:   "myrepo",
-			Tag:    ptrfrom.String(""),
-			Commit: ptrfrom.String(""),
+			Name: "myrepo",
 		}},
 	}},
 }
@@ -110,9 +108,7 @@ var S2out = &model.Source{
 	Namespaces: []*model.SourceNamespace{{
 		Namespace: "github.com/bob",
 		Names: []*model.SourceName{{
-			Name:   "bobsrepo",
-			Tag:    ptrfrom.String(""),
-			Commit: ptrfrom.String(""),
+			Name: "bobsrepo",
 		}},
 	}},
 }
@@ -128,9 +124,8 @@ var S3out = &model.Source{
 	Namespaces: []*model.SourceNamespace{{
 		Namespace: "github.com/jeff",
 		Names: []*model.SourceName{{
-			Name:   "myrepo",
-			Tag:    ptrfrom.String("v1.0"),
-			Commit: ptrfrom.String(""),
+			Name: "myrepo",
+			Tag:  ptrfrom.String("v1.0"),
 		}},
 	}},
 }
@@ -147,7 +142,6 @@ var S4out = &model.Source{
 		Namespace: "github.com/bob",
 		Names: []*model.SourceName{{
 			Name:   "bobsrepo",
-			Tag:    ptrfrom.String(""),
 			Commit: ptrfrom.String("5e7c41f"),
 		}},
 	}},

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -678,12 +678,18 @@ func (c *arangoClient) querySrcNameNodeByID(ctx context.Context, id string, filt
 		return nil, "", fmt.Errorf("number of source name nodes found for ID: %s is greater than one", id)
 	}
 
-	return &model.SourceName{
-		ID:     collectedValues[0].NameID,
-		Name:   collectedValues[0].Name,
-		Tag:    &collectedValues[0].Tag,
-		Commit: &collectedValues[0].Commit,
-	}, collectedValues[0].Parent, nil
+	sn := &model.SourceName{
+		ID:   collectedValues[0].NameID,
+		Name: collectedValues[0].Name,
+	}
+	if collectedValues[0].Tag != "" {
+		sn.Tag = &collectedValues[0].Tag
+	}
+	if collectedValues[0].Commit != "" {
+		sn.Commit = &collectedValues[0].Commit
+	}
+
+	return sn, collectedValues[0].Parent, nil
 }
 
 func (c *arangoClient) querySrcNamespaceNodeByID(ctx context.Context, id string, filter *model.SourceSpec, snl []*model.SourceName) (*model.SourceNamespace, string, error) {

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -491,10 +491,14 @@ func getSources(ctx context.Context, cursor driver.Cursor) ([]*model.Source, err
 			typeString := doc.SrcType + "," + doc.TypeID
 
 			srcName := &model.SourceName{
-				ID:     doc.NameID,
-				Name:   nameString,
-				Tag:    &tagString,
-				Commit: &commitString,
+				ID:   doc.NameID,
+				Name: nameString,
+			}
+			if tagString != "" {
+				srcName.Tag = &tagString
+			}
+			if commitString != "" {
+				srcName.Commit = &commitString
 			}
 			if srcNamespaces, ok := srcTypes[typeString]; ok {
 				srcNamespaces[namespaceString] = append(srcNamespaces[namespaceString], srcName)
@@ -530,10 +534,14 @@ func getSources(ctx context.Context, cursor driver.Cursor) ([]*model.Source, err
 
 func generateModelSource(srcTypeID, srcType, namespaceID, namespaceStr, nameID, nameStr string, commitValue, tagValue string) *model.Source {
 	name := &model.SourceName{
-		ID:     nameID,
-		Name:   nameStr,
-		Tag:    &tagValue,
-		Commit: &commitValue,
+		ID:   nameID,
+		Name: nameStr,
+	}
+	if tagValue != "" {
+		name.Tag = &tagValue
+	}
+	if commitValue != "" {
+		name.Commit = &commitValue
 	}
 
 	namespace := &model.SourceNamespace{

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -178,9 +178,7 @@ var s1out = &model.Source{
 	Namespaces: []*model.SourceNamespace{{
 		Namespace: "github.com/jeff",
 		Names: []*model.SourceName{{
-			Name:   "myrepo",
-			Tag:    ptrfrom.String(""),
-			Commit: ptrfrom.String(""),
+			Name: "myrepo",
 		}},
 	}},
 }
@@ -197,7 +195,6 @@ var s2out = &model.Source{
 		Namespace: "github.com/bob",
 		Names: []*model.SourceName{{
 			Name:   "bobsrepo",
-			Tag:    ptrfrom.String(""),
 			Commit: ptrfrom.String("5e7c41f"),
 		}},
 	}},

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -355,12 +355,17 @@ func toModelSource(s *ent.SourceType) *model.Source {
 				ID:        nodeID(n.ID),
 				Namespace: n.Namespace,
 				Names: collect(n.Edges.Names, func(n *ent.SourceName) *model.SourceName {
-					return &model.SourceName{
-						ID:     nodeID(n.ID),
-						Name:   n.Name,
-						Tag:    &n.Tag,
-						Commit: &n.Commit,
+					sn := &model.SourceName{
+						ID:   nodeID(n.ID),
+						Name: n.Name,
 					}
+					if n.Tag != "" {
+						sn.Tag = &n.Tag
+					}
+					if n.Commit != "" {
+						sn.Commit = &n.Commit
+					}
+					return sn
 				}),
 			}
 		}),


### PR DESCRIPTION
Source name can have Tag or Commit but not both. The model marks these as optional which results in go structs with pointers. The backends should only fill the pointers if the field is valid.

The generated go structs do have "omitempty" in the json annotation, so I believe the gql results still look correct without this change. This does clean up the expected test data. All the backends will need to be consistent to have the same expected testdata.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
