### PR TITLE
Ent: IngestSources optimized with concurrently

### DIFF
--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -30,6 +30,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 func (b *EntBackend) HasSourceAt(ctx context.Context, filter *model.HasSourceAtSpec) ([]*model.HasSourceAt, error) {
@@ -162,12 +163,20 @@ func (b *EntBackend) Sources(ctx context.Context, filter *model.SourceSpec) ([]*
 
 func (b *EntBackend) IngestSources(ctx context.Context, sources []*model.SourceInputSpec) ([]*model.SourceIDs, error) {
 	ids := make([]*model.SourceIDs, len(sources))
-	for i, src := range sources {
-		s, err := b.IngestSource(ctx, *src)
-		if err != nil {
-			return nil, err
-		}
-		ids[i] = s
+	eg, ctx := errgroup.WithContext(ctx)
+	for i := range sources {
+		index := i
+		src := sources[index]
+		concurrently(eg, func() error {
+			s, err := b.IngestSource(ctx, *src)
+			if err == nil {
+				ids[index] = s
+			}
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return ids, nil
 }
@@ -248,7 +257,7 @@ func upsertSource(ctx context.Context, client *ent.Tx, src model.SourceInputSpec
 		ID(ctx)
 	if err != nil {
 		if err != stdsql.ErrNoRows {
-			return nil, errors.Wrap(err, "upsert package version")
+			return nil, errors.Wrap(err, "upsert source name")
 		}
 
 		sourceNameID, err = client.SourceName.Query().


### PR DESCRIPTION
# Description of the PR


Ent backend, implemented concurrent approach [1] for:

- `IngestSources`

[1] from https://github.com/guacsec/guac/pull/1440

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
