### PR TITLE
Create a single backend acceptance test suite.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,31 +34,6 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     name: CI for integration tests
-    services:
-      neo4j:
-        image: neo4j:latest # TODO(mihaimaruseac): Pin to hash
-        env:
-          NEO4J_AUTH: none
-        ports:
-          - 7687:7687
-      postgres:
-        image: postgres:16.0@sha256:f007ec48ff3ef9b75dc473d915a3ea3713167ba015340316f6bcabfa86a7b4a6
-        env:
-          POSTGRES_USER: guac
-          POSTGRES_PASSWORD: guac
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-      arango:
-        image: arangodb:latest@sha256:085b45e8c56d5d4114e409482694d40fc8d1678c6b5d98d774bab31193034d6a
-        env:
-          ARANGO_ROOT_PASSWORD: test123
-        ports:
-          - 8529:8529
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v3
@@ -72,6 +47,14 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Setup the project
         run: go mod download
+      - name: Run backends
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd internal/testing/backend
+          docker-compose up -d
+          sleep 10
+          echo "backends started"
       - name: Run integration tests
         env:
             ENT_TEST_DATABASE_URL: 'postgresql://guac:guac@localhost/guac?sslmode=disable'

--- a/internal/testing/backend/README.md
+++ b/internal/testing/backend/README.md
@@ -1,0 +1,51 @@
+# GUAC Backend Acceptance Test Suite
+
+## How to run
+
+Run all the backend containers using the compose yaml and then run the tests:
+
+```shell
+cd internal/testing/backend
+docker-compose up -d
+go test -v --tags=integration .
+```
+
+Also, these tests run in CI. See the "CI for integration tests" job in
+[ci.yaml](/.github/workflows/ci.yaml)
+
+All the files here must use the `//go:build integration` tag, so they are not
+run with normal unit tests.
+
+## Writing more tests
+
+* Write normal go test functions. For example
+  `func TestMytestname(t *testing.T) {`. These will be executed multiple times,
+  once for each backend.
+
+* Tests should receive a `backends.Backend` object by calling
+  `setupTest(t)`. All testing is done on the received backend.
+
+* Use `github.com/google/go-cmp/cmp` to compare expected and recieved
+  values. The `commonOpts` global is used for any `Diff()` calls to that
+  library. Add any needed options to that global in `setupOpts()`.
+
+* Use `/internal/testing/testdata` for any test node data.
+
+* Put any simple test data in `helpers_test.go` for reuse, such as `curTime`.
+
+## Adding a backend
+
+* Create a new `<name>_test.go` file and implement the `backend` interface.
+
+* In [main_test.go](main_test.go):
+
+  * Add a new global string to name the backend.
+
+  * Add the backend to the `testBackends` map, with a constructor for the
+    `backend` interface.
+
+  * Add any needed skips to the `skipMatrix` map, if the new backend does not
+    support all the node types yet.
+
+* Before submitting, update this [docker-compse.yaml](docker-compose.yaml) to start any
+  external dependencies needed.

--- a/internal/testing/backend/README.md
+++ b/internal/testing/backend/README.md
@@ -47,5 +47,5 @@ run with normal unit tests.
   * Add any needed skips to the `skipMatrix` map, if the new backend does not
     support all the node types yet.
 
-* Before submitting, update this [docker-compse.yaml](docker-compose.yaml) to start any
+* Before submitting, update this [docker-compose.yaml](docker-compose.yaml) to start any
   external dependencies needed.

--- a/internal/testing/backend/arango_test.go
+++ b/internal/testing/backend/arango_test.go
@@ -1,0 +1,66 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"context"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	"github.com/guacsec/guac/pkg/assembler/backends/arangodb"
+)
+
+type arangoBE struct {
+	be   backends.Backend
+	args *arangodb.ArangoConfig
+}
+
+func newArango() backend {
+	return &arangoBE{
+		args: &arangodb.ArangoConfig{
+			User:   "root",
+			Pass:   "test123",
+			DBAddr: "http://localhost:8529",
+		},
+	}
+}
+
+func (m *arangoBE) Setup() error {
+	if err := arangodb.DeleteDatabase(context.Background(), m.args); err != nil {
+		return err
+	}
+	be, err := backends.Get("arango", context.Background(), m.args)
+	m.be = be
+	return err
+}
+
+func (m *arangoBE) Get() backends.Backend {
+	return m.be
+}
+
+func (m *arangoBE) Clear() error {
+	if err := arangodb.DeleteDatabase(context.Background(), m.args); err != nil {
+		return err
+	}
+	// For some reason, need to call Get again after delete
+	be, err := backends.Get("arango", context.Background(), m.args)
+	m.be = be
+	return err
+}
+
+func (m *arangoBE) Cleanup() {
+}

--- a/internal/testing/backend/docker-compose.yaml
+++ b/internal/testing/backend/docker-compose.yaml
@@ -1,0 +1,84 @@
+version: "3.8"
+networks:
+  frontend:
+    driver: bridge
+volumes:
+  pd_guac_data:
+  tikv_guac_data:
+  redis_guac_data:
+  arangodb_data_container:
+  arangodb_apps_data_container:
+  postgres_data:
+services:
+  arangodb:
+    networks: [frontend]
+    image: docker.io/library/arangodb:latest
+    environment:
+      ARANGO_ROOT_PASSWORD: test123
+    ports:
+      - "8529:8529"
+    volumes:
+      - arangodb_data_container:/var/lib/arangodb3
+      - arangodb_apps_data_container:/var/lib/arangodb3-apps
+  postgres:
+    image: docker.io/library/postgres:16
+    environment:
+      POSTGRES_USER: guac
+      POSTGRES_PASSWORD: guac
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks: [frontend]
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  redis:
+    networks: [frontend]
+    image: cgr.dev/chainguard/redis
+    ports:
+    - "6379:6379"
+    restart: on-failure
+    volumes:
+    - redis_guac_data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 1s
+  pd:
+    networks: [frontend]
+    image: docker.io/pingcap/pd:latest
+    ports:
+      - "2379:2379"
+    volumes:
+      - pd_guac_data:/data
+    command:
+      - --name=pd
+      - --client-urls=http://0.0.0.0:2379
+      - --peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://127.0.0.1:2379,http://pd:2379
+      - --advertise-peer-urls=http://pd:2380
+      - --initial-cluster=pd=http://pd:2380
+      - --data-dir=/data
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "127.0.0.1:2379/pd/api/v1/stores"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 1s
+  tikv:
+    networks: [frontend]
+    image: docker.io/pingcap/tikv:latest
+    volumes:
+      - tikv_guac_data:/data
+    ports:
+      - "20160:20160"
+    command:
+      - --addr=0.0.0.0:20160
+      - --advertise-addr=127.0.0.1:20160
+      - --data-dir=/data
+      - --pd=pd:2379
+    depends_on:
+      - "pd"
+    restart: on-failure

--- a/internal/testing/backend/ent_test.go
+++ b/internal/testing/backend/ent_test.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	entbackend "github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
+	"github.com/segmentio/ksuid"
+)
+
+type entBE struct {
+	be        backends.Backend
+	urlString string
+	topSQL    *sql.DB
+	topURL    *url.URL
+}
+
+func newEnt() backend {
+	return &entBE{
+		urlString: "postgres://guac:guac@localhost/guac?sslmode=disable",
+	}
+}
+
+func (m *entBE) Setup() error {
+	db, err := sql.Open("postgres", m.urlString)
+	if err != nil {
+		return err
+	}
+	m.topSQL = db
+	u, err := url.Parse(m.urlString)
+	if err != nil {
+		return err
+	}
+	m.topURL = u
+
+	return m.setupNewDB()
+}
+
+func (m *entBE) Get() backends.Backend {
+	return m.be
+}
+
+func (m *entBE) Clear() error {
+	return m.setupNewDB()
+}
+
+func (m *entBE) Cleanup() {
+	m.topSQL.Close()
+}
+
+func (m *entBE) setupNewDB() error {
+	ctx := context.Background()
+	ident := ksuid.New().String()
+	_, err := m.topSQL.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE \"%v\"", ident))
+	if err != nil {
+		return err
+	}
+	testURL := *m.topURL
+	testURL.Path = ident
+	opts := &entbackend.BackendOptions{
+		DriverName:  "postgres",
+		Address:     testURL.String(),
+		Debug:       false,
+		AutoMigrate: true,
+	}
+	be, err := backends.Get("ent", ctx, opts)
+	m.be = be
+	return err
+}

--- a/internal/testing/backend/helpers_test.go
+++ b/internal/testing/backend/helpers_test.go
@@ -1,0 +1,39 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var commonOpts cmp.Options
+
+var curTime = time.Now()
+var timeAfterOneSecond = curTime.Add(time.Second)
+
+func setupOpts() {
+	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.Compare(".ID", p[len(p)-1].String()) == 0
+	}, cmp.Ignore())
+	approxMilli := cmpopts.EquateApproxTime(time.Millisecond)
+	commonOpts = cmp.Options{ignoreID, approxMilli}
+}

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -1,0 +1,119 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+)
+
+const (
+	memmap = "memmap"
+	arango = "arango"
+	redis  = "redis"
+	ent    = "ent"
+	tikv   = "tikv"
+)
+
+var skipMatrix = map[string]map[string]bool{
+	// Just some examples here
+	"TestPkg":       {arango: true},
+	"TestArtifacts": {memmap: true},
+	"TestBuilder":   {arango: true, memmap: true},
+	// "TestCertifyBad":          {arango: true},
+	// "TestIngestCertifyBads":   {arango: true},
+	"TestCertifyBadNeighbors": {arango: true},
+}
+
+type backend interface {
+	Setup() error
+	Get() backends.Backend
+	Clear() error
+	Cleanup()
+}
+
+var testBackends = map[string]backend{
+	memmap: newMemMap(),
+	arango: newArango(),
+	redis:  newRedis(),
+	ent:    newEnt(),
+	tikv:   newTikv(),
+}
+
+var currentBackend string
+
+func TestMain(m *testing.M) {
+	setupOpts()
+	var rv int
+	for beName, be := range testBackends {
+		currentBackend = beName
+		if err := be.Setup(); err != nil {
+			fmt.Printf("Could not setup backend %q, err: %s\n", currentBackend, err)
+			rv = 1
+			continue
+		}
+		fmt.Printf("Testing backend %q\n", currentBackend)
+		start := time.Now()
+		code := m.Run()
+		end := time.Now()
+		if code != 0 {
+			rv = code
+		}
+		be.Cleanup()
+		fmt.Printf("Backend %q done in %06.3fs\n", currentBackend, end.Sub(start).Seconds())
+	}
+	os.Exit(rv)
+}
+
+func setupTest(t *testing.T) backends.Backend {
+	t.Helper()
+	checkSkip(t)
+	be := testBackends[currentBackend]
+	t.Cleanup(func() {
+		if err := be.Clear(); err != nil {
+			t.Fatalf("Error clearing backend %q between tests: %s", currentBackend, err)
+		}
+	})
+	return be.Get()
+}
+
+func checkSkip(t *testing.T) {
+	t.Helper()
+	pc, _, _, ok := runtime.Caller(2) // setupTest -> checkSkip
+	if !ok {
+		t.Fatal("Could not get caller")
+	}
+	f := runtime.FuncForPC(pc)
+	funcName := trimFuncName(f.Name())
+	if skipMatrix[funcName] != nil {
+		if skipMatrix[funcName][currentBackend] {
+			t.Skip()
+		}
+	}
+}
+
+func trimFuncName(fullName string) string {
+	parts := strings.Split(fullName, ".")
+	return parts[len(parts)-1]
+}

--- a/internal/testing/backend/memmap_test.go
+++ b/internal/testing/backend/memmap_test.go
@@ -1,0 +1,56 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"github.com/guacsec/guac/internal/testing/stablememmap"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+)
+
+type memmapBE struct {
+	be backends.Backend
+}
+
+func newMemMap() backend {
+	return &memmapBE{}
+}
+
+func (m *memmapBE) Setup() error {
+	be, err := setupStableMemmap()
+	m.be = be
+	return err
+}
+
+func (m *memmapBE) Get() backends.Backend {
+	return m.be
+}
+
+func (m *memmapBE) Clear() error {
+	be, err := setupStableMemmap()
+	m.be = be
+	return err
+}
+
+func (m *memmapBE) Cleanup() {
+}
+
+func setupStableMemmap() (backends.Backend, error) {
+	store := stablememmap.GetStore()
+	return backends.Get("keyvalue", nil, store)
+}

--- a/internal/testing/backend/redis_test.go
+++ b/internal/testing/backend/redis_test.go
@@ -1,0 +1,69 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"context"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	redisstore "github.com/guacsec/guac/pkg/assembler/kv/redis"
+	redislib "github.com/redis/go-redis/v9"
+)
+
+type redisBE struct {
+	be      backends.Backend
+	connStr string
+	c       *redislib.Client
+}
+
+func newRedis() backend {
+	return &redisBE{
+		connStr: "redis://user@localhost:6379/0",
+	}
+}
+
+func (m *redisBE) Setup() error {
+	opt, err := redislib.ParseURL(m.connStr)
+	if err != nil {
+		return err
+	}
+	m.c = redislib.NewClient(opt)
+	if err := m.c.FlushDB(context.Background()).Err(); err != nil {
+		return err
+	}
+	store, err := redisstore.GetStore(m.connStr)
+	if err != nil {
+		return err
+	}
+	be, err := backends.Get("keyvalue", nil, store)
+	m.be = be
+	return err
+}
+
+func (m *redisBE) Get() backends.Backend {
+	return m.be
+}
+
+func (m *redisBE) Clear() error {
+	return m.c.FlushDB(context.Background()).Err()
+}
+
+func (m *redisBE) Cleanup() {
+	m.c.Close()
+}

--- a/internal/testing/backend/tikv_test.go
+++ b/internal/testing/backend/tikv_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package backend_test
+
+import (
+	"context"
+
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	tikvstore "github.com/guacsec/guac/pkg/assembler/kv/tikv"
+	"github.com/tikv/client-go/v2/config"
+	"github.com/tikv/client-go/v2/rawkv"
+)
+
+type tikvBE struct {
+	be      backends.Backend
+	connStr string
+	c       *rawkv.Client
+}
+
+func newTikv() backend {
+	return &tikvBE{
+		connStr: "127.0.0.1:2379",
+	}
+}
+
+func (m *tikvBE) Setup() error {
+	ctx := context.Background()
+	c, err := rawkv.NewClient(ctx, []string{m.connStr}, config.Security{})
+	if err != nil {
+		return err
+	}
+	m.c = c
+	if err := m.c.DeleteRange(ctx, []byte{0}, []byte{255, 255, 255, 255}); err != nil {
+		return err
+	}
+	store, err := tikvstore.GetStore(ctx, m.connStr)
+	if err != nil {
+		return err
+	}
+	be, err := backends.Get("keyvalue", nil, store)
+	m.be = be
+	return err
+}
+
+func (m *tikvBE) Get() backends.Backend {
+	return m.be
+}
+
+func (m *tikvBE) Clear() error {
+	return m.c.DeleteRange(context.Background(), []byte{0}, []byte{255, 255, 255, 255})
+}
+
+func (m *tikvBE) Cleanup() {
+	m.c.Close()
+}

--- a/pkg/assembler/backends/arangodb/artifact_test.go
+++ b/pkg/assembler/backends/arangodb/artifact_test.go
@@ -44,7 +44,7 @@ func lessArtifact(a, b *model.Artifact) int {
 func Test_IngestArtifactIDs(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -87,7 +87,7 @@ func Test_IngestArtifactIDs(t *testing.T) {
 func Test_IngestArtifactID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -151,7 +151,7 @@ func Test_IngestArtifactID(t *testing.T) {
 func Test_Artifacts(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -242,7 +242,7 @@ func Test_Artifacts(t *testing.T) {
 func Test_buildArtifactResponseByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -332,7 +332,7 @@ func arangoDBConnect(address, user, password string) (driver.Client, error) {
 	return client, nil
 }
 
-func deleteDatabase(ctx context.Context, args backends.BackendArgs) error {
+func DeleteDatabase(ctx context.Context, args backends.BackendArgs) error {
 	config, ok := args.(*ArangoConfig)
 	if !ok {
 		return fmt.Errorf("failed to assert arango config from backend args")

--- a/pkg/assembler/backends/arangodb/builder_test.go
+++ b/pkg/assembler/backends/arangodb/builder_test.go
@@ -31,7 +31,7 @@ import (
 func Test_IngestBuilder(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -81,7 +81,7 @@ func lessBuilder(a, b *model.Builder) int {
 func Test_IngestBuilders(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -200,7 +200,7 @@ func Test_Builders(t *testing.T) {
 func Test_buildBuilderResponseByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyBad_test.go
+++ b/pkg/assembler/backends/arangodb/certifyBad_test.go
@@ -32,7 +32,7 @@ import (
 func TestCertifyBad(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -717,7 +717,7 @@ func TestCertifyBad(t *testing.T) {
 func TestIngestCertifyBads(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1022,7 +1022,7 @@ func TestIngestCertifyBads(t *testing.T) {
 func Test_buildCertifyBadByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyGood_test.go
+++ b/pkg/assembler/backends/arangodb/certifyGood_test.go
@@ -32,7 +32,7 @@ import (
 func TestCertifyGood(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -714,7 +714,7 @@ func TestCertifyGood(t *testing.T) {
 func TestIngestCertifyGoods(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 func Test_buildCertifyGoodByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyLegal_test.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal_test.go
@@ -532,7 +532,7 @@ func TestLegal(t *testing.T) {
 	}, cmp.Ignore())
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -640,7 +640,7 @@ func TestLegals(t *testing.T) {
 	}, cmp.Ignore())
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -841,7 +841,7 @@ func Test_buildCertifyLegalByID(t *testing.T) {
 	}, cmp.Ignore())
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyScorecard_test.go
+++ b/pkg/assembler/backends/arangodb/certifyScorecard_test.go
@@ -32,7 +32,7 @@ import (
 func TestCertifyScorecard(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -559,7 +559,7 @@ func TestCertifyScorecard(t *testing.T) {
 func TestIngestScorecards(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -769,7 +769,7 @@ func TestIngestScorecards(t *testing.T) {
 func Test_buildCertifyScorecardByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement_test.go
@@ -32,7 +32,7 @@ import (
 func TestVEX(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -929,7 +929,7 @@ func TestVEX(t *testing.T) {
 func TestVEXBulkIngest(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1321,7 +1321,7 @@ func TestVEXBulkIngest(t *testing.T) {
 func Test_buildCertifyVexByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/certifyVuln_test.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln_test.go
@@ -43,7 +43,7 @@ var vmd1 = &model.ScanMetadata{
 func TestIngestCertifyVulnerability(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1003,7 +1003,7 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 func TestIngestCertifyVulns(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1432,7 +1432,7 @@ func TestIngestCertifyVulns(t *testing.T) {
 func Test_buildCertifyVulnByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/hasSBOM_test.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM_test.go
@@ -294,7 +294,7 @@ var includedTestExpectedSBOM = &model.HasSbom{
 func TestHasSBOM(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -2816,7 +2816,7 @@ func TestHasSBOM(t *testing.T) {
 func TestIngestHasSBOMs(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -3141,7 +3141,7 @@ func TestIngestHasSBOMs(t *testing.T) {
 func Test_buildHasSbomByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/hasSLSA_test.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA_test.go
@@ -32,7 +32,7 @@ import (
 func TestHasSLSA(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -682,7 +682,7 @@ func TestHasSLSA(t *testing.T) {
 func TestIngestHasSLSAs(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -908,7 +908,7 @@ func TestIngestHasSLSAs(t *testing.T) {
 func Test_buildHasSlsaByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/hasSourceAt_test.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt_test.go
@@ -32,7 +32,7 @@ import (
 func TestHasSourceAt(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -637,7 +637,7 @@ func TestHasSourceAt(t *testing.T) {
 func TestIngestHasSourceAts(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -912,7 +912,7 @@ func TestIngestHasSourceAts(t *testing.T) {
 func Test_buildHasSourceAtByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/hashEqual_test.go
+++ b/pkg/assembler/backends/arangodb/hashEqual_test.go
@@ -32,7 +32,7 @@ import (
 func TestHashEqual(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestHashEqual(t *testing.T) {
 func TestIngestHashEquals(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -836,7 +836,7 @@ func TestIngestHashEquals(t *testing.T) {
 func Test_buildHashEqualByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/isDependency_test.go
+++ b/pkg/assembler/backends/arangodb/isDependency_test.go
@@ -36,7 +36,7 @@ var (
 func TestIsDependency(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -915,7 +915,7 @@ func TestIsDependency(t *testing.T) {
 func TestIsDependencies(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1022,7 +1022,7 @@ func TestIsDependencies(t *testing.T) {
 func Test_buildIsDependencyByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/isOccurrence_test.go
+++ b/pkg/assembler/backends/arangodb/isOccurrence_test.go
@@ -32,7 +32,7 @@ import (
 func TestOccurrence(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -562,7 +562,7 @@ func TestOccurrence(t *testing.T) {
 func TestIngestOccurrences(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -677,7 +677,7 @@ func TestIngestOccurrences(t *testing.T) {
 func Test_buildIsOccurrenceByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/license_test.go
+++ b/pkg/assembler/backends/arangodb/license_test.go
@@ -36,7 +36,7 @@ func lessLicense(a, b *model.License) int {
 func Test_Licenses(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -145,7 +145,7 @@ func Test_Licenses(t *testing.T) {
 func Test_LicensesBulk(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -223,7 +223,7 @@ func Test_LicensesBulk(t *testing.T) {
 func Test_getLicenseByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/path_test.go
+++ b/pkg/assembler/backends/arangodb/path_test.go
@@ -31,7 +31,7 @@ import (
 func Test_Path(t *testing.T) {
 	ctx := context.Background()
 	arangoArg := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArg)
+	err := DeleteDatabase(ctx, arangoArg)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -255,7 +255,7 @@ func Test_Path(t *testing.T) {
 func Test_Nodes(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -994,7 +994,7 @@ func Test_Nodes(t *testing.T) {
 func Test_Neighbors(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/pkgEqual_test.go
+++ b/pkg/assembler/backends/arangodb/pkgEqual_test.go
@@ -32,7 +32,7 @@ import (
 func TestPkgEqual(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -632,7 +632,7 @@ func TestPkgEqual(t *testing.T) {
 func TestIngestPkgEquals(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1034,7 +1034,7 @@ func TestPkgInputSpecToPurl(t *testing.T) {
 func Test_buildPkgEqualByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/pkg_test.go
+++ b/pkg/assembler/backends/arangodb/pkg_test.go
@@ -32,7 +32,7 @@ import (
 func Test_Packages(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -155,7 +155,7 @@ func Test_Packages(t *testing.T) {
 func Test_PackageTypes(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -265,7 +265,7 @@ func Test_PackageTypes(t *testing.T) {
 func Test_PackagesNamespace(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -379,7 +379,7 @@ func Test_PackagesNamespace(t *testing.T) {
 func Test_PackagesName(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -516,7 +516,7 @@ func lessPkg(a, b *model.Package) int {
 func Test_IngestPackages(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -550,7 +550,7 @@ func Test_IngestPackages(t *testing.T) {
 func Test_buildPackageResponseFromID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/pointOfContact_test.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact_test.go
@@ -32,7 +32,7 @@ import (
 func TestPointOfContact(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -851,7 +851,7 @@ func TestPointOfContact(t *testing.T) {
 func TestIngestPointOfContacts(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1159,7 +1159,7 @@ func TestIngestPointOfContacts(t *testing.T) {
 func Test_buildPointOfContactByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/search_test.go
+++ b/pkg/assembler/backends/arangodb/search_test.go
@@ -31,7 +31,7 @@ import (
 func Test_arangoClient_FindSoftware(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/src_test.go
+++ b/pkg/assembler/backends/arangodb/src_test.go
@@ -37,7 +37,7 @@ func lessSource(a, b *model.Source) int {
 func Test_IngestSources(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -71,7 +71,7 @@ func Test_IngestSources(t *testing.T) {
 func Test_Sources(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -155,7 +155,7 @@ func Test_Sources(t *testing.T) {
 func Test_SourceTypes(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -255,7 +255,7 @@ func Test_SourceTypes(t *testing.T) {
 func Test_SourceNamespaces(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -366,7 +366,7 @@ func Test_SourceNamespaces(t *testing.T) {
 func Test_buildSourceResponseFromID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/vulnEqual_test.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual_test.go
@@ -31,7 +31,7 @@ import (
 func TestVulnEqual(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -646,7 +646,7 @@ func TestVulnEqual(t *testing.T) {
 func TestIngestVulnEquals(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -842,7 +842,7 @@ func TestIngestVulnEquals(t *testing.T) {
 func Test_buildVulnEqualByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/vulnMetadata_test.go
+++ b/pkg/assembler/backends/arangodb/vulnMetadata_test.go
@@ -42,7 +42,7 @@ var cvss2ScoreType model.VulnerabilityScoreType = model.VulnerabilityScoreTypeCV
 func TestIngestVulnMetadata(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func TestIngestVulnMetadata(t *testing.T) {
 func TestIngestVulnMetadatas(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -1337,7 +1337,7 @@ func TestIngestVulnMetadatas(t *testing.T) {
 func Test_buildVulnerabilityMetadataByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}

--- a/pkg/assembler/backends/arangodb/vulnerability_test.go
+++ b/pkg/assembler/backends/arangodb/vulnerability_test.go
@@ -37,7 +37,7 @@ func lessCve(a, b *model.Vulnerability) int {
 func TestVulnerability(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestVulnerability(t *testing.T) {
 func TestVulnerabilityType(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestVulnerabilityType(t *testing.T) {
 func TestIngestVulnerabilities(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestIngestVulnerabilities(t *testing.T) {
 func Test_buildVulnResponseByID(t *testing.T) {
 	ctx := context.Background()
 	arangoArgs := getArangoConfig()
-	err := deleteDatabase(ctx, arangoArgs)
+	err := DeleteDatabase(ctx, arangoArgs)
 	if err != nil {
 		t.Fatalf("error deleting arango database: %v", err)
 	}


### PR DESCRIPTION
A new integration test suite is added under internal/testing/backend to test all backends with the same set of tests. All the test scaffolding is seutp to run all the backends. Only "CertifyBad" tests have been copied in in this first commit.

Arango, keyvalue, and ent tests are all close copies of each other. A large amount of work in implementing API changes is updating the tests for each backend. Also, we wish to have a gold standard test suite so that new backends can be tested to the same standards as the existing ones. This code supports adding new backends piecemeal and skipping tests on unimplemented node types.

I've only put CertifyBad here now, so all the setup can be reviewed before I move all the types over. The plan is to remove all the integration tests from arango, keyvalue, and ent, and just use these.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
