### PR TITLE
Ent: ingest Builders, CertifyBads, CertifyGoods, CertifyLegals refactored concurrently

### DIFF
--- a/pkg/assembler/backends/ent/backend/certifyLegal_test.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal_test.go
@@ -608,7 +608,7 @@ func (s *Suite) TestLegals() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpLegal, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpLegal, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
# Description of the PR

Ent backend, implemented concurrent approach [1] for:

- `IngestBuilders`
- `IngestCertifyBads`
- `IngestCertifyGoods`
- `IngestCertifyLegals`

[1] from https://github.com/guacsec/guac/pull/1440

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
