### PR TITLE
Update vuln query to utilize hasSBOM and pass in SBOM URI or purl to search

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -51,7 +51,7 @@ type queryOptions struct {
 }
 
 var queryVulnCmd = &cobra.Command{
-	Use:   "vuln [flags] purl/sbomURI",
+	Use:   "vuln [flags] <purl/sbomURI>",
 	Short: "query if a package is affected by the specified vulnerability",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/Khan/genqlient/graphql"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
@@ -42,18 +43,18 @@ type queryOptions struct {
 	// gql endpoint
 	graphqlEndpoint string
 
-	purl            string
+	searchString    string
+	isPurl          bool
 	vulnerabilityID string
 	depth           int
 	pathsToReturn   int
 }
 
 var queryVulnCmd = &cobra.Command{
-	Use:   "vuln [flags] purl",
+	Use:   "vuln [flags] purl/sbomURI",
 	Short: "query if a package is affected by the specified vulnerability",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
-		logger := logging.FromContext(ctx)
 
 		opts, err := validateQueryVulnFlags(
 			viper.GetString("gql-addr"),
@@ -77,68 +78,59 @@ var queryVulnCmd = &cobra.Command{
 		tTemp.Render()
 		t.AppendHeader(rowHeader)
 
-		pkgInput, err := helpers.PurlToPkg(opts.purl)
-		if err != nil {
-			logger.Fatalf("failed to parse PURL: %v", err)
-		}
-
-		pkgQualifierFilter := []model.PackageQualifierSpec{}
-		for _, qualifier := range pkgInput.Qualifiers {
-			pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
-				Key:   qualifier.Key,
-				Value: &qualifier.Value,
-			})
-		}
-
-		pkgFilter := &model.PkgSpec{
-			Type:       &pkgInput.Type,
-			Namespace:  pkgInput.Namespace,
-			Name:       &pkgInput.Name,
-			Version:    pkgInput.Version,
-			Subpath:    pkgInput.Subpath,
-			Qualifiers: pkgQualifierFilter,
-		}
-		pkgResponse, err := model.Packages(ctx, gqlclient, *pkgFilter)
-		if err != nil {
-			logger.Fatalf("error querying for package: %v", err)
-		}
-		if len(pkgResponse.Packages) != 1 {
-			logger.Fatalf("failed to located package based on purl")
-		}
-
 		if opts.vulnerabilityID != "" {
-			printVulnInfoByVulnId(ctx, gqlclient, pkgResponse, t, opts)
+			printVulnInfoByVulnId(ctx, gqlclient, t, opts)
 		} else {
-			printVulnInfo(ctx, gqlclient, pkgResponse, t, opts)
+			printVulnInfo(ctx, gqlclient, t, opts)
 		}
 	},
 }
 
-func printVulnInfo(ctx context.Context, gqlclient graphql.Client, pkgResponse *model.PackagesResponse, t table.Writer, opts queryOptions) {
+func getPkgResponseFromPurl(ctx context.Context, gqlclient graphql.Client, purl string) (*model.PackagesResponse, error) {
+	pkgInput, err := helpers.PurlToPkg(purl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PURL: %v", err)
+	}
+
+	pkgQualifierFilter := []model.PackageQualifierSpec{}
+	for _, qualifier := range pkgInput.Qualifiers {
+		pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
+			Key:   qualifier.Key,
+			Value: &qualifier.Value,
+		})
+	}
+
+	pkgFilter := &model.PkgSpec{
+		Type:       &pkgInput.Type,
+		Namespace:  pkgInput.Namespace,
+		Name:       &pkgInput.Name,
+		Version:    pkgInput.Version,
+		Subpath:    pkgInput.Subpath,
+		Qualifiers: pkgQualifierFilter,
+	}
+	pkgResponse, err := model.Packages(ctx, gqlclient, *pkgFilter)
+	if err != nil {
+		return nil, fmt.Errorf("error querying for package: %v", err)
+	}
+	if len(pkgResponse.Packages) != 1 {
+		return nil, fmt.Errorf("failed to located package based on purl")
+	}
+	return pkgResponse, nil
+}
+
+func printVulnInfo(ctx context.Context, gqlclient graphql.Client, t table.Writer, opts queryOptions) {
 	logger := logging.FromContext(ctx)
 	var path []string
 	var tableRows []table.Row
 
-	if pkgResponse.Packages[0].Type != guacType {
-		vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id)
-		if err != nil {
-			logger.Fatalf("error querying neighbor: %v", err)
-		}
-		path = append(path, vulnPath...)
-		tableRows = append(tableRows, pkgVulnTableRows...)
-	}
-
-	depVulnPath, depVulnTableRows, err := searchDependencyPackages(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, opts.depth)
+	depVulnPath, depVulnTableRows, err := searchPkgViaHasSBOM(ctx, gqlclient, opts.searchString, opts.depth, opts.isPurl)
 	if err != nil {
-		logger.Fatalf("error searching dependency packages match: %v", err)
+		logger.Fatalf("error searching via hasSBOM: %v", err)
 	}
 	path = append(path, depVulnPath...)
 	tableRows = append(tableRows, depVulnTableRows...)
 
 	if len(path) > 0 {
-		path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
-			pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
-			pkgResponse.Packages[0].Id}, path...)
 		t.AppendRows(tableRows)
 
 		fmt.Println(t.Render())
@@ -148,7 +140,7 @@ func printVulnInfo(ctx context.Context, gqlclient graphql.Client, pkgResponse *m
 	}
 }
 
-func printVulnInfoByVulnId(ctx context.Context, gqlclient graphql.Client, pkgResponse *model.PackagesResponse, t table.Writer, opts queryOptions) {
+func printVulnInfoByVulnId(ctx context.Context, gqlclient graphql.Client, t table.Writer, opts queryOptions) {
 	logger := logging.FromContext(ctx)
 	var tableRows []table.Row
 
@@ -162,13 +154,34 @@ func printVulnInfoByVulnId(ctx context.Context, gqlclient graphql.Client, pkgRes
 		return
 	}
 	var path []string
+	var vexTableRows []table.Row
 
 	tableRows = append(tableRows, table.Row{vulnResponse.Vulnerabilities[0].Type, vulnResponse.Vulnerabilities[0].Id, "vulnerability ID: " + vulnResponse.Vulnerabilities[0].VulnerabilityIDs[0].VulnerabilityID})
-	var vexTableRows []table.Row
-	path, vexTableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
-
-	if err != nil {
-		logger.Fatalf("error querying neighbor: %v", err)
+	if opts.isPurl {
+		pkgResponse, err := getPkgResponseFromPurl(ctx, gqlclient, opts.searchString)
+		if err != nil {
+			logger.Fatalf("getPkgResponseFromPurl - error: %v", err)
+		}
+		path, vexTableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
+		if err != nil {
+			logger.Fatalf("error querying neighbor: %v", err)
+		}
+	} else {
+		foundHasSBOMPkg, err := model.HasSBOMs(ctx, gqlclient, model.HasSBOMSpec{Uri: &opts.searchString})
+		if err != nil {
+			logger.Fatalf("failed getting hasSBOM via URI: %s with error: %w", opts.searchString, err)
+		}
+		if len(foundHasSBOMPkg.HasSBOM) != 1 {
+			logger.Fatalf("failed to located singular hasSBOM based on URI")
+		}
+		if pkgResponse, ok := foundHasSBOMPkg.HasSBOM[0].Subject.(*model.AllHasSBOMTreeSubjectPackage); ok {
+			path, vexTableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
+			if err != nil {
+				logger.Fatalf("error querying neighbor: %v", err)
+			}
+		} else {
+			logger.Fatalf("located hasSBOM does not have a subject that is a package")
+		}
 	}
 	if len(vexTableRows) > 0 {
 		tableRows = append(tableRows, vexTableRows...)
@@ -251,111 +264,7 @@ func vexSubjectIds(s model.AllCertifyVEXStatementSubjectPackageOrArtifact) []str
 	}
 }
 
-func searchDependencyPackages(ctx context.Context, gqlclient graphql.Client, topPkgID string, maxLength int) ([]string, []table.Row, error) {
-	var path []string
-	var tableRows []table.Row
-
-	queue := make([]string, 0) // the queue of nodes in bfs
-	type dfsNode struct {
-		expanded bool // true once all node neighbors are added to queue
-		parent   string
-		depth    int
-	}
-	nodeMap := map[string]dfsNode{}
-
-	nodeMap[topPkgID] = dfsNode{}
-	queue = append(queue, topPkgID)
-
-	for len(queue) > 0 {
-		now := queue[0]
-		queue = queue[1:]
-		nowNode := nodeMap[now]
-
-		if maxLength != 0 && nowNode.depth >= maxLength {
-			break
-		}
-
-		isDependencyNeighborResponses, err := model.Neighbors(ctx, gqlclient, now, []model.Edge{model.EdgePackageIsDependency})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed getting package parent:%w", err)
-		}
-		for _, neighbor := range isDependencyNeighborResponses.Neighbors {
-			if isDependency, ok := neighbor.(*model.NeighborsNeighborsIsDependency); ok {
-				if isDependency.DependencyPackage.Type == guacType {
-					continue
-				}
-
-				var matchingDepPkgVersionIDs []string
-				if len(isDependency.DependencyPackage.Namespaces[0].Names[0].Versions) == 0 {
-					depPkgFilter := &model.PkgSpec{
-						Type:      &isDependency.DependencyPackage.Type,
-						Namespace: &isDependency.DependencyPackage.Namespaces[0].Namespace,
-						Name:      &isDependency.DependencyPackage.Namespaces[0].Names[0].Name,
-					}
-
-					depPkgResponse, err := model.Packages(ctx, gqlclient, *depPkgFilter)
-					if err != nil {
-						return nil, nil, fmt.Errorf("error querying for dependent package: %w", err)
-					}
-
-					depPkgVersionsMap := map[string]string{}
-					depPkgVersions := []string{}
-					for _, depPkgVersion := range depPkgResponse.Packages[0].Namespaces[0].Names[0].Versions {
-						depPkgVersions = append(depPkgVersions, depPkgVersion.Version)
-						depPkgVersionsMap[depPkgVersion.Version] = depPkgVersion.Id
-					}
-
-					matchingDepPkgVersions, err := depversion.WhichVersionMatches(depPkgVersions, isDependency.VersionRange)
-					if err != nil {
-						// TODO(jeffmendoza): depversion is not handling all/new possible
-						// version ranges from deps.dev. Continue here to report possible
-						// vulns even if some paths cannot be followed.
-						matchingDepPkgVersions = nil
-						//return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
-					}
-
-					for matchingDepPkgVersion := range matchingDepPkgVersions {
-						matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, depPkgVersionsMap[matchingDepPkgVersion])
-					}
-				} else {
-					matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, isDependency.DependencyPackage.Namespaces[0].Names[0].Versions[0].Id)
-				}
-				for _, matchingDepPkgVersionID := range matchingDepPkgVersionIDs {
-					dfsN, seen := nodeMap[matchingDepPkgVersionID]
-					if !seen {
-						dfsN = dfsNode{
-							parent: now,
-							depth:  nowNode.depth + 1,
-						}
-						nodeMap[matchingDepPkgVersionID] = dfsN
-					} else {
-						continue
-					}
-					if !dfsN.expanded {
-						queue = append(queue, matchingDepPkgVersionID)
-					}
-					vulnPath, foundVulnTableRow, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, matchingDepPkgVersionID)
-					if err != nil {
-						return nil, nil, fmt.Errorf("error querying neighbor: %w", err)
-					}
-					if len(vulnPath) > 0 {
-						path = append(path, isDependency.Id, matchingDepPkgVersionID,
-							isDependency.DependencyPackage.Namespaces[0].Names[0].Id, isDependency.DependencyPackage.Namespaces[0].Id,
-							isDependency.DependencyPackage.Id)
-						path = append(path, vulnPath...)
-						tableRows = append(tableRows, foundVulnTableRow...)
-					}
-				}
-			}
-		}
-		nowNode.expanded = true
-		nodeMap[now] = nowNode
-	}
-
-	return path, tableRows, nil
-}
-
-func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgResponse *model.PackagesResponse, vulnerabilitiesResponses []model.VulnerabilitiesVulnerabilitiesVulnerability, depth int, pathsToReturn int) ([]string, []table.Row, error) {
+func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Client, topPkgVersionID string, vulnerabilitiesResponses []model.VulnerabilitiesVulnerabilitiesVulnerability, depth int, pathsToReturn int) ([]string, []table.Row, error) {
 	type vulnNeighbor struct {
 		node model.NeighborsNeighborsNode
 		id   string
@@ -385,7 +294,7 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 	for _, neighbor := range vulnNodeNeighborResponses {
 		if certifyVuln, ok := neighbor.node.(*model.NeighborsNeighborsCertifyVuln); ok {
 			certifyVulnFound = true
-			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
+			pkgPath, err := searchDependencyPackagesReverse(ctx, gqlclient, topPkgVersionID, certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id, depth)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error searching dependency packages match: %w", err)
 			}
@@ -523,6 +432,215 @@ func searchDependencyPackagesReverse(ctx context.Context, gqlclient graphql.Clie
 	}
 }
 
+func concurrentVulnAndVexNeighbors(ctx context.Context, gqlclient graphql.Client, pkgID string, isDep model.AllHasSBOMTreeIncludedDependenciesIsDependency, resultChan chan<- struct {
+	pkgVersionNeighborResponse *model.NeighborsResponse
+	isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
+}, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	logger := logging.FromContext(ctx)
+	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgID, []model.Edge{model.EdgePackageCertifyVuln, model.EdgePackageCertifyVexStatement})
+	if err != nil {
+		logger.Errorf("error querying neighbor for vulnerability: %w", err)
+		return
+	}
+
+	// Send the results to the resultChan
+	resultChan <- struct {
+		pkgVersionNeighborResponse *model.NeighborsResponse
+		isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
+	}{pkgVersionNeighborResponse, isDep}
+}
+
+// searchPkgViaHasSBOM takes in either a purl or URI for the initial value to find the hasSBOM node.
+// From there is recursively searches through all the dependencies to determine if it contains hasSBOM nodes.
+// It concurrent checks the package version node if it contains vulnerabilities and VEX data.
+func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchString string, maxLength int, isPurl bool) ([]string, []table.Row, error) {
+	var path []string
+	var tableRows []table.Row
+	checkedIDs := map[string]bool{}
+	var wg sync.WaitGroup
+
+	queue := make([]string, 0) // the queue of nodes in bfs
+	type dfsNode struct {
+		expanded bool // true once all node neighbors are added to queue
+		parent   string
+		pkgID    string
+		depth    int
+	}
+	nodeMap := map[string]dfsNode{}
+
+	nodeMap[searchString] = dfsNode{}
+	queue = append(queue, searchString)
+
+	resultChan := make(chan struct {
+		pkgVersionNeighborResponse *model.NeighborsResponse
+		isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
+	})
+
+	for len(queue) > 0 {
+		now := queue[0]
+		queue = queue[1:]
+		nowNode := nodeMap[now]
+
+		if maxLength != 0 && nowNode.depth >= maxLength {
+			break
+		}
+
+		var foundHasSBOMPkg *model.HasSBOMsResponse
+		var err error
+
+		// if the initial depth, check if its a purl or an SBOM URI. Otherwise always search by pkgID
+		if nowNode.depth == 0 {
+			if isPurl {
+				pkgResponse, err := getPkgResponseFromPurl(ctx, gqlclient, now)
+				if err != nil {
+					return nil, nil, fmt.Errorf("getPkgResponseFromPurl - error: %v", err)
+				}
+				foundHasSBOMPkg, err = model.HasSBOMs(ctx, gqlclient, model.HasSBOMSpec{Subject: &model.PackageOrArtifactSpec{Package: &model.PkgSpec{Id: &pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id}}})
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed getting hasSBOM via purl: %s with error :%w", now, err)
+				}
+			} else {
+				foundHasSBOMPkg, err = model.HasSBOMs(ctx, gqlclient, model.HasSBOMSpec{Uri: &now})
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed getting hasSBOM via URI: %s with error: %w", now, err)
+				}
+			}
+		} else {
+			foundHasSBOMPkg, err = model.HasSBOMs(ctx, gqlclient, model.HasSBOMSpec{Subject: &model.PackageOrArtifactSpec{Package: &model.PkgSpec{Id: &now}}})
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed getting hasSBOM via purl: %s with error :%w", now, err)
+			}
+		}
+
+		for _, hasSBOM := range foundHasSBOMPkg.HasSBOM {
+			if pkgResponse, ok := foundHasSBOMPkg.HasSBOM[0].Subject.(*model.AllHasSBOMTreeSubjectPackage); ok {
+				if pkgResponse.Type != guacType {
+					if !checkedIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] {
+						vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Namespaces[0].Names[0].Versions[0].Id)
+						if err != nil {
+							return nil, nil, fmt.Errorf("error querying neighbor: %v", err)
+						}
+						path = append(path, vulnPath...)
+						tableRows = append(tableRows, pkgVulnTableRows...)
+						path = append([]string{pkgResponse.Namespaces[0].Names[0].Versions[0].Id,
+							pkgResponse.Namespaces[0].Names[0].Id, pkgResponse.Namespaces[0].Id,
+							pkgResponse.Id}, path...)
+					}
+				}
+			} else {
+				continue
+			}
+			for _, isDep := range hasSBOM.IncludedDependencies {
+				var matchingDepPkgVersionIDs []string
+				if len(isDep.DependencyPackage.Namespaces[0].Names[0].Versions) == 0 {
+					findMatchingDepPkgVersionIDs, err := findDepPkgVersionIDs(ctx, gqlclient, isDep.DependencyPackage.Type, isDep.DependencyPackage.Namespaces[0].Namespace,
+						isDep.DependencyPackage.Namespaces[0].Names[0].Name, isDep.VersionRange)
+					if err != nil {
+						return nil, nil, fmt.Errorf("error from findMatchingDepPkgVersionIDs:%w", err)
+					}
+					matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, findMatchingDepPkgVersionIDs...)
+				} else {
+					matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, isDep.DependencyPackage.Namespaces[0].Names[0].Versions[0].Id)
+				}
+				for _, pkgID := range matchingDepPkgVersionIDs {
+					if !checkedIDs[pkgID] {
+						dfsN, seen := nodeMap[pkgID]
+						if !seen {
+							dfsN = dfsNode{
+								parent: now,
+								pkgID:  pkgID,
+								depth:  nowNode.depth + 1,
+							}
+							nodeMap[pkgID] = dfsN
+						}
+						if !dfsN.expanded {
+							queue = append(queue, pkgID)
+						}
+						wg.Add(1)
+						go concurrentVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep, resultChan, &wg)
+						checkedIDs[pkgID] = true
+					}
+				}
+			}
+		}
+		nowNode.expanded = true
+		nodeMap[now] = nowNode
+	}
+
+	// Close the result channel once all goroutines are done
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	// Collect results from the channel
+	for result := range resultChan {
+		for _, neighbor := range result.pkgVersionNeighborResponse.Neighbors {
+			if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
+				if certifyVuln.Vulnerability.Type != noVulnType {
+					for _, vuln := range certifyVuln.Vulnerability.VulnerabilityIDs {
+						tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
+						path = append(path, []string{vuln.Id, certifyVuln.Id,
+							certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
+							certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
+							certifyVuln.Package.Id}...)
+					}
+					path = append(path, result.isDep.Id, result.isDep.Package.Namespaces[0].Names[0].Versions[0].Id,
+						result.isDep.DependencyPackage.Namespaces[0].Names[0].Id, result.isDep.DependencyPackage.Namespaces[0].Id,
+						result.isDep.DependencyPackage.Id)
+				}
+			}
+
+			if certifyVex, ok := neighbor.(*model.NeighborsNeighborsCertifyVEXStatement); ok {
+				for _, vuln := range certifyVex.Vulnerability.VulnerabilityIDs {
+					tableRows = append(tableRows, table.Row{vexLinkStr, certifyVex.Id, "vulnerability ID: " + vuln.VulnerabilityID + ", Vex Status: " + string(certifyVex.Status) + ", Subject: " + vexSubjectString(certifyVex.Subject)})
+					path = append(path, certifyVex.Id, vuln.Id)
+				}
+				path = append(path, vexSubjectIds(certifyVex.Subject)...)
+			}
+		}
+	}
+	return path, tableRows, nil
+}
+
+func findDepPkgVersionIDs(ctx context.Context, gqlclient graphql.Client, depPkgType string, depPkgNameSpace string, depPkgName string, versionRange string) ([]string, error) {
+	var matchingDepPkgVersionIDs []string
+
+	depPkgFilter := &model.PkgSpec{
+		Type:      &depPkgType,
+		Namespace: &depPkgNameSpace,
+		Name:      &depPkgName,
+	}
+
+	depPkgResponse, err := model.Packages(ctx, gqlclient, *depPkgFilter)
+	if err != nil {
+		return nil, fmt.Errorf("error querying for dependent package: %w", err)
+	}
+
+	depPkgVersionsMap := map[string]string{}
+	depPkgVersions := []string{}
+	for _, depPkgVersion := range depPkgResponse.Packages[0].Namespaces[0].Names[0].Versions {
+		depPkgVersions = append(depPkgVersions, depPkgVersion.Version)
+		depPkgVersionsMap[depPkgVersion.Version] = depPkgVersion.Id
+	}
+
+	matchingDepPkgVersions, err := depversion.WhichVersionMatches(depPkgVersions, versionRange)
+	if err != nil {
+		// TODO(jeffmendoza): depversion is not handling all/new possible
+		// version ranges from deps.dev. Continue here to report possible
+		// vulns even if some paths cannot be followed.
+		matchingDepPkgVersions = nil
+		//return nil, nil, fmt.Errorf("error determining dependent version matches: %w", err)
+	}
+
+	for matchingDepPkgVersion := range matchingDepPkgVersions {
+		matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, depPkgVersionsMap[matchingDepPkgVersion])
+	}
+	return matchingDepPkgVersionIDs, nil
+}
+
 func removeDuplicateValuesFromPath(path []string) []string {
 	keys := make(map[string]bool)
 	var list []string
@@ -544,9 +662,15 @@ func validateQueryVulnFlags(graphqlEndpoint, vulnID string, depth, path int, arg
 	opts.pathsToReturn = path
 
 	if len(args) > 0 {
-		opts.purl = args[0]
+		_, err := helpers.PurlToPkg(args[0])
+		if err != nil {
+			opts.isPurl = false
+		} else {
+			opts.isPurl = true
+		}
+		opts.searchString = args[0]
 	} else {
-		return opts, fmt.Errorf("expected subject input to be purl")
+		return opts, fmt.Errorf("expected subject input to be purl or SBOM URI")
 	}
 	return opts, nil
 }

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -154,15 +154,13 @@ func printVulnInfoByVulnId(ctx context.Context, gqlclient graphql.Client, t tabl
 		return
 	}
 	var path []string
-	var vexTableRows []table.Row
 
-	tableRows = append(tableRows, table.Row{vulnResponse.Vulnerabilities[0].Type, vulnResponse.Vulnerabilities[0].Id, "vulnerability ID: " + vulnResponse.Vulnerabilities[0].VulnerabilityIDs[0].VulnerabilityID})
 	if opts.isPurl {
 		pkgResponse, err := getPkgResponseFromPurl(ctx, gqlclient, opts.searchString)
 		if err != nil {
 			logger.Fatalf("getPkgResponseFromPurl - error: %v", err)
 		}
-		path, vexTableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
+		path, tableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
 		if err != nil {
 			logger.Fatalf("error querying neighbor: %v", err)
 		}
@@ -175,16 +173,13 @@ func printVulnInfoByVulnId(ctx context.Context, gqlclient graphql.Client, t tabl
 			logger.Fatalf("failed to located singular hasSBOM based on URI")
 		}
 		if pkgResponse, ok := foundHasSBOMPkg.HasSBOM[0].Subject.(*model.AllHasSBOMTreeSubjectPackage); ok {
-			path, vexTableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
+			path, tableRows, err = queryVulnsViaVulnNodeNeighbors(ctx, gqlclient, pkgResponse.Namespaces[0].Names[0].Versions[0].Id, vulnResponse.Vulnerabilities, opts.depth, opts.pathsToReturn)
 			if err != nil {
 				logger.Fatalf("error querying neighbor: %v", err)
 			}
 		} else {
 			logger.Fatalf("located hasSBOM does not have a subject that is a package")
 		}
-	}
-	if len(vexTableRows) > 0 {
-		tableRows = append(tableRows, vexTableRows...)
 	}
 	if len(path) > 0 {
 		t.AppendRows(tableRows)
@@ -278,11 +273,9 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 	for _, vulnerabilitiesResponse := range vulnerabilitiesResponses {
 		for _, vulnerabilityNodeID := range vulnerabilitiesResponse.VulnerabilityIDs {
 			vulnNodeNeighborResponse, err := model.Neighbors(ctx, gqlclient, vulnerabilityNodeID.Id, edgeTypes)
-
 			if err != nil {
 				return nil, nil, fmt.Errorf("error querying neighbor for vulnerability: %w", err)
 			}
-
 			for _, neighbor := range vulnNodeNeighborResponse.Neighbors {
 				vulnNodeNeighborResponses = append(vulnNodeNeighborResponses, vulnNeighbor{neighbor, vulnerabilityNodeID.Id})
 			}
@@ -299,7 +292,8 @@ func queryVulnsViaVulnNodeNeighbors(ctx context.Context, gqlclient graphql.Clien
 				return nil, nil, fmt.Errorf("error searching dependency packages match: %w", err)
 			}
 			if len(pkgPath) > 0 {
-				fullVulnPath := append([]string{neighbor.id, certifyVuln.Id,
+				tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + certifyVuln.Vulnerability.VulnerabilityIDs[0].VulnerabilityID})
+				fullVulnPath := append([]string{certifyVuln.Vulnerability.Id, certifyVuln.Vulnerability.VulnerabilityIDs[0].Id, certifyVuln.Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
 					certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
 					certifyVuln.Package.Id}, pkgPath...)
@@ -529,8 +523,6 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 							pkgResponse.Id}, path...)
 					}
 				}
-			} else {
-				continue
 			}
 			for _, isDep := range hasSBOM.IncludedDependencies {
 				var matchingDepPkgVersionIDs []string

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -8005,6 +8005,226 @@ type HasSBOMPkgsResponse struct {
 // GetIngestHasSBOMs returns HasSBOMPkgsResponse.IngestHasSBOMs, and is useful for accessing the field via an interface.
 func (v *HasSBOMPkgsResponse) GetIngestHasSBOMs() []string { return v.IngestHasSBOMs }
 
+// HasSBOMSpec allows filtering the list of HasSBOM to return.
+//
+// Only the package or artifact can be added, not both.
+//
+// If KnownSince is specified, the returned value will be after or equal to the specified time.
+// Any nodes time that is before KnownSince is excluded.
+type HasSBOMSpec struct {
+	Id                   *string                  `json:"id"`
+	Subject              *PackageOrArtifactSpec   `json:"subject"`
+	Uri                  *string                  `json:"uri"`
+	Algorithm            *string                  `json:"algorithm"`
+	Digest               *string                  `json:"digest"`
+	DownloadLocation     *string                  `json:"downloadLocation"`
+	Origin               *string                  `json:"origin"`
+	Collector            *string                  `json:"collector"`
+	KnownSince           *time.Time               `json:"knownSince"`
+	IncludedSoftware     []*PackageOrArtifactSpec `json:"includedSoftware"`
+	IncludedDependencies []*IsDependencySpec      `json:"includedDependencies"`
+	IncludedOccurrences  []*IsOccurrenceSpec      `json:"includedOccurrences"`
+}
+
+// GetId returns HasSBOMSpec.Id, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetId() *string { return v.Id }
+
+// GetSubject returns HasSBOMSpec.Subject, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetSubject() *PackageOrArtifactSpec { return v.Subject }
+
+// GetUri returns HasSBOMSpec.Uri, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetUri() *string { return v.Uri }
+
+// GetAlgorithm returns HasSBOMSpec.Algorithm, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetAlgorithm() *string { return v.Algorithm }
+
+// GetDigest returns HasSBOMSpec.Digest, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetDigest() *string { return v.Digest }
+
+// GetDownloadLocation returns HasSBOMSpec.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetDownloadLocation() *string { return v.DownloadLocation }
+
+// GetOrigin returns HasSBOMSpec.Origin, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetOrigin() *string { return v.Origin }
+
+// GetCollector returns HasSBOMSpec.Collector, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetCollector() *string { return v.Collector }
+
+// GetKnownSince returns HasSBOMSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetKnownSince() *time.Time { return v.KnownSince }
+
+// GetIncludedSoftware returns HasSBOMSpec.IncludedSoftware, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetIncludedSoftware() []*PackageOrArtifactSpec { return v.IncludedSoftware }
+
+// GetIncludedDependencies returns HasSBOMSpec.IncludedDependencies, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetIncludedDependencies() []*IsDependencySpec { return v.IncludedDependencies }
+
+// GetIncludedOccurrences returns HasSBOMSpec.IncludedOccurrences, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetIncludedOccurrences() []*IsOccurrenceSpec { return v.IncludedOccurrences }
+
+// HasSBOMsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
+type HasSBOMsHasSBOM struct {
+	AllHasSBOMTree `json:"-"`
+}
+
+// GetId returns HasSBOMsHasSBOM.Id, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetId() string { return v.AllHasSBOMTree.Id }
+
+// GetSubject returns HasSBOMsHasSBOM.Subject, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetSubject() AllHasSBOMTreeSubjectPackageOrArtifact {
+	return v.AllHasSBOMTree.Subject
+}
+
+// GetUri returns HasSBOMsHasSBOM.Uri, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetUri() string { return v.AllHasSBOMTree.Uri }
+
+// GetAlgorithm returns HasSBOMsHasSBOM.Algorithm, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetAlgorithm() string { return v.AllHasSBOMTree.Algorithm }
+
+// GetDigest returns HasSBOMsHasSBOM.Digest, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetDigest() string { return v.AllHasSBOMTree.Digest }
+
+// GetDownloadLocation returns HasSBOMsHasSBOM.DownloadLocation, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetDownloadLocation() string { return v.AllHasSBOMTree.DownloadLocation }
+
+// GetOrigin returns HasSBOMsHasSBOM.Origin, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetOrigin() string { return v.AllHasSBOMTree.Origin }
+
+// GetCollector returns HasSBOMsHasSBOM.Collector, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetCollector() string { return v.AllHasSBOMTree.Collector }
+
+// GetKnownSince returns HasSBOMsHasSBOM.KnownSince, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetKnownSince() time.Time { return v.AllHasSBOMTree.KnownSince }
+
+// GetIncludedSoftware returns HasSBOMsHasSBOM.IncludedSoftware, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetIncludedSoftware() []AllHasSBOMTreeIncludedSoftwarePackageOrArtifact {
+	return v.AllHasSBOMTree.IncludedSoftware
+}
+
+// GetIncludedDependencies returns HasSBOMsHasSBOM.IncludedDependencies, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetIncludedDependencies() []AllHasSBOMTreeIncludedDependenciesIsDependency {
+	return v.AllHasSBOMTree.IncludedDependencies
+}
+
+// GetIncludedOccurrences returns HasSBOMsHasSBOM.IncludedOccurrences, and is useful for accessing the field via an interface.
+func (v *HasSBOMsHasSBOM) GetIncludedOccurrences() []AllHasSBOMTreeIncludedOccurrencesIsOccurrence {
+	return v.AllHasSBOMTree.IncludedOccurrences
+}
+
+func (v *HasSBOMsHasSBOM) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*HasSBOMsHasSBOM
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.HasSBOMsHasSBOM = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllHasSBOMTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalHasSBOMsHasSBOM struct {
+	Id string `json:"id"`
+
+	Subject json.RawMessage `json:"subject"`
+
+	Uri string `json:"uri"`
+
+	Algorithm string `json:"algorithm"`
+
+	Digest string `json:"digest"`
+
+	DownloadLocation string `json:"downloadLocation"`
+
+	Origin string `json:"origin"`
+
+	Collector string `json:"collector"`
+
+	KnownSince time.Time `json:"knownSince"`
+
+	IncludedSoftware []json.RawMessage `json:"includedSoftware"`
+
+	IncludedDependencies []AllHasSBOMTreeIncludedDependenciesIsDependency `json:"includedDependencies"`
+
+	IncludedOccurrences []AllHasSBOMTreeIncludedOccurrencesIsOccurrence `json:"includedOccurrences"`
+}
+
+func (v *HasSBOMsHasSBOM) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *HasSBOMsHasSBOM) __premarshalJSON() (*__premarshalHasSBOMsHasSBOM, error) {
+	var retval __premarshalHasSBOMsHasSBOM
+
+	retval.Id = v.AllHasSBOMTree.Id
+	{
+
+		dst := &retval.Subject
+		src := v.AllHasSBOMTree.Subject
+		var err error
+		*dst, err = __marshalAllHasSBOMTreeSubjectPackageOrArtifact(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal HasSBOMsHasSBOM.AllHasSBOMTree.Subject: %w", err)
+		}
+	}
+	retval.Uri = v.AllHasSBOMTree.Uri
+	retval.Algorithm = v.AllHasSBOMTree.Algorithm
+	retval.Digest = v.AllHasSBOMTree.Digest
+	retval.DownloadLocation = v.AllHasSBOMTree.DownloadLocation
+	retval.Origin = v.AllHasSBOMTree.Origin
+	retval.Collector = v.AllHasSBOMTree.Collector
+	retval.KnownSince = v.AllHasSBOMTree.KnownSince
+	{
+
+		dst := &retval.IncludedSoftware
+		src := v.AllHasSBOMTree.IncludedSoftware
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalAllHasSBOMTreeIncludedSoftwarePackageOrArtifact(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal HasSBOMsHasSBOM.AllHasSBOMTree.IncludedSoftware: %w", err)
+			}
+		}
+	}
+	retval.IncludedDependencies = v.AllHasSBOMTree.IncludedDependencies
+	retval.IncludedOccurrences = v.AllHasSBOMTree.IncludedOccurrences
+	return &retval, nil
+}
+
+// HasSBOMsResponse is returned by HasSBOMs on success.
+type HasSBOMsResponse struct {
+	// Returns all SBOM certifications.
+	HasSBOM []HasSBOMsHasSBOM `json:"HasSBOM"`
+}
+
+// GetHasSBOM returns HasSBOMsResponse.HasSBOM, and is useful for accessing the field via an interface.
+func (v *HasSBOMsResponse) GetHasSBOM() []HasSBOMsHasSBOM { return v.HasSBOM }
+
 // HasSourceAtInputSpec is the same as HasSourceAt but for mutation input.
 type HasSourceAtInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
@@ -8408,6 +8628,47 @@ type IsDependencyResponse struct {
 // GetIngestDependency returns IsDependencyResponse.IngestDependency, and is useful for accessing the field via an interface.
 func (v *IsDependencyResponse) GetIngestDependency() string { return v.IngestDependency }
 
+// IsDependencySpec allows filtering the list of dependencies to return.
+//
+// To obtain the list of dependency packages, caller must fill in the package
+// field.
+//
+// Dependency packages must be defined at PackageName, not PackageVersion.
+type IsDependencySpec struct {
+	Id                *string         `json:"id"`
+	Package           *PkgSpec        `json:"package"`
+	DependencyPackage *PkgSpec        `json:"dependencyPackage"`
+	VersionRange      *string         `json:"versionRange"`
+	DependencyType    *DependencyType `json:"dependencyType"`
+	Justification     *string         `json:"justification"`
+	Origin            *string         `json:"origin"`
+	Collector         *string         `json:"collector"`
+}
+
+// GetId returns IsDependencySpec.Id, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetId() *string { return v.Id }
+
+// GetPackage returns IsDependencySpec.Package, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetPackage() *PkgSpec { return v.Package }
+
+// GetDependencyPackage returns IsDependencySpec.DependencyPackage, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetDependencyPackage() *PkgSpec { return v.DependencyPackage }
+
+// GetVersionRange returns IsDependencySpec.VersionRange, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetVersionRange() *string { return v.VersionRange }
+
+// GetDependencyType returns IsDependencySpec.DependencyType, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetDependencyType() *DependencyType { return v.DependencyType }
+
+// GetJustification returns IsDependencySpec.Justification, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetJustification() *string { return v.Justification }
+
+// GetOrigin returns IsDependencySpec.Origin, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetOrigin() *string { return v.Origin }
+
+// GetCollector returns IsDependencySpec.Collector, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetCollector() *string { return v.Collector }
+
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
 	Justification string `json:"justification"`
@@ -8432,6 +8693,35 @@ type IsOccurrencePkgResponse struct {
 
 // GetIngestOccurrence returns IsOccurrencePkgResponse.IngestOccurrence, and is useful for accessing the field via an interface.
 func (v *IsOccurrencePkgResponse) GetIngestOccurrence() string { return v.IngestOccurrence }
+
+// IsOccurrenceSpec allows filtering the list of artifact occurences to return in
+// a query.
+type IsOccurrenceSpec struct {
+	Id            *string              `json:"id"`
+	Subject       *PackageOrSourceSpec `json:"subject"`
+	Artifact      *ArtifactSpec        `json:"artifact"`
+	Justification *string              `json:"justification"`
+	Origin        *string              `json:"origin"`
+	Collector     *string              `json:"collector"`
+}
+
+// GetId returns IsOccurrenceSpec.Id, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetId() *string { return v.Id }
+
+// GetSubject returns IsOccurrenceSpec.Subject, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetSubject() *PackageOrSourceSpec { return v.Subject }
+
+// GetArtifact returns IsOccurrenceSpec.Artifact, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetArtifact() *ArtifactSpec { return v.Artifact }
+
+// GetJustification returns IsOccurrenceSpec.Justification, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetJustification() *string { return v.Justification }
+
+// GetOrigin returns IsOccurrenceSpec.Origin, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetOrigin() *string { return v.Origin }
+
+// GetCollector returns IsOccurrenceSpec.Collector, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetCollector() *string { return v.Collector }
 
 // IsOccurrenceSrcResponse is returned by IsOccurrenceSrc on success.
 type IsOccurrenceSrcResponse struct {
@@ -17720,6 +18010,21 @@ func (v *PackageNamespacesResponse) GetPackages() []PackageNamespacesPackagesPac
 	return v.Packages
 }
 
+// PackageOrArtifactSpec allows using PackageOrArtifact union as
+// input type to be used in read queries.
+//
+// Exactly one of the value must be set to non-nil.
+type PackageOrArtifactSpec struct {
+	Package  *PkgSpec      `json:"package"`
+	Artifact *ArtifactSpec `json:"artifact"`
+}
+
+// GetPackage returns PackageOrArtifactSpec.Package, and is useful for accessing the field via an interface.
+func (v *PackageOrArtifactSpec) GetPackage() *PkgSpec { return v.Package }
+
+// GetArtifact returns PackageOrArtifactSpec.Artifact, and is useful for accessing the field via an interface.
+func (v *PackageOrArtifactSpec) GetArtifact() *ArtifactSpec { return v.Artifact }
+
 // PackageOrSourceSpec allows using PackageOrSource union as input for queries.
 //
 // Exactly one field must be specified.
@@ -22394,6 +22699,14 @@ func (v *__HasSBOMPkgsInput) GetHasSBOMs() []HasSBOMInputSpec { return v.HasSBOM
 // GetIncludes returns __HasSBOMPkgsInput.Includes, and is useful for accessing the field via an interface.
 func (v *__HasSBOMPkgsInput) GetIncludes() []HasSBOMIncludesInputSpec { return v.Includes }
 
+// __HasSBOMsInput is used internally by genqlient
+type __HasSBOMsInput struct {
+	Filter HasSBOMSpec `json:"filter"`
+}
+
+// GetFilter returns __HasSBOMsInput.Filter, and is useful for accessing the field via an interface.
+func (v *__HasSBOMsInput) GetFilter() HasSBOMSpec { return v.Filter }
+
 // __IngestArtifactInput is used internally by genqlient
 type __IngestArtifactInput struct {
 	Artifact ArtifactInputSpec `json:"artifact"`
@@ -24575,6 +24888,147 @@ func HasSBOMPkgs(
 	var err error
 
 	var data HasSBOMPkgsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by HasSBOMs.
+const HasSBOMs_Operation = `
+query HasSBOMs ($filter: HasSBOMSpec!) {
+	HasSBOM(hasSBOMSpec: $filter) {
+		... AllHasSBOMTree
+	}
+}
+fragment AllHasSBOMTree on HasSBOM {
+	id
+	subject {
+		__typename
+		... on Artifact {
+			... AllArtifactTree
+		}
+		... on Package {
+			... AllPkgTree
+		}
+	}
+	uri
+	algorithm
+	digest
+	downloadLocation
+	origin
+	collector
+	knownSince
+	includedSoftware {
+		__typename
+		... on Artifact {
+			... AllArtifactTree
+		}
+		... on Package {
+			... AllPkgTree
+		}
+	}
+	includedDependencies {
+		... AllIsDependencyTree
+	}
+	includedOccurrences {
+		... AllIsOccurrencesTree
+	}
+}
+fragment AllArtifactTree on Artifact {
+	id
+	algorithm
+	digest
+}
+fragment AllPkgTree on Package {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			versions {
+				id
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+fragment AllIsDependencyTree on IsDependency {
+	id
+	justification
+	package {
+		... AllPkgTree
+	}
+	dependencyPackage {
+		... AllPkgTree
+	}
+	dependencyType
+	versionRange
+	origin
+	collector
+}
+fragment AllIsOccurrencesTree on IsOccurrence {
+	id
+	subject {
+		__typename
+		... on Package {
+			... AllPkgTree
+		}
+		... on Source {
+			... AllSourceTree
+		}
+	}
+	artifact {
+		... AllArtifactTree
+	}
+	justification
+	origin
+	collector
+}
+fragment AllSourceTree on Source {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			tag
+			commit
+		}
+	}
+}
+`
+
+func HasSBOMs(
+	ctx context.Context,
+	client graphql.Client,
+	filter HasSBOMSpec,
+) (*HasSBOMsResponse, error) {
+	req := &graphql.Request{
+		OpName: "HasSBOMs",
+		Query:  HasSBOMs_Operation,
+		Variables: &__HasSBOMsInput{
+			Filter: filter,
+		},
+	}
+	var err error
+
+	var data HasSBOMsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -8012,18 +8012,18 @@ func (v *HasSBOMPkgsResponse) GetIngestHasSBOMs() []string { return v.IngestHasS
 // If KnownSince is specified, the returned value will be after or equal to the specified time.
 // Any nodes time that is before KnownSince is excluded.
 type HasSBOMSpec struct {
-	Id                   *string                  `json:"id"`
-	Subject              *PackageOrArtifactSpec   `json:"subject"`
-	Uri                  *string                  `json:"uri"`
-	Algorithm            *string                  `json:"algorithm"`
-	Digest               *string                  `json:"digest"`
-	DownloadLocation     *string                  `json:"downloadLocation"`
-	Origin               *string                  `json:"origin"`
-	Collector            *string                  `json:"collector"`
-	KnownSince           *time.Time               `json:"knownSince"`
-	IncludedSoftware     []*PackageOrArtifactSpec `json:"includedSoftware"`
-	IncludedDependencies []*IsDependencySpec      `json:"includedDependencies"`
-	IncludedOccurrences  []*IsOccurrenceSpec      `json:"includedOccurrences"`
+	Id                   *string                 `json:"id"`
+	Subject              *PackageOrArtifactSpec  `json:"subject"`
+	Uri                  *string                 `json:"uri"`
+	Algorithm            *string                 `json:"algorithm"`
+	Digest               *string                 `json:"digest"`
+	DownloadLocation     *string                 `json:"downloadLocation"`
+	Origin               *string                 `json:"origin"`
+	Collector            *string                 `json:"collector"`
+	KnownSince           *time.Time              `json:"knownSince"`
+	IncludedSoftware     []PackageOrArtifactSpec `json:"includedSoftware"`
+	IncludedDependencies []IsDependencySpec      `json:"includedDependencies"`
+	IncludedOccurrences  []IsOccurrenceSpec      `json:"includedOccurrences"`
 }
 
 // GetId returns HasSBOMSpec.Id, and is useful for accessing the field via an interface.
@@ -8054,13 +8054,13 @@ func (v *HasSBOMSpec) GetCollector() *string { return v.Collector }
 func (v *HasSBOMSpec) GetKnownSince() *time.Time { return v.KnownSince }
 
 // GetIncludedSoftware returns HasSBOMSpec.IncludedSoftware, and is useful for accessing the field via an interface.
-func (v *HasSBOMSpec) GetIncludedSoftware() []*PackageOrArtifactSpec { return v.IncludedSoftware }
+func (v *HasSBOMSpec) GetIncludedSoftware() []PackageOrArtifactSpec { return v.IncludedSoftware }
 
 // GetIncludedDependencies returns HasSBOMSpec.IncludedDependencies, and is useful for accessing the field via an interface.
-func (v *HasSBOMSpec) GetIncludedDependencies() []*IsDependencySpec { return v.IncludedDependencies }
+func (v *HasSBOMSpec) GetIncludedDependencies() []IsDependencySpec { return v.IncludedDependencies }
 
 // GetIncludedOccurrences returns HasSBOMSpec.IncludedOccurrences, and is useful for accessing the field via an interface.
-func (v *HasSBOMSpec) GetIncludedOccurrences() []*IsOccurrenceSpec { return v.IncludedOccurrences }
+func (v *HasSBOMSpec) GetIncludedOccurrences() []IsOccurrenceSpec { return v.IncludedOccurrences }
 
 // HasSBOMsHasSBOM includes the requested fields of the GraphQL type HasSBOM.
 type HasSBOMsHasSBOM struct {

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -42,3 +42,11 @@ mutation HasSBOMArtifacts(
 ) {
   ingestHasSBOMs(subjects: { artifacts: $artifacts }, hasSBOMs: $hasSBOMs, includes: $includes)
 }
+
+# Exposes GraphQL queries to retrieve hasSBOMs
+
+query HasSBOMs($filter: HasSBOMSpec!) {
+  HasSBOM(hasSBOMSpec: $filter) {
+    ...AllHasSBOMTree
+  }
+}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -985,6 +985,11 @@ func (ec *executionContext) unmarshalNPackageOrArtifactInputs2githubᚗcomᚋgua
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx context.Context, v interface{}) (*model.PackageOrArtifactSpec, error) {
+	res, err := ec.unmarshalInputPackageOrArtifactSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNVexJustification2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexJustification(ctx context.Context, v interface{}) (model.VexJustification, error) {
 	var res model.VexJustification
 	err := res.UnmarshalGQL(v)
@@ -1032,7 +1037,7 @@ func (ec *executionContext) marshalNVexStatus2githubᚗcomᚋguacsecᚋguacᚋpk
 	return v
 }
 
-func (ec *executionContext) unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx context.Context, v interface{}) ([]*model.PackageOrArtifactSpec, error) {
+func (ec *executionContext) unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpecᚄ(ctx context.Context, v interface{}) ([]*model.PackageOrArtifactSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -1044,7 +1049,7 @@ func (ec *executionContext) unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcom�
 	res := make([]*model.PackageOrArtifactSpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -985,23 +985,6 @@ func (ec *executionContext) unmarshalNPackageOrArtifactInputs2githubᚗcomᚋgua
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx context.Context, v interface{}) ([]*model.PackageOrArtifactSpec, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.PackageOrArtifactSpec, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) unmarshalNVexJustification2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexJustification(ctx context.Context, v interface{}) (model.VexJustification, error) {
 	var res model.VexJustification
 	err := res.UnmarshalGQL(v)
@@ -1047,6 +1030,26 @@ func (ec *executionContext) unmarshalNVexStatus2githubᚗcomᚋguacsecᚋguacᚋ
 
 func (ec *executionContext) marshalNVexStatus2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐVexStatus(ctx context.Context, sel ast.SelectionSet, v model.VexStatus) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx context.Context, v interface{}) ([]*model.PackageOrArtifactSpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.PackageOrArtifactSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOPackageOrArtifactSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx context.Context, v interface{}) (*model.PackageOrArtifactSpec, error) {

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -783,21 +783,21 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 			it.KnownSince = data
 		case "includedSoftware":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedSoftware"))
-			data, err := ec.unmarshalNPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, v)
+			data, err := ec.unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.IncludedSoftware = data
 		case "includedDependencies":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedDependencies"))
-			data, err := ec.unmarshalNIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, v)
+			data, err := ec.unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.IncludedDependencies = data
 		case "includedOccurrences":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedOccurrences"))
-			data, err := ec.unmarshalNIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, v)
+			data, err := ec.unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -783,21 +783,21 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 			it.KnownSince = data
 		case "includedSoftware":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedSoftware"))
-			data, err := ec.unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpec(ctx, v)
+			data, err := ec.unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.IncludedSoftware = data
 		case "includedDependencies":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedDependencies"))
-			data, err := ec.unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, v)
+			data, err := ec.unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.IncludedDependencies = data
 		case "includedOccurrences":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedOccurrences"))
-			data, err := ec.unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, v)
+			data, err := ec.unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpecᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -714,23 +714,6 @@ func (ec *executionContext) unmarshalNIsDependencySpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) ([]*model.IsDependencySpec, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.IsDependencySpec, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) unmarshalODependencyType2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐDependencyType(ctx context.Context, v interface{}) (*model.DependencyType, error) {
 	if v == nil {
 		return nil, nil
@@ -745,6 +728,26 @@ func (ec *executionContext) marshalODependencyType2ᚖgithubᚗcomᚋguacsecᚋg
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) ([]*model.IsDependencySpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.IsDependencySpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) (*model.IsDependencySpec, error) {

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -714,6 +714,11 @@ func (ec *executionContext) unmarshalNIsDependencySpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) (*model.IsDependencySpec, error) {
+	res, err := ec.unmarshalInputIsDependencySpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalODependencyType2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐDependencyType(ctx context.Context, v interface{}) (*model.DependencyType, error) {
 	if v == nil {
 		return nil, nil
@@ -730,7 +735,7 @@ func (ec *executionContext) marshalODependencyType2ᚖgithubᚗcomᚋguacsecᚋg
 	return v
 }
 
-func (ec *executionContext) unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) ([]*model.IsDependencySpec, error) {
+func (ec *executionContext) unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpecᚄ(ctx context.Context, v interface{}) ([]*model.IsDependencySpec, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -742,20 +747,12 @@ func (ec *executionContext) unmarshalOIsDependencySpec2ᚕᚖgithubᚗcomᚋguac
 	res := make([]*model.IsDependencySpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
 	}
 	return res, nil
-}
-
-func (ec *executionContext) unmarshalOIsDependencySpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencySpec(ctx context.Context, v interface{}) (*model.IsDependencySpec, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputIsDependencySpec(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -695,6 +695,11 @@ func (ec *executionContext) unmarshalNIsOccurrenceSpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) (*model.IsOccurrenceSpec, error) {
+	res, err := ec.unmarshalInputIsOccurrenceSpec(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNPackageOrSource2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrSource(ctx context.Context, sel ast.SelectionSet, v model.PackageOrSource) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -715,7 +720,7 @@ func (ec *executionContext) unmarshalNPackageOrSourceInputs2githubᚗcomᚋguacs
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) ([]*model.IsOccurrenceSpec, error) {
+func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpecᚄ(ctx context.Context, v interface{}) ([]*model.IsOccurrenceSpec, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -727,20 +732,12 @@ func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguac
 	res := make([]*model.IsOccurrenceSpec, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
 	}
 	return res, nil
-}
-
-func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) (*model.IsOccurrenceSpec, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputIsOccurrenceSpec(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOPackageOrSourceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrSourceSpec(ctx context.Context, v interface{}) (*model.PackageOrSourceSpec, error) {

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -695,23 +695,6 @@ func (ec *executionContext) unmarshalNIsOccurrenceSpec2githubᚗcomᚋguacsecᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) ([]*model.IsOccurrenceSpec, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.IsOccurrenceSpec, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) marshalNPackageOrSource2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrSource(ctx context.Context, sel ast.SelectionSet, v model.PackageOrSource) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -730,6 +713,26 @@ func (ec *executionContext) unmarshalNPackageOrSourceInput2githubᚗcomᚋguacse
 func (ec *executionContext) unmarshalNPackageOrSourceInputs2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrSourceInputs(ctx context.Context, v interface{}) (model.PackageOrSourceInputs, error) {
 	res, err := ec.unmarshalInputPackageOrSourceInputs(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) ([]*model.IsOccurrenceSpec, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.IsOccurrenceSpec, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOIsOccurrenceSpec2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsOccurrenceSpec(ctx context.Context, v interface{}) (*model.IsOccurrenceSpec, error) {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3862,9 +3862,9 @@ input HasSBOMSpec {
   origin: String
   collector: String
   knownSince: Time
-  includedSoftware: [PackageOrArtifactSpec]!
-  includedDependencies: [IsDependencySpec]!
-  includedOccurrences: [IsOccurrenceSpec]!
+  includedSoftware: [PackageOrArtifactSpec]
+  includedDependencies: [IsDependencySpec]
+  includedOccurrences: [IsOccurrenceSpec]
 }
 
 input HasSBOMIncludesInputSpec {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3862,9 +3862,9 @@ input HasSBOMSpec {
   origin: String
   collector: String
   knownSince: Time
-  includedSoftware: [PackageOrArtifactSpec]
-  includedDependencies: [IsDependencySpec]
-  includedOccurrences: [IsOccurrenceSpec]
+  includedSoftware: [PackageOrArtifactSpec!]
+  includedDependencies: [IsDependencySpec!]
+  includedOccurrences: [IsOccurrenceSpec!]
 }
 
 input HasSBOMIncludesInputSpec {

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -492,9 +492,9 @@ type HasSBOMSpec struct {
 	Origin               *string                  `json:"origin,omitempty"`
 	Collector            *string                  `json:"collector,omitempty"`
 	KnownSince           *time.Time               `json:"knownSince,omitempty"`
-	IncludedSoftware     []*PackageOrArtifactSpec `json:"includedSoftware"`
-	IncludedDependencies []*IsDependencySpec      `json:"includedDependencies"`
-	IncludedOccurrences  []*IsOccurrenceSpec      `json:"includedOccurrences"`
+	IncludedSoftware     []*PackageOrArtifactSpec `json:"includedSoftware,omitempty"`
+	IncludedDependencies []*IsDependencySpec      `json:"includedDependencies,omitempty"`
+	IncludedOccurrences  []*IsOccurrenceSpec      `json:"includedOccurrences,omitempty"`
 }
 
 // HasSLSA records that a subject node has a SLSA attestation.

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -61,9 +61,9 @@ input HasSBOMSpec {
   origin: String
   collector: String
   knownSince: Time
-  includedSoftware: [PackageOrArtifactSpec]
-  includedDependencies: [IsDependencySpec]
-  includedOccurrences: [IsOccurrenceSpec]
+  includedSoftware: [PackageOrArtifactSpec!]
+  includedDependencies: [IsDependencySpec!]
+  includedOccurrences: [IsOccurrenceSpec!]
 }
 
 input HasSBOMIncludesInputSpec {

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -61,9 +61,9 @@ input HasSBOMSpec {
   origin: String
   collector: String
   knownSince: Time
-  includedSoftware: [PackageOrArtifactSpec]!
-  includedDependencies: [IsDependencySpec]!
-  includedOccurrences: [IsOccurrenceSpec]!
+  includedSoftware: [PackageOrArtifactSpec]
+  includedDependencies: [IsDependencySpec]
+  includedOccurrences: [IsOccurrenceSpec]
 }
 
 input HasSBOMIncludesInputSpec {

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -83,6 +83,11 @@ func addMetadata(predicates *assembler.IngestPredicates, foundIdentities []Trust
 		v.HasSlsa.Origin = srcInfo.Source
 	}
 
+	for _, v := range predicates.HasSBOM {
+		v.HasSBOM.Collector = srcInfo.Collector
+		v.HasSBOM.Origin = srcInfo.Source
+	}
+
 	for _, v := range predicates.CertifyVuln {
 		v.VulnData.Collector = srcInfo.Collector
 		v.VulnData.Origin = srcInfo.Source


### PR DESCRIPTION
# Description of the PR

update vulnerability query to utilize hasSBOM in query and be searchable via sbom URI or purl (this will make searching for packages with guac generated purls easier).

For CDX - the URI is the `"serialNumber": "urn:uuid:bc2d1509-298e-42cd-a4d0-b5fac740b4ae"`
For SPDX - the URI is the `"documentNamespace": "https://anchore.com/syft/image/k8s.gcr.io/kube-apiserver-v1.24.1-583a02ce-8f7e-4794-91af-35f27ffeb73d"` (which is unique per the spec: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field)

[guac vuln CLI documentation](https://docs.guac.sh/querying-via-cli/) will have to be updated.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
