### PR TITLE
Fix condition in exactPackageName function

### DIFF
--- a/pkg/assembler/backends/keyvalue/pkg.go
+++ b/pkg/assembler/backends/keyvalue/pkg.go
@@ -943,7 +943,7 @@ func (c *demoClient) exactPackageName(ctx context.Context, filter *model.PkgSpec
 			return nil, nil
 		}
 	}
-	if filter.Type == nil || filter.Namespace != nil || filter.Name == nil {
+	if filter.Type == nil || filter.Namespace == nil || filter.Name == nil {
 		return nil, nil
 	}
 	inType := &pkgType{


### PR DESCRIPTION
# Description of the PR

Fixes #1565 

Corrects the condition in `exactPackageName` such that not providing a package namespace will result in actually exiting the function early as intended. `exactPackageName` is intended to only continue if each of the package type, namespace, and name are present.

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
