### PR TITLE
Fixed has_sbom graphql example

### DIFF
--- a/pkg/assembler/graphql/examples/has_sbom.gql
+++ b/pkg/assembler/graphql/examples/has_sbom.gql
@@ -39,29 +39,57 @@ fragment allHasSBOMTree on HasSBOM {
 }
 
 query HasSBOMQ1 {
-  HasSBOM(hasSBOMSpec: {}) {
+  HasSBOM(hasSBOMSpec: {
+    includedSoftware: {}
+    includedOccurrences: {}
+    includedDependencies: {}
+  }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ2 {
-  HasSBOM(hasSBOMSpec: { origin: "Demo ingestion" }) {
+  HasSBOM(hasSBOMSpec: { 
+    origin: "Demo ingestion" 
+    includedSoftware: {}
+    includedOccurrences: {}
+    includedDependencies: {}
+  }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ3 {
-  HasSBOM(hasSBOMSpec: { subject: { package: { name: "openssl" } } }) {
+  HasSBOM(hasSBOMSpec: { 
+    subject: { 
+      package: { 
+        name: "openssl" 
+      } 
+    } 
+    includedSoftware: {}
+    includedOccurrences: {}
+    includedDependencies: {}
+  }) {
     ...allHasSBOMTree
   }
 }
 
 query HasSBOMQ4 {
-  HasSBOM(hasSBOMSpec: { subject: { artifact: { algorithm: "sha256" } } }) {
+  HasSBOM(hasSBOMSpec: { 
+    subject: { 
+      artifact: { 
+        algorithm: "sha256" 
+      }
+    }
+    includedSoftware: {}
+    includedOccurrences: {}
+    includedDependencies: {}
+  }) {
     ...allHasSBOMTree
   }
 }
 
+# Invalid Example Query, only one subject should be ingested, a package or an artifact
 query HasSBOMQ5 {
   HasSBOM(
     hasSBOMSpec: {
@@ -69,6 +97,9 @@ query HasSBOMQ5 {
         package: { name: "openssl" }
         artifact: { algorithm: "sha256" }
       }
+      includedSoftware: {}
+    	includedOccurrences: {}
+    	includedDependencies: {}
     }
   ) {
     ...allHasSBOMTree


### PR DESCRIPTION
* The has_sbom graphql example wasn't up to date, so the queries now have `includedSoftware`, `includedOccurrences`, and `includedDependencies`.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
