### PR TITLE
remove check if pkgID has already been checked for recursive vuln query

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -521,6 +521,7 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 						path = append([]string{pkgResponse.Namespaces[0].Names[0].Versions[0].Id,
 							pkgResponse.Namespaces[0].Names[0].Id, pkgResponse.Namespaces[0].Id,
 							pkgResponse.Id}, path...)
+						checkedIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] = true
 					}
 				}
 			}
@@ -537,23 +538,21 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 					matchingDepPkgVersionIDs = append(matchingDepPkgVersionIDs, isDep.DependencyPackage.Namespaces[0].Names[0].Versions[0].Id)
 				}
 				for _, pkgID := range matchingDepPkgVersionIDs {
-					if !checkedIDs[pkgID] {
-						dfsN, seen := nodeMap[pkgID]
-						if !seen {
-							dfsN = dfsNode{
-								parent: now,
-								pkgID:  pkgID,
-								depth:  nowNode.depth + 1,
-							}
-							nodeMap[pkgID] = dfsN
+					dfsN, seen := nodeMap[pkgID]
+					if !seen {
+						dfsN = dfsNode{
+							parent: now,
+							pkgID:  pkgID,
+							depth:  nowNode.depth + 1,
 						}
-						if !dfsN.expanded {
-							queue = append(queue, pkgID)
-						}
-						wg.Add(1)
-						go concurrentVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep, resultChan, &wg)
-						checkedIDs[pkgID] = true
+						nodeMap[pkgID] = dfsN
 					}
+					if !dfsN.expanded {
+						queue = append(queue, pkgID)
+					}
+					wg.Add(1)
+					go concurrentVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep, resultChan, &wg)
+					checkedIDs[pkgID] = true
 				}
 			}
 		}
@@ -580,8 +579,8 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 							certifyVuln.Package.Id}...)
 					}
 					path = append(path, result.isDep.Id, result.isDep.Package.Namespaces[0].Names[0].Versions[0].Id,
-						result.isDep.DependencyPackage.Namespaces[0].Names[0].Id, result.isDep.DependencyPackage.Namespaces[0].Id,
-						result.isDep.DependencyPackage.Id)
+						result.isDep.Package.Namespaces[0].Names[0].Id, result.isDep.Package.Namespaces[0].Id,
+						result.isDep.Package.Id)
 				}
 			}
 


### PR DESCRIPTION
# Description of the PR

A quick fix to remove `if !checkedIDs[pkgID] {` from line 540 as we would want to show a path to transient dependencies that also have the dependency on the same vulnerable package (even if it was already checked). 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
