### PR TITLE
Add comment for id field on PkgSpec

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -21425,6 +21425,9 @@ const (
 // that level. For example, to get all packages in GUAC backend, use a PkgSpec
 // where every field is null.
 //
+// The id field can be used to match on a specific node in the trie to match packageTypeID,
+// packageNamespaceID, packageNameID, or packageVersionID.
+//
 // Empty string at a field means matching with the empty string. If passing in
 // qualifiers, all of the values in the list must match. Since we want to return
 // nodes with any number of qualifiers if no qualifiers are passed in the input,

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -4752,6 +4752,9 @@ Each field matches a qualifier from pURL. Use null to match on all values at
 that level. For example, to get all packages in GUAC backend, use a PkgSpec
 where every field is null.
 
+The id field can be used to match on a specific node in the trie to match packageTypeID, 
+packageNamespaceID, packageNameID, or packageVersionID.
+
 Empty string at a field means matching with the empty string. If passing in
 qualifiers, all of the values in the list must match. Since we want to return
 nodes with any number of qualifiers if no qualifiers are passed in the input,

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -991,6 +991,9 @@ type PkgInputSpec struct {
 // that level. For example, to get all packages in GUAC backend, use a PkgSpec
 // where every field is null.
 //
+// The id field can be used to match on a specific node in the trie to match packageTypeID,
+// packageNamespaceID, packageNameID, or packageVersionID.
+//
 // Empty string at a field means matching with the empty string. If passing in
 // qualifiers, all of the values in the list must match. Since we want to return
 // nodes with any number of qualifiers if no qualifiers are passed in the input,

--- a/pkg/assembler/graphql/schema/package.graphql
+++ b/pkg/assembler/graphql/schema/package.graphql
@@ -133,6 +133,9 @@ Each field matches a qualifier from pURL. Use null to match on all values at
 that level. For example, to get all packages in GUAC backend, use a PkgSpec
 where every field is null.
 
+The id field can be used to match on a specific node in the trie to match packageTypeID, 
+packageNamespaceID, packageNameID, or packageVersionID.
+
 Empty string at a field means matching with the empty string. If passing in
 qualifiers, all of the values in the list must match. Since we want to return
 nodes with any number of qualifiers if no qualifiers are passed in the input,


### PR DESCRIPTION
# Description of the PR

Add a comment to specify how the `id` field on `PkgSpec` is used to filter the response.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
