### PR TITLE
Add comment on Edge schema to note that edges are bidirectional

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -7283,7 +7283,8 @@ const (
 //
 // Each member of the enum is formed by merging two Node names with _. Each name
 // is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
-// (pairs from Node to Node) are included.
+// (pairs from Node to Node) are included. Edges are defined in both directions,
+// which means nodes can be traversed from either direction.
 //
 // The only exception to the above rule is for links out of HasSLSA. The names are
 // HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -4877,7 +4877,8 @@ possible GUAC links.
 
 Each member of the enum is formed by merging two Node names with _. Each name
 is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
-(pairs from Node to Node) are included.
+(pairs from Node to Node) are included. Edges are defined in both directions,
+which means nodes can be traversed from either direction.
 
 The only exception to the above rule is for links out of HasSLSA. The names are
 HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -1627,7 +1627,8 @@ func (e DependencyType) MarshalGQL(w io.Writer) {
 //
 // Each member of the enum is formed by merging two Node names with _. Each name
 // is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
-// (pairs from Node to Node) are included.
+// (pairs from Node to Node) are included. Edges are defined in both directions,
+// which means nodes can be traversed from either direction.
 //
 // The only exception to the above rule is for links out of HasSLSA. The names are
 // HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because

--- a/pkg/assembler/graphql/schema/path.graphql
+++ b/pkg/assembler/graphql/schema/path.graphql
@@ -55,7 +55,8 @@ possible GUAC links.
 
 Each member of the enum is formed by merging two Node names with _. Each name
 is converted from CamelCase to CAPITALS_WITH_UNDERSCORES. Only valid edges
-(pairs from Node to Node) are included.
+(pairs from Node to Node) are included. Edges are defined in both directions,
+which means nodes can be traversed from either direction.
 
 The only exception to the above rule is for links out of HasSLSA. The names are
 HAS_SLSA_SUBJECT, HAS_SLSA_BUILT_BY, and HAS_SLSA_MATERIALS. This is because


### PR DESCRIPTION
# Description of the PR

Make it explicitly clear in the schema docs that `Edge` can be traversed bidirectionally.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
