### PR TITLE
remove s3 from guacone until further testing is done on the collector

### DIFF
--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -183,5 +183,6 @@ func init() {
 		os.Exit(1)
 	}
 
-	collectCmd.AddCommand(s3Cmd)
+	// TODO (pxp928): S3 command is removed from guacone until further testing and re-review is done for the S3 collector
+	//collectCmd.AddCommand(s3Cmd)
 }


### PR DESCRIPTION
# Description of the PR

remove s3 from guacone until further testing is done on the collector

Related to issue https://github.com/guacsec/guac/issues/1644

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
