### PR TITLE
fix bug where duplicate certifyVuln values showed on output

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -452,7 +452,7 @@ func concurrentVulnAndVexNeighbors(ctx context.Context, gqlclient graphql.Client
 func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchString string, maxLength int, isPurl bool) ([]string, []table.Row, error) {
 	var path []string
 	var tableRows []table.Row
-	checkedIDs := map[string]bool{}
+	checkedPkgIDs := make(map[string]bool)
 	var wg sync.WaitGroup
 
 	queue := make([]string, 0) // the queue of nodes in bfs
@@ -511,7 +511,7 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 		for _, hasSBOM := range foundHasSBOMPkg.HasSBOM {
 			if pkgResponse, ok := foundHasSBOMPkg.HasSBOM[0].Subject.(*model.AllHasSBOMTreeSubjectPackage); ok {
 				if pkgResponse.Type != guacType {
-					if !checkedIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] {
+					if !checkedPkgIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] {
 						vulnPath, pkgVulnTableRows, err := queryVulnsViaPackageNeighbors(ctx, gqlclient, pkgResponse.Namespaces[0].Names[0].Versions[0].Id)
 						if err != nil {
 							return nil, nil, fmt.Errorf("error querying neighbor: %v", err)
@@ -521,7 +521,7 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 						path = append([]string{pkgResponse.Namespaces[0].Names[0].Versions[0].Id,
 							pkgResponse.Namespaces[0].Names[0].Id, pkgResponse.Namespaces[0].Id,
 							pkgResponse.Id}, path...)
-						checkedIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] = true
+						checkedPkgIDs[pkgResponse.Namespaces[0].Names[0].Versions[0].Id] = true
 					}
 				}
 			}
@@ -555,7 +555,7 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 					}
 					wg.Add(1)
 					go concurrentVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep, resultChan, &wg)
-					checkedIDs[pkgID] = true
+					checkedPkgIDs[pkgID] = true
 				}
 			}
 		}
@@ -569,21 +569,26 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 		close(resultChan)
 	}()
 
+	checkedCertifyVulnIDs := make(map[string]bool)
+
 	// Collect results from the channel
 	for result := range resultChan {
 		for _, neighbor := range result.pkgVersionNeighborResponse.Neighbors {
 			if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
-				if certifyVuln.Vulnerability.Type != noVulnType {
-					for _, vuln := range certifyVuln.Vulnerability.VulnerabilityIDs {
-						tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
-						path = append(path, []string{vuln.Id, certifyVuln.Id,
-							certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
-							certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
-							certifyVuln.Package.Id}...)
+				if !checkedCertifyVulnIDs[certifyVuln.Id] {
+					if certifyVuln.Vulnerability.Type != noVulnType {
+						checkedCertifyVulnIDs[certifyVuln.Id] = true
+						for _, vuln := range certifyVuln.Vulnerability.VulnerabilityIDs {
+							tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
+							path = append(path, []string{vuln.Id, certifyVuln.Id,
+								certifyVuln.Package.Namespaces[0].Names[0].Versions[0].Id,
+								certifyVuln.Package.Namespaces[0].Names[0].Id, certifyVuln.Package.Namespaces[0].Id,
+								certifyVuln.Package.Id}...)
+						}
+						path = append(path, result.isDep.Id, result.isDep.Package.Namespaces[0].Names[0].Versions[0].Id,
+							result.isDep.Package.Namespaces[0].Names[0].Id, result.isDep.Package.Namespaces[0].Id,
+							result.isDep.Package.Id)
 					}
-					path = append(path, result.isDep.Id, result.isDep.Package.Namespaces[0].Names[0].Versions[0].Id,
-						result.isDep.Package.Namespaces[0].Names[0].Id, result.isDep.Package.Namespaces[0].Id,
-						result.isDep.Package.Id)
 				}
 			}
 


### PR DESCRIPTION
# Description of the PR

fix bug where duplicate certifyVuln values showed on output when querying for vulnerabilities

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
