### PR TITLE
update dsse processor to not guess unpacked payload

### DIFF
--- a/pkg/handler/processor/dsse/dsse.go
+++ b/pkg/handler/processor/dsse/dsse.go
@@ -62,26 +62,15 @@ func (d *DSSEProcessor) Unpack(i *processor.Document) ([]*processor.Document, er
 		return nil, err
 	}
 
-	var doc *processor.Document
 	decodedPayload, err := base64.StdEncoding.DecodeString(envelope.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode payload: %w", err)
 	}
-	switch pt := envelope.PayloadType; pt {
-	case string(dsseITE6):
-		doc = &processor.Document{
-			Blob:              decodedPayload,
-			Type:              processor.DocumentITE6Generic,
-			Format:            processor.FormatJSON,
-			SourceInformation: i.SourceInformation,
-		}
-	default:
-		doc = &processor.Document{
-			Blob:              decodedPayload,
-			Type:              processor.DocumentUnknown,
-			Format:            processor.FormatUnknown,
-			SourceInformation: i.SourceInformation,
-		}
+	doc := &processor.Document{
+		Blob:              decodedPayload,
+		Type:              processor.DocumentUnknown,
+		Format:            processor.FormatUnknown,
+		SourceInformation: i.SourceInformation,
 	}
 
 	return []*processor.Document{doc}, nil

--- a/pkg/handler/processor/dsse/dsse_test.go
+++ b/pkg/handler/processor/dsse/dsse_test.go
@@ -17,9 +17,9 @@ package dsse
 
 import (
 	"encoding/base64"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
@@ -97,8 +97,8 @@ var (
 	}
 	ite6SLSADoc = processor.Document{
 		Blob:   []byte(ite6SLSA),
-		Type:   processor.DocumentITE6Generic,
-		Format: processor.FormatJSON,
+		Type:   processor.DocumentUnknown,
+		Format: processor.FormatUnknown,
 		SourceInformation: processor.SourceInformation{
 			Collector: "TestCollector",
 			Source:    "TestSource",
@@ -127,6 +127,7 @@ func TestDSSEProcessor_Unpack(t *testing.T) {
 		expected:  []*processor.Document{&unpackedUnknownDSSEDoc},
 		expectErr: false,
 	}, {
+		// DSSE should not worry about internal payload details
 		name:      "DSSE Envelope with ITE6",
 		doc:       ite6DSSEDoc,
 		expected:  []*processor.Document{&ite6SLSADoc},
@@ -144,8 +145,8 @@ func TestDSSEProcessor_Unpack(t *testing.T) {
 			if (err != nil) != tt.expectErr {
 				t.Errorf("DSSEProcessor.Unpack() error = %v, expectErr %v", err, tt.expectErr)
 			}
-			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Errorf("DSSEProcessor.Unpack() = %v, expected %v", actual, tt.expected)
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("Unexpected DSSEProcessor.Unpack() results. (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
# Description of the PR

Fixes #1633 . The format of the DSSE payload should not be handled by the processor and it should leave the handler pipeline to handle it via the guesser. DSSE implementation should be agnostic and not introspect its payload.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
