### PR TITLE
Use graphql.HasOperationContext in arangodb assembler

### DIFF
--- a/pkg/assembler/backends/arangodb/pkg.go
+++ b/pkg/assembler/backends/arangodb/pkg.go
@@ -433,7 +433,7 @@ func (c *arangoClient) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]
 		return []*model.Package{p}, nil
 	}
 
-	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {
+	if graphql.HasOperationContext(ctx) {
 		// fields: [type namespaces namespaces.namespace namespaces.names namespaces.names.name namespaces.names.versions
 		// namespaces.names.versions.version namespaces.names.versions.qualifiers namespaces.names.versions.qualifiers.key
 		// namespaces.names.versions.qualifiers.value namespaces.names.versions.subpath]

--- a/pkg/assembler/backends/arangodb/src.go
+++ b/pkg/assembler/backends/arangodb/src.go
@@ -319,7 +319,7 @@ func (c *arangoClient) Sources(ctx context.Context, sourceSpec *model.SourceSpec
 	}
 
 	// fields: [type namespaces namespaces.namespace namespaces.names namespaces.names.name namespaces.names.tag namespaces.names.commit]
-	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {
+	if graphql.HasOperationContext(ctx) {
 		fields := getPreloads(ctx)
 
 		nameRequired := false

--- a/pkg/assembler/backends/arangodb/vulnerability.go
+++ b/pkg/assembler/backends/arangodb/vulnerability.go
@@ -63,7 +63,7 @@ func (c *arangoClient) Vulnerabilities(ctx context.Context, vulnSpec *model.Vuln
 		return []*model.Vulnerability{p}, nil
 	}
 
-	if _, ok := ctx.Value("graphql").(graphql.OperationContext); ok {
+	if graphql.HasOperationContext(ctx) {
 		// fields: [type vulnerabilityIDs ]
 		fields := getPreloads(ctx)
 


### PR DESCRIPTION
# Description of the PR
It seems we're not entering the logic to determine what graphql fields are present in some of the arangodb methods. This is because we are checking `ctx.Value("graphql").(graphql.OperationContext)` which isn't actually present. This is because the operation context is stored using the value `operation_context` as seen [here](https://github.com/99designs/gqlgen/blob/master/graphql/context_operation.go#L54). Instead of doing this logic here, we can just call the[ `HasOperationContext` function](https://github.com/99designs/gqlgen/blob/master/graphql/context_operation.go#L75) provided by the `gqlgen` library.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
