### PR TITLE
Update default `blob-addr` to use filesystem (for docker-compose and k8s)

### DIFF
--- a/container_files/arango/guac.yaml
+++ b/container_files/arango/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/arango/guac.yaml
+++ b/container_files/arango/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/ent/guac.yaml
+++ b/container_files/ent/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/ent/guac.yaml
+++ b/container_files/ent/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/neo4j/guac.yaml
+++ b/container_files/neo4j/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/neo4j/guac.yaml
+++ b/container_files/neo4j/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/redis/guac.yaml
+++ b/container_files/redis/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/redis/guac.yaml
+++ b/container_files/redis/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/tikv/guac.yaml
+++ b/container_files/tikv/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/container_files/tikv/guac.yaml
+++ b/container_files/tikv/guac.yaml
@@ -2,7 +2,7 @@
 pubsub-addr: nats://nats:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # collect-sub
 csub-addr: guac-collectsub:2782

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
         condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
+      - blobstore:/tmp/blobstore
 
   oci-collector:
     networks: [ frontend ]
@@ -69,6 +70,7 @@ services:
         condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
+      - blobstore:/tmp/blobstore
 
   depsdev-collector:
     networks: [ frontend ]
@@ -83,6 +85,7 @@ services:
         condition: service_healthy
     volumes:
       - ./container_files/guac:/guac:z
+      - blobstore:/tmp/blobstore
     ports:
       - "9091:9091" # for prometheus metrics
 
@@ -101,3 +104,6 @@ services:
 networks:
   frontend:
     driver: bridge
+
+volumes:
+    blobstore:

--- a/guac.yaml
+++ b/guac.yaml
@@ -21,7 +21,7 @@ neptune-realm: neptune
 pubsub-addr: nats://localhost:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///tmp/blobstore
+blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # CSub setup
 csub-addr: localhost:2782

--- a/guac.yaml
+++ b/guac.yaml
@@ -21,7 +21,7 @@ neptune-realm: neptune
 pubsub-addr: nats://localhost:4222
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
-blob-addr: file:///path/to/dir
+blob-addr: file:///tmp/blobstore
 
 # CSub setup
 csub-addr: localhost:2782

--- a/k8s/k8s.yaml
+++ b/k8s/k8s.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: guac-collectsub
     spec:
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: pv-claim
       containers:
         - name: guac-collectsub
           image: local-organic-guac
@@ -107,6 +111,10 @@ spec:
       labels:
         app: guac-ingestor
     spec:
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: pv-claim
       containers:
         - name: guac-ingestor
           image: local-organic-guac
@@ -115,6 +123,9 @@ spec:
           env:
             - name: GUAC_PUBSUB_ADDR
               value: nats://nats:4222
+          volumeMounts:
+            - mountPath: "/tmp/blobstore"
+              name: pv-storage
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -130,6 +141,10 @@ spec:
       labels:
         app: oci-collector
     spec:
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: pv-claim
       containers:
         - name: oci-collector
           image: local-organic-guac
@@ -140,6 +155,9 @@ spec:
               value: nats://nats:4222
             - name: GUAC_CSUB_ADDR
               value: guac-collectsub:2782
+          volumeMounts:
+            - mountPath: "/tmp/blobstore"
+              name: pv-storage
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -155,6 +173,10 @@ spec:
       labels:
         app: depsdev-collector
     spec:
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: pv-claim
       containers:
         - name: depsdev-collector
           image: local-organic-guac
@@ -165,3 +187,33 @@ spec:
               value: nats://nats:4222
             - name: GUAC_CSUB_ADDR
               value: guac-collectsub:2782
+          volumeMounts:
+            - mountPath: "/tmp/blobstore"
+              name: pv-storage
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/tmp"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -58,7 +58,7 @@ func init() {
 	set.String("neo4j-realm", "neo4j", "realm to connect to graph db")
 
 	// blob store address
-	set.String("blob-addr", "file:///tmp/blobstore", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/")
+	set.String("blob-addr", "file:///tmp/blobstore?no_tmp_dir=true", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/ (defualt: filesystem)")
 
 	set.String("neptune-endpoint", "localhost", "address to neptune db")
 	set.Int("neptune-port", 8182, "port used for neptune db connection")

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -58,7 +58,7 @@ func init() {
 	set.String("neo4j-realm", "neo4j", "realm to connect to graph db")
 
 	// blob store address
-	set.String("blob-addr", "file:///path/to/dir", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/")
+	set.String("blob-addr", "file:///tmp/blobstore", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/")
 
 	set.String("neptune-endpoint", "localhost", "address to neptune db")
 	set.Int("neptune-port", 8182, "port used for neptune db connection")

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -58,7 +58,7 @@ func init() {
 	set.String("neo4j-realm", "neo4j", "realm to connect to graph db")
 
 	// blob store address
-	set.String("blob-addr", "file:///tmp/blobstore?no_tmp_dir=true", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/ (defualt: filesystem)")
+	set.String("blob-addr", "file:///tmp/blobstore?no_tmp_dir=true", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/ (default: filesystem)")
 
 	set.String("neptune-endpoint", "localhost", "address to neptune db")
 	set.Int("neptune-port", 8182, "port used for neptune db connection")


### PR DESCRIPTION
# Description of the PR

Update the the `blob-addr` to be filesystem for docker-compose and k8s. Adds a shared volume between the collector and ingestor container for blob store.

The address is now set to `file:///tmp/blobstore?no_tmp_dir=true`

Note: `no_tmp_dir=true` is need to get around https://github.com/google/go-cloud/issues/3294

closes https://github.com/guacsec/guac/issues/1650

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
