### PR TITLE
add purl helper to convert from allPkgTree fragment

### DIFF
--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -42,6 +42,32 @@ func PurlToPkg(purlUri string) (*model.PkgInputSpec, error) {
 	return purlConvert(p)
 }
 
+// AllPkgTreeToPurl takes one package trie evaluation and converts it into a PURL
+// it will only do this for one PURL, and will ignore other pkg tries in the fragment
+func AllPkgTreeToPurl(v *model.AllPkgTree) string {
+	ns := v.Namespaces[0]
+	nsStr := ns.Namespace
+
+	name := ns.Names[0]
+	nameStr := name.Name
+
+	versionStr := ""
+	subpathStr := ""
+	qualifierStrs := []string{}
+	if len(name.Versions) > 0 {
+		version := v.Namespaces[0].Names[0].Versions[0]
+		versionStr = version.Version
+		subpathStr = version.Subpath
+		for _, v := range version.Qualifiers {
+			qualifierStrs = append(qualifierStrs, v.GetKey())
+			qualifierStrs = append(qualifierStrs, v.GetValue())
+		}
+	}
+
+	purl := PkgToPurl(v.Type, nsStr, nameStr, versionStr, subpathStr, qualifierStrs)
+	return purl
+}
+
 func PkgInputSpecToPurl(currentPkg *model.PkgInputSpec) string {
 	qualifiersMap := map[string]string{}
 	keys := []string{}


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
add purl helper to convert from allPkgTree fragment, in preparation for implementing recursive query known.
<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
