### PR TITLE
save qualifiers from golang loop semantics

### DIFF
--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -118,6 +118,8 @@ var queryKnownCmd = &cobra.Command{
 
 			pkgQualifierFilter := []model.PackageQualifierSpec{}
 			for _, qualifier := range pkgInput.Qualifiers {
+				// to prevent https://github.com/golang/go/discussions/56010
+				qualifier := qualifier
 				pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
 					Key:   qualifier.Key,
 					Value: &qualifier.Value,

--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -223,6 +223,9 @@ func getPkgID(ctx context.Context, gqlClient graphql.Client, purl string, isPack
 	if isPackageVersion {
 		pkgQualifierFilter := []model.PackageQualifierSpec{}
 		for _, qualifier := range pkgInput.Qualifiers {
+			// to prevent https://github.com/golang/go/discussions/56010
+			qualifier := qualifier
+
 			pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
 				Key:   qualifier.Key,
 				Value: &qualifier.Value,

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -94,6 +94,8 @@ func getPkgResponseFromPurl(ctx context.Context, gqlclient graphql.Client, purl 
 
 	pkgQualifierFilter := []model.PackageQualifierSpec{}
 	for _, qualifier := range pkgInput.Qualifiers {
+		// to prevent https://github.com/golang/go/discussions/56010
+		qualifier := qualifier
 		pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
 			Key:   qualifier.Key,
 			Value: &qualifier.Value,


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
For some reason queries with qualifiers were not getting the right value from `guacone`, investigation showed that there seemed to be an issue related to confused references.

From query bin/guacone query vuln 'pkg:alpine/dumb-init@1.2.5-r1?arch=x86_64&distro=alpine-3.15.6&upstream=dumb-init'

```

LUMJJB values: 1.2.5-r1  map[arch:dumb-init distro:dumb-init upstream:dumb-init]
LUMJJB KEY(): c6f2188f41bc12dfcc1c39aab72e5f88


LUMJJB values: 1.2.5-r1  map[arch:dumb-init distro:dumb-init upstream:dumb-init]
LUMJJB KEY(): c6f2188f41bc12dfcc1c39aab72e5f88


LUMJJB values: 1.2.5-r1  map[arch:x86_64 distro:x86_64 upstream:x86_64]
LUMJJB KEY(): 2ab5edb9bb69ead5ce7459488758f016


LUMJJB values: 1.2.5-r1  map[arch:dumb-init distro:dumb-init upstream:dumb-init]
LUMJJB KEY(): c6f2188f41bc12dfcc1c39aab72e5f88
```

This PR fixes the issue that was introduced with this.
<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
