### PR TITLE
add ability to have search depth in query known

### DIFF
--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -56,6 +56,8 @@ type queryKnownOptions struct {
 	subjectType string
 	// purl / source (<vcs_tool>+<transport>) / artifact (algorithm:digest)
 	subject string
+	// search depth to search (0 is unlimited, 1 is just root node neighbors)
+	searchDepth int
 }
 
 type neighbors struct {
@@ -73,10 +75,11 @@ type neighbors struct {
 }
 
 var (
+	colSubject       = "Subject"
 	colTitleNodeType = "Node Type"
 	colTitleNodeID   = "Node ID #"
 	colTitleNodeInfo = "Additional Information"
-	rowHeader        = table.Row{colTitleNodeType, colTitleNodeID, colTitleNodeInfo}
+	rowHeader        = table.Row{colSubject, colTitleNodeType, colTitleNodeID, colTitleNodeInfo}
 )
 
 var queryKnownCmd = &cobra.Command{
@@ -87,10 +90,10 @@ var queryKnownCmd = &cobra.Command{
   <subject> is in the form of "<purl>" for package, "<vcs_tool>+<transport>" for source, or "<algorithm>:<digest>" for artiact.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
-		logger := logging.FromContext(ctx)
 
 		opts, err := validateQueryKnownFlags(
 			viper.GetString("gql-addr"),
+			viper.GetInt("search-depth"),
 			args,
 		)
 
@@ -109,174 +112,226 @@ var queryKnownCmd = &cobra.Command{
 		t.AppendHeader(rowHeader)
 
 		var path []string
-		switch opts.subjectType {
-		case packageSubjectType:
-			pkgInput, err := helpers.PurlToPkg(opts.subject)
-			if err != nil {
-				logger.Fatalf("failed to parse PURL: %v", err)
+		queue := []target{{
+			depth:       0,
+			subjectType: opts.subjectType,
+			subject:     opts.subject,
+		}}
+
+		visited := map[string]bool{}
+		for len(queue) > 0 {
+			targetNode := queue[0]
+			queue = queue[1:]
+
+			if opts.searchDepth > 0 && targetNode.depth >= opts.searchDepth {
+				break
+			}
+			if ok := visited[targetNode.subject]; ok {
+				continue
 			}
 
-			pkgQualifierFilter := []model.PackageQualifierSpec{}
-			for _, qualifier := range pkgInput.Qualifiers {
-				// to prevent https://github.com/golang/go/discussions/56010
-				qualifier := qualifier
-				pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
-					Key:   qualifier.Key,
-					Value: &qualifier.Value,
-				})
+			retVisited, retFrontier := exploreKnown(ctx, gqlclient, t, path, targetNode)
+			queue = append(queue, retFrontier...)
+			visited[targetNode.subject] = true
+			for _, v := range retVisited {
+				visited[v] = true
 			}
-
-			pkgFilter := &model.PkgSpec{
-				Type:       &pkgInput.Type,
-				Namespace:  pkgInput.Namespace,
-				Name:       &pkgInput.Name,
-				Version:    pkgInput.Version,
-				Subpath:    pkgInput.Subpath,
-				Qualifiers: pkgQualifierFilter,
-			}
-			pkgResponse, err := model.Packages(ctx, gqlclient, *pkgFilter)
-			if err != nil {
-				logger.Fatalf("error querying for package: %v", err)
-			}
-			if len(pkgResponse.Packages) != 1 {
-				logger.Fatalf("failed to located package based on purl")
-			}
-
-			pkgNameNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Id)
-			if err != nil {
-				logger.Fatalf("error querying for package name neighbors: %v", err)
-			}
-			t.SetTitle("Package Name Nodes")
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, hasSrcAtStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, badLinkStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, goodLinkStr, packageSubjectType))
-			t.AppendSeparator()
-
-			path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Id,
-				pkgResponse.Packages[0].Namespaces[0].Id,
-				pkgResponse.Packages[0].Id}, neighborsPath...)
-
-			fmt.Println(t.Render())
-			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
-
-			pkgVersionNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id)
-			if err != nil {
-				logger.Fatalf("error querying for package version neighbors: %v", err)
-			}
-
-			// instantiate new table for package version nodes
-			t := table.NewWriter()
-			tTemp := table.Table{}
-			tTemp.Render()
-			t.AppendHeader(rowHeader)
-
-			t.SetTitle("Package Version Nodes")
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSrcAtStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, occurrenceStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, certifyVulnStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSBOMStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSLSAStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, vexLinkStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, pkgEqualStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, badLinkStr, packageSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, goodLinkStr, packageSubjectType))
-			path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
-				pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
-				pkgResponse.Packages[0].Id}, neighborsPath...)
-
-			fmt.Println(t.Render())
-			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
-
-		case sourceSubjectType:
-			srcInput, err := helpers.VcsToSrc(opts.subject)
-			if err != nil {
-				logger.Fatalf("failed to parse source: %v", err)
-			}
-
-			srcFilter := &model.SourceSpec{
-				Type:      &srcInput.Type,
-				Namespace: &srcInput.Namespace,
-				Name:      &srcInput.Name,
-				Tag:       srcInput.Tag,
-				Commit:    srcInput.Commit,
-			}
-			srcResponse, err := model.Sources(ctx, gqlclient, *srcFilter)
-			if err != nil {
-				logger.Fatalf("error querying for sources: %v", err)
-			}
-			if len(srcResponse.Sources) != 1 {
-				logger.Fatalf("failed to located sources based on vcs")
-			}
-			sourceNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, srcResponse.Sources[0].Namespaces[0].Names[0].Id)
-			if err != nil {
-				logger.Fatalf("error querying for source neighbors: %v", err)
-			}
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, hasSrcAtStr, sourceSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, occurrenceStr, sourceSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, scorecardStr, sourceSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, badLinkStr, sourceSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, goodLinkStr, sourceSubjectType))
-			path = append([]string{srcResponse.Sources[0].Namespaces[0].Names[0].Id,
-				srcResponse.Sources[0].Namespaces[0].Id, srcResponse.Sources[0].Id}, neighborsPath...)
-
-			fmt.Println(t.Render())
-			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
-		case artifactSubjectType:
-			split := strings.Split(opts.subject, ":")
-			if len(split) != 2 {
-				logger.Fatalf("failed to parse artifact. Needs to be in algorithm:digest form")
-			}
-			artifactFilter := &model.ArtifactSpec{
-				Algorithm: ptrfrom.String(strings.ToLower(string(split[0]))),
-				Digest:    ptrfrom.String(strings.ToLower(string(split[1]))),
-			}
-
-			artifactResponse, err := model.Artifacts(ctx, gqlclient, *artifactFilter)
-			if err != nil {
-				logger.Fatalf("error querying for artifacts: %v", err)
-			}
-			if len(artifactResponse.Artifacts) != 1 {
-				logger.Fatalf("failed to located artifacts based on (algorithm:digest)")
-			}
-			artifactNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, artifactResponse.Artifacts[0].Id)
-			if err != nil {
-				logger.Fatalf("error querying for artifact neighbors: %v", err)
-			}
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hashEqualStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, occurrenceStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hasSBOMStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hasSLSAStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, vexLinkStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, badLinkStr, artifactSubjectType))
-			t.AppendSeparator()
-			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, goodLinkStr, artifactSubjectType))
-			path = append([]string{artifactResponse.Artifacts[0].Id}, neighborsPath...)
-
-			fmt.Println(t.Render())
-			fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
-		default:
-			logger.Fatalf("expected type to be either a package, source or artifact")
 		}
 	},
+}
+
+type target struct {
+	depth       int
+	subjectType string
+	subject     string
+}
+
+func exploreKnown(ctx context.Context, gqlclient graphql.Client, t table.Writer, path []string, node target) (retVisited []string, retFrontier []target) {
+
+	logger := logging.FromContext(ctx)
+	switch node.subjectType {
+	case packageSubjectType:
+		pkgInput, err := helpers.PurlToPkg(node.subject)
+		if err != nil {
+			logger.Fatalf("failed to parse PURL: %v", err)
+		}
+
+		var pkgQualifierFilter []model.PackageQualifierSpec
+		for _, qualifier := range pkgInput.Qualifiers {
+			qualifier := qualifier
+			pkgQualifierFilter = append(pkgQualifierFilter, model.PackageQualifierSpec{
+				Key:   qualifier.Key,
+				Value: &qualifier.Value,
+			})
+		}
+
+		pkgFilter := &model.PkgSpec{
+			Type:       &pkgInput.Type,
+			Namespace:  pkgInput.Namespace,
+			Name:       &pkgInput.Name,
+			Version:    pkgInput.Version,
+			Subpath:    pkgInput.Subpath,
+			Qualifiers: pkgQualifierFilter,
+		}
+		pkgResponse, err := model.Packages(ctx, gqlclient, *pkgFilter)
+		if err != nil {
+			logger.Fatalf("error querying for package: %v", err)
+		}
+		if len(pkgResponse.Packages) != 1 {
+			if pkgInput.Version == nil || *pkgInput.Version == "" {
+				// do not explore generic packages without versions
+				logger.Infof("skipping exploration of generic pacakages without versions: %v", node.subject)
+				return
+			}
+			logger.Fatalf("failed to located package based on purl: %v", node.subject)
+		}
+
+		retVisited = append(retVisited, helpers.AllPkgTreeToPurl(&pkgResponse.Packages[0].AllPkgTree))
+
+		pkgNameNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Id)
+		if err != nil {
+			logger.Fatalf("error querying for package name neighbors: %v", err)
+		}
+		t.SetTitle("Package Name Nodes")
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, hasSrcAtStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, badLinkStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgNameNeighbors, goodLinkStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+
+		path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Id,
+			pkgResponse.Packages[0].Namespaces[0].Id,
+			pkgResponse.Packages[0].Id}, neighborsPath...)
+
+		fmt.Println(t.Render())
+		fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
+
+		retFrontier = append(retFrontier, getFrontierBasedOnNode(ctx, gqlclient, pkgNameNeighbors, packageSubjectType, node)...)
+
+		pkgVersionNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id)
+		if err != nil {
+			logger.Fatalf("error querying for package version neighbors: %v", err)
+		}
+
+		// instantiate new table for package version nodes
+		t := table.NewWriter()
+		tTemp := table.Table{}
+		tTemp.Render()
+		t.AppendHeader(rowHeader)
+
+		t.SetTitle("Package Version Nodes")
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSrcAtStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, occurrenceStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, certifyVulnStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSBOMStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSLSAStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, vexLinkStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, pkgEqualStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, badLinkStr, packageSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, goodLinkStr, packageSubjectType, node.subject))
+		path = append([]string{pkgResponse.Packages[0].Namespaces[0].Names[0].Versions[0].Id,
+			pkgResponse.Packages[0].Namespaces[0].Names[0].Id, pkgResponse.Packages[0].Namespaces[0].Id,
+			pkgResponse.Packages[0].Id}, neighborsPath...)
+
+		// Get frontier for pacakge version nodes
+		retFrontier = append(retFrontier, getFrontierBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, packageSubjectType, node)...)
+
+		fmt.Println(t.Render())
+		fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
+
+	case sourceSubjectType:
+		srcInput, err := helpers.VcsToSrc(node.subject)
+		if err != nil {
+			logger.Fatalf("failed to parse source %v: %v", node.subject, err)
+		}
+
+		srcFilter := &model.SourceSpec{
+			Type:      &srcInput.Type,
+			Namespace: &srcInput.Namespace,
+			Name:      &srcInput.Name,
+			Tag:       srcInput.Tag,
+			Commit:    srcInput.Commit,
+		}
+		srcResponse, err := model.Sources(ctx, gqlclient, *srcFilter)
+		if err != nil {
+			logger.Fatalf("error querying for sources: %v", err)
+		}
+		if len(srcResponse.Sources) != 1 {
+			logger.Fatalf("failed to located sources based on vcs")
+		}
+		sourceNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, srcResponse.Sources[0].Namespaces[0].Names[0].Id)
+		if err != nil {
+			logger.Fatalf("error querying for source neighbors: %v", err)
+		}
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, hasSrcAtStr, sourceSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, occurrenceStr, sourceSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, scorecardStr, sourceSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, badLinkStr, sourceSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, sourceNeighbors, goodLinkStr, sourceSubjectType, node.subject))
+		path = append([]string{srcResponse.Sources[0].Namespaces[0].Names[0].Id,
+			srcResponse.Sources[0].Namespaces[0].Id, srcResponse.Sources[0].Id}, neighborsPath...)
+
+		fmt.Println(t.Render())
+		fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
+
+		retFrontier = append(retFrontier, getFrontierBasedOnNode(ctx, gqlclient, sourceNeighbors, sourceSubjectType, node)...)
+	case artifactSubjectType:
+		split := strings.Split(node.subject, ":")
+		if len(split) != 2 {
+			logger.Fatalf("failed to parse artifact. Needs to be in algorithm:digest form")
+		}
+		artifactFilter := &model.ArtifactSpec{
+			Algorithm: ptrfrom.String(strings.ToLower(string(split[0]))),
+			Digest:    ptrfrom.String(strings.ToLower(string(split[1]))),
+		}
+
+		artifactResponse, err := model.Artifacts(ctx, gqlclient, *artifactFilter)
+		if err != nil {
+			logger.Fatalf("error querying for artifacts: %v", err)
+		}
+		if len(artifactResponse.Artifacts) != 1 {
+			logger.Fatalf("failed to located artifacts based on (algorithm:digest)")
+		}
+		artifactNeighbors, neighborsPath, err := queryKnownNeighbors(ctx, gqlclient, artifactResponse.Artifacts[0].Id)
+		if err != nil {
+			logger.Fatalf("error querying for artifact neighbors: %v", err)
+		}
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hashEqualStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, occurrenceStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hasSBOMStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, hasSLSAStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, vexLinkStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, badLinkStr, artifactSubjectType, node.subject))
+		t.AppendSeparator()
+		t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, artifactNeighbors, goodLinkStr, artifactSubjectType, node.subject))
+		path = append([]string{artifactResponse.Artifacts[0].Id}, neighborsPath...)
+
+		fmt.Println(t.Render())
+		fmt.Printf("Visualizer url: http://localhost:3000/?path=%v\n", strings.Join(removeDuplicateValuesFromPath(path), `,`))
+
+		retFrontier = append(retFrontier, getFrontierBasedOnNode(ctx, gqlclient, artifactNeighbors, artifactSubjectType, node)...)
+	default:
+		logger.Fatalf("expected type to be either a package, source or artifact")
+	}
+	return
 }
 
 func queryKnownNeighbors(ctx context.Context, gqlclient graphql.Client, subjectQueryID string) (*neighbors, []string, error) {
@@ -328,7 +383,7 @@ func queryKnownNeighbors(ctx context.Context, gqlclient graphql.Client, subjectQ
 	return collectedNeighbors, path, nil
 }
 
-func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collectedNeighbors *neighbors, nodeType string, subjectType string) []table.Row {
+func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collectedNeighbors *neighbors, nodeType string, subjectType string, subject string) []table.Row {
 	logger := logging.FromContext(ctx)
 	var tableRows []table.Row
 	switch nodeType {
@@ -336,36 +391,36 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 		for _, certVuln := range collectedNeighbors.certifyVulns {
 			if certVuln.Vulnerability.Type != noVulnType {
 				for _, vuln := range certVuln.Vulnerability.VulnerabilityIDs {
-					tableRows = append(tableRows, table.Row{certifyVulnStr, certVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
+					tableRows = append(tableRows, table.Row{subject, certifyVulnStr, certVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
 				}
 			} else {
-				tableRows = append(tableRows, table.Row{certifyVulnStr, certVuln.Id, "vulnerability ID: " + noVulnType})
+				tableRows = append(tableRows, table.Row{subject, certifyVulnStr, certVuln.Id, "vulnerability ID: " + noVulnType})
 			}
 		}
 	case badLinkStr:
 		for _, bad := range collectedNeighbors.badLinks {
-			tableRows = append(tableRows, table.Row{badLinkStr, bad.Id, "justification: " + bad.Justification})
+			tableRows = append(tableRows, table.Row{subject, badLinkStr, bad.Id, "justification: " + bad.Justification})
 		}
 	case goodLinkStr:
 		for _, good := range collectedNeighbors.goodLinks {
-			tableRows = append(tableRows, table.Row{goodLinkStr, good.Id, "justification: " + good.Justification})
+			tableRows = append(tableRows, table.Row{subject, goodLinkStr, good.Id, "justification: " + good.Justification})
 		}
 	case scorecardStr:
 		for _, score := range collectedNeighbors.scorecards {
-			tableRows = append(tableRows, table.Row{scorecardStr, score.Id, "Overall Score: " + fmt.Sprintf("%f", score.Scorecard.AggregateScore)})
+			tableRows = append(tableRows, table.Row{subject, scorecardStr, score.Id, "Overall Score: " + fmt.Sprintf("%f", score.Scorecard.AggregateScore)})
 		}
 	case vexLinkStr:
 		for _, vex := range collectedNeighbors.vexLinks {
-			tableRows = append(tableRows, table.Row{vexLinkStr, vex.Id, "Vex Status: " + vex.Status})
+			tableRows = append(tableRows, table.Row{subject, vexLinkStr, vex.Id, "Vex Status: " + vex.Status})
 		}
 	case hasSBOMStr:
 		for _, sbom := range collectedNeighbors.hasSBOMs {
-			tableRows = append(tableRows, table.Row{hasSBOMStr, sbom.Id, "SBOM Download Location: " + sbom.DownloadLocation})
+			tableRows = append(tableRows, table.Row{subject, hasSBOMStr, sbom.Id, "SBOM Download Location: " + sbom.DownloadLocation})
 		}
 	case hasSLSAStr:
 		if len(collectedNeighbors.hasSLSAs) > 0 {
 			for _, slsa := range collectedNeighbors.hasSLSAs {
-				tableRows = append(tableRows, table.Row{hasSLSAStr, slsa.Id, "SLSA Attestation Location: " + slsa.Slsa.Origin})
+				tableRows = append(tableRows, table.Row{subject, hasSLSAStr, slsa.Id, "SLSA Attestation Location: " + slsa.Slsa.Origin})
 			}
 		} else {
 			// if there is an isOccurrence, check to see if there are slsa attestation associated with it
@@ -387,7 +442,7 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 				} else {
 					for _, neighborHasSLSA := range neighborResponseHasSLSA.Neighbors {
 						if hasSLSA, ok := neighborHasSLSA.(*model.NeighborsNeighborsHasSLSA); ok {
-							tableRows = append(tableRows, table.Row{hasSLSAStr, hasSLSA.Id, "SLSA Attestation Location: " + hasSLSA.Slsa.Origin})
+							tableRows = append(tableRows, table.Row{subject, hasSLSAStr, hasSLSA.Id, "SLSA Attestation Location: " + hasSLSA.Slsa.Origin})
 						}
 					}
 				}
@@ -402,18 +457,18 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 				} else {
 					namespace = src.Source.Namespaces[0].Namespace
 				}
-				tableRows = append(tableRows, table.Row{hasSrcAtStr, src.Id, "Source: " + src.Source.Type + "+" + namespace + "/" +
+				tableRows = append(tableRows, table.Row{subject, hasSrcAtStr, src.Id, "Source: " + src.Source.Type + "+" + namespace + "/" +
 					src.Source.Namespaces[0].Names[0].Name})
 			} else {
 				purl := helpers.PkgToPurl(src.Package.Type, src.Package.Namespaces[0].Namespace,
 					src.Package.Namespaces[0].Names[0].Name, "", "", []string{})
 
-				tableRows = append(tableRows, table.Row{hasSrcAtStr, src.Id, "Source for Package: " + purl})
+				tableRows = append(tableRows, table.Row{subject, hasSrcAtStr, src.Id, "Source for Package: " + purl})
 			}
 		}
 	case hashEqualStr:
 		for _, hash := range collectedNeighbors.hashEquals {
-			tableRows = append(tableRows, table.Row{hashEqualStr, hash.Id, ""})
+			tableRows = append(tableRows, table.Row{subject, hashEqualStr, hash.Id, ""})
 		}
 	case occurrenceStr:
 		for _, occurrence := range collectedNeighbors.occurrences {
@@ -423,7 +478,7 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 					purl := helpers.PkgToPurl(v.Type, v.Namespaces[0].Namespace,
 						v.Namespaces[0].Names[0].Name, v.Namespaces[0].Names[0].Versions[0].Version, "", []string{})
 
-					tableRows = append(tableRows, table.Row{occurrenceStr, occurrence.Id, "Occurrence for Package: " + purl})
+					tableRows = append(tableRows, table.Row{subject, occurrenceStr, occurrence.Id, "Occurrence for Package: " + purl})
 				case *model.AllIsOccurrencesTreeSubjectSource:
 					namespace := ""
 					if !strings.HasPrefix(v.Namespaces[0].Namespace, "https://") {
@@ -431,25 +486,163 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 					} else {
 						namespace = v.Namespaces[0].Namespace
 					}
-					tableRows = append(tableRows, table.Row{occurrenceStr, occurrence.Id, "Occurrence for Package: " + v.Type + "+" + namespace + "/" +
+					tableRows = append(tableRows, table.Row{subject, occurrenceStr, occurrence.Id, "Occurrence for Package: " + v.Type + "+" + namespace + "/" +
 						v.Namespaces[0].Names[0].Name})
 				}
 			} else {
-				tableRows = append(tableRows, table.Row{occurrenceStr, occurrence.Id, "Occurrence for Artifact: " + occurrence.Artifact.Algorithm + ":" + occurrence.Artifact.Digest})
+				tableRows = append(tableRows, table.Row{subject, occurrenceStr, occurrence.Id, "Occurrence for Artifact: " + occurrence.Artifact.Algorithm + ":" + occurrence.Artifact.Digest})
 			}
 		}
 	case pkgEqualStr:
 		for _, equal := range collectedNeighbors.pkgEquals {
-			tableRows = append(tableRows, table.Row{pkgEqualStr, equal.Id, ""})
+			tableRows = append(tableRows, table.Row{subject, pkgEqualStr, equal.Id, ""})
 		}
 	}
 
 	return tableRows
 }
 
-func validateQueryKnownFlags(graphqlEndpoint string, args []string) (queryKnownOptions, error) {
+func allArtifactTreeToSubject(v *model.AllArtifactTree) string {
+	return fmt.Sprintf("%s:%s", v.Algorithm, v.Digest)
+}
+
+func allSourceTreeToSubject(v *model.AllSourceTree) string {
+	// <vcs_tool>+<transport>://<host_name>[/<path_to_repository>][@<revision_tag_or_branch>][#<sub_path>]
+
+	namespace := ""
+	if !strings.HasPrefix(v.Namespaces[0].Namespace, "https://") {
+		namespace = "https://" + v.Namespaces[0].Namespace
+	} else {
+		namespace = v.Namespaces[0].Namespace
+	}
+
+	s := fmt.Sprintf("%s+%s", v.Type, namespace)
+	if len(v.Namespaces[0].Names) > 0 {
+		name := v.Namespaces[0].Names[0]
+		s += "/" + name.Name
+		if name.Commit != nil {
+			s += "@" + *name.Commit
+		} else if name.Tag != nil {
+			s += "@" + *name.Tag
+		}
+	}
+
+	return s
+}
+
+func getFrontierBasedOnNode(ctx context.Context, gqlclient graphql.Client, collectedNeighbors *neighbors, subjectType string, currentTarget target) []target {
+	var frontier []target
+
+	// case certifyVulnStr:
+	// case badLinkStr:
+	// case goodLinkStr:
+	// case scorecardStr:
+	// case vexLinkStr:
+
+	//case hasSBOMStr:
+	for _, sbom := range collectedNeighbors.hasSBOMs {
+		for _, s := range sbom.IncludedSoftware {
+			switch s := s.(type) {
+			case *model.AllHasSBOMTreeIncludedSoftwarePackage:
+				frontier = append(frontier, target{
+					subjectType: packageSubjectType,
+					subject:     helpers.AllPkgTreeToPurl(&s.AllPkgTree),
+				})
+			case *model.AllHasSBOMTreeIncludedSoftwareArtifact:
+				frontier = append(frontier, target{
+					subjectType: artifactSubjectType,
+					subject:     allArtifactTreeToSubject(&s.AllArtifactTree),
+				})
+			}
+		}
+	}
+
+	// case hasSLSAStr:
+	if len(collectedNeighbors.hasSLSAs) > 0 {
+		for _, slsa := range collectedNeighbors.hasSLSAs {
+			for _, v := range slsa.Slsa.BuiltFrom {
+				frontier = append(frontier, target{
+					subjectType: artifactSubjectType,
+					subject:     allArtifactTreeToSubject(&v.AllArtifactTree),
+				})
+			}
+		}
+	}
+	//case hasSrcAtStr:
+	for _, src := range collectedNeighbors.hasSrcAt {
+		if subjectType == packageSubjectType {
+			frontier = append(frontier, target{
+				subjectType: sourceSubjectType,
+				subject:     allSourceTreeToSubject(&src.Source.AllSourceTree),
+			})
+
+		} else {
+			frontier = append(frontier, target{
+				subjectType: packageSubjectType,
+				subject:     helpers.AllPkgTreeToPurl(&src.Package.AllPkgTree),
+			})
+
+		}
+	}
+	//case hashEqualStr:
+	for _, hash := range collectedNeighbors.hashEquals {
+		for _, v := range hash.Artifacts {
+			frontier = append(frontier, target{
+				subjectType: artifactSubjectType,
+				subject:     allArtifactTreeToSubject(&v.AllArtifactTree),
+			})
+		}
+	}
+	//case occurrenceStr:
+	for _, occurrence := range collectedNeighbors.occurrences {
+		if subjectType == artifactSubjectType {
+			switch v := occurrence.Subject.(type) {
+			case *model.AllIsOccurrencesTreeSubjectPackage:
+				frontier = append(frontier, target{
+					subjectType: packageSubjectType,
+					subject:     helpers.AllPkgTreeToPurl(&v.AllPkgTree),
+				})
+
+			case *model.AllIsOccurrencesTreeSubjectSource:
+				frontier = append(frontier, target{
+					subjectType: sourceSubjectType,
+					subject:     allSourceTreeToSubject(&v.AllSourceTree),
+				})
+
+			}
+		} else {
+			frontier = append(frontier, target{
+				subjectType: artifactSubjectType,
+				subject:     allArtifactTreeToSubject(&occurrence.Artifact.AllArtifactTree),
+			})
+		}
+	}
+	//case pkgEqualStr:
+	for _, equal := range collectedNeighbors.pkgEquals {
+		for _, v := range equal.Packages {
+			frontier = append(frontier, target{
+				subjectType: artifactSubjectType,
+				subject:     helpers.AllPkgTreeToPurl(&v.AllPkgTree),
+			})
+		}
+
+	}
+
+	for i := 0; i < len(frontier); i++ {
+		frontier[i].depth = currentTarget.depth + 1
+	}
+	return frontier
+}
+
+func validateQueryKnownFlags(graphqlEndpoint string, searchDepth int, args []string) (queryKnownOptions, error) {
 	var opts queryKnownOptions
 	opts.graphqlEndpoint = graphqlEndpoint
+
+	if searchDepth < 0 {
+		return opts, fmt.Errorf("known depth must be non-negative")
+	}
+
+	opts.searchDepth = searchDepth
 
 	if len(args) != 2 {
 		return opts, fmt.Errorf("expected positional arguments for <type> <subject>")

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"gql-addr", "csub-addr", "csub-tls", "csub-tls-skip-verify"})
+	set, err := cli.BuildFlags([]string{"gql-addr", "csub-addr", "csub-tls", "csub-tls-skip-verify", "search-depth"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

Add `--search-depth` parameter to allow recursive search for query known, will default to 0 which will recursively query max depth. In addition, added `SUBJECT` to output tables which says which subject the predicate is referring to within the tree of metadata returned.


```
guacone query known package pkg:guac/cdx/docker.io/library/consul@sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c
```

Before (without recursion):

```
+----------------------------------------------------------+
| Package Name Nodes                                       |
+---------+-----------+-----------+------------------------+
| SUBJECT | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION |
+---------+-----------+-----------+------------------------+
+---------+-----------+-----------+------------------------+
Visualizer url: http://localhost:3000/?path=833,24,23
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                                                                                                                                                                                   |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
| SUBJECT                                                                                                       | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                                                                                          |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
| pkg:guac/cdx/docker.io/library/consul@sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c | hasSBOM   | 1300      | SBOM Download Location: file:///../guac-data/docs/cyclonedx/syft-cyclonedx-docker.io-library-consul.latest.json |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
Visualizer url: http://localhost:3000/?path=834,833,24,23,1300
```

With recursive:

```
+----------------------------------------------------------+
| Package Name Nodes                                       |
+---------+-----------+-----------+------------------------+
| SUBJECT | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION |
+---------+-----------+-----------+------------------------+
+---------+-----------+-----------+------------------------+
Visualizer url: http://localhost:3000/?path=833,24,23
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                                                                                                                                                                                   |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
| SUBJECT                                                                                                       | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                                                                                          |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
| pkg:guac/cdx/docker.io/library/consul@sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c | hasSBOM   | 1300      | SBOM Download Location: file:///../guac-data/docs/cyclonedx/syft-cyclonedx-docker.io-library-consul.latest.json |
+---------------------------------------------------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------------------------------------------------------------------+
Visualizer url: http://localhost:3000/?path=834,833,24,23,1300
+------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Name Nodes                                                                                                                             |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| SUBJECT                                                          | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | hasSrcAt  | 136898    | Source: git+https://github.com/form3tech-oss/jwt-go |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
Visualizer url: http://localhost:3000/?path=1001,1000,94,136898
+-------------------------------------------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                                                         |
+------------------------------------------------------------------+-------------+-----------+----------------------------------+
| SUBJECT                                                          | NODE TYPE   | NODE ID # | ADDITIONAL INFORMATION           |
+------------------------------------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | certifyVuln | 146067    | vulnerability ID: novuln         |
+------------------------------------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | hasSBOM     | 150996    | SBOM Download Location: deps.dev |
+------------------------------------------------------------------+-------------+-----------+----------------------------------+
Visualizer url: http://localhost:3000/?path=1002,1001,1000,94,146067,150996
+------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Name Nodes                                                                                                                             |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| SUBJECT                                                          | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | hasSrcAt  | 136898    | Source: git+https://github.com/form3tech-oss/jwt-go |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/kr/text@v0.2.0                             | hasSrcAt  | 136861    | Source: git+https://github.com/kr/text              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
Visualizer url: http://localhost:3000/?path=1004,1003,94,136861
+---------------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                             |
+--------------------------------------+-------------+-----------+----------------------------------+
| SUBJECT                              | NODE TYPE   | NODE ID # | ADDITIONAL INFORMATION           |
+--------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/kr/text@v0.2.0 | certifyVuln | 146070    | vulnerability ID: novuln         |
+--------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/kr/text@v0.2.0 | hasSBOM     | 140634    | SBOM Download Location: deps.dev |
+--------------------------------------+-------------+-----------+----------------------------------+
Visualizer url: http://localhost:3000/?path=1005,1004,1003,94,146070,140634
+------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Name Nodes                                                                                                                             |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| SUBJECT                                                          | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | hasSrcAt  | 136898    | Source: git+https://github.com/form3tech-oss/jwt-go |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/kr/text@v0.2.0                             | hasSrcAt  | 136861    | Source: git+https://github.com/kr/text              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/azure/go-autorest/autorest/date@v0.3.0     | hasSrcAt  | 136851    | Source: git+https://github.com/azure/go-autorest    |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
Visualizer url: http://localhost:3000/?path=1006,785,94,136851
+---------------------------------------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                                                     |
+--------------------------------------------------------------+-------------+-----------+----------------------------------+
| SUBJECT                                                      | NODE TYPE   | NODE ID # | ADDITIONAL INFORMATION           |
+--------------------------------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/azure/go-autorest/autorest/date@v0.3.0 | certifyVuln | 145840    | vulnerability ID: novuln         |
+--------------------------------------------------------------+-------------+-----------+----------------------------------+
| pkg:golang/github.com/azure/go-autorest/autorest/date@v0.3.0 | hasSBOM     | 150987    | SBOM Download Location: deps.dev |
+--------------------------------------------------------------+-------------+-----------+----------------------------------+
Visualizer url: http://localhost:3000/?path=1007,1006,785,94,145840,150987
+------------------------------------------------------------------------------------------------------------------------------------------------+
| Package Name Nodes                                                                                                                             |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| SUBJECT                                                          | NODE TYPE | NODE ID # | ADDITIONAL INFORMATION                              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/form3tech-oss/jwt-go@v3.2.2%2Bincompatible | hasSrcAt  | 136898    | Source: git+https://github.com/form3tech-oss/jwt-go |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/kr/text@v0.2.0                             | hasSrcAt  | 136861    | Source: git+https://github.com/kr/text              |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
| pkg:golang/github.com/azure/go-autorest/autorest/date@v0.3.0     | hasSrcAt  | 136851    | Source: git+https://github.com/azure/go-autorest    |
+------------------------------------------------------------------+-----------+-----------+-----------------------------------------------------+
Visualizer url: http://localhost:3000/?path=305,199,94
+-----------------------------------------------------------------------------------------+
| Package Version Nodes                                                                   |
+------------------------------------+-------------+-----------+--------------------------+
| SUBJECT                            | NODE TYPE   | NODE ID # | ADDITIONAL INFORMATION   |
+------------------------------------+-------------+-----------+--------------------------+
| pkg:golang/gopkg.in/yaml.v2@v2.2.8 | certifyVuln | 145535    | vulnerability ID: novuln |
+------------------------------------+-------------+-----------+--------------------------+
Visualizer url: http://localhost:3000/?path=1008,305,199,94,145535
...
```


This change will require doc change 
<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
