### PR TITLE
feature: Verify the DSSE envelope if the verifier-key-path and verifi…

### DIFF
--- a/pkg/ingestor/parser/dsse/parser_dsse.go
+++ b/pkg/ingestor/parser/dsse/parser_dsse.go
@@ -22,7 +22,9 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
+	"github.com/guacsec/guac/pkg/ingestor/verifier"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
 type dsseParser struct {
@@ -50,7 +52,7 @@ func (d *dsseParser) Parse(ctx context.Context, doc *processor.Document) error {
 func (d *dsseParser) getIdentity(ctx context.Context) error {
 	// TODO (pxp928): enable dsse verification once the identity and key management is finalized
 	// See issue: https://github.com/guacsec/guac/issues/75 and https://github.com/guacsec/guac/issues/443
-	/* identities, err := verifier.VerifyIdentity(ctx, d.doc)
+	identities, err := verifier.VerifyIdentity(ctx, d.doc)
 	if err != nil {
 		return fmt.Errorf("failed to verify identity: %w", err)
 	}
@@ -69,9 +71,7 @@ func (d *dsseParser) getIdentity(ctx context.Context) error {
 			logger := logging.FromContext(ctx)
 			logger.Errorf("failed to verify DSSE with provided key: %v", i.ID)
 		}
-	} */
-	logger := logging.FromContext(ctx)
-	logger.Warn("DSSE verification currently not implemented in this release. Continuing without DSSE verification")
+	}
 	return nil
 }
 

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier.go
@@ -59,20 +59,21 @@ func (d *sigstoreVerifier) Verify(ctx context.Context, payloadBytes []byte) ([]v
 		// see:
 		// https://github.com/sigstore/sigstore/blob/main/pkg/signature/dsse/dsse.go#L107
 		// and
-		// https://github.com/secure-systems-lab/go-securesystemslib/blob/main/dsse/verify.go#L69
-		foundIdentity := verifier.Identity{
+		// https://github.com/secure-systems-lab/go-securesystemslib/blob/main/dsse/verify.go#L69s
+		/*foundIdentity := verifier.Identity{
 			ID:  signature.KeyID,
 			Key: *key,
-		}
+		}*/
 		err = verifySignature(key.Val, payloadBytes)
 		if err != nil {
 			// logging here as we don't want to fail but record that the signature check failed
 			logger := logging.FromContext(ctx)
 			logger.Errorf("failed to verify signature with provided key: %v", key.Hash)
+			return nil, err
 		}
 		// if err (meaning that the keyID or the signature verification failed), verified is set to false
-		foundIdentity.Verified = (err == nil)
-		identities = append(identities, foundIdentity)
+		/*foundIdentity.Verified = (err == nil)
+		identities = append(identities, foundIdentity)*/
 	}
 
 	return identities, nil

--- a/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
+++ b/pkg/ingestor/verifier/sigstore_verifier/sigstore_verifier_test.go
@@ -102,15 +102,6 @@ func randomData(t *testing.T, n int) []byte {
 func TestSigstoreVerifier_Verify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 	setupOneProvider(t)
-	foundECDSAKey, err := key.Find(ctx, ecdsaKeyID)
-	if err != nil {
-		t.Fatal("failed to find key in mock key provider")
-	}
-	foundRSAKey, err := key.Find(ctx, rsaKeyID)
-	if err != nil {
-		t.Fatal("failed to find key in mock key provider")
-	}
-	// Get some random data so it's unique each run
 	d := randomData(t, 10)
 	id := base64.StdEncoding.EncodeToString(d)
 
@@ -190,27 +181,15 @@ func TestSigstoreVerifier_Verify(t *testing.T) {
 		want    []verifier.Identity
 		wantErr bool
 	}{{
-		name: "verify Document",
-		doc:  doc,
-		want: []verifier.Identity{
-			{
-				ID:       ecdsaKeyID,
-				Key:      *foundECDSAKey,
-				Verified: true,
-			},
-		},
+		name:    "verify Document",
+		doc:     doc,
+		want:    []verifier.Identity{},
 		wantErr: false,
 	}, {
-		name: "unverified Document",
-		doc:  badDoc,
-		want: []verifier.Identity{
-			{
-				ID:       rsaKeyID,
-				Key:      *foundRSAKey,
-				Verified: false,
-			},
-		},
-		wantErr: false,
+		name:    "unverified Document",
+		doc:     badDoc,
+		want:    []verifier.Identity{},
+		wantErr: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -235,14 +214,6 @@ func TestSigstoreVerifier_Verify(t *testing.T) {
 func TestMultiSignatureSigstoreVerifier_Verify(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 	setupOneProvider(t)
-	foundECDSAKey, err := key.Find(ctx, ecdsaKeyID)
-	if err != nil {
-		t.Fatal("failed to find key in mock key provider")
-	}
-	foundRSAKey, err := key.Find(ctx, rsaKeyID)
-	if err != nil {
-		t.Fatal("failed to find key in mock key provider")
-	}
 	// Get some random data so it's unique each run
 	d := randomData(t, 10)
 	id := base64.StdEncoding.EncodeToString(d)
@@ -314,20 +285,9 @@ func TestMultiSignatureSigstoreVerifier_Verify(t *testing.T) {
 		want    []verifier.Identity
 		wantErr bool
 	}{{
-		name: "verify Document",
-		doc:  doc,
-		want: []verifier.Identity{
-			{
-				ID:       ecdsaKeyID,
-				Key:      *foundECDSAKey,
-				Verified: true,
-			},
-			{
-				ID:       rsaKeyID,
-				Key:      *foundRSAKey,
-				Verified: true,
-			},
-		},
+		name:    "verify Document",
+		doc:     doc,
+		want:    []verifier.Identity{},
 		wantErr: false,
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION

# Description of the PR
- Verify the DSSE envelope if the verifier-key-path and verifier-key-id are provided
- Fails the DSSE envelope ingestion if the document is not verified.


"Fixes https://github.com/guacsec/guac/issues/304"


Note: I have commented the identity creation part, we can add it back once once the identity and key management is finalised.