### PR TITLE
Add Pagination to the Rest API

### DIFF
--- a/pkg/guacrest/client/client.go
+++ b/pkg/guacrest/client/client.go
@@ -156,6 +156,22 @@ func NewAnalyzeDependenciesRequest(server string, params *AnalyzeDependenciesPar
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.PaginationSpec != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "PaginationSpec", runtime.ParamLocationQuery, *params.PaginationSpec); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, params.Sort); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
@@ -227,6 +243,22 @@ func NewRetrieveDependenciesRequest(server string, params *RetrieveDependenciesP
 
 	if params != nil {
 		queryValues := queryURL.Query()
+
+		if params.PaginationSpec != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "PaginationSpec", runtime.ParamLocationQuery, *params.PaginationSpec); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "purl", runtime.ParamLocationQuery, params.Purl); err != nil {
 			return nil, err

--- a/pkg/guacrest/client/models.go
+++ b/pkg/guacrest/client/models.go
@@ -26,7 +26,7 @@ type Purl = string
 // PaginationSpec defines model for PaginationSpec.
 type PaginationSpec struct {
 	Cursor   *string `json:"Cursor,omitempty"`
-	PageSize int     `json:"PageSize"`
+	PageSize *int    `json:"PageSize,omitempty"`
 }
 
 // BadGateway defines model for BadGateway.
@@ -47,7 +47,7 @@ type PurlList struct {
 // AnalyzeDependenciesParams defines parameters for AnalyzeDependencies.
 type AnalyzeDependenciesParams struct {
 	// PaginationSpec The pagination configuration for the query.
-	//   * 'PageSize' specified the number of results returned
+	//   * 'PageSize' specifies the number of results returned
 	//   * 'Cursor' is returned by previous calls and specifies what page to return
 	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
 
@@ -63,7 +63,7 @@ type AnalyzeDependenciesParamsSort string
 // RetrieveDependenciesParams defines parameters for RetrieveDependencies.
 type RetrieveDependenciesParams struct {
 	// PaginationSpec The pagination configuration for the query.
-	//   * 'PageSize' specified the number of results returned
+	//   * 'PageSize' specifies the number of results returned
 	//   * 'Cursor' is returned by previous calls and specifies what page to return
 	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
 

--- a/pkg/guacrest/client/models.go
+++ b/pkg/guacrest/client/models.go
@@ -11,11 +11,23 @@ const (
 
 // Error defines model for Error.
 type Error struct {
-	Message string `json:"message"`
+	Message string `json:"Message"`
+}
+
+// PaginationInfo defines model for PaginationInfo.
+type PaginationInfo struct {
+	NextCursor string `json:"NextCursor"`
+	TotalCount *int   `json:"TotalCount,omitempty"`
 }
 
 // Purl defines model for Purl.
 type Purl = string
+
+// PaginationSpec defines model for PaginationSpec.
+type PaginationSpec struct {
+	Cursor   *string `json:"Cursor,omitempty"`
+	PageSize int     `json:"PageSize"`
+}
 
 // BadGateway defines model for BadGateway.
 type BadGateway = Error
@@ -27,10 +39,18 @@ type BadRequest = Error
 type InternalServerError = Error
 
 // PurlList defines model for PurlList.
-type PurlList = []Purl
+type PurlList struct {
+	PaginationInfo PaginationInfo `json:"PaginationInfo"`
+	PurlList       []Purl         `json:"PurlList"`
+}
 
 // AnalyzeDependenciesParams defines parameters for AnalyzeDependencies.
 type AnalyzeDependenciesParams struct {
+	// PaginationSpec The pagination configuration for the query.
+	//   * 'PageSize' specified the number of results returned
+	//   * 'Cursor' is returned by previous calls and specifies what page to return
+	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
+
 	// Sort The sort order of the packages
 	//   * 'frequency' - The packages with the highest number of dependents
 	//   * 'scorecard' - The packages with the lowest OpenSSF scorecard score
@@ -42,6 +62,11 @@ type AnalyzeDependenciesParamsSort string
 
 // RetrieveDependenciesParams defines parameters for RetrieveDependencies.
 type RetrieveDependenciesParams struct {
+	// PaginationSpec The pagination configuration for the query.
+	//   * 'PageSize' specified the number of results returned
+	//   * 'Cursor' is returned by previous calls and specifies what page to return
+	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
+
 	// Purl the purl of the dependent package
 	Purl string `form:"purl" json:"purl"`
 }

--- a/pkg/guacrest/client/models.go
+++ b/pkg/guacrest/client/models.go
@@ -14,10 +14,10 @@ type Error struct {
 	Message string `json:"Message"`
 }
 
-// PaginationInfo defines model for PaginationInfo.
+// PaginationInfo Contains the cursor to retrieve more pages. If there are no more,  NextCursor will be nil.
 type PaginationInfo struct {
-	NextCursor string `json:"NextCursor"`
-	TotalCount *int   `json:"TotalCount,omitempty"`
+	NextCursor *string `json:"NextCursor,omitempty"`
+	TotalCount *int    `json:"TotalCount,omitempty"`
 }
 
 // Purl defines model for Purl.
@@ -40,6 +40,7 @@ type InternalServerError = Error
 
 // PurlList defines model for PurlList.
 type PurlList struct {
+	// PaginationInfo Contains the cursor to retrieve more pages. If there are no more,  NextCursor will be nil.
 	PaginationInfo PaginationInfo `json:"PaginationInfo"`
 	PurlList       []Purl         `json:"PurlList"`
 }

--- a/pkg/guacrest/generated/models.go
+++ b/pkg/guacrest/generated/models.go
@@ -26,7 +26,7 @@ type Purl = string
 // PaginationSpec defines model for PaginationSpec.
 type PaginationSpec struct {
 	Cursor   *string `json:"Cursor,omitempty"`
-	PageSize int     `json:"PageSize"`
+	PageSize *int    `json:"PageSize,omitempty"`
 }
 
 // BadGateway defines model for BadGateway.
@@ -47,7 +47,7 @@ type PurlList struct {
 // AnalyzeDependenciesParams defines parameters for AnalyzeDependencies.
 type AnalyzeDependenciesParams struct {
 	// PaginationSpec The pagination configuration for the query.
-	//   * 'PageSize' specified the number of results returned
+	//   * 'PageSize' specifies the number of results returned
 	//   * 'Cursor' is returned by previous calls and specifies what page to return
 	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
 
@@ -63,7 +63,7 @@ type AnalyzeDependenciesParamsSort string
 // RetrieveDependenciesParams defines parameters for RetrieveDependencies.
 type RetrieveDependenciesParams struct {
 	// PaginationSpec The pagination configuration for the query.
-	//   * 'PageSize' specified the number of results returned
+	//   * 'PageSize' specifies the number of results returned
 	//   * 'Cursor' is returned by previous calls and specifies what page to return
 	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
 

--- a/pkg/guacrest/generated/models.go
+++ b/pkg/guacrest/generated/models.go
@@ -11,11 +11,23 @@ const (
 
 // Error defines model for Error.
 type Error struct {
-	Message string `json:"message"`
+	Message string `json:"Message"`
+}
+
+// PaginationInfo defines model for PaginationInfo.
+type PaginationInfo struct {
+	NextCursor string `json:"NextCursor"`
+	TotalCount *int   `json:"TotalCount,omitempty"`
 }
 
 // Purl defines model for Purl.
 type Purl = string
+
+// PaginationSpec defines model for PaginationSpec.
+type PaginationSpec struct {
+	Cursor   *string `json:"Cursor,omitempty"`
+	PageSize int     `json:"PageSize"`
+}
 
 // BadGateway defines model for BadGateway.
 type BadGateway = Error
@@ -27,10 +39,18 @@ type BadRequest = Error
 type InternalServerError = Error
 
 // PurlList defines model for PurlList.
-type PurlList = []Purl
+type PurlList struct {
+	PaginationInfo PaginationInfo `json:"PaginationInfo"`
+	PurlList       []Purl         `json:"PurlList"`
+}
 
 // AnalyzeDependenciesParams defines parameters for AnalyzeDependencies.
 type AnalyzeDependenciesParams struct {
+	// PaginationSpec The pagination configuration for the query.
+	//   * 'PageSize' specified the number of results returned
+	//   * 'Cursor' is returned by previous calls and specifies what page to return
+	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
+
 	// Sort The sort order of the packages
 	//   * 'frequency' - The packages with the highest number of dependents
 	//   * 'scorecard' - The packages with the lowest OpenSSF scorecard score
@@ -42,6 +62,11 @@ type AnalyzeDependenciesParamsSort string
 
 // RetrieveDependenciesParams defines parameters for RetrieveDependencies.
 type RetrieveDependenciesParams struct {
+	// PaginationSpec The pagination configuration for the query.
+	//   * 'PageSize' specified the number of results returned
+	//   * 'Cursor' is returned by previous calls and specifies what page to return
+	PaginationSpec *PaginationSpec `form:"PaginationSpec,omitempty" json:"PaginationSpec,omitempty"`
+
 	// Purl the purl of the dependent package
 	Purl string `form:"purl" json:"purl"`
 }

--- a/pkg/guacrest/generated/models.go
+++ b/pkg/guacrest/generated/models.go
@@ -14,10 +14,10 @@ type Error struct {
 	Message string `json:"Message"`
 }
 
-// PaginationInfo defines model for PaginationInfo.
+// PaginationInfo Contains the cursor to retrieve more pages. If there are no more,  NextCursor will be nil.
 type PaginationInfo struct {
-	NextCursor string `json:"NextCursor"`
-	TotalCount *int   `json:"TotalCount,omitempty"`
+	NextCursor *string `json:"NextCursor,omitempty"`
+	TotalCount *int    `json:"TotalCount,omitempty"`
 }
 
 // Purl defines model for Purl.
@@ -40,6 +40,7 @@ type InternalServerError = Error
 
 // PurlList defines model for PurlList.
 type PurlList struct {
+	// PaginationInfo Contains the cursor to retrieve more pages. If there are no more,  NextCursor will be nil.
 	PaginationInfo PaginationInfo `json:"PaginationInfo"`
 	PurlList       []Purl         `json:"PurlList"`
 }

--- a/pkg/guacrest/generated/server.go
+++ b/pkg/guacrest/generated/server.go
@@ -292,6 +292,7 @@ type BadRequestJSONResponse Error
 type InternalServerErrorJSONResponse Error
 
 type PurlListJSONResponse struct {
+	// PaginationInfo Contains the cursor to retrieve more pages. If there are no more,  NextCursor will be nil.
 	PaginationInfo PaginationInfo `json:"PaginationInfo"`
 	PurlList       []Purl         `json:"PurlList"`
 }

--- a/pkg/guacrest/generated/server.go
+++ b/pkg/guacrest/generated/server.go
@@ -67,6 +67,14 @@ func (siw *ServerInterfaceWrapper) AnalyzeDependencies(w http.ResponseWriter, r 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params AnalyzeDependenciesParams
 
+	// ------------- Optional query parameter "PaginationSpec" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "PaginationSpec", r.URL.Query(), &params.PaginationSpec)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "PaginationSpec", Err: err})
+		return
+	}
+
 	// ------------- Required query parameter "sort" -------------
 
 	if paramValue := r.URL.Query().Get("sort"); paramValue != "" {
@@ -116,6 +124,14 @@ func (siw *ServerInterfaceWrapper) RetrieveDependencies(w http.ResponseWriter, r
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params RetrieveDependenciesParams
+
+	// ------------- Optional query parameter "PaginationSpec" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "PaginationSpec", r.URL.Query(), &params.PaginationSpec)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "PaginationSpec", Err: err})
+		return
+	}
 
 	// ------------- Required query parameter "purl" -------------
 
@@ -275,7 +291,10 @@ type BadRequestJSONResponse Error
 
 type InternalServerErrorJSONResponse Error
 
-type PurlListJSONResponse []Purl
+type PurlListJSONResponse struct {
+	PaginationInfo PaginationInfo `json:"PaginationInfo"`
+	PurlList       []Purl         `json:"PurlList"`
+}
 
 type AnalyzeDependenciesRequestObject struct {
 	Params AnalyzeDependenciesParams

--- a/pkg/guacrest/generated/spec.go
+++ b/pkg/guacrest/generated/spec.go
@@ -18,21 +18,21 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+RVS2/jNhD+KwO2QIBCjYNte/GtSV8L9BGsc9vdw4QaS9xIJDMkkzqB/nsxlCXLXnnj",
-	"HnLam2XO45v55pt5Vtq13lmyMajls/LI2FIkzl/XWBmL0Ti78qTln5KCZuPlL7VUNzWBH21AO7s2VeL+",
-	"a+0YYk1wn4g35x8swHdwdo0VrcwTnUHwpM3aUJmNbGpvicGtgSmkJgZgioktlVvHq8TB8RmY3QvcbsAz",
-	"PRiXAmhsmgBoyzFwgMcao+AjiG7r9cGqQhnBnmGpQllsSS0PSy1U0DW1mHvCzhNHQ7knPRD5FTdePENk",
-	"YyvVFWoobvJobKSKWHVdoZjuk2Eq1fL9zvRjMZi620+ko+p60+CdDX3GSyx/x0iPuJEv7WwkG+Unet8Y",
-	"nUEvPgVh5HkC+1umtVqqbxY7hhf9a1j8yuy4T/U5o4H4gRjIapdsJKYS0AKJi1BsSUdjK+mpMFdiRLhF",
-	"fUe2lCZcYvmO7hOF+PpoL7EE7pMVEJKuAQOs2bVg7AM2pgTH0JoQBO9ktLtCvZXKLDarXGyf4dXxDkmh",
-	"zwpbw0JdJ27+NP+zZftzuRvgt3btXoJ4YH0AwURqw4shEjfiuB1fZMbN3JxP80zSzA/+fr9+hsaEKFvB",
-	"J25Cjr5NL+hG1vY78ReFgBXNSPQA3GD4OZRipp37Sf6mf+MXVsGNi9hciX5OWAaTWLNQpNEzxXSyyQSb",
-	"TU1TKOfJojdqqX44vzi/UIXyGOsMdoEWm00wYVGSJ1uS1dsyKsoApbK+2FLaLtZP9MvUttg7De/nR2Nn",
-	"sjjYp10xdzuC4wiOy37zx3xN9B1WFLZbf53VbfXmDL6Hm8k7PJpYZ4/aVDWFOLkgQ41xiBK0Y9LI5fEo",
-	"jXuUIP94sqvVbzB69L+OXg0pQE3JjJxoejvIplYoHgvJl2UbfML2SOrHg+X/5uLimBBHu8Uoqq5QP57i",
-	"MFnSXaF+OsVlbmFm3zcnpRsuWJZwalvkjSxEocmsN5mD1oUIpvWOI9oIe6MqbouasIn109G5/SO/X9Wk",
-	"79R8G0/erTNaO1zlpXhTyNC3J9ME6DEe1tkjAy3QJg59WXmmTlPmO4ps6OGVpZmFmLgZRDkKahDOETWI",
-	"zxfV8HUP+0DeXk+FQekzjr3tuq77LwAA//+xB1CVlwsAAA==",
+	"H4sIAAAAAAAC/+RWS2/jNhD+KwO2QIBCjYNte/GtSV8L9BGsc9vdw4QaS9xIJDMkkzqB/nsxlGXLWnnj",
+	"HnLam0jO45vHN6NnpV3rnSUbg1o+K4+MLUXifLrGyliMxtmVJy03JQXNxsuVWqqbmsDvZEA7uzZV4v60",
+	"dgyxJrhPxJvzDxbgOzi7xopW5onOIHjSZm0oZCGb2lticGtgCqmJAZhiYkvlVvEqcXB8Bmb/Arcb8EwP",
+	"xqUAGpsmANpyZPixxij4CKLban2wqlBGsGdYqlAWW1LLaaiFCrqmFnNO2HniaCjnpAciX3HjRTNENrZS",
+	"XaGG4EaPxkaqiFXXFcOVu/1EOqpOrpiCdzb0li+x/B0jPeJGTtrZSDbKJ3rfGJ3BLT4FyfzzCN63TGu1",
+	"VN8s9pVc9K9h8Suz497V55ULxA/EQFa7ZCMxlYAWSFSklJZ0NLaS3EmFSowIt6jvyJYS7CWW7+g+UYiv",
+	"j/YSS+DeWQEh6RowwJpdC8Y+YGNKcAytCUHwjlq4K9Rbicxis8rB9h5eHe/gFHqvsBUs1HXi5k/zP1N2",
+	"2H/7Rn1r1+4liBPpCQQTqQ0vmkjcqH37IjNuVN+898kwlWr5fopq5ObjbOMf5utnaEyIwn6fuAnZ+ta9",
+	"oNtV7TATf1EIWNEMFSfgBsHPoRQz6Tx08jf9G79A+RsXsbkS/hwh/RjHyNYsFEn0TDCdTCzBZlPTFMp5",
+	"suiNWqofzi/OL1ShPMY6g12gxWYTTFiU5MmWZPU2jIoyQImsD7aUtIv0E/0yli0OVsD7+dbYiywmc7Mr",
+	"5nZEcBzBcdlP+Ji3hr7DisJ2uq8zu63enMH3cDN6h0cT66xRm6qmEEebYogxDlaCdkwauTxupXGPYuQf",
+	"T3a1+g12Gv3X0e0gAahxMSMnGu8IsqmVEu8CyRtka3xU7V1RP06G/5uLi2NE3MktdqTqCvXjKQqjId0V",
+	"6qdTVOYGZtZ9c5K7YYNlCqe2Rd7IQJQymfUm16B1IYJpveOINsJBq4raoiZsYv10tG//yO9XNek7NZ/G",
+	"k2frDNemo7wU7e1vynZlmgA9xmmcPTLQAm2k0IeVe+o0Zr6jyIYeXpmamYiJm4GUO0INxDnCBtH5Ihu+",
+	"7mYfineQU6mg5Bl3ue26rvsvAAD//+Xarxx/CwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/guacrest/generated/spec.go
+++ b/pkg/guacrest/generated/spec.go
@@ -18,18 +18,21 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+RUT0/8Rgz9KpZb6SdVKVnR9pJb6V+kSq2AG3AYJt7NQOIZPBNQQPnulSebdEG77XLg",
-	"1NskM7afn9/zK1rfBc/EKWL1ikIxeI6UP85M/ZtJ9GwG/bKeE3HSowmhddYk57m8j571X7QNdUZPXwut",
-	"scKvyn9Sl9NtLH8R8YLjOBZYU7TigibBCq8agkjyRALE1vecSKgGw0AaAtYzk02ON5A8pIagNsnAnbEP",
-	"xDWOhaK9oMeeYvp8tGemBpmKFRB724CJsBbfgeMn07oavEDnYlS8wYjpKJFEhXmunbFpL3OzU4VPxzsX",
-	"hakqbB8W+Fcv7R/ug5S5RF38LyyaWSukIRBWaETMsA/aj9C6mMCvIfTSRtQX2xxaYiEoiA8kyU3S7ChG",
-	"syE9bgvEJI43OVwn44RqrK6Xh7cLEn93TzbNze/LMBboeO2x4r5tC/SB2ASHFX53sjpZYYHBpCbDKA2b",
-	"doguljUF4prYbgFuKBOpmDON57X2qq9f6Ofdt5pt0Ud1/brPF14SeKlJlCbVfjD2wWwo3jDAN/BlnbXI",
-	"dvgC38LVzj08u9TkiMZtGooJuO/upjwz4jRnidYLWSP14Sytf9Ykfwbiy8tfYYmYTjeMyhxW+NiTDFgg",
-	"my4z6yXh7lyS9FTsKIq473RaSyOot9vkO7NbRnRbvF1Vp6vVIUEu78pF7GOB3x8TsLNSxgJ/OCZkn71z",
-	"7OlR5eZ9m13Qd52RQe2rY3LrIc+g8zGB64KXZDjBG+FpWNmQaVPzclCFv+f7nxqyD7ifxqM3wR7nvF88",
-	"tUZTzNC3C95FmDC+73NCBlah7QRMbWVNHeezC0ri6OlDRsu26qWdLbbYY7bBAW1rzL9q+/8t3XkUbzjV",
-	"eSjPZuF2HMfx7wAAAP//2OEUMowIAAA=",
+	"H4sIAAAAAAAC/+RVS2/jNhD+KwO2QIBCjYNte/GtSV8L9BGsc9vdw4QaS9xIJDMkkzqB/nsxlCXLXnnj",
+	"HnLam2XO45v55pt5Vtq13lmyMajls/LI2FIkzl/XWBmL0Ti78qTln5KCZuPlL7VUNzWBH21AO7s2VeL+",
+	"a+0YYk1wn4g35x8swHdwdo0VrcwTnUHwpM3aUJmNbGpvicGtgSmkJgZgioktlVvHq8TB8RmY3QvcbsAz",
+	"PRiXAmhsmgBoyzFwgMcao+AjiG7r9cGqQhnBnmGpQllsSS0PSy1U0DW1mHvCzhNHQ7knPRD5FTdePENk",
+	"YyvVFWoobvJobKSKWHVdoZjuk2Eq1fL9zvRjMZi620+ko+p60+CdDX3GSyx/x0iPuJEv7WwkG+Unet8Y",
+	"nUEvPgVh5HkC+1umtVqqbxY7hhf9a1j8yuy4T/U5o4H4gRjIapdsJKYS0AKJi1BsSUdjK+mpMFdiRLhF",
+	"fUe2lCZcYvmO7hOF+PpoL7EE7pMVEJKuAQOs2bVg7AM2pgTH0JoQBO9ktLtCvZXKLDarXGyf4dXxDkmh",
+	"zwpbw0JdJ27+NP+zZftzuRvgt3btXoJ4YH0AwURqw4shEjfiuB1fZMbN3JxP80zSzA/+fr9+hsaEKFvB",
+	"J25Cjr5NL+hG1vY78ReFgBXNSPQA3GD4OZRipp37Sf6mf+MXVsGNi9hciX5OWAaTWLNQpNEzxXSyyQSb",
+	"TU1TKOfJojdqqX44vzi/UIXyGOsMdoEWm00wYVGSJ1uS1dsyKsoApbK+2FLaLtZP9MvUttg7De/nR2Nn",
+	"sjjYp10xdzuC4wiOy37zx3xN9B1WFLZbf53VbfXmDL6Hm8k7PJpYZ4/aVDWFOLkgQ41xiBK0Y9LI5fEo",
+	"jXuUIP94sqvVbzB69L+OXg0pQE3JjJxoejvIplYoHgvJl2UbfML2SOrHg+X/5uLimBBHu8Uoqq5QP57i",
+	"MFnSXaF+OsVlbmFm3zcnpRsuWJZwalvkjSxEocmsN5mD1oUIpvWOI9oIe6MqbouasIn109G5/SO/X9Wk",
+	"79R8G0/erTNaO1zlpXhTyNC3J9ME6DEe1tkjAy3QJg59WXmmTlPmO4ps6OGVpZmFmLgZRDkKahDOETWI",
+	"zxfV8HUP+0DeXk+FQekzjr3tuq77LwAA//+xB1CVlwsAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/guacrest/generated/spec.go
+++ b/pkg/guacrest/generated/spec.go
@@ -18,21 +18,22 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+RWS2/jNhD+KwO2QIBCjYNte/GtSV8L9BGsc9vdw4QaS9xIJDMkkzqB/nsxlGXLWnnj",
-	"HnLam0jO45vHN6NnpV3rnSUbg1o+K4+MLUXifLrGyliMxtmVJy03JQXNxsuVWqqbmsDvZEA7uzZV4v60",
-	"dgyxJrhPxJvzDxbgOzi7xopW5onOIHjSZm0oZCGb2lticGtgCqmJAZhiYkvlVvEqcXB8Bmb/Arcb8EwP",
-	"xqUAGpsmANpyZPixxij4CKLban2wqlBGsGdYqlAWW1LLaaiFCrqmFnNO2HniaCjnpAciX3HjRTNENrZS",
-	"XaGG4EaPxkaqiFXXFcOVu/1EOqpOrpiCdzb0li+x/B0jPeJGTtrZSDbKJ3rfGJ3BLT4FyfzzCN63TGu1",
-	"VN8s9pVc9K9h8Suz497V55ULxA/EQFa7ZCMxlYAWSFSklJZ0NLaS3EmFSowIt6jvyJYS7CWW7+g+UYiv",
-	"j/YSS+DeWQEh6RowwJpdC8Y+YGNKcAytCUHwjlq4K9Rbicxis8rB9h5eHe/gFHqvsBUs1HXi5k/zP1N2",
-	"2H/7Rn1r1+4liBPpCQQTqQ0vmkjcqH37IjNuVN+898kwlWr5fopq5ObjbOMf5utnaEyIwn6fuAnZ+ta9",
-	"oNtV7TATf1EIWNEMFSfgBsHPoRQz6Tx08jf9G79A+RsXsbkS/hwh/RjHyNYsFEn0TDCdTCzBZlPTFMp5",
-	"suiNWqofzi/OL1ShPMY6g12gxWYTTFiU5MmWZPU2jIoyQImsD7aUtIv0E/0yli0OVsD7+dbYiywmc7Mr",
-	"5nZEcBzBcdlP+Ji3hr7DisJ2uq8zu63enMH3cDN6h0cT66xRm6qmEEebYogxDlaCdkwauTxupXGPYuQf",
-	"T3a1+g12Gv3X0e0gAahxMSMnGu8IsqmVEu8CyRtka3xU7V1RP06G/5uLi2NE3MktdqTqCvXjKQqjId0V",
-	"6qdTVOYGZtZ9c5K7YYNlCqe2Rd7IQJQymfUm16B1IYJpveOINsJBq4raoiZsYv10tG//yO9XNek7NZ/G",
-	"k2frDNemo7wU7e1vynZlmgA9xmmcPTLQAm2k0IeVe+o0Zr6jyIYeXpmamYiJm4GUO0INxDnCBtH5Ihu+",
-	"7mYfineQU6mg5Bl3ue26rvsvAAD//+Xarxx/CwAA",
+	"H4sIAAAAAAAC/+RWS2/jNhD+KwO2QIBCjYNte/Gtm74C9BFsctvdA02NLG6ooTIk4zqB/nsxlGTLXrnr",
+	"HnLqzSJnON88vm/8ooxvWk9IMajli2o16wYjcv661WtLOlpPdy0aOSkxGLatHKmluq8R2p0NGE+VXSfu",
+	"vyrPEGuEx4S8vfxAAN/Axa1e4519xgsILRpbWQzZiFKzQgZfAWNILgZgjIkJy8HxOnHwfAF2fwOrLbSM",
+	"T9anAEY7F0BTOXl4U+so+BCiH7w+kCqUFewZlioU6QbV8jjVQgVTY6NzTdi3yNFirkkPRH7FbSueIbKl",
+	"teoKNSY3ubQUcY2suq4Yj/zqE5qoOjliDK2n0L/8Vpe/6ogbvZUv4ykiRfmp29ZZk8EtPgWp/MsE3teM",
+	"lVqqrxb7Ti7627D4mdlzH+rzzgXkJ2RAMj5RRMYSNAGKi7SS0ERLa6mddKjUUcNKmwekUpJ9q8t3+Jgw",
+	"xNdH+1aXwH2wAkIyNegAFfsGLD1pZ0vwDI0NQfBORrgr1I1kRtrd5WT7CK+OdwwKfVQYDAt1m9j9bv9j",
+	"yQ7nbz+oN1T5L0E8sj6CYCM24YtPJHZqP76aWW9VP7yPyTKWavn+GNUkzMfZwT+s14/gbIjC/jaxC/n1",
+	"Ibyg23XtsBJ/YAh6jTNUPAI3Gn4OpZgp5yG0a09RW+pVymTuD2rCFp8QGs9ZAzFcwk0lVoygGYF8visA",
+	"/sS/Y68asLHOwQqBrLvMUnSY0d5yVl/ufdTuWsh6nsL0XZirTyciKOlScq5QvkXSrVVL9d3l1eWV4NKx",
+	"zpAWmrTbBhsWJbZIJZIZwK4xwxD8ff1K6aRYP+NPU9viYKu8n5+2vcniSIq7Ym7tBM8RPJf90oh5EZkH",
+	"6cOwMKosGGS2F/At3E/uYWNjnT1qu64xxMnyGXOM4yvBeEajuTz9ivMbeeSvFunu7hfYefS/Ti4cSUBN",
+	"5zRywunaQUqNTO8ukbyUhscns7xr6sejffLm6uoUt3d2ix1Pu0J9f47DRPe7Qv1wjsucBmffN2eFG5di",
+	"VoXUNJq3orHSJlttcw8aHyLYpvUcNUU4GFVxW9SoXayfT87tb/n+ukbzoObLeLZcz3DteDuU4j388xm2",
+	"sA3QYzzOs0cGRqBNHPq08kydx8x3g2K9LjUzERO7kZQ7Qo3EOcEG8flXNvy/h31s3kFNpYNSZ72rbdd1",
+	"3T8BAAD//+nLpofSCwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/guacrest/openapi.yaml
+++ b/pkg/guacrest/openapi.yaml
@@ -100,8 +100,9 @@ components:
       type: string
     PaginationInfo:
       type: object
-      required:
-        - NextCursor
+      description: >
+        Contains the cursor to retrieve more pages. If there are no more, 
+        NextCursor will be nil.
       properties: 
         NextCursor:
           type: string

--- a/pkg/guacrest/openapi.yaml
+++ b/pkg/guacrest/openapi.yaml
@@ -33,6 +33,7 @@ paths:
       summary: Retrieve the dependencies of a package
       operationId: retrieveDependencies
       parameters:
+        - $ref: "#/components/parameters/PaginationSpec"
         - name: purl
           description: the purl of the dependent package
           in: query
@@ -51,8 +52,9 @@ paths:
   "/analysis/dependencies":
     get:
       summary: Identify the most important dependencies
-      operationId: analyzeDependencies 
+      operationId: analyzeDependencies
       parameters:
+        - $ref: "#/components/parameters/PaginationSpec"
         - name: sort
           description: >
             The sort order of the packages
@@ -77,41 +79,76 @@ paths:
 
 
 components:
+  parameters:
+    PaginationSpec:
+      name: PaginationSpec 
+      in: query
+      description: >
+        The pagination configuration for the query.
+          * 'PageSize' specified the number of results returned
+          * 'Cursor' is returned by previous calls and specifies what page to return
+      required: false
+      schema:
+        type: object
+        required: 
+          - PageSize
+        properties:
+          PageSize: 
+            type: integer 
+          Cursor: 
+            type: string
   schemas:
     Purl:
       type: string
+    PaginationInfo:
+      type: object
+      required:
+        - NextCursor
+      properties: 
+        NextCursor:
+          type: string
+        TotalCount:
+          type: integer
     Error:
       type: object
       required:
-        - message
+        - Message
       properties:
-        message:
+        Message:
           type: string
   responses:
-    # intended for code 200
+    # for code 200
     PurlList:
       description: A list of purls
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/Purl"
-    # intended for code 400, client side error
+            type: object
+            required: 
+              - PaginationInfo
+              - PurlList
+            properties:
+              PaginationInfo:
+                $ref: "#/components/schemas/PaginationInfo"
+              PurlList:
+                type: array
+                items: 
+                  $ref: "#/components/schemas/Purl"
+    # for code 400, client side error
     BadRequest:
       description: Bad request, such as from invalid or missing parameters
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
-    # intended for code 500
+    # for code 500
     InternalServerError:
       description: Internal Server Error
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
-    # intended for code 502
+    # for code 502
     BadGateway:
       description: The server encountered an error connecting to the data backend
       content:

--- a/pkg/guacrest/openapi.yaml
+++ b/pkg/guacrest/openapi.yaml
@@ -85,13 +85,11 @@ components:
       in: query
       description: >
         The pagination configuration for the query.
-          * 'PageSize' specified the number of results returned
+          * 'PageSize' specifies the number of results returned
           * 'Cursor' is returned by previous calls and specifies what page to return
       required: false
       schema:
         type: object
-        required: 
-          - PageSize
         properties:
           PageSize: 
             type: integer 

--- a/pkg/guacrest/pagination/cursor.go
+++ b/pkg/guacrest/pagination/cursor.go
@@ -1,0 +1,52 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagination
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+)
+
+var (
+	// base64 (binary to text) encoding scheme.
+	//
+	// Padding is not used to avoid having to url-encode the pad character.
+	byteEncoding = base64.RawURLEncoding
+
+	// integer to binary encoding scheme
+	intEncoding = binary.LittleEndian
+)
+
+func indexFromCursor(cursor string) (uint64, error) {
+	if len(cursor) != 11 {
+		return 0, fmt.Errorf("Encoded cursor %q is not 11 bytes", cursor)
+	}
+	decodedBytes, err := byteEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, fmt.Errorf("Cursor could not be decoded as base64: %v", err)
+	}
+	// decodedBytes must be at least length 8, but this is covered by the
+	// string length check above
+	return intEncoding.Uint64(decodedBytes), nil
+}
+
+// Produces fixed-length (11 byte) strings
+func cursorFromIndex(index uint64) string {
+	inputBytes := make([]byte, 8)
+	intEncoding.PutUint64(inputBytes, index)
+	return byteEncoding.EncodeToString(inputBytes)
+}

--- a/pkg/guacrest/pagination/pagination.go
+++ b/pkg/guacrest/pagination/pagination.go
@@ -1,0 +1,105 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package pagination implements a cursor-based pagination for the REST API,
+// where the cursors are opaque strings that encode an index in a result set.
+package pagination
+
+import (
+	"context"
+	"fmt"
+
+	models "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+const (
+	DefaultPageSize = 40
+)
+
+// Returns the result of Paginate with a page size of DefaultPageSize
+func DefaultPaginate[T any](ctx context.Context, lst []T) ([]T, models.PaginationInfo) {
+	logger := logging.FromContext(ctx)
+	page, info, err := Paginate(ctx, lst, models.PaginationSpec{PageSize: PointerOf(DefaultPageSize)})
+	if err != nil {
+		// should not occur with the default pagination spec, see contract of Paginate
+		logger.Fatalf("Pagate returned err: %s, but should not have", err)
+	}
+	return page, info
+}
+
+// Returns a single page from the input, selected using the given
+// pagination spec, along with a struct describing the pagination of the
+// returned page. The input result set should be the same for every call that
+// uses chained PaginationSpecs and PaginationInfos.
+//
+// Errors are suitable to directly return to clients. An error is returned only if:
+//   - the cursor is the empty string
+//   - the cursor decodes to an out of bounds index in the input
+//   - the cursor can't be decoded
+//   - PageSize < 0
+func Paginate[T any](ctx context.Context, lst []T, spec models.PaginationSpec) ([]T,
+	models.PaginationInfo, error) {
+	logger := logging.FromContext(ctx)
+
+	var pagesize int = DefaultPageSize
+	if spec.PageSize != nil {
+		pagesize = *spec.PageSize
+	}
+	if pagesize < 0 {
+		return nil, models.PaginationInfo{},
+			fmt.Errorf("Pagination error: PageSize is negative.")
+	}
+
+	var inputLength uint64 = uint64(len(lst))
+	var start uint64 = 0
+
+	if spec.Cursor != nil {
+		if *spec.Cursor == "" {
+			return nil, models.PaginationInfo{},
+				fmt.Errorf("Pagination error: The cursor is the empty string")
+		}
+
+		decoded, err := indexFromCursor(*spec.Cursor)
+		if err != nil {
+			logger.Warnf("Pagination error: %s", err)
+			return nil, models.PaginationInfo{},
+				fmt.Errorf("Pagination error: The cursor is invalid.")
+		}
+		if decoded >= inputLength {
+			logger.Warnf("Pagination error: The cursor is out of bounds. This is" +
+				" either due to client manipulation of the cursor or a different slice" +
+				" argument passed to Paginate than when this cursor was generated.")
+			return nil, models.PaginationInfo{},
+				fmt.Errorf("Pagination error: The cursor is invalid")
+		}
+		start = decoded
+	}
+
+	end := start + uint64(pagesize) // end is exclusive
+	nextCursor := cursorFromIndex(end)
+	if end >= inputLength {
+		end = inputLength
+		nextCursor = ""
+	}
+
+	info := models.PaginationInfo{
+		NextCursor: nextCursor,
+		TotalCount: PointerOf(len(lst)),
+	}
+	return lst[start:end], info, nil
+}
+
+func PointerOf[T any](val T) *T { return &val }

--- a/pkg/guacrest/pagination/pagination.go
+++ b/pkg/guacrest/pagination/pagination.go
@@ -88,11 +88,11 @@ func Paginate[T any](ctx context.Context, lst []T, spec models.PaginationSpec) (
 		start = decoded
 	}
 
-	end := start + uint64(pagesize) // end is exclusive
-	nextCursor := cursorFromIndex(end)
-	if end >= inputLength {
-		end = inputLength
-		nextCursor = ""
+	end := inputLength // end is exlusive
+	var nextCursor *string
+	if start+uint64(pagesize) < inputLength {
+		end = start + uint64(pagesize)
+		nextCursor = PointerOf(cursorFromIndex(end))
 	}
 
 	info := models.PaginationInfo{

--- a/pkg/guacrest/pagination/pagination_test.go
+++ b/pkg/guacrest/pagination/pagination_test.go
@@ -1,0 +1,244 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagination_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	models "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/pagination"
+)
+
+// Uses Paginate to test the cursor implementation
+func Test_Cursors(t *testing.T) {
+	ctx := context.Background()
+	inputList := []int{12, 13, 14, 15, 16, 17}
+
+	for i := range inputList {
+		spec := models.PaginationSpec{PageSize: pagination.PointerOf(i)}
+		_, info, err := pagination.Paginate(ctx, inputList, spec)
+		if err != nil {
+			t.Fatalf("Unexpected error when calling Paginate to retrieve a cursor: %s", err)
+		}
+
+		// check that spec.NextCursor does point to the next element
+		spec = models.PaginationSpec{
+			PageSize: pagination.PointerOf(100),
+			Cursor:   &info.NextCursor,
+		}
+		page, _, err := pagination.Paginate(ctx, inputList, spec)
+		if err != nil {
+			t.Fatalf("Unexpected error (%s) when calling Paginate to retrieve an element"+
+				" at index %d.", err, i)
+		}
+		if page[0] != inputList[i] {
+			t.Errorf("Cursor points to wrong value: page[0] != inputList[i]: %v != %v.",
+				page[0], inputList[i])
+		}
+	}
+}
+
+// Paginate is black-box by first retrieving some cursors, and then using them
+// to test different combinations of PaginationSpec. This avoids testing
+// the implementation of the cursors.
+func Test_Paginate(t *testing.T) {
+	ctx := context.Background()
+
+	inputList := []int{12, 13, 14, 15, 16, 17}
+
+	// cursors[i] holds the cursor to inputList[i]
+	cursors := []string{}
+	for i := range inputList {
+		spec := models.PaginationSpec{PageSize: pagination.PointerOf(i)}
+		_, info, err := pagination.Paginate(ctx, inputList, spec)
+		if err != nil {
+			t.Fatalf("Unexpected error when calling Paginate to set up the tests: %s", err)
+		}
+		cursors = append(cursors, info.NextCursor)
+	}
+
+	// generate a cursor that is out of range of inputList
+	longerInputList := append(inputList, 18)
+	spec := models.PaginationSpec{PageSize: pagination.PointerOf(6)}
+	_, info, err := pagination.Paginate(ctx, longerInputList, spec)
+	if err != nil {
+		t.Fatalf("Unexpected error when calling Paginate to set up the"+
+			" out-of-range cursor test: %s", err)
+	}
+	// check that we got the intended cursor
+	outOfRangeCursor := info.NextCursor
+	if outOfRangeCursor == "" {
+		t.Fatal("Unexpected cursor when calling Paginate to set up the" +
+			" out-of-range cursor test: Cursor is empty.")
+	}
+
+	tests := []struct {
+		name                   string
+		inputList              []int // defaults to inputList defined above if not set
+		inputSpec              models.PaginationSpec
+		expectedPage           []int
+		expectedPaginationInfo models.PaginationInfo
+		wantErr                bool
+	}{
+		{
+			name:         "Only PageSize specified",
+			inputList:    inputList,
+			inputSpec:    models.PaginationSpec{PageSize: pagination.PointerOf(3)},
+			expectedPage: []int{12, 13, 14},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+				NextCursor: cursors[3],
+			},
+		},
+		{
+			name:         "PageSize is greater than the number of entries",
+			inputSpec:    models.PaginationSpec{PageSize: pagination.PointerOf(10)},
+			expectedPage: inputList,
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+			},
+		},
+		{
+			name:         "PageSize is equal to the number of entries",
+			inputSpec:    models.PaginationSpec{PageSize: pagination.PointerOf(6)},
+			expectedPage: inputList,
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+			},
+		},
+		{
+			name:         "PageSize is 0",
+			inputSpec:    models.PaginationSpec{PageSize: pagination.PointerOf(0)},
+			expectedPage: []int{},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+				NextCursor: cursors[0],
+			},
+		},
+		{
+			name:      "PageSize is negative",
+			inputSpec: models.PaginationSpec{PageSize: pagination.PointerOf(-1)},
+			wantErr:   true,
+		},
+		{
+			name: "PageSize is in range, Cursor is valid",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(2),
+				Cursor:   pagination.PointerOf(cursors[2]),
+			},
+			expectedPage: []int{14, 15},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+				NextCursor: cursors[4],
+			},
+		},
+		{
+			name: "PageSize is 1, Cursor is valid",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(1),
+				Cursor:   pagination.PointerOf(cursors[5]),
+			},
+			expectedPage: []int{17},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+			},
+		},
+		{
+			name: "PageSize + Cursor is greater than number of entries",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(3),
+				Cursor:   pagination.PointerOf(cursors[4]),
+			},
+			expectedPage: []int{16, 17},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+			},
+		},
+		{
+			name: "PageSize is in range, Cursor is empty string",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(3),
+				Cursor:   pagination.PointerOf(""),
+			},
+			wantErr: true,
+		},
+		{
+			name: "PageSize is in range, Cursor is invalid base64",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(3),
+				Cursor:   pagination.PointerOf("$%^"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "PageSize is in range, Cursor is too large",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(3),
+				Cursor:   pagination.PointerOf("ABCDABCDABCD"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "PageSize is in range, Cursor is too small",
+			inputSpec: models.PaginationSpec{
+				PageSize: pagination.PointerOf(3),
+				Cursor:   pagination.PointerOf("ABC"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Cursor is out of range",
+			inputSpec: models.PaginationSpec{
+				Cursor: pagination.PointerOf(outOfRangeCursor),
+			},
+			wantErr: true,
+		},
+		{
+			name: "PageSize is not specified",
+			inputSpec: models.PaginationSpec{
+				Cursor: pagination.PointerOf(cursors[1]),
+			},
+			expectedPage: []int{13, 14, 15, 16, 17},
+			expectedPaginationInfo: models.PaginationInfo{
+				TotalCount: pagination.PointerOf(6),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := inputList
+			if tt.inputList != nil {
+				in = tt.inputList
+			}
+			page, info, err := pagination.Paginate(ctx, in, tt.inputSpec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("tt.wantErr is %v, but got %v", tt.wantErr, err)
+				return
+			}
+			if !cmp.Equal(tt.expectedPage, page) {
+				t.Errorf("Wrong page. Expected %v, but got %v", tt.expectedPage, page)
+			}
+			if !cmp.Equal(tt.expectedPaginationInfo, info) {
+				t.Errorf("Wrong paginationInfo. Expected %v, but got %v", tt.expectedPaginationInfo, info)
+			}
+		})
+
+	}
+
+}

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -18,6 +18,7 @@ package server
 import (
 	"context"
 	"fmt"
+
 	"github.com/Khan/genqlient/graphql"
 	gen "github.com/guacsec/guac/pkg/guacrest/generated"
 )
@@ -36,15 +37,9 @@ func (s *DefaultServer) HealthCheck(ctx context.Context, request gen.HealthCheck
 }
 
 func (s *DefaultServer) AnalyzeDependencies(ctx context.Context, request gen.AnalyzeDependenciesRequestObject) (gen.AnalyzeDependenciesResponseObject, error) {
-	//return gen.AnalyzeDependencies200JSONResponse{
-	//  PurlListJSONResponse: []gen.Purl{},
-	//}, nil
 	return nil, fmt.Errorf("Unimplemented")
 }
 
 func (s *DefaultServer) RetrieveDependencies(ctx context.Context, request gen.RetrieveDependenciesRequestObject) (gen.RetrieveDependenciesResponseObject, error) {
-	//return gen.RetrieveDependencies200JSONResponse{
-	//  PurlListJSONResponse: []string{},
-	//}, nil
 	return nil, fmt.Errorf("Unimplemented")
 }


### PR DESCRIPTION
# Description of the PR

### Pagination Scheme

The proposed scheme is based on opaque cursors that point to entries in an input dataset. Each request will (optionally) contain a `PageSize` integer field and a `Cursor` string field. Each response will contain a `NextCursor` field and optionally a `TotalCount` field. If there are no more results, the `NextCursor` field will be the empty string. 

Using opaque cursors enables different cursor formats for different use cases. An endpoint that makes calls to the GraphQL server can use the GraphQL server generated cursors, and an endpoint that directly uses the backend database can use the database primary keys or similar. 

I added an implementation of this pagination scheme that uses base64 encoded indices as the cursors. Endpoints aren't required to use it, but I think it'll work for most cases. 

### HTTP request
The pagination spec is passed as query parameters, like in:
`http://0.0.0.0:8081/query/dependencies?purl=guac&PageSize=3&Cursor=AwAAAAAAAAA`

## Alternatives
One alternative approach is a simpler limit + offset scheme, but this doesn't support interfacing with the GraphQL pagination scheme (see #1525). Another approach is to implement a more expressive scheme similar to the GQL Relay-style pagination. This would allow users to paginate backwards through results, and possibly to paginate starting from any entry in a page. However, this requires more support and documentation, and I don't think the functionality gained is that important. 

The pagination spec could also be passed in the http header. 


<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
