### PR TITLE
Update CONTRIBUTING.md about DCO and CLA.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,11 @@ Refer to the [GraphQL Guide](https://docs.guac.sh/guac-graphql/) to go through
 a setup.  Optionally, you can also consult [docker compose
 documentation](https://docs.guac.sh/setup/).
 
-## Contributor License Agreement
+## Developer Certificate of Origin
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement (CLA). You (or your employer) retain the copyright to your
-contribution; this simply gives us permission to use and redistribute your
-contributions as part of the project. Head over to
-<https://cla.developers.google.com/> to see your current agreements on file or
-to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+We require all commits in a PR to contain a `Signed-off-by` line which can be
+added by using the `-s` flag of `git commit`. This is to enforce
+[a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
 
 ## Code Reviews
 
@@ -26,10 +19,6 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
-
-We require all commits in a PR to contain a `Signed-off-by` line which can be
-added by using the `-s` flag of `git commit`. This is to enforce
-[a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
 
 We also require two reviewers on every PR as this follows good security
 practices. For reasoning, see


### PR DESCRIPTION
Google CLA is removed and obsolete. Only mention DCO and highlight it as its own section.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
