### PR TITLE
 Fix the incorrect `callingFuncName` in the `getNeighborIDFromCursor`  function within the arangodb/certifyVEXStatement.go file

### DIFF
--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -734,7 +734,7 @@ func (c *arangoClient) certifyVexNeighbors(ctx context.Context, nodeID string, a
 		setVexMatchValues(arangoQueryBuilder, &model.CertifyVEXStatementSpec{ID: &nodeID}, values)
 		arangoQueryBuilder.query.WriteString("\nRETURN { neighbor:  certifyVex.packageID }")
 
-		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyScorecardNeighbors - package")
+		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyVexNeighbors - package")
 		if err != nil {
 			return out, fmt.Errorf("failed to get neighbors for node ID: %s from arango cursor with error: %w", nodeID, err)
 		}
@@ -746,7 +746,7 @@ func (c *arangoClient) certifyVexNeighbors(ctx context.Context, nodeID string, a
 		setVexMatchValues(arangoQueryBuilder, &model.CertifyVEXStatementSpec{ID: &nodeID}, values)
 		arangoQueryBuilder.query.WriteString("\nRETURN { neighbor:  certifyVex.artifactID }")
 
-		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyScorecardNeighbors - package")
+		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyVexNeighbors - artifact")
 		if err != nil {
 			return out, fmt.Errorf("failed to get neighbors for node ID: %s from arango cursor with error: %w", nodeID, err)
 		}
@@ -758,7 +758,7 @@ func (c *arangoClient) certifyVexNeighbors(ctx context.Context, nodeID string, a
 		setVexMatchValues(arangoQueryBuilder, &model.CertifyVEXStatementSpec{ID: &nodeID}, values)
 		arangoQueryBuilder.query.WriteString("\nRETURN { neighbor:  certifyVex.vulnerabilityID }")
 
-		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyScorecardNeighbors - package")
+		foundIDs, err := c.getNeighborIDFromCursor(ctx, arangoQueryBuilder, values, "certifyVexNeighbors - vulnerability")
 		if err != nil {
 			return out, fmt.Errorf("failed to get neighbors for node ID: %s from arango cursor with error: %w", nodeID, err)
 		}


### PR DESCRIPTION
# Description of the PR

Fix the incorrect `callingFuncName` in the `getNeighborIDFromCursor`  function within the arangodb/certifyVEXStatement.go file

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
