### PR TITLE
Fix License node ingestion when no LicenseListVersion provided.

### DIFF
--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -330,10 +330,14 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 		}
 	}
 
+	lv := s.spdxDoc.CreationInfo.LicenseListVersion
+	if lv == "" {
+		lv = "UNKNOWN"
+	}
 	for id, cls := range s.packageLegals {
 		for _, cl := range cls {
-			dec := common.ParseLicenses(cl.DeclaredLicense, s.spdxDoc.CreationInfo.LicenseListVersion)
-			dis := common.ParseLicenses(cl.DiscoveredLicense, s.spdxDoc.CreationInfo.LicenseListVersion)
+			dec := common.ParseLicenses(cl.DeclaredLicense, lv)
+			dis := common.ParseLicenses(cl.DiscoveredLicense, lv)
 			for i := range dec {
 				o, n := fixLicense(ctx, &dec[i], s.spdxDoc.OtherLicenses)
 				if o != "" {


### PR DESCRIPTION
This is an optional field apparently, and some generators fill in the license, but do not fill in the list version. In GAUC we key of this being non-empty to differentiate between licenses on the list, and licenses that are provided "inline".

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
