### PR TITLE
ENT - update hasSBOM ingestion for large SBOMs and increase batch size

### DIFF
--- a/pkg/assembler/backends/ent/backend/artifact.go
+++ b/pkg/assembler/backends/ent/backend/artifact.go
@@ -88,7 +88,7 @@ func (b *EntBackend) IngestArtifact(ctx context.Context, art *model.IDorArtifact
 }
 
 func upsertBulkArtifact(ctx context.Context, tx *ent.Tx, artInputs []*model.IDorArtifactInput) (*[]string, error) {
-	batches := chunk(artInputs, 100)
+	batches := chunk(artInputs, MaxBatchSize)
 	ids := make([]string, 0)
 
 	for _, artifacts := range batches {

--- a/pkg/assembler/backends/ent/backend/backend.go
+++ b/pkg/assembler/backends/ent/backend/backend.go
@@ -27,11 +27,16 @@ import (
 	_ "github.com/lib/pq"
 )
 
-var Errorf = gqlerror.Errorf
+const (
+	// MaxPageSize is the maximum number of results that will be returned in a single query.
+	// const MaxPageSize = 1000
+	MaxPageSize = 999999
 
-// MaxPageSize is the maximum number of results that will be returned in a single query.
-// const MaxPageSize = 1000
-const MaxPageSize = 999999
+	// Batch size for ingesting in bulk. Increasing this could results in "PostgreSQL only supports 65535 parameters" error
+	MaxBatchSize = 5000
+)
+
+var Errorf = gqlerror.Errorf
 
 type EntBackend struct {
 	client *ent.Client

--- a/pkg/assembler/backends/ent/backend/builders.go
+++ b/pkg/assembler/backends/ent/backend/builders.go
@@ -89,7 +89,7 @@ func (b *EntBackend) IngestBuilders(ctx context.Context, builders []*model.IDorB
 }
 
 func upsertBulkBuilder(ctx context.Context, tx *ent.Tx, buildInputs []*model.IDorBuilderInput) (*[]string, error) {
-	batches := chunk(buildInputs, 100)
+	batches := chunk(buildInputs, MaxBatchSize)
 	ids := make([]string, 0)
 
 	for _, builders := range batches {

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -377,7 +377,7 @@ func upsertBulkCertification[T certificationInputSpec](ctx context.Context, tx *
 
 	switch certifies := any(spec).(type) {
 	case []*model.CertifyBadInputSpec:
-		batches := chunk(certifies, 100)
+		batches := chunk(certifies, MaxBatchSize)
 
 		index := 0
 		for _, certifyBads := range batches {
@@ -417,7 +417,7 @@ func upsertBulkCertification[T certificationInputSpec](ctx context.Context, tx *
 			}
 		}
 	case []*model.CertifyGoodInputSpec:
-		batches := chunk(certifies, 100)
+		batches := chunk(certifies, MaxBatchSize)
 
 		index := 0
 		for _, certifyGoods := range batches {

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -281,7 +281,7 @@ func upsertBulkCertifyLegal(ctx context.Context, tx *ent.Tx, subjects model.Pack
 		return nil, gqlerror.Errorf("%v :: %s", "upsertBulkCertifyLegal", "subject must be either a package or source")
 	}
 
-	batches := chunk(certifyLegals, 100)
+	batches := chunk(certifyLegals, MaxBatchSize)
 
 	index := 0
 	for _, cls := range batches {

--- a/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
+++ b/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
@@ -219,7 +219,7 @@ func upsertBulkVEX(ctx context.Context, tx *ent.Tx, subjects model.PackageOrArti
 		)
 	}
 
-	batches := chunk(vexStatements, 100)
+	batches := chunk(vexStatements, MaxBatchSize)
 
 	index := 0
 	for _, vexs := range batches {

--- a/pkg/assembler/backends/ent/backend/certifyVuln.go
+++ b/pkg/assembler/backends/ent/backend/certifyVuln.go
@@ -166,7 +166,7 @@ func upsertBulkCertifyVuln(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPk
 		certifyvuln.FieldTimeScanned,
 	}
 
-	batches := chunk(certifyVulns, 100)
+	batches := chunk(certifyVulns, MaxBatchSize)
 
 	index := 0
 	for _, vulns := range batches {

--- a/pkg/assembler/backends/ent/backend/dependency.go
+++ b/pkg/assembler/backends/ent/backend/dependency.go
@@ -96,7 +96,7 @@ func upsertBulkDependencies(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorP
 		)
 	}
 
-	batches := chunk(dependencies, 100)
+	batches := chunk(dependencies, MaxBatchSize)
 
 	index := 0
 	for _, deps := range batches {

--- a/pkg/assembler/backends/ent/backend/hasMetadata.go
+++ b/pkg/assembler/backends/ent/backend/hasMetadata.go
@@ -305,7 +305,7 @@ func upsertBulkHasMetadata(ctx context.Context, tx *ent.Tx, subjects model.Packa
 		)
 	}
 
-	batches := chunk(hasMetadataList, 100)
+	batches := chunk(hasMetadataList, MaxBatchSize)
 
 	index := 0
 	for _, hms := range batches {

--- a/pkg/assembler/backends/ent/backend/hashequal.go
+++ b/pkg/assembler/backends/ent/backend/hashequal.go
@@ -116,7 +116,7 @@ func upsertBulkHashEqual(ctx context.Context, tx *ent.Tx, artifacts []*model.IDo
 		hashequal.FieldJustification,
 	}
 
-	batches := chunk(hashEquals, 100)
+	batches := chunk(hashEquals, MaxBatchSize)
 
 	index := 0
 	for _, hes := range batches {

--- a/pkg/assembler/backends/ent/backend/license.go
+++ b/pkg/assembler/backends/ent/backend/license.go
@@ -85,7 +85,7 @@ func getLicenses(ctx context.Context, client *ent.Client, filter model.LicenseSp
 }
 
 func upsertBulkLicense(ctx context.Context, tx *ent.Tx, licenseInputs []*model.IDorLicenseInput) (*[]string, error) {
-	batches := chunk(licenseInputs, 100)
+	batches := chunk(licenseInputs, MaxBatchSize)
 	ids := make([]string, 0)
 
 	for _, licenses := range batches {

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -100,7 +100,7 @@ func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.Packa
 		return nil, gqlerror.Errorf("%v :: %s", "upsertBulkOccurrences", "subject must be either a package or source")
 	}
 
-	batches := chunk(occurrences, 100)
+	batches := chunk(occurrences, MaxBatchSize)
 
 	index := 0
 	for _, occurs := range batches {

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -137,7 +137,7 @@ func generatePackageVersionCreate(tx *ent.Tx, pkgVersionID *uuid.UUID, pkgNameID
 }
 
 func upsertBulkPackage(ctx context.Context, tx *ent.Tx, pkgInputs []*model.IDorPkgInput) (*[]model.PackageIDs, error) {
-	batches := chunk(pkgInputs, 100)
+	batches := chunk(pkgInputs, MaxBatchSize)
 	pkgNameIDs := make([]string, 0)
 	pkgVersionIDs := make([]string, 0)
 

--- a/pkg/assembler/backends/ent/backend/pkgequal.go
+++ b/pkg/assembler/backends/ent/backend/pkgequal.go
@@ -91,7 +91,7 @@ func upsertBulkPkgEquals(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPkgI
 		pkgequal.FieldJustification,
 	}
 
-	batches := chunk(pkgEquals, 100)
+	batches := chunk(pkgEquals, MaxBatchSize)
 
 	index := 0
 	for _, pes := range batches {

--- a/pkg/assembler/backends/ent/backend/pointOfContact.go
+++ b/pkg/assembler/backends/ent/backend/pointOfContact.go
@@ -152,7 +152,7 @@ func upsertBulkPointOfContact(ctx context.Context, tx *ent.Tx, subjects model.Pa
 		)
 	}
 
-	batches := chunk(pointOfContactList, 100)
+	batches := chunk(pointOfContactList, MaxBatchSize)
 
 	index := 0
 	for _, pocs := range batches {

--- a/pkg/assembler/backends/ent/backend/scorecard.go
+++ b/pkg/assembler/backends/ent/backend/scorecard.go
@@ -158,7 +158,7 @@ func upsertBulkScorecard(ctx context.Context, tx *ent.Tx, sources []*model.IDorS
 		certifyscorecard.FieldAggregateScore,
 		certifyscorecard.FieldChecksHash}
 
-	batches := chunk(scorecards, 100)
+	batches := chunk(scorecards, MaxBatchSize)
 
 	index := 0
 	for _, css := range batches {

--- a/pkg/assembler/backends/ent/backend/slsa.go
+++ b/pkg/assembler/backends/ent/backend/slsa.go
@@ -112,7 +112,7 @@ func upsertBulkSLSA(ctx context.Context, tx *ent.Tx, subjects []*model.IDorArtif
 		slsaattestation.FieldBuiltByID,
 		slsaattestation.FieldBuiltFromHash}
 
-	batches := chunk(slsaList, 100)
+	batches := chunk(slsaList, MaxBatchSize)
 
 	index := 0
 	for _, css := range batches {

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -122,7 +122,7 @@ func upsertBulkHasSourceAts(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorP
 		conflictWhere = sql.And(sql.NotNull(hassourceat.FieldPackageVersionID), sql.IsNull(hassourceat.FieldPackageNameID))
 	}
 
-	batches := chunk(hasSourceAts, 100)
+	batches := chunk(hasSourceAts, MaxBatchSize)
 
 	index := 0
 	for _, hsas := range batches {
@@ -305,7 +305,7 @@ func (b *EntBackend) IngestSource(ctx context.Context, source model.IDorSourceIn
 }
 
 func upsertBulkSource(ctx context.Context, tx *ent.Tx, srcInputs []*model.IDorSourceInput) (*[]model.SourceIDs, error) {
-	batches := chunk(srcInputs, 100)
+	batches := chunk(srcInputs, MaxBatchSize)
 	srcNameIDs := make([]string, 0)
 
 	for _, srcs := range batches {

--- a/pkg/assembler/backends/ent/backend/vulnEqual.go
+++ b/pkg/assembler/backends/ent/backend/vulnEqual.go
@@ -144,7 +144,7 @@ func upsertBulkVulnEquals(ctx context.Context, tx *ent.Tx, vulnerabilities []*mo
 		vulnequal.FieldJustification,
 	}
 
-	batches := chunk(vulnEquals, 100)
+	batches := chunk(vulnEquals, MaxBatchSize)
 
 	index := 0
 	for _, ves := range batches {

--- a/pkg/assembler/backends/ent/backend/vulnMetadata.go
+++ b/pkg/assembler/backends/ent/backend/vulnMetadata.go
@@ -138,7 +138,7 @@ func upsertBulkVulnerabilityMetadata(ctx context.Context, tx *ent.Tx, vulnerabil
 		vulnerabilitymetadata.FieldCollector,
 	}
 
-	batches := chunk(vulnerabilityMetadataList, 100)
+	batches := chunk(vulnerabilityMetadataList, MaxBatchSize)
 
 	index := 0
 	for _, vml := range batches {

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -102,7 +102,7 @@ func getVulnerabilities(ctx context.Context, client *ent.Client, filter model.Vu
 }
 
 func upsertBulkVulnerability(ctx context.Context, tx *ent.Tx, vulnInputs []*model.IDorVulnerabilityInput) (*[]model.VulnerabilityIDs, error) {
-	batches := chunk(vulnInputs, 100)
+	batches := chunk(vulnInputs, MaxBatchSize)
 	ids := make([]model.VulnerabilityIDs, 0)
 
 	for _, vulns := range batches {


### PR DESCRIPTION
# Description of the PR

Update hasSBOM ingestion to batch the `includes` into separate batched queries to avoid `pq: got 70000 parameters but PostgreSQL only supports 65535 parameters`

Updated Batch size to 5000 for improved performance

see: https://github.com/ent/ent/pull/2539

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
