### PR TITLE
move message acknowledgment for pubsub to be done after the ingestion has occured

### DIFF
--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/guacsec/guac/pkg/events"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
+	"gocloud.dev/pubsub"
 )
 
 type mockQuery struct {
@@ -264,13 +265,13 @@ func Test_Publish(t *testing.T) {
 
 	err = testSubscribe(ctx, transportFunc, blobStore, pubsub)
 	if err != nil {
-		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("nats emitter Subscribe test errored = %v", err)
 		}
 	}
 }
 
-func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub) error {
+func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error, blobStore *blob.BlobStore, emPubSub *emitter.EmitterPubSub) error {
 	logger := logging.FromContext(ctx)
 
 	uuid, err := uuid.NewV4()
@@ -278,13 +279,13 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return fmt.Errorf("failed to get uuid with the following error: %w", err)
 	}
 	uuidString := uuid.String()
-	sub, err := pubsub.Subscribe(ctx, uuidString)
+	sub, err := emPubSub.Subscribe(ctx, uuidString)
 	if err != nil {
 		return err
 	}
-	processFunc := func(d []byte) error {
+	processFunc := func(d *pubsub.Message) error {
 
-		blobStoreKey, err := events.DecodeEventSubject(ctx, d)
+		blobStoreKey, err := events.DecodeEventSubject(ctx, d.Body)
 		if err != nil {
 			logger.Errorf("[processor: %s] failed decode event: %v", uuidString, err)
 			return nil
@@ -317,6 +318,10 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		}
 
 		logger.Infof("[processor: %s] docTree Processed: %+v", uuidString, docTree.Document.SourceInformation)
+		// ack the message from the queue once the ingestion has occurred
+		d.Ack()
+		logger.Infof("[processor: %s] message acknowledged in pusbub", uuidString)
+
 		return nil
 	}
 

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/collector/file"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
+	"gocloud.dev/pubsub"
 )
 
 func TestCollect(t *testing.T) {
@@ -143,7 +144,7 @@ func Test_Publish(t *testing.T) {
 	}
 }
 
-func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub) error {
+func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTree) error, blobStore *blob.BlobStore, emPubSub *emitter.EmitterPubSub) error {
 	logger := logging.FromContext(ctx)
 
 	uuid, err := uuid.NewV4()
@@ -151,13 +152,13 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 		return fmt.Errorf("failed to get uuid with the following error: %w", err)
 	}
 	uuidString := uuid.String()
-	sub, err := pubsub.Subscribe(ctx, uuidString)
+	sub, err := emPubSub.Subscribe(ctx, uuidString)
 	if err != nil {
 		return err
 	}
-	processFunc := func(d []byte) error {
+	processFunc := func(d *pubsub.Message) error {
 
-		blobStoreKey, err := events.DecodeEventSubject(ctx, d)
+		blobStoreKey, err := events.DecodeEventSubject(ctx, d.Body)
 		if err != nil {
 			logger.Errorf("[processor: %s] failed decode event: %v", uuidString, err)
 			return nil
@@ -189,6 +190,10 @@ func testSubscribe(ctx context.Context, transportFunc func(processor.DocumentTre
 			return fmt.Errorf(fmtErrString+": %w", err)
 		}
 		logger.Infof("[processor: %s] docTree Processed: %+v", uuidString, docTree.Document.SourceInformation)
+		// ack the message from the queue once the ingestion has occurred
+		d.Ack()
+		logger.Infof("[processor: %s] message acknowledged in pusbub", uuidString)
+
 		return nil
 	}
 


### PR DESCRIPTION
# Description of the PR

Previously pubsub message ack was done before the processor or the ingestor had time to run. This could result in the message being removed from queue before successful ingestion (or if the ingestor was offline). 

This fix changes the message ack to happen after the processor and ingestor have ran successfully.

Tested it by running multiple ingestors pulling from the pubsub

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
