### PR TITLE
Support image references by digest in the OCI collector

### DIFF
--- a/pkg/handler/collector/oci/oci_test.go
+++ b/pkg/handler/collector/oci/oci_test.go
@@ -290,6 +290,66 @@ func Test_ociCollector_RetrieveArtifacts(t *testing.T) {
 		},
 		errMessage: errors.New("image tag not specified to fetch"),
 		wantErr:    true,
+	}, {
+		name: "reference by digest",
+		fields: fields{
+			ociValues: []string{
+				"ghcr.io/guacsec/guac-test-image@sha256:9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09",
+			},
+			poll:     false,
+			interval: 0,
+		},
+		want: []*processor.Document{
+			{
+				Blob:   dochelper.ConsistentJsonBytes(testdata.OCIDsseAttExample),
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
+				SourceInformation: processor.SourceInformation{
+					Collector: string(OCICollector),
+					Source:    "ghcr.io/guacsec/guac-test-image:sha256-9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09.att",
+				},
+			},
+			{
+				Blob:   dochelper.ConsistentJsonBytes(testdata.OCISPDXExample),
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
+				SourceInformation: processor.SourceInformation{
+					Collector: string(OCICollector),
+					Source:    "ghcr.io/guacsec/guac-test-image:sha256-9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09.sbom",
+				},
+			},
+		},
+		wantErr: false,
+	}, {
+		name: "reference by tag AND digest",
+		fields: fields{
+			ociValues: []string{
+				"ghcr.io/guacsec/guac-test-image:carrot@sha256:9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09",
+			},
+			poll:     false,
+			interval: 0,
+		},
+		want: []*processor.Document{
+			{
+				Blob:   dochelper.ConsistentJsonBytes(testdata.OCIDsseAttExample),
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
+				SourceInformation: processor.SourceInformation{
+					Collector: string(OCICollector),
+					Source:    "ghcr.io/guacsec/guac-test-image:sha256-9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09.att",
+				},
+			},
+			{
+				Blob:   dochelper.ConsistentJsonBytes(testdata.OCISPDXExample),
+				Type:   processor.DocumentUnknown,
+				Format: processor.FormatUnknown,
+				SourceInformation: processor.SourceInformation{
+					Collector: string(OCICollector),
+					Source:    "ghcr.io/guacsec/guac-test-image:sha256-9e183c89765d92a440f44ac7059385c778cbadad0ee8fe3208360efb07c0ba09.sbom",
+				},
+			},
+		},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

Modifies the OCI collector so that it supports image references by digest.

If both a tag and digest are provided, the collector will ignore the tag. This follows how major clients like docker and crane treat references of this form.

Fixes #1407 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
