### PR TITLE
Run the guacgql HTTP server on only one port

### DIFF
--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -84,7 +84,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetBool("retrieve-dependencies"),
 			args,
 			viper.GetBool("enable-prometheus"),
-			viper.GetInt("prometheus-addr"),
+			viper.GetInt("prometheus-port"),
 		)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -159,7 +159,7 @@ func validateDepsDevFlags(pubsubAddr string, blobAddr string, csubAddr string, c
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"retrieve-dependencies"})
+	set, err := cli.BuildFlags([]string{"retrieve-dependencies", "prometheus-port"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -29,7 +29,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"pubsub-addr", "blob-addr", "csub-addr", "use-csub", "service-poll", "enable-prometheus", "prometheus-addr"})
+	set, err := cli.BuildFlags([]string{"pubsub-addr", "blob-addr", "csub-addr", "use-csub", "service-poll", "enable-prometheus"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guacgql/cmd/root.go
+++ b/cmd/guacgql/cmd/root.go
@@ -113,7 +113,7 @@ func init() {
 		"neptune-endpoint", "neptune-port", "neptune-region", "neptune-user", "neptune-realm",
 		"gql-listen-port", "gql-tls-cert-file", "gql-tls-key-file", "gql-debug", "gql-backend", "gql-trace",
 		"db-address", "db-driver", "db-debug", "db-migrate",
-		"kv-store", "kv-redis", "kv-tikv", "enable-prometheus", "prometheus-addr",
+		"kv-store", "kv-redis", "kv-tikv", "enable-prometheus",
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -91,7 +91,7 @@ func init() {
 
 	set.Bool("enable-prometheus", true, "enable prometheus metrics")
 
-	set.Int("prometheus-addr", 9091, "port to listen to on prometheus server")
+	set.Int("prometheus-port", 9091, "port to listen to on prometheus server")
 
 	set.StringP("interval", "i", "5m", "if polling set interval, m, h, s, etc.")
 

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -21,7 +21,7 @@ To use this metrics package in your application, you need to do the following:
 To scrape the metrics from Prometheus, you can use the following example:
 
 ```bash
-curl http://localhost:9091/metrics
+curl http://localhost:8080/metrics
 ```
 
 This will return a plain text page with a series of lines like this:


### PR DESCRIPTION
# Description of the PR

- Fixes https://github.com/guacsec/guac/issues/1676

Currently, if I check out `main` and run `go run ./cmd/guacgql --gql-debug`, then I will be able to access `/` (playground), `/query` (GQL server), and `/metrics` on both ports 8080 and 9091 of localhost. I don't think that this makes sense so I have changed the behavior in this PR so that all of these paths are served off of just one port.

To test this change, run each of the following commands in a terminal tab:

1. `docker run -p 4222:4222 -p 8222:8222 nats -m 8222 -js`
2. `go run ./cmd/guacgql --gql-debug`
3. `go run ./cmd/guaccsub`
4. `go run ./cmd/guaccollect deps_dev`

Then you will be able to access the GraphQL playground on http://localhost:8080, the GraphQL server metrics endpoint on http://localhost:8080/metrics, and the guaccollect deps.dev collector metrics on http://localhost:9091/metrics.

In addition, you may add a `--gql-listen-port nnn` to the second command and see the port for the GraphQL URLs change to nnn, and/or add a `--prometheus-port mmm` to the fourth command and see the port for the collector metrics change to mmm.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
