### PR TITLE
[fix] OSV unit test update and replaced deprecated `types.Descriptor`

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1378,7 +1378,12 @@ var (
 			"scanner": {
 				"uri": "osv.dev",
 				"version": "0.0.14",
-				"db": {}
+				"db": {},
+				"result": [
+					{
+						"vulnerability_id": "GHSA-9ph3-v2vh-3qx7"
+					}
+				]
 			},
 			"metadata": {
 				"scannedOn": "2023-02-15T11:10:08.986506-08:00"

--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -29,7 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/regclient/regclient"
-	"github.com/regclient/regclient/types"
+	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/manifest"
 	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
@@ -355,7 +355,7 @@ func (o *ociCollector) fetchReferrerArtifacts(ctx context.Context, repo string, 
 	for _, referrerDesc := range referrerList.Descriptors {
 		// Increment the WaitGroup counter
 		wg.Add(1)
-		go func(referrerDesc types.Descriptor) {
+		go func(referrerDesc descriptor.Descriptor) {
 			defer wg.Done() // Decrement the WaitGroup counter when done
 			if _, ok := wellKnownOCIArtifactTypes[referrerDesc.ArtifactType]; ok {
 				referrerDescDigest := referrerDesc.Digest.String()


### PR DESCRIPTION
# Description of the PR
update osv unit test to include new found vulnerability. Also fix lint issue below.

```
pkg/handler/collector/oci/oci.go:358:24: SA1019: types.Descriptor is deprecated: replace with [descriptor.Descriptor]. (staticcheck)
		go func(referrerDesc types.Descriptor) {
```
# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
