### PR TITLE
Fix goreleaser flag deprecation warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --snapshot --skip-sign
+          args: release --clean --snapshot --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v0.0.0-snapshot-tag

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build_local_container:
 	GITHUB_REPOSITORY=$(GITHUB_REPOSITORY) \
 	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) \
 	DOCKER_CONTEXT=$(shell docker context ls | grep '*' | awk '{print $$1}') \
-	goreleaser release --clean --snapshot --skip-sign --skip-sbom
+	goreleaser release --clean --snapshot --skip=sign --skip=sbom
 
 # Build and package a guac container for local testing
 # Separate build_container as its own target to ensure (workaround) goreleaser finish writing dist/artifacts.json


### PR DESCRIPTION
# Description of the PR

Fixes #1813
I spotted these minor deprecation warnings during local development. I tested the script on my local and it introduced no change in behaviour.
Thank you!

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
