### PR TITLE
Fix GitHub collector to accept explicit tag in urls

### DIFF
--- a/pkg/handler/collector/github/github.go
+++ b/pkg/handler/collector/github/github.go
@@ -383,7 +383,7 @@ func ParseGithubReleaseDataSource(source datasource.Source) (*client.Repo, TagOr
 	if len(path) < 3 || len(path) > 5 {
 		return nil, "", fmt.Errorf("invalid github url path: %v invalid number of subpaths: %v", u.Path, len(path))
 	}
-	if path[2] != "releases" || (len(path) == 5 && path[3] != "tags") {
+	if path[2] != "releases" || (len(path) == 5 && path[3] != "tag") {
 		return nil, "", fmt.Errorf("invalid github path: %v", u.Path)
 	}
 	var tol TagOrLatest

--- a/pkg/handler/collector/github/github_test.go
+++ b/pkg/handler/collector/github/github_test.go
@@ -37,11 +37,12 @@ type MockGithubClient struct {
 }
 
 const (
-	mockTag               = "mockTag"
-	mockCommit            = "mockCommit"
-	mockReleaseUrlLatest  = "https://github.com/mock/repo/releases"
-	mockReleaseUrlWithTag = "https://github.com/mock/repo/releases/v1"
-	mockAssetUrl          = "https://github.com/mock/repo/releases/releaseAsset.json"
+	mockTag                       = "mockTag"
+	mockCommit                    = "mockCommit"
+	mockReleaseUrlLatest          = "https://github.com/mock/repo/releases"
+	mockReleaseUrlWithTag         = "https://github.com/mock/repo/releases/v1"
+	mockReleaseUrlWithTagFullPath = "https://github.com/mock/repo/releases/tag/v1"
+	mockAssetUrl                  = "https://github.com/mock/repo/releases/releaseAsset.json"
 )
 
 func mockReleaseAsset() client.ReleaseAsset {
@@ -580,6 +581,20 @@ func TestParseGithubReleaseDataSource(t *testing.T) {
 			args: args{
 				source: datasource.Source{
 					Value: mockReleaseUrlWithTag,
+				},
+			},
+			want: &client.Repo{
+				Owner: "mock",
+				Repo:  "repo",
+			},
+			want1:   "v1",
+			wantErr: false,
+		},
+		{
+			name: "parse valid tag github url with full path",
+			args: args{
+				source: datasource.Source{
+					Value: mockReleaseUrlWithTagFullPath,
 				},
 			},
 			want: &client.Repo{


### PR DESCRIPTION
# Description of the PR

Fixes #1817
Found this error while trying to ingest data from a GitHub release via CLI.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
