### PR TITLE
Add missing dev tools to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,10 +8,13 @@ mkShell {
     jq  
     gcc
     go_1_21
+    golangci-lint
     gopls
     gotests
     goreleaser
     nats-server
     protobuf
+    protoc-gen-go
+    protoc-gen-go-grpc
   ];
 }


### PR DESCRIPTION
# Description of the PR

I discovered that the tools needed to run `make photo` and `make lint` are missing from the Nix shell file. As these are required steps before opening a contribution PR, I would like to have them in the local dev environment.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
