### PR TITLE
Add Github Release URLs parsing to identifier strings

### DIFF
--- a/pkg/collectsub/collectsub/input/identifier_strings.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings.go
@@ -58,6 +58,13 @@ func identifierStringsToCollectEntry(i *parser_common.IdentifierStrings) []*pb.C
 		})
 	}
 
+	for _, v := range i.GithubReleaseStrings {
+		entries = append(entries, &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_GITHUB_RELEASE,
+			Value: v,
+		})
+	}
+
 	for _, v := range i.UnclassifiedStrings {
 		e, err := guessUnknownIdentifierString(v)
 		if err == nil {
@@ -76,6 +83,16 @@ func guessUnknownIdentifierString(s string) (*pb.CollectEntry, error) {
 		strings.HasPrefix(s, "gcr.io") {
 		return &pb.CollectEntry{
 			Type:  pb.CollectDataType_DATATYPE_OCI,
+			Value: s,
+		}, nil
+	}
+
+	urlSegments := strings.SplitAfter(s, "/")
+	if strings.HasPrefix(s, "github.com") &&
+		len(urlSegments) >= 4 &&
+		strings.HasPrefix(urlSegments[3], "releases") {
+		return &pb.CollectEntry{
+			Type:  pb.CollectDataType_DATATYPE_GITHUB_RELEASE,
 			Value: s,
 		}, nil
 	}

--- a/pkg/collectsub/collectsub/input/identifier_strings_test.go
+++ b/pkg/collectsub/collectsub/input/identifier_strings_test.go
@@ -35,15 +35,18 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 		name: "simple test",
 		input: []*parser_common.IdentifierStrings{
 			{
-				OciStrings:  []string{"index.docker.io/guacsec/local-organic-guac"},
-				VcsStrings:  []string{"git+https://github.com/guacsec/guac"},
-				PurlStrings: []string{"pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease"},
+				OciStrings:           []string{"index.docker.io/guacsec/local-organic-guac"},
+				VcsStrings:           []string{"git+https://github.com/guacsec/guac"},
+				PurlStrings:          []string{"pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease"},
+				GithubReleaseStrings: []string{"https://github.com/guacsec/guac/releases", "https://github.com/grafana/grafana/releases/tag/v10.2.6"},
 			},
 		},
 		expected: []*pb.CollectEntry{
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "index.docker.io/guacsec/local-organic-guac"},
 			{Type: pb.CollectDataType_DATATYPE_GIT, Value: "git+https://github.com/guacsec/guac"},
 			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease"},
+			{Type: pb.CollectDataType_DATATYPE_GITHUB_RELEASE, Value: "https://github.com/guacsec/guac/releases"},
+			{Type: pb.CollectDataType_DATATYPE_GITHUB_RELEASE, Value: "https://github.com/grafana/grafana/releases/tag/v10.2.6"},
 		},
 	}, {
 		name: "simple unclassified string test",
@@ -54,7 +57,11 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 					"pkg:npm/%40angular/animation@12.3.1",
 					"https://not-oci-registry.com/guacsec/local-organic-guac",
 					"gcr.io/guacsec/local-organic-guac",
-					"pkg:golang/google.golang.org/genproto#googleapis/api/annotations"},
+					"pkg:golang/google.golang.org/genproto#googleapis/api/annotations",
+					"https://github.com/namespace/project/-/releases/permalink/latest",
+					"https://api.github.com/repos/grafana/grafana/releases/tags/v10.2.6",
+					"github.com/kubernetes/kubernetes/releases",
+					"github.com/kubernetes/kubernetes"},
 			},
 		},
 		expected: []*pb.CollectEntry{
@@ -63,6 +70,7 @@ func Test_IdentifierStringsSliceToCollectEntries(t *testing.T) {
 			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:npm/%40angular/animation@12.3.1"},
 			{Type: pb.CollectDataType_DATATYPE_OCI, Value: "gcr.io/guacsec/local-organic-guac"},
 			{Type: pb.CollectDataType_DATATYPE_PURL, Value: "pkg:golang/google.golang.org/genproto#googleapis/api/annotations"},
+			{Type: pb.CollectDataType_DATATYPE_GITHUB_RELEASE, Value: "github.com/kubernetes/kubernetes/releases"},
 		},
 	}, {
 		name: "simple slice test",

--- a/pkg/ingestor/parser/common/types.go
+++ b/pkg/ingestor/parser/common/types.go
@@ -52,6 +52,8 @@ type IdentifierStrings struct {
 	VcsStrings []string
 	// PurlStrings should contain package url to specific packages
 	PurlStrings []string
+	// GithubReleaseStrings should contain url to specific GitHub releases
+	GithubReleaseStrings []string
 	// UnclassifiedStrings contains other strings that have identifiers that
 	// parsers may not be sure what category they fall under.
 	UnclassifiedStrings []string


### PR DESCRIPTION
# Description of the PR

Fixes #591

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
