### PR TITLE
[ENT] FIx node query not returning via builtIn `Noder` function

### DIFF
--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -301,16 +301,14 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 
 	switch foundGlobalID.nodeType {
 	case artifact.Table:
-		record, err := b.client.Noder(ctx, nodeID, ent.WithFixedNodeType(foundGlobalID.nodeType))
+		artifacts, err := b.Artifacts(ctx, &model.ArtifactSpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to query for Artifacts via ID: %s, with error: %w", nodeID.String(), err)
 		}
-
-		if art, ok := record.(*ent.Artifact); ok {
-			return toModelArtifact(art), nil
-		} else {
-			return nil, fmt.Errorf("failed to assert type of artifact")
+		if len(artifacts) != 1 {
+			return nil, fmt.Errorf("ID returned multiple Artifacts nodes %s", nodeID.String())
 		}
+		return artifacts[0], nil
 	case packageversion.Table:
 		pv, err := b.client.PackageVersion.Query().
 			Where(packageversion.ID(nodeID)).
@@ -330,49 +328,41 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 		}
 		return toModelPackage(backReferencePackageName(pn)), nil
 	case sourcename.Table:
-		record, err := b.client.Noder(ctx, nodeID, ent.WithFixedNodeType(foundGlobalID.nodeType))
+		sources, err := b.Sources(ctx, &model.SourceSpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to query for Sources via ID: %s, with error: %w", nodeID.String(), err)
 		}
-
-		if sn, ok := record.(*ent.SourceName); ok {
-			return toModelSourceName(sn), nil
-		} else {
-			return nil, fmt.Errorf("failed to assert type of SourceName")
+		if len(sources) != 1 {
+			return nil, fmt.Errorf("ID returned multiple Sources nodes %s", nodeID.String())
 		}
+		return sources[0], nil
 	case builder.Table:
-		record, err := b.client.Noder(ctx, nodeID, ent.WithFixedNodeType(foundGlobalID.nodeType))
+		builders, err := b.Builders(ctx, &model.BuilderSpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to query for Builders via ID: %s, with error: %w", nodeID.String(), err)
 		}
-
-		if b, ok := record.(*ent.Builder); ok {
-			return toModelBuilder(b), nil
-		} else {
-			return nil, fmt.Errorf("failed to assert type of Builder")
+		if len(builders) != 1 {
+			return nil, fmt.Errorf("ID returned multiple Builders nodes %s", nodeID.String())
 		}
+		return builders[0], nil
 	case license.Table:
-		record, err := b.client.Noder(ctx, nodeID, ent.WithFixedNodeType(foundGlobalID.nodeType))
+		licenses, err := b.Licenses(ctx, &model.LicenseSpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to query for Licenses via ID: %s, with error: %w", nodeID.String(), err)
 		}
-
-		if lic, ok := record.(*ent.License); ok {
-			return toModelLicense(lic), nil
-		} else {
-			return nil, fmt.Errorf("failed to assert type of License")
+		if len(licenses) != 1 {
+			return nil, fmt.Errorf("ID returned multiple Licenses nodes %s", nodeID.String())
 		}
+		return licenses[0], nil
 	case vulnerabilityid.Table:
-		record, err := b.client.Noder(ctx, nodeID, ent.WithFixedNodeType(foundGlobalID.nodeType))
+		vulnerabilities, err := b.Vulnerabilities(ctx, &model.VulnerabilitySpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to query for Vulnerabilities via ID: %s, with error: %w", nodeID.String(), err)
 		}
-
-		if v, ok := record.(*ent.VulnerabilityID); ok {
-			return toModelVulnerabilityFromVulnerabilityID(v), nil
-		} else {
-			return nil, fmt.Errorf("failed to assert type of VulnerabilityID")
+		if len(vulnerabilities) != 1 {
+			return nil, fmt.Errorf("ID returned multiple Vulnerabilities nodes %s", nodeID.String())
 		}
+		return vulnerabilities[0], nil
 	case certifyBadString:
 		certs, err := b.CertifyBad(ctx, &model.CertifyBadSpec{ID: ptrfrom.String(nodeID.String())})
 		if err != nil {


### PR DESCRIPTION
# Description of the PR

remove built-in query noder as it was not properly returning the fields in the queried nodes.

This fixes the issues where the source name was not properly being output (before fix `src://`):
```
source_names:a2cf72e6-7740-5a52-8350-61e52618936d: src:git/github.com/caddyserver/caddy
```

in the patch plan below

```
go run ./cmd/guacone query patch --start-purl "pkg:golang/github.com/antlr/antlr4/runtime/go/antlr" --search-depth 10

{"level":"info","ts":1712667286.4790232,"caller":"logging/logger.go:70","msg":"Logging at info level"}
{"level":"info","ts":1712667286.479159,"caller":"cli/init.go:69","msg":"Using config file: /Users/parth/Documents/pxp928/artifact-ff/guac.yaml"}

---FRONTIER LEVEL 0---
package_versions:f7bd33b1-dcad-5a5a-a338-ab123b24d150: pkg:golang/github.com/antlr/antlr4/runtime/go/antlr@v0.0.0-20220418222510-f25a4f6275ed
package_names:cefcc651-9ea3-5677-b00f-90e59b04bd81: pkg:golang/github.com/antlr/antlr4/runtime/go/antlr

---FRONTIER LEVEL 1---
package_names:6eb2a82f-138e-54ba-9673-5e600cdc7c23: pkg:golang/github.com/google/cel-go
package_versions:5d80d7e7-08f8-5125-afd0-e5d861652bfa: pkg:golang/github.com/google/cel-go@v0.12.5

---FRONTIER LEVEL 2---
package_names:5f50860d-e06c-5e4b-91a3-0ce44bfe9b99: pkg:guac/spdx/k8s.gcr.io/kube-apiserver-v1.25.2
package_names:0f2a695e-432a-5e19-8dd1-ef6dc01e7aba: pkg:golang/github.com/caddyserver/caddy/v2
package_versions:1bc904e8-8354-50ab-b614-8d7660f68801: pkg:guac/spdx/k8s.gcr.io/kube-apiserver-v1.25.2
package_names:d27af5e1-f33b-545c-afe7-f44a739b3b45: pkg:guac/spdx/k8s.gcr.io/kube-apiserver-v1.25.1
package_versions:a1b32803-50dd-5303-8640-4a64d2d63950: pkg:guac/spdx/k8s.gcr.io/kube-apiserver-v1.25.1
source_names:cc43fd47-758e-5401-9a69-4e4f8c79962f: src:git/github.com/google/cel-go
package_versions:63715865-3d8f-53ba-a8cf-ab0f50d08e37: pkg:golang/github.com/caddyserver/caddy/v2@v2.6.2

---FRONTIER LEVEL 3---
package_names:17f2995e-5726-5d86-be83-e7048844ed1e: pkg:guac/cdx/docker.io/library/caddy
source_names:a2cf72e6-7740-5a52-8350-61e52618936d: src:git/github.com/caddyserver/caddy
package_versions:cb93bc44-7363-53e8-a10b-b90e054f8799: pkg:guac/cdx/docker.io/library/caddy@sha256%3A7992b931b7da3cf0840dd69ea74b2c67d423faf03408da8abdc31b7590a239a7?tag=latest

---INFO NODES---
no info nodes found

---POINTS OF CONTACT---
no POCs found


---SUBGRAPH VISUALIZER URL---
http://localhost:3000/?path=dependencies:5f86c829-00bd-5997-8e59-60047bc2d568,pkgNamespace:6eb2a82f-138e-54ba-9673-5e600cdc7c23,dependencies:a14185ae-4279-5723-97ce-5faae42d00ef,pkgNamespace:5f50860d-e06c-5e4b-91a3-0ce44bfe9b99,dependencies:e8eaf958-456d-5d66-8788-6a09cfdc67fe,pkgNamespace:d27af5e1-f33b-545c-afe7-f44a739b3b45,dependencies:eeb70b3e-12ae-54db-bb05-db764acff5dd,pkgNamespace:17f2995e-5726-5d86-be83-e7048844ed1e,dependencies:28bbf396-db10-53d6-b2f2-04a0dc6b90cf,dependencies:7291c7f0-3edf-59fd-a715-a81cb5b21ff1,pkgNamespace:0f2a695e-432a-5e19-8dd1-ef6dc01e7aba,dependencies:cafa2d53-6681-5786-bdf0-ffde514fa5f4,dependencies:f8ed309d-57a5-5838-bec3-cb74b6526719,has_source_ats:018ec2ea-057e-79d0-a42e-dbb999a5f349,srcNamespace:cc43fd47-758e-5401-9a69-4e4f8c79962f,dependencies:761b4703-9155-5fd5-a7d0-7095917186a6,has_source_ats:018ec2ea-057e-7991-9ca9-9b3143458e43,srcNamespace:a2cf72e6-7740-5a52-8350-61e52618936d,package_versions:f7bd33b1-dcad-5a5a-a338-ab123b24d150,package_names:cefcc651-9ea3-5677-b00f-90e59b04bd81,package_names:6eb2a82f-138e-54ba-9673-5e600cdc7c23,package_versions:5d80d7e7-08f8-5125-afd0-e5d861652bfa,package_names:5f50860d-e06c-5e4b-91a3-0ce44bfe9b99,package_names:0f2a695e-432a-5e19-8dd1-ef6dc01e7aba,package_versions:1bc904e8-8354-50ab-b614-8d7660f68801,package_names:d27af5e1-f33b-545c-afe7-f44a739b3b45,package_versions:a1b32803-50dd-5303-8640-4a64d2d63950,source_names:cc43fd47-758e-5401-9a69-4e4f8c79962f,package_versions:63715865-3d8f-53ba-a8cf-ab0f50d08e37,package_names:17f2995e-5726-5d86-be83-e7048844ed1e,source_names:a2cf72e6-7740-5a52-8350-61e52618936d,package_versions:cb93bc44-7363-53e8-a10b-b90e054f8799
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
