### PR TITLE
Update error handling on ingestion

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -90,7 +90,10 @@ func ingest(cmd *cobra.Command, args []string) {
 	defer csubClient.Close()
 
 	emit := func(d *processor.Document) error {
-		return ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient)
+		if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient); err != nil {
+			logger.Errorf("unable to ingest document %q : %v", d.SourceInformation.Source, err)
+		}
+		return nil
 	}
 
 	// Assuming that publisher and consumer are different processes.

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -54,15 +54,14 @@ func Ingest(ctx context.Context, d *processor.Document, graphqlEndpoint string, 
 		return fmt.Errorf("unable to ingest doc tree: %v", err)
 	}
 
-	err = collectSubEmitFunc(idstrings)
-	if err != nil {
+	if err := collectSubEmitFunc(idstrings); err != nil {
 		logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
 	}
 
-	err = assemblerFunc(predicates)
-	if err != nil {
-		return fmt.Errorf("unable to assemble graphs: %v", err)
+	if err := assemblerFunc(predicates); err != nil {
+		return fmt.Errorf("error assembling graphs for %q : %w", d.SourceInformation.Source, err)
 	}
+
 	t := time.Now()
 	elapsed := t.Sub(start)
 	logger.Infof("[%v] completed doc %+v", elapsed, d.SourceInformation)


### PR DESCRIPTION
Bulk emitter will return errors now. It continues to try to ingest all verbs even if one fails. It stops ingestion on a single noun failure. Guacone files command will log all errors and continue to ingest all files found even if one errors. Summary should list errors. Guacingest service will log errors and continue, it will ack messages even if errored.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
