### PR TITLE
Update graphQL schema to add documentRef field to all verbs

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -6632,7 +6632,7 @@ type CertifyBadInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef"`
 }
 
 // GetJustification returns CertifyBadInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -6648,7 +6648,7 @@ func (v *CertifyBadInputSpec) GetOrigin() string { return v.Origin }
 func (v *CertifyBadInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns CertifyBadInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *CertifyBadInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *CertifyBadInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
 // query.
@@ -6816,7 +6816,7 @@ type CertifyGoodInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef"`
 }
 
 // GetJustification returns CertifyGoodInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -6832,7 +6832,7 @@ func (v *CertifyGoodInputSpec) GetOrigin() string { return v.Origin }
 func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns CertifyGoodInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *CertifyGoodInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *CertifyGoodInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // CertifyLegalInputSpec represents the input for certifying legal information in
 // mutations.
@@ -7830,7 +7830,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef"`
 }
 
 // GetKey returns HasMetadataInputSpec.Key, and is useful for accessing the field via an interface.
@@ -7852,7 +7852,7 @@ func (v *HasMetadataInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *HasMetadataInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 type HasSBOMIncludesInputSpec struct {
 	Packages     []string `json:"packages"`
@@ -7882,7 +7882,7 @@ type HasSBOMInputSpec struct {
 	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	DocumentRef      string    `json:"documentRef"`
+	DocumentRef      *string   `json:"documentRef"`
 }
 
 // GetUri returns HasSBOMInputSpec.Uri, and is useful for accessing the field via an interface.
@@ -7907,7 +7907,7 @@ func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasSBOMInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasSBOMInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *HasSBOMInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
 //
@@ -8139,7 +8139,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef"`
 }
 
 // GetKnownSince returns HasSourceAtInputSpec.KnownSince, and is useful for accessing the field via an interface.
@@ -8155,14 +8155,14 @@ func (v *HasSourceAtInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasSourceAtInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasSourceAtInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *HasSourceAtInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef"`
 }
 
 // GetJustification returns HashEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -8175,7 +8175,7 @@ func (v *HashEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *HashEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HashEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HashEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *HashEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // IDorArtifactInput allows for specifying either the artifact ID or the ArtifactInputSpec.
 //
@@ -9117,7 +9117,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
-	DocumentRef    string         `json:"documentRef"`
+	DocumentRef    *string        `json:"documentRef"`
 }
 
 // GetVersionRange returns IsDependencyInputSpec.VersionRange, and is useful for accessing the field via an interface.
@@ -9136,7 +9136,7 @@ func (v *IsDependencyInputSpec) GetOrigin() string { return v.Origin }
 func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns IsDependencyInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *IsDependencyInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *IsDependencyInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // IsDependencySpec allows filtering the list of dependencies to return.
 //
@@ -9185,10 +9185,10 @@ func (v *IsDependencySpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef"`
 }
 
 // GetJustification returns IsOccurrenceInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -9201,7 +9201,7 @@ func (v *IsOccurrenceInputSpec) GetOrigin() string { return v.Origin }
 func (v *IsOccurrenceInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns IsOccurrenceInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *IsOccurrenceInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
 // a query.
@@ -21851,10 +21851,10 @@ func (v *PathResponse) __premarshalJSON() (*__premarshalPathResponse, error) {
 
 // PkgEqualInputSpec represents the input to certify that packages are similar.
 type PkgEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef"`
 }
 
 // GetJustification returns PkgEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -21867,7 +21867,7 @@ func (v *PkgEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *PkgEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns PkgEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *PkgEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *PkgEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // PkgInputSpec specifies a package for mutations.
 //
@@ -21967,7 +21967,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef"`
 }
 
 // GetEmail returns PointOfContactInputSpec.Email, and is useful for accessing the field via an interface.
@@ -21989,7 +21989,7 @@ func (v *PointOfContactInputSpec) GetOrigin() string { return v.Origin }
 func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns PointOfContactInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *PointOfContactInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *PointOfContactInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
 type SLSAInputSpec struct {
@@ -22000,7 +22000,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time               `json:"finishedOn"`
 	Origin        string                   `json:"origin"`
 	Collector     string                   `json:"collector"`
-	DocumentRef   string                   `json:"documentRef"`
+	DocumentRef   *string                  `json:"documentRef"`
 }
 
 // GetBuildType returns SLSAInputSpec.BuildType, and is useful for accessing the field via an interface.
@@ -22025,7 +22025,7 @@ func (v *SLSAInputSpec) GetOrigin() string { return v.Origin }
 func (v *SLSAInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns SLSAInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *SLSAInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec.
 type SLSAPredicateInputSpec struct {
@@ -22049,7 +22049,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
-	DocumentRef    string    `json:"documentRef"`
+	DocumentRef    *string   `json:"documentRef"`
 }
 
 // GetTimeScanned returns ScanMetadataInput.TimeScanned, and is useful for accessing the field via an interface.
@@ -22074,7 +22074,7 @@ func (v *ScanMetadataInput) GetOrigin() string { return v.Origin }
 func (v *ScanMetadataInput) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns ScanMetadataInput.DocumentRef, and is useful for accessing the field via an interface.
-func (v *ScanMetadataInput) GetDocumentRef() string { return v.DocumentRef }
+func (v *ScanMetadataInput) GetDocumentRef() *string { return v.DocumentRef }
 
 // ScorecardCheckInputSpec represents the mutation input for a Scorecard check.
 type ScorecardCheckInputSpec struct {
@@ -22109,7 +22109,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                    `json:"scorecardCommit"`
 	Origin           string                    `json:"origin"`
 	Collector        string                    `json:"collector"`
-	DocumentRef      string                    `json:"documentRef"`
+	DocumentRef      *string                   `json:"documentRef"`
 }
 
 // GetChecks returns ScorecardInputSpec.Checks, and is useful for accessing the field via an interface.
@@ -22134,7 +22134,7 @@ func (v *ScorecardInputSpec) GetOrigin() string { return v.Origin }
 func (v *ScorecardInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns ScorecardInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *ScorecardInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *ScorecardInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // ScorecardsResponse is returned by Scorecards on success.
 type ScorecardsResponse struct {
@@ -22394,7 +22394,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
-	DocumentRef      string           `json:"documentRef"`
+	DocumentRef      *string          `json:"documentRef"`
 }
 
 // GetStatus returns VexStatementInputSpec.Status, and is useful for accessing the field via an interface.
@@ -22419,7 +22419,7 @@ func (v *VexStatementInputSpec) GetOrigin() string { return v.Origin }
 func (v *VexStatementInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VexStatementInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VexStatementInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *VexStatementInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // Records the status of a VEX statement subject.
 type VexStatus string
@@ -22433,10 +22433,10 @@ const (
 
 // VulnEqualInputSpec represents the input to link vulnerabilities to each other.
 type VulnEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef"`
 }
 
 // GetJustification returns VulnEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -22449,7 +22449,7 @@ func (v *VulnEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *VulnEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VulnEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VulnEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *VulnEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // VulnerabilitiesResponse is returned by Vulnerabilities on success.
 type VulnerabilitiesResponse struct {
@@ -22581,7 +22581,7 @@ type VulnerabilityMetadataInputSpec struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Origin      string                 `json:"origin"`
 	Collector   string                 `json:"collector"`
-	DocumentRef string                 `json:"documentRef"`
+	DocumentRef *string                `json:"documentRef"`
 }
 
 // GetScoreType returns VulnerabilityMetadataInputSpec.ScoreType, and is useful for accessing the field via an interface.
@@ -22600,7 +22600,7 @@ func (v *VulnerabilityMetadataInputSpec) GetOrigin() string { return v.Origin }
 func (v *VulnerabilityMetadataInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VulnerabilityMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VulnerabilityMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
+func (v *VulnerabilityMetadataInputSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // Records the type of the score being captured by the score node
 type VulnerabilityScoreType string

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -68,12 +68,17 @@ func (v *AllBuilderTree) GetUri() string { return v.Uri }
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type AllCertifyBad struct {
-	Id            string                                      `json:"id"`
-	Justification string                                      `json:"justification"`
-	KnownSince    time.Time                                   `json:"knownSince"`
-	Subject       AllCertifyBadSubjectPackageSourceOrArtifact `json:"-"`
-	Origin        string                                      `json:"origin"`
-	Collector     string                                      `json:"collector"`
+	Id string `json:"id"`
+	// The justification for the subject being certified bad
+	Justification string `json:"justification"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	KnownSince time.Time `json:"knownSince"`
+	// The package, source or artifact that is attested
+	Subject AllCertifyBadSubjectPackageSourceOrArtifact `json:"-"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
 }
 
 // GetId returns AllCertifyBad.Id, and is useful for accessing the field via an interface.
@@ -544,12 +549,17 @@ func (v *AllCertifyBadSubjectSource) __premarshalJSON() (*__premarshalAllCertify
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type AllCertifyGood struct {
-	Id            string                                       `json:"id"`
-	Justification string                                       `json:"justification"`
-	KnownSince    time.Time                                    `json:"knownSince"`
-	Subject       AllCertifyGoodSubjectPackageSourceOrArtifact `json:"-"`
-	Origin        string                                       `json:"origin"`
-	Collector     string                                       `json:"collector"`
+	Id string `json:"id"`
+	// The justification for the subject being certified good
+	Justification string `json:"justification"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	KnownSince time.Time `json:"knownSince"`
+	// The package, source or artifact that is attested
+	Subject AllCertifyGoodSubjectPackageSourceOrArtifact `json:"-"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
 }
 
 // GetId returns AllCertifyGood.Id, and is useful for accessing the field via an interface.
@@ -2582,14 +2592,21 @@ func (v *AllCertifyVulnVulnerability) __premarshalJSON() (*__premarshalAllCertif
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type AllHasMetadata struct {
-	Id            string                                       `json:"id"`
-	Subject       AllHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
-	Key           string                                       `json:"key"`
-	Value         string                                       `json:"value"`
-	Timestamp     time.Time                                    `json:"timestamp"`
-	Justification string                                       `json:"justification"`
-	Origin        string                                       `json:"origin"`
-	Collector     string                                       `json:"collector"`
+	Id string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject AllHasMetadataSubjectPackageSourceOrArtifact `json:"-"`
+	// Key in the key value pair
+	Key string `json:"key"`
+	// Value in the key value pair
+	Value string `json:"value"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	Timestamp time.Time `json:"timestamp"`
+	// The justification for the metadata
+	Justification string `json:"justification"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
 }
 
 // GetId returns AllHasMetadata.Id, and is useful for accessing the field via an interface.
@@ -5307,14 +5324,21 @@ func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVers
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type AllPointOfContact struct {
-	Id            string                                          `json:"id"`
-	Subject       AllPointOfContactSubjectPackageSourceOrArtifact `json:"-"`
-	Email         string                                          `json:"email"`
-	Info          string                                          `json:"info"`
-	Since         time.Time                                       `json:"since"`
-	Justification string                                          `json:"justification"`
-	Origin        string                                          `json:"origin"`
-	Collector     string                                          `json:"collector"`
+	Id string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject AllPointOfContactSubjectPackageSourceOrArtifact `json:"-"`
+	// Email for the POC
+	Email string `json:"email"`
+	// Generic info for the POC
+	Info string `json:"info"`
+	// Timestamp when the certification for POC was created (in RFC 3339 format)
+	Since time.Time `json:"since"`
+	// The justification for the POC attestation
+	Justification string `json:"justification"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
 }
 
 // GetId returns AllPointOfContact.Id, and is useful for accessing the field via an interface.
@@ -6309,13 +6333,19 @@ func (v *AllVulnEqualVulnerabilitiesVulnerability) __premarshalJSON() (*__premar
 //
 // The timestamp is used to determine when the score was evaluated for the specific vulnerability.
 type AllVulnMetadataTree struct {
-	Id            string                           `json:"id"`
+	Id string `json:"id"`
+	// The subject vulnerability that the metadata applies to
 	Vulnerability AllVulnMetadataTreeVulnerability `json:"vulnerability"`
-	ScoreType     VulnerabilityScoreType           `json:"scoreType"`
-	ScoreValue    float64                          `json:"scoreValue"`
-	Timestamp     time.Time                        `json:"timestamp"`
-	Origin        string                           `json:"origin"`
-	Collector     string                           `json:"collector"`
+	// The specific score type for the score value
+	ScoreType VulnerabilityScoreType `json:"scoreType"`
+	// The score value based on the score type
+	ScoreValue float64 `json:"scoreValue"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	Timestamp time.Time `json:"timestamp"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
 }
 
 // GetId returns AllVulnMetadataTree.Id, and is useful for accessing the field via an interface.
@@ -6599,13 +6629,17 @@ func (v *BuilderInputSpec) GetUri() string { return v.Uri }
 // evidence.
 type CertifyBadInputSpec struct {
 	Justification string    `json:"justification"`
+	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	KnownSince    time.Time `json:"knownSince"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetJustification returns CertifyBadInputSpec.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyBadInputSpec) GetJustification() string { return v.Justification }
+
+// GetKnownSince returns CertifyBadInputSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *CertifyBadInputSpec) GetKnownSince() time.Time { return v.KnownSince }
 
 // GetOrigin returns CertifyBadInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *CertifyBadInputSpec) GetOrigin() string { return v.Origin }
@@ -6613,8 +6647,8 @@ func (v *CertifyBadInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns CertifyBadInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyBadInputSpec) GetCollector() string { return v.Collector }
 
-// GetKnownSince returns CertifyBadInputSpec.KnownSince, and is useful for accessing the field via an interface.
-func (v *CertifyBadInputSpec) GetKnownSince() time.Time { return v.KnownSince }
+// GetDocumentRef returns CertifyBadInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyBadInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
 // query.
@@ -6632,9 +6666,10 @@ type CertifyBadSpec struct {
 	Id            *string                      `json:"id"`
 	Subject       *PackageSourceOrArtifactSpec `json:"subject"`
 	Justification *string                      `json:"justification"`
+	KnownSince    *time.Time                   `json:"knownSince"`
 	Origin        *string                      `json:"origin"`
 	Collector     *string                      `json:"collector"`
-	KnownSince    *time.Time                   `json:"knownSince"`
+	DocumentRef   *string                      `json:"documentRef"`
 }
 
 // GetId returns CertifyBadSpec.Id, and is useful for accessing the field via an interface.
@@ -6646,14 +6681,17 @@ func (v *CertifyBadSpec) GetSubject() *PackageSourceOrArtifactSpec { return v.Su
 // GetJustification returns CertifyBadSpec.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyBadSpec) GetJustification() *string { return v.Justification }
 
+// GetKnownSince returns CertifyBadSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *CertifyBadSpec) GetKnownSince() *time.Time { return v.KnownSince }
+
 // GetOrigin returns CertifyBadSpec.Origin, and is useful for accessing the field via an interface.
 func (v *CertifyBadSpec) GetOrigin() *string { return v.Origin }
 
 // GetCollector returns CertifyBadSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyBadSpec) GetCollector() *string { return v.Collector }
 
-// GetKnownSince returns CertifyBadSpec.KnownSince, and is useful for accessing the field via an interface.
-func (v *CertifyBadSpec) GetKnownSince() *time.Time { return v.KnownSince }
+// GetDocumentRef returns CertifyBadSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyBadSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // CertifyBadsCertifyBad includes the requested fields of the GraphQL type CertifyBad.
 // The GraphQL type's documentation follows.
@@ -6775,13 +6813,17 @@ func (v *CertifyBadsResponse) GetCertifyBad() []CertifyBadsCertifyBad { return v
 // CertifyGoodInputSpec represents the mutation input to ingest a CertifyGood evidence.
 type CertifyGoodInputSpec struct {
 	Justification string    `json:"justification"`
+	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	KnownSince    time.Time `json:"knownSince"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetJustification returns CertifyGoodInputSpec.Justification, and is useful for accessing the field via an interface.
 func (v *CertifyGoodInputSpec) GetJustification() string { return v.Justification }
+
+// GetKnownSince returns CertifyGoodInputSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *CertifyGoodInputSpec) GetKnownSince() time.Time { return v.KnownSince }
 
 // GetOrigin returns CertifyGoodInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *CertifyGoodInputSpec) GetOrigin() string { return v.Origin }
@@ -6789,8 +6831,8 @@ func (v *CertifyGoodInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns CertifyGoodInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 
-// GetKnownSince returns CertifyGoodInputSpec.KnownSince, and is useful for accessing the field via an interface.
-func (v *CertifyGoodInputSpec) GetKnownSince() time.Time { return v.KnownSince }
+// GetDocumentRef returns CertifyGoodInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyGoodInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // CertifyLegalInputSpec represents the input for certifying legal information in
 // mutations.
@@ -6802,6 +6844,7 @@ type CertifyLegalInputSpec struct {
 	TimeScanned       time.Time `json:"timeScanned"`
 	Origin            string    `json:"origin"`
 	Collector         string    `json:"collector"`
+	DocumentRef       *string   `json:"documentRef"`
 }
 
 // GetDeclaredLicense returns CertifyLegalInputSpec.DeclaredLicense, and is useful for accessing the field via an interface.
@@ -6825,6 +6868,9 @@ func (v *CertifyLegalInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns CertifyLegalInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyLegalInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns CertifyLegalInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyLegalInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+
 // CertifyLegalSpec allows filtering the list of legal certifications to
 // return in a query.
 //
@@ -6842,6 +6888,7 @@ type CertifyLegalSpec struct {
 	TimeScanned        *time.Time           `json:"timeScanned"`
 	Origin             *string              `json:"origin"`
 	Collector          *string              `json:"collector"`
+	DocumentRef        *string              `json:"documentRef"`
 }
 
 // GetId returns CertifyLegalSpec.Id, and is useful for accessing the field via an interface.
@@ -6876,6 +6923,9 @@ func (v *CertifyLegalSpec) GetOrigin() *string { return v.Origin }
 
 // GetCollector returns CertifyLegalSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyLegalSpec) GetCollector() *string { return v.Collector }
+
+// GetDocumentRef returns CertifyLegalSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyLegalSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // CertifyLegalsCertifyLegal includes the requested fields of the GraphQL type CertifyLegal.
 // The GraphQL type's documentation follows.
@@ -7050,6 +7100,7 @@ type CertifyScorecardSpec struct {
 	ScorecardCommit  *string              `json:"scorecardCommit"`
 	Origin           *string              `json:"origin"`
 	Collector        *string              `json:"collector"`
+	DocumentRef      *string              `json:"documentRef"`
 }
 
 // GetId returns CertifyScorecardSpec.Id, and is useful for accessing the field via an interface.
@@ -7078,6 +7129,9 @@ func (v *CertifyScorecardSpec) GetOrigin() *string { return v.Origin }
 
 // GetCollector returns CertifyScorecardSpec.Collector, and is useful for accessing the field via an interface.
 func (v *CertifyScorecardSpec) GetCollector() *string { return v.Collector }
+
+// GetDocumentRef returns CertifyScorecardSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *CertifyScorecardSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // DependenciesIsDependency includes the requested fields of the GraphQL type IsDependency.
 // The GraphQL type's documentation follows.
@@ -7776,6 +7830,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetKey returns HasMetadataInputSpec.Key, and is useful for accessing the field via an interface.
@@ -7795,6 +7850,9 @@ func (v *HasMetadataInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns HasMetadataInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns HasMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *HasMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 type HasSBOMIncludesInputSpec struct {
 	Packages     []string `json:"packages"`
@@ -7821,9 +7879,10 @@ type HasSBOMInputSpec struct {
 	Algorithm        string    `json:"algorithm"`
 	Digest           string    `json:"digest"`
 	DownloadLocation string    `json:"downloadLocation"`
+	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	KnownSince       time.Time `json:"knownSince"`
+	DocumentRef      string    `json:"documentRef"`
 }
 
 // GetUri returns HasSBOMInputSpec.Uri, and is useful for accessing the field via an interface.
@@ -7838,14 +7897,17 @@ func (v *HasSBOMInputSpec) GetDigest() string { return v.Digest }
 // GetDownloadLocation returns HasSBOMInputSpec.DownloadLocation, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetDownloadLocation() string { return v.DownloadLocation }
 
+// GetKnownSince returns HasSBOMInputSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetKnownSince() time.Time { return v.KnownSince }
+
 // GetOrigin returns HasSBOMInputSpec.Origin, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns HasSBOMInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
-// GetKnownSince returns HasSBOMInputSpec.KnownSince, and is useful for accessing the field via an interface.
-func (v *HasSBOMInputSpec) GetKnownSince() time.Time { return v.KnownSince }
+// GetDocumentRef returns HasSBOMInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *HasSBOMInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
 //
@@ -7860,9 +7922,10 @@ type HasSBOMSpec struct {
 	Algorithm            *string                 `json:"algorithm"`
 	Digest               *string                 `json:"digest"`
 	DownloadLocation     *string                 `json:"downloadLocation"`
+	KnownSince           *time.Time              `json:"knownSince"`
 	Origin               *string                 `json:"origin"`
 	Collector            *string                 `json:"collector"`
-	KnownSince           *time.Time              `json:"knownSince"`
+	DocumentRef          *string                 `json:"documentRef"`
 	IncludedSoftware     []PackageOrArtifactSpec `json:"includedSoftware"`
 	IncludedDependencies []IsDependencySpec      `json:"includedDependencies"`
 	IncludedOccurrences  []IsOccurrenceSpec      `json:"includedOccurrences"`
@@ -7886,14 +7949,17 @@ func (v *HasSBOMSpec) GetDigest() *string { return v.Digest }
 // GetDownloadLocation returns HasSBOMSpec.DownloadLocation, and is useful for accessing the field via an interface.
 func (v *HasSBOMSpec) GetDownloadLocation() *string { return v.DownloadLocation }
 
+// GetKnownSince returns HasSBOMSpec.KnownSince, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetKnownSince() *time.Time { return v.KnownSince }
+
 // GetOrigin returns HasSBOMSpec.Origin, and is useful for accessing the field via an interface.
 func (v *HasSBOMSpec) GetOrigin() *string { return v.Origin }
 
 // GetCollector returns HasSBOMSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasSBOMSpec) GetCollector() *string { return v.Collector }
 
-// GetKnownSince returns HasSBOMSpec.KnownSince, and is useful for accessing the field via an interface.
-func (v *HasSBOMSpec) GetKnownSince() *time.Time { return v.KnownSince }
+// GetDocumentRef returns HasSBOMSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *HasSBOMSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // GetIncludedSoftware returns HasSBOMSpec.IncludedSoftware, and is useful for accessing the field via an interface.
 func (v *HasSBOMSpec) GetIncludedSoftware() []PackageOrArtifactSpec { return v.IncludedSoftware }
@@ -8073,6 +8139,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetKnownSince returns HasSourceAtInputSpec.KnownSince, and is useful for accessing the field via an interface.
@@ -8087,11 +8154,15 @@ func (v *HasSourceAtInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns HasSourceAtInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns HasSourceAtInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *HasSourceAtInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns HashEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -8102,6 +8173,9 @@ func (v *HashEqualInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns HashEqualInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *HashEqualInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns HashEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *HashEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // IDorArtifactInput allows for specifying either the artifact ID or the ArtifactInputSpec.
 //
@@ -9043,6 +9117,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
+	DocumentRef    string         `json:"documentRef"`
 }
 
 // GetVersionRange returns IsDependencyInputSpec.VersionRange, and is useful for accessing the field via an interface.
@@ -9060,6 +9135,9 @@ func (v *IsDependencyInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns IsDependencyInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns IsDependencyInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *IsDependencyInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // IsDependencySpec allows filtering the list of dependencies to return.
 //
 // To obtain the list of dependency packages, caller must fill in the package
@@ -9075,6 +9153,7 @@ type IsDependencySpec struct {
 	Justification     *string         `json:"justification"`
 	Origin            *string         `json:"origin"`
 	Collector         *string         `json:"collector"`
+	DocumentRef       *string         `json:"documentRef"`
 }
 
 // GetId returns IsDependencySpec.Id, and is useful for accessing the field via an interface.
@@ -9101,11 +9180,15 @@ func (v *IsDependencySpec) GetOrigin() *string { return v.Origin }
 // GetCollector returns IsDependencySpec.Collector, and is useful for accessing the field via an interface.
 func (v *IsDependencySpec) GetCollector() *string { return v.Collector }
 
+// GetDocumentRef returns IsDependencySpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *IsDependencySpec) GetDocumentRef() *string { return v.DocumentRef }
+
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns IsOccurrenceInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -9117,6 +9200,9 @@ func (v *IsOccurrenceInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns IsOccurrenceInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *IsOccurrenceInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns IsOccurrenceInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
 // a query.
 type IsOccurrenceSpec struct {
@@ -9126,6 +9212,7 @@ type IsOccurrenceSpec struct {
 	Justification *string              `json:"justification"`
 	Origin        *string              `json:"origin"`
 	Collector     *string              `json:"collector"`
+	DocumentRef   *string              `json:"documentRef"`
 }
 
 // GetId returns IsOccurrenceSpec.Id, and is useful for accessing the field via an interface.
@@ -9145,6 +9232,9 @@ func (v *IsOccurrenceSpec) GetOrigin() *string { return v.Origin }
 
 // GetCollector returns IsOccurrenceSpec.Collector, and is useful for accessing the field via an interface.
 func (v *IsOccurrenceSpec) GetCollector() *string { return v.Collector }
+
+// GetDocumentRef returns IsOccurrenceSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *IsOccurrenceSpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // LicenseInputSpec specifies an license for mutations. One of inline or
 // listVersion should be empty or missing.
@@ -21764,6 +21854,7 @@ type PkgEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns PkgEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -21774,6 +21865,9 @@ func (v *PkgEqualInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns PkgEqualInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *PkgEqualInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns PkgEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *PkgEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // PkgInputSpec specifies a package for mutations.
 //
@@ -21873,6 +21967,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetEmail returns PointOfContactInputSpec.Email, and is useful for accessing the field via an interface.
@@ -21893,6 +21988,9 @@ func (v *PointOfContactInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns PointOfContactInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns PointOfContactInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *PointOfContactInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // SLSAInputSpec is the same as SLSA but for mutation input.
 type SLSAInputSpec struct {
 	BuildType     string                   `json:"buildType"`
@@ -21902,6 +22000,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time               `json:"finishedOn"`
 	Origin        string                   `json:"origin"`
 	Collector     string                   `json:"collector"`
+	DocumentRef   string                   `json:"documentRef"`
 }
 
 // GetBuildType returns SLSAInputSpec.BuildType, and is useful for accessing the field via an interface.
@@ -21925,6 +22024,9 @@ func (v *SLSAInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns SLSAInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *SLSAInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns SLSAInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *SLSAInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec.
 type SLSAPredicateInputSpec struct {
 	Key   string `json:"key"`
@@ -21947,6 +22049,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
+	DocumentRef    string    `json:"documentRef"`
 }
 
 // GetTimeScanned returns ScanMetadataInput.TimeScanned, and is useful for accessing the field via an interface.
@@ -21969,6 +22072,9 @@ func (v *ScanMetadataInput) GetOrigin() string { return v.Origin }
 
 // GetCollector returns ScanMetadataInput.Collector, and is useful for accessing the field via an interface.
 func (v *ScanMetadataInput) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns ScanMetadataInput.DocumentRef, and is useful for accessing the field via an interface.
+func (v *ScanMetadataInput) GetDocumentRef() string { return v.DocumentRef }
 
 // ScorecardCheckInputSpec represents the mutation input for a Scorecard check.
 type ScorecardCheckInputSpec struct {
@@ -22003,6 +22109,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                    `json:"scorecardCommit"`
 	Origin           string                    `json:"origin"`
 	Collector        string                    `json:"collector"`
+	DocumentRef      string                    `json:"documentRef"`
 }
 
 // GetChecks returns ScorecardInputSpec.Checks, and is useful for accessing the field via an interface.
@@ -22025,6 +22132,9 @@ func (v *ScorecardInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns ScorecardInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *ScorecardInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns ScorecardInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *ScorecardInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // ScorecardsResponse is returned by Scorecards on success.
 type ScorecardsResponse struct {
@@ -22284,6 +22394,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
+	DocumentRef      string           `json:"documentRef"`
 }
 
 // GetStatus returns VexStatementInputSpec.Status, and is useful for accessing the field via an interface.
@@ -22307,6 +22418,9 @@ func (v *VexStatementInputSpec) GetOrigin() string { return v.Origin }
 // GetCollector returns VexStatementInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *VexStatementInputSpec) GetCollector() string { return v.Collector }
 
+// GetDocumentRef returns VexStatementInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *VexStatementInputSpec) GetDocumentRef() string { return v.DocumentRef }
+
 // Records the status of a VEX statement subject.
 type VexStatus string
 
@@ -22322,6 +22436,7 @@ type VulnEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns VulnEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -22332,6 +22447,9 @@ func (v *VulnEqualInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns VulnEqualInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *VulnEqualInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns VulnEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *VulnEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // VulnerabilitiesResponse is returned by Vulnerabilities on success.
 type VulnerabilitiesResponse struct {
@@ -22458,11 +22576,12 @@ func (v *VulnerabilityInputSpec) GetVulnerabilityID() string { return v.Vulnerab
 
 // VulnerabilityMetadataInputSpec represents the mutation input to ingest a vulnerability metadata.
 type VulnerabilityMetadataInputSpec struct {
-	ScoreType  VulnerabilityScoreType `json:"scoreType"`
-	ScoreValue float64                `json:"scoreValue"`
-	Timestamp  time.Time              `json:"timestamp"`
-	Origin     string                 `json:"origin"`
-	Collector  string                 `json:"collector"`
+	ScoreType   VulnerabilityScoreType `json:"scoreType"`
+	ScoreValue  float64                `json:"scoreValue"`
+	Timestamp   time.Time              `json:"timestamp"`
+	Origin      string                 `json:"origin"`
+	Collector   string                 `json:"collector"`
+	DocumentRef string                 `json:"documentRef"`
 }
 
 // GetScoreType returns VulnerabilityMetadataInputSpec.ScoreType, and is useful for accessing the field via an interface.
@@ -22479,6 +22598,9 @@ func (v *VulnerabilityMetadataInputSpec) GetOrigin() string { return v.Origin }
 
 // GetCollector returns VulnerabilityMetadataInputSpec.Collector, and is useful for accessing the field via an interface.
 func (v *VulnerabilityMetadataInputSpec) GetCollector() string { return v.Collector }
+
+// GetDocumentRef returns VulnerabilityMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
+func (v *VulnerabilityMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // Records the type of the score being captured by the score node
 type VulnerabilityScoreType string

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -4641,12 +4641,14 @@ func (ec *executionContext) fieldContext_Query_CertifyBad(ctx context.Context, f
 				return ec.fieldContext_CertifyBad_subject(ctx, field)
 			case "justification":
 				return ec.fieldContext_CertifyBad_justification(ctx, field)
+			case "knownSince":
+				return ec.fieldContext_CertifyBad_knownSince(ctx, field)
 			case "origin":
 				return ec.fieldContext_CertifyBad_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_CertifyBad_collector(ctx, field)
-			case "knownSince":
-				return ec.fieldContext_CertifyBad_knownSince(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_CertifyBad_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CertifyBad", field.Name)
 		},
@@ -4707,12 +4709,14 @@ func (ec *executionContext) fieldContext_Query_CertifyGood(ctx context.Context, 
 				return ec.fieldContext_CertifyGood_subject(ctx, field)
 			case "justification":
 				return ec.fieldContext_CertifyGood_justification(ctx, field)
+			case "knownSince":
+				return ec.fieldContext_CertifyGood_knownSince(ctx, field)
 			case "origin":
 				return ec.fieldContext_CertifyGood_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_CertifyGood_collector(ctx, field)
-			case "knownSince":
-				return ec.fieldContext_CertifyGood_knownSince(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_CertifyGood_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CertifyGood", field.Name)
 		},
@@ -4789,6 +4793,8 @@ func (ec *executionContext) fieldContext_Query_CertifyLegal(ctx context.Context,
 				return ec.fieldContext_CertifyLegal_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_CertifyLegal_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_CertifyLegal_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CertifyLegal", field.Name)
 		},
@@ -4923,6 +4929,8 @@ func (ec *executionContext) fieldContext_Query_CertifyVEXStatement(ctx context.C
 				return ec.fieldContext_CertifyVEXStatement_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_CertifyVEXStatement_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_CertifyVEXStatement_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CertifyVEXStatement", field.Name)
 		},
@@ -5055,6 +5063,8 @@ func (ec *executionContext) fieldContext_Query_PointOfContact(ctx context.Contex
 				return ec.fieldContext_PointOfContact_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_PointOfContact_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_PointOfContact_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PointOfContact", field.Name)
 		},
@@ -5121,12 +5131,14 @@ func (ec *executionContext) fieldContext_Query_HasSBOM(ctx context.Context, fiel
 				return ec.fieldContext_HasSBOM_digest(ctx, field)
 			case "downloadLocation":
 				return ec.fieldContext_HasSBOM_downloadLocation(ctx, field)
+			case "knownSince":
+				return ec.fieldContext_HasSBOM_knownSince(ctx, field)
 			case "origin":
 				return ec.fieldContext_HasSBOM_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_HasSBOM_collector(ctx, field)
-			case "knownSince":
-				return ec.fieldContext_HasSBOM_knownSince(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_HasSBOM_documentRef(ctx, field)
 			case "includedSoftware":
 				return ec.fieldContext_HasSBOM_includedSoftware(ctx, field)
 			case "includedDependencies":
@@ -5261,6 +5273,8 @@ func (ec *executionContext) fieldContext_Query_HasSourceAt(ctx context.Context, 
 				return ec.fieldContext_HasSourceAt_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_HasSourceAt_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_HasSourceAt_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HasSourceAt", field.Name)
 		},
@@ -5325,6 +5339,8 @@ func (ec *executionContext) fieldContext_Query_HashEqual(ctx context.Context, fi
 				return ec.fieldContext_HashEqual_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_HashEqual_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_HashEqual_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HashEqual", field.Name)
 		},
@@ -5395,6 +5411,8 @@ func (ec *executionContext) fieldContext_Query_IsDependency(ctx context.Context,
 				return ec.fieldContext_IsDependency_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
 		},
@@ -5461,6 +5479,8 @@ func (ec *executionContext) fieldContext_Query_IsOccurrence(ctx context.Context,
 				return ec.fieldContext_IsOccurrence_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_IsOccurrence_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsOccurrence_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IsOccurrence", field.Name)
 		},
@@ -5593,6 +5613,8 @@ func (ec *executionContext) fieldContext_Query_HasMetadata(ctx context.Context, 
 				return ec.fieldContext_HasMetadata_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_HasMetadata_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_HasMetadata_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HasMetadata", field.Name)
 		},
@@ -5925,6 +5947,8 @@ func (ec *executionContext) fieldContext_Query_PkgEqual(ctx context.Context, fie
 				return ec.fieldContext_PkgEqual_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_PkgEqual_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_PkgEqual_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PkgEqual", field.Name)
 		},
@@ -6101,6 +6125,8 @@ func (ec *executionContext) fieldContext_Query_vulnEqual(ctx context.Context, fi
 				return ec.fieldContext_VulnEqual_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_VulnEqual_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_VulnEqual_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type VulnEqual", field.Name)
 		},
@@ -6169,6 +6195,8 @@ func (ec *executionContext) fieldContext_Query_vulnerabilityMetadata(ctx context
 				return ec.fieldContext_VulnerabilityMetadata_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_VulnerabilityMetadata_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_VulnerabilityMetadata_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type VulnerabilityMetadata", field.Name)
 		},

--- a/pkg/assembler/graphql/generated/certifyBad.generated.go
+++ b/pkg/assembler/graphql/generated/certifyBad.generated.go
@@ -153,6 +153,47 @@ func (ec *executionContext) fieldContext_CertifyBad_justification(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _CertifyBad_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.CertifyBad) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyBad_knownSince(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KnownSince, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CertifyBad_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CertifyBad",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CertifyBad_origin(ctx context.Context, field graphql.CollectedField, obj *model.CertifyBad) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CertifyBad_origin(ctx, field)
 	if err != nil {
@@ -235,8 +276,8 @@ func (ec *executionContext) fieldContext_CertifyBad_collector(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _CertifyBad_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.CertifyBad) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CertifyBad_knownSince(ctx, field)
+func (ec *executionContext) _CertifyBad_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.CertifyBad) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyBad_documentRef(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -249,7 +290,7 @@ func (ec *executionContext) _CertifyBad_knownSince(ctx context.Context, field gr
 	}()
 	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.KnownSince, nil
+		return obj.DocumentRef, nil
 	})
 
 	if resTmp == nil {
@@ -258,19 +299,19 @@ func (ec *executionContext) _CertifyBad_knownSince(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_CertifyBad_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_CertifyBad_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CertifyBad",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Time does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -287,7 +328,7 @@ func (ec *executionContext) unmarshalInputCertifyBadInputSpec(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector", "knownSince"}
+	fieldsInOrder := [...]string{"justification", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -301,6 +342,13 @@ func (ec *executionContext) unmarshalInputCertifyBadInputSpec(ctx context.Contex
 				return it, err
 			}
 			it.Justification = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -315,13 +363,13 @@ func (ec *executionContext) unmarshalInputCertifyBadInputSpec(ctx context.Contex
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		}
 	}
 
@@ -335,7 +383,7 @@ func (ec *executionContext) unmarshalInputCertifyBadSpec(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "justification", "origin", "collector", "knownSince"}
+	fieldsInOrder := [...]string{"id", "subject", "justification", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -363,6 +411,13 @@ func (ec *executionContext) unmarshalInputCertifyBadSpec(ctx context.Context, ob
 				return it, err
 			}
 			it.Justification = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -377,13 +432,13 @@ func (ec *executionContext) unmarshalInputCertifyBadSpec(ctx context.Context, ob
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		}
 	}
 
@@ -604,6 +659,11 @@ func (ec *executionContext) _CertifyBad(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "knownSince":
+			out.Values[i] = ec._CertifyBad_knownSince(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "origin":
 			out.Values[i] = ec._CertifyBad_origin(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -614,8 +674,8 @@ func (ec *executionContext) _CertifyBad(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "knownSince":
-			out.Values[i] = ec._CertifyBad_knownSince(ctx, field, obj)
+		case "documentRef":
+			out.Values[i] = ec._CertifyBad_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyBad.generated.go
+++ b/pkg/assembler/graphql/generated/certifyBad.generated.go
@@ -294,14 +294,11 @@ func (ec *executionContext) _CertifyBad_documentRef(ctx context.Context, field g
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyBad_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -365,7 +362,7 @@ func (ec *executionContext) unmarshalInputCertifyBadInputSpec(ctx context.Contex
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -676,9 +673,6 @@ func (ec *executionContext) _CertifyBad(ctx context.Context, sel ast.SelectionSe
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyBad_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyGood.generated.go
+++ b/pkg/assembler/graphql/generated/certifyGood.generated.go
@@ -152,6 +152,47 @@ func (ec *executionContext) fieldContext_CertifyGood_justification(ctx context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _CertifyGood_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.CertifyGood) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyGood_knownSince(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KnownSince, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CertifyGood_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CertifyGood",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CertifyGood_origin(ctx context.Context, field graphql.CollectedField, obj *model.CertifyGood) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CertifyGood_origin(ctx, field)
 	if err != nil {
@@ -234,8 +275,8 @@ func (ec *executionContext) fieldContext_CertifyGood_collector(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _CertifyGood_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.CertifyGood) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CertifyGood_knownSince(ctx, field)
+func (ec *executionContext) _CertifyGood_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.CertifyGood) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyGood_documentRef(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -248,7 +289,7 @@ func (ec *executionContext) _CertifyGood_knownSince(ctx context.Context, field g
 	}()
 	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.KnownSince, nil
+		return obj.DocumentRef, nil
 	})
 
 	if resTmp == nil {
@@ -257,19 +298,19 @@ func (ec *executionContext) _CertifyGood_knownSince(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_CertifyGood_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_CertifyGood_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "CertifyGood",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Time does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -286,7 +327,7 @@ func (ec *executionContext) unmarshalInputCertifyGoodInputSpec(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector", "knownSince"}
+	fieldsInOrder := [...]string{"justification", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -300,6 +341,13 @@ func (ec *executionContext) unmarshalInputCertifyGoodInputSpec(ctx context.Conte
 				return it, err
 			}
 			it.Justification = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -314,13 +362,13 @@ func (ec *executionContext) unmarshalInputCertifyGoodInputSpec(ctx context.Conte
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		}
 	}
 
@@ -334,7 +382,7 @@ func (ec *executionContext) unmarshalInputCertifyGoodSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "justification", "origin", "collector", "knownSince"}
+	fieldsInOrder := [...]string{"id", "subject", "justification", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -362,6 +410,13 @@ func (ec *executionContext) unmarshalInputCertifyGoodSpec(ctx context.Context, o
 				return it, err
 			}
 			it.Justification = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -376,13 +431,13 @@ func (ec *executionContext) unmarshalInputCertifyGoodSpec(ctx context.Context, o
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		}
 	}
 
@@ -423,6 +478,11 @@ func (ec *executionContext) _CertifyGood(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "knownSince":
+			out.Values[i] = ec._CertifyGood_knownSince(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "origin":
 			out.Values[i] = ec._CertifyGood_origin(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -433,8 +493,8 @@ func (ec *executionContext) _CertifyGood(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "knownSince":
-			out.Values[i] = ec._CertifyGood_knownSince(ctx, field, obj)
+		case "documentRef":
+			out.Values[i] = ec._CertifyGood_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyGood.generated.go
+++ b/pkg/assembler/graphql/generated/certifyGood.generated.go
@@ -293,14 +293,11 @@ func (ec *executionContext) _CertifyGood_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyGood_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -364,7 +361,7 @@ func (ec *executionContext) unmarshalInputCertifyGoodInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -495,9 +492,6 @@ func (ec *executionContext) _CertifyGood(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyGood_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyLegal.generated.go
+++ b/pkg/assembler/graphql/generated/certifyLegal.generated.go
@@ -519,14 +519,11 @@ func (ec *executionContext) _CertifyLegal_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyLegal_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -802,9 +799,6 @@ func (ec *executionContext) _CertifyLegal(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyLegal_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyLegal.generated.go
+++ b/pkg/assembler/graphql/generated/certifyLegal.generated.go
@@ -501,6 +501,47 @@ func (ec *executionContext) fieldContext_CertifyLegal_collector(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _CertifyLegal_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.CertifyLegal) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyLegal_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CertifyLegal_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CertifyLegal",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -512,7 +553,7 @@ func (ec *executionContext) unmarshalInputCertifyLegalInputSpec(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"declaredLicense", "discoveredLicense", "attribution", "justification", "timeScanned", "origin", "collector"}
+	fieldsInOrder := [...]string{"declaredLicense", "discoveredLicense", "attribution", "justification", "timeScanned", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -568,6 +609,13 @@ func (ec *executionContext) unmarshalInputCertifyLegalInputSpec(ctx context.Cont
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -581,7 +629,7 @@ func (ec *executionContext) unmarshalInputCertifyLegalSpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -665,6 +713,13 @@ func (ec *executionContext) unmarshalInputCertifyLegalSpec(ctx context.Context, 
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -742,6 +797,11 @@ func (ec *executionContext) _CertifyLegal(ctx context.Context, sel ast.Selection
 			}
 		case "collector":
 			out.Values[i] = ec._CertifyLegal_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._CertifyLegal_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -490,14 +490,11 @@ func (ec *executionContext) _Scorecard_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Scorecard_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -826,7 +823,7 @@ func (ec *executionContext) unmarshalInputScorecardInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -942,9 +939,6 @@ func (ec *executionContext) _Scorecard(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._Scorecard_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -170,6 +170,8 @@ func (ec *executionContext) fieldContext_CertifyScorecard_scorecard(ctx context.
 				return ec.fieldContext_Scorecard_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_Scorecard_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_Scorecard_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Scorecard", field.Name)
 		},
@@ -470,6 +472,47 @@ func (ec *executionContext) fieldContext_Scorecard_collector(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Scorecard_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.Scorecard) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Scorecard_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Scorecard_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Scorecard",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ScorecardCheck_check(ctx context.Context, field graphql.CollectedField, obj *model.ScorecardCheck) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ScorecardCheck_check(ctx, field)
 	if err != nil {
@@ -567,7 +610,7 @@ func (ec *executionContext) unmarshalInputCertifyScorecardSpec(ctx context.Conte
 		asMap["checks"] = []interface{}{}
 	}
 
-	fieldsInOrder := [...]string{"id", "source", "timeScanned", "aggregateScore", "checks", "scorecardVersion", "scorecardCommit", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "source", "timeScanned", "aggregateScore", "checks", "scorecardVersion", "scorecardCommit", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -637,6 +680,13 @@ func (ec *executionContext) unmarshalInputCertifyScorecardSpec(ctx context.Conte
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -718,7 +768,7 @@ func (ec *executionContext) unmarshalInputScorecardInputSpec(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"checks", "aggregateScore", "timeScanned", "scorecardVersion", "scorecardCommit", "origin", "collector"}
+	fieldsInOrder := [...]string{"checks", "aggregateScore", "timeScanned", "scorecardVersion", "scorecardCommit", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -774,6 +824,13 @@ func (ec *executionContext) unmarshalInputScorecardInputSpec(ctx context.Context
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -880,6 +937,11 @@ func (ec *executionContext) _Scorecard(ctx context.Context, sel ast.SelectionSet
 			}
 		case "collector":
 			out.Values[i] = ec._Scorecard_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._Scorecard_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -448,6 +448,47 @@ func (ec *executionContext) fieldContext_CertifyVEXStatement_collector(ctx conte
 	return fc, nil
 }
 
+func (ec *executionContext) _CertifyVEXStatement_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.CertifyVEXStatement) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CertifyVEXStatement_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CertifyVEXStatement_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CertifyVEXStatement",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -459,7 +500,7 @@ func (ec *executionContext) unmarshalInputCertifyVEXStatementSpec(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "vulnerability", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "vulnerability", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -536,6 +577,13 @@ func (ec *executionContext) unmarshalInputCertifyVEXStatementSpec(ctx context.Co
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -651,7 +699,7 @@ func (ec *executionContext) unmarshalInputVexStatementInputSpec(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", "collector"}
+	fieldsInOrder := [...]string{"status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -707,6 +755,13 @@ func (ec *executionContext) unmarshalInputVexStatementInputSpec(ctx context.Cont
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -802,6 +857,11 @@ func (ec *executionContext) _CertifyVEXStatement(ctx context.Context, sel ast.Se
 			}
 		case "collector":
 			out.Values[i] = ec._CertifyVEXStatement_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._CertifyVEXStatement_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -466,14 +466,11 @@ func (ec *executionContext) _CertifyVEXStatement_documentRef(ctx context.Context
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyVEXStatement_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -757,7 +754,7 @@ func (ec *executionContext) unmarshalInputVexStatementInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -862,9 +859,6 @@ func (ec *executionContext) _CertifyVEXStatement(ctx context.Context, sel ast.Se
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyVEXStatement_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -219,6 +219,8 @@ func (ec *executionContext) fieldContext_CertifyVuln_metadata(ctx context.Contex
 				return ec.fieldContext_ScanMetadata_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_ScanMetadata_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_ScanMetadata_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ScanMetadata", field.Name)
 		},
@@ -513,6 +515,47 @@ func (ec *executionContext) fieldContext_ScanMetadata_collector(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _ScanMetadata_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.ScanMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ScanMetadata_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ScanMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ScanMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -524,7 +567,7 @@ func (ec *executionContext) unmarshalInputCertifyVulnSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "package", "vulnerability", "timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "package", "vulnerability", "timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -601,6 +644,13 @@ func (ec *executionContext) unmarshalInputCertifyVulnSpec(ctx context.Context, o
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -614,7 +664,7 @@ func (ec *executionContext) unmarshalInputScanMetadataInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector"}
+	fieldsInOrder := [...]string{"timeScanned", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -670,6 +720,13 @@ func (ec *executionContext) unmarshalInputScanMetadataInput(ctx context.Context,
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -781,6 +838,11 @@ func (ec *executionContext) _ScanMetadata(ctx context.Context, sel ast.Selection
 			}
 		case "collector":
 			out.Values[i] = ec._ScanMetadata_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._ScanMetadata_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -533,14 +533,11 @@ func (ec *executionContext) _ScanMetadata_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ScanMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -722,7 +719,7 @@ func (ec *executionContext) unmarshalInputScanMetadataInput(ctx context.Context,
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -843,9 +840,6 @@ func (ec *executionContext) _ScanMetadata(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._ScanMetadata_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/contact.generated.go
+++ b/pkg/assembler/graphql/generated/contact.generated.go
@@ -375,14 +375,11 @@ func (ec *executionContext) _PointOfContact_documentRef(ctx context.Context, fie
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PointOfContact_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -460,7 +457,7 @@ func (ec *executionContext) unmarshalInputPointOfContactInputSpec(ctx context.Co
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -615,9 +612,6 @@ func (ec *executionContext) _PointOfContact(ctx context.Context, sel ast.Selecti
 			}
 		case "documentRef":
 			out.Values[i] = ec._PointOfContact_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/contact.generated.go
+++ b/pkg/assembler/graphql/generated/contact.generated.go
@@ -357,6 +357,47 @@ func (ec *executionContext) fieldContext_PointOfContact_collector(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _PointOfContact_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.PointOfContact) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PointOfContact_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PointOfContact_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PointOfContact",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -368,7 +409,7 @@ func (ec *executionContext) unmarshalInputPointOfContactInputSpec(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email", "info", "since", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"email", "info", "since", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -417,6 +458,13 @@ func (ec *executionContext) unmarshalInputPointOfContactInputSpec(ctx context.Co
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -430,7 +478,7 @@ func (ec *executionContext) unmarshalInputPointOfContactSpec(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "email", "info", "since", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "email", "info", "since", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -493,6 +541,13 @@ func (ec *executionContext) unmarshalInputPointOfContactSpec(ctx context.Context
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -555,6 +610,11 @@ func (ec *executionContext) _PointOfContact(ctx context.Context, sel ast.Selecti
 			}
 		case "collector":
 			out.Values[i] = ec._PointOfContact_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._PointOfContact_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -276,6 +276,47 @@ func (ec *executionContext) fieldContext_HasSBOM_downloadLocation(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _HasSBOM_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_knownSince(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KnownSince, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSBOM_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSBOM",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HasSBOM_origin(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HasSBOM_origin(ctx, field)
 	if err != nil {
@@ -358,8 +399,8 @@ func (ec *executionContext) fieldContext_HasSBOM_collector(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _HasSBOM_knownSince(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_HasSBOM_knownSince(ctx, field)
+func (ec *executionContext) _HasSBOM_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.HasSbom) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSBOM_documentRef(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -372,7 +413,7 @@ func (ec *executionContext) _HasSBOM_knownSince(ctx context.Context, field graph
 	}()
 	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.KnownSince, nil
+		return obj.DocumentRef, nil
 	})
 
 	if resTmp == nil {
@@ -381,19 +422,19 @@ func (ec *executionContext) _HasSBOM_knownSince(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_HasSBOM_knownSince(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_HasSBOM_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HasSBOM",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Time does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -492,6 +533,8 @@ func (ec *executionContext) fieldContext_HasSBOM_includedDependencies(ctx contex
 				return ec.fieldContext_IsDependency_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
 		},
@@ -547,6 +590,8 @@ func (ec *executionContext) fieldContext_HasSBOM_includedOccurrences(ctx context
 				return ec.fieldContext_IsOccurrence_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_IsOccurrence_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsOccurrence_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IsOccurrence", field.Name)
 		},
@@ -613,7 +658,7 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"uri", "algorithm", "digest", "downloadLocation", "origin", "collector", "knownSince"}
+	fieldsInOrder := [...]string{"uri", "algorithm", "digest", "downloadLocation", "knownSince", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -648,6 +693,13 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 				return it, err
 			}
 			it.DownloadLocation = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -662,13 +714,13 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		}
 	}
 
@@ -682,7 +734,7 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "uri", "algorithm", "digest", "downloadLocation", "origin", "collector", "knownSince", "includedSoftware", "includedDependencies", "includedOccurrences"}
+	fieldsInOrder := [...]string{"id", "subject", "uri", "algorithm", "digest", "downloadLocation", "knownSince", "origin", "collector", "documentRef", "includedSoftware", "includedDependencies", "includedOccurrences"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -731,6 +783,13 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 				return it, err
 			}
 			it.DownloadLocation = data
+		case "knownSince":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.KnownSince = data
 		case "origin":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("origin"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -745,13 +804,13 @@ func (ec *executionContext) unmarshalInputHasSBOMSpec(ctx context.Context, obj i
 				return it, err
 			}
 			it.Collector = data
-		case "knownSince":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("knownSince"))
-			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.KnownSince = data
+			it.DocumentRef = data
 		case "includedSoftware":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includedSoftware"))
 			data, err := ec.unmarshalOPackageOrArtifactSpec2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPackageOrArtifactSpecᚄ(ctx, v)
@@ -828,6 +887,11 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "knownSince":
+			out.Values[i] = ec._HasSBOM_knownSince(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "origin":
 			out.Values[i] = ec._HasSBOM_origin(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -838,8 +902,8 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "knownSince":
-			out.Values[i] = ec._HasSBOM_knownSince(ctx, field, obj)
+		case "documentRef":
+			out.Values[i] = ec._HasSBOM_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -417,14 +417,11 @@ func (ec *executionContext) _HasSBOM_documentRef(ctx context.Context, field grap
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSBOM_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -716,7 +713,7 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -904,9 +901,6 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasSBOM_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "includedSoftware":
 			out.Values[i] = ec._HasSBOM_includedSoftware(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -174,6 +174,8 @@ func (ec *executionContext) fieldContext_HasSLSA_slsa(ctx context.Context, field
 				return ec.fieldContext_SLSA_origin(ctx, field)
 			case "collector":
 				return ec.fieldContext_SLSA_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_SLSA_documentRef(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SLSA", field.Name)
 		},
@@ -564,6 +566,47 @@ func (ec *executionContext) fieldContext_SLSA_collector(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _SLSA_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.Slsa) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SLSA_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SLSA_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SLSA",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SLSAPredicate_key(ctx context.Context, field graphql.CollectedField, obj *model.SLSAPredicate) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SLSAPredicate_key(ctx, field)
 	if err != nil {
@@ -661,7 +704,7 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 		asMap["predicate"] = []interface{}{}
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "builtFrom", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "builtFrom", "builtBy", "buildType", "predicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -745,6 +788,13 @@ func (ec *executionContext) unmarshalInputHasSLSASpec(ctx context.Context, obj i
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -758,7 +808,7 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"buildType", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector"}
+	fieldsInOrder := [...]string{"buildType", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -814,6 +864,13 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -992,6 +1049,11 @@ func (ec *executionContext) _SLSA(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "collector":
 			out.Values[i] = ec._SLSA_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._SLSA_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -584,14 +584,11 @@ func (ec *executionContext) _SLSA_documentRef(ctx context.Context, field graphql
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SLSA_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -866,7 +863,7 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1054,9 +1051,6 @@ func (ec *executionContext) _SLSA(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "documentRef":
 			out.Values[i] = ec._SLSA_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -333,6 +333,47 @@ func (ec *executionContext) fieldContext_HasSourceAt_collector(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _HasSourceAt_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.HasSourceAt) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasSourceAt_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasSourceAt_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasSourceAt",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -344,7 +385,7 @@ func (ec *executionContext) unmarshalInputHasSourceAtInputSpec(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"knownSince", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"knownSince", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -379,6 +420,13 @@ func (ec *executionContext) unmarshalInputHasSourceAtInputSpec(ctx context.Conte
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -392,7 +440,7 @@ func (ec *executionContext) unmarshalInputHasSourceAtSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "package", "source", "knownSince", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "package", "source", "knownSince", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -448,6 +496,13 @@ func (ec *executionContext) unmarshalInputHasSourceAtSpec(ctx context.Context, o
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -505,6 +560,11 @@ func (ec *executionContext) _HasSourceAt(ctx context.Context, sel ast.SelectionS
 			}
 		case "collector":
 			out.Values[i] = ec._HasSourceAt_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._HasSourceAt_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -351,14 +351,11 @@ func (ec *executionContext) _HasSourceAt_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSourceAt_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -422,7 +419,7 @@ func (ec *executionContext) unmarshalInputHasSourceAtInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -565,9 +562,6 @@ func (ec *executionContext) _HasSourceAt(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasSourceAt_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/hashEqual.generated.go
+++ b/pkg/assembler/graphql/generated/hashEqual.generated.go
@@ -242,6 +242,47 @@ func (ec *executionContext) fieldContext_HashEqual_collector(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _HashEqual_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.HashEqual) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HashEqual_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HashEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HashEqual",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -253,7 +294,7 @@ func (ec *executionContext) unmarshalInputHashEqualInputSpec(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -281,6 +322,13 @@ func (ec *executionContext) unmarshalInputHashEqualInputSpec(ctx context.Context
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -294,7 +342,7 @@ func (ec *executionContext) unmarshalInputHashEqualSpec(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "artifacts", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "artifacts", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -336,6 +384,13 @@ func (ec *executionContext) unmarshalInputHashEqualSpec(ctx context.Context, obj
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -383,6 +438,11 @@ func (ec *executionContext) _HashEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "collector":
 			out.Values[i] = ec._HashEqual_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._HashEqual_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/hashEqual.generated.go
+++ b/pkg/assembler/graphql/generated/hashEqual.generated.go
@@ -260,14 +260,11 @@ func (ec *executionContext) _HashEqual_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HashEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -324,7 +321,7 @@ func (ec *executionContext) unmarshalInputHashEqualInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -443,9 +440,6 @@ func (ec *executionContext) _HashEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._HashEqual_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -391,14 +391,11 @@ func (ec *executionContext) _IsDependency_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_IsDependency_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -469,7 +466,7 @@ func (ec *executionContext) unmarshalInputIsDependencyInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -624,9 +621,6 @@ func (ec *executionContext) _IsDependency(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._IsDependency_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -373,6 +373,47 @@ func (ec *executionContext) fieldContext_IsDependency_collector(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _IsDependency_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.IsDependency) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IsDependency_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IsDependency_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IsDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -384,7 +425,7 @@ func (ec *executionContext) unmarshalInputIsDependencyInputSpec(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"versionRange", "dependencyType", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"versionRange", "dependencyType", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -426,6 +467,13 @@ func (ec *executionContext) unmarshalInputIsDependencyInputSpec(ctx context.Cont
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -439,7 +487,7 @@ func (ec *executionContext) unmarshalInputIsDependencySpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "package", "dependencyPackage", "versionRange", "dependencyType", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "package", "dependencyPackage", "versionRange", "dependencyType", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -502,6 +550,13 @@ func (ec *executionContext) unmarshalInputIsDependencySpec(ctx context.Context, 
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -564,6 +619,11 @@ func (ec *executionContext) _IsDependency(ctx context.Context, sel ast.Selection
 			}
 		case "collector":
 			out.Values[i] = ec._IsDependency_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._IsDependency_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -301,14 +301,11 @@ func (ec *executionContext) _IsOccurrence_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_IsOccurrence_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -365,7 +362,7 @@ func (ec *executionContext) unmarshalInputIsOccurrenceInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -621,9 +618,6 @@ func (ec *executionContext) _IsOccurrence(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._IsOccurrence_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -283,6 +283,47 @@ func (ec *executionContext) fieldContext_IsOccurrence_collector(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _IsOccurrence_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.IsOccurrence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IsOccurrence_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IsOccurrence_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IsOccurrence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -294,7 +335,7 @@ func (ec *executionContext) unmarshalInputIsOccurrenceInputSpec(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -322,6 +363,13 @@ func (ec *executionContext) unmarshalInputIsOccurrenceInputSpec(ctx context.Cont
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -335,7 +383,7 @@ func (ec *executionContext) unmarshalInputIsOccurrenceSpec(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "artifact", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "artifact", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -384,6 +432,13 @@ func (ec *executionContext) unmarshalInputIsOccurrenceSpec(ctx context.Context, 
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -561,6 +616,11 @@ func (ec *executionContext) _IsOccurrence(ctx context.Context, sel ast.Selection
 			}
 		case "collector":
 			out.Values[i] = ec._IsOccurrence_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._IsOccurrence_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/metadata.generated.go
+++ b/pkg/assembler/graphql/generated/metadata.generated.go
@@ -375,14 +375,11 @@ func (ec *executionContext) _HasMetadata_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -460,7 +457,7 @@ func (ec *executionContext) unmarshalInputHasMetadataInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -615,9 +612,6 @@ func (ec *executionContext) _HasMetadata(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasMetadata_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/metadata.generated.go
+++ b/pkg/assembler/graphql/generated/metadata.generated.go
@@ -357,6 +357,47 @@ func (ec *executionContext) fieldContext_HasMetadata_collector(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _HasMetadata_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.HasMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HasMetadata_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HasMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HasMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -368,7 +409,7 @@ func (ec *executionContext) unmarshalInputHasMetadataInputSpec(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"key", "value", "timestamp", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"key", "value", "timestamp", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -417,6 +458,13 @@ func (ec *executionContext) unmarshalInputHasMetadataInputSpec(ctx context.Conte
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -430,7 +478,7 @@ func (ec *executionContext) unmarshalInputHasMetadataSpec(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "subject", "since", "key", "value", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "subject", "since", "key", "value", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -493,6 +541,13 @@ func (ec *executionContext) unmarshalInputHasMetadataSpec(ctx context.Context, o
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -555,6 +610,11 @@ func (ec *executionContext) _HasMetadata(ctx context.Context, sel ast.SelectionS
 			}
 		case "collector":
 			out.Values[i] = ec._HasMetadata_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._HasMetadata_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/pkgEqual.generated.go
+++ b/pkg/assembler/graphql/generated/pkgEqual.generated.go
@@ -260,14 +260,11 @@ func (ec *executionContext) _PkgEqual_documentRef(ctx context.Context, field gra
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PkgEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -324,7 +321,7 @@ func (ec *executionContext) unmarshalInputPkgEqualInputSpec(ctx context.Context,
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -443,9 +440,6 @@ func (ec *executionContext) _PkgEqual(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "documentRef":
 			out.Values[i] = ec._PkgEqual_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/pkgEqual.generated.go
+++ b/pkg/assembler/graphql/generated/pkgEqual.generated.go
@@ -242,6 +242,47 @@ func (ec *executionContext) fieldContext_PkgEqual_collector(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _PkgEqual_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.PkgEqual) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PkgEqual_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PkgEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PkgEqual",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -253,7 +294,7 @@ func (ec *executionContext) unmarshalInputPkgEqualInputSpec(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -281,6 +322,13 @@ func (ec *executionContext) unmarshalInputPkgEqualInputSpec(ctx context.Context,
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -294,7 +342,7 @@ func (ec *executionContext) unmarshalInputPkgEqualSpec(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "packages", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "packages", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -336,6 +384,13 @@ func (ec *executionContext) unmarshalInputPkgEqualSpec(ctx context.Context, obj 
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -383,6 +438,11 @@ func (ec *executionContext) _PkgEqual(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "collector":
 			out.Values[i] = ec._PkgEqual_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._PkgEqual_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -56,6 +56,7 @@ type ComplexityRoot struct {
 
 	CertifyBad struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		KnownSince    func(childComplexity int) int
@@ -65,6 +66,7 @@ type ComplexityRoot struct {
 
 	CertifyGood struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		KnownSince    func(childComplexity int) int
@@ -79,6 +81,7 @@ type ComplexityRoot struct {
 		DeclaredLicenses   func(childComplexity int) int
 		DiscoveredLicense  func(childComplexity int) int
 		DiscoveredLicenses func(childComplexity int) int
+		DocumentRef        func(childComplexity int) int
 		ID                 func(childComplexity int) int
 		Justification      func(childComplexity int) int
 		Origin             func(childComplexity int) int
@@ -94,6 +97,7 @@ type ComplexityRoot struct {
 
 	CertifyVEXStatement struct {
 		Collector        func(childComplexity int) int
+		DocumentRef      func(childComplexity int) int
 		ID               func(childComplexity int) int
 		KnownSince       func(childComplexity int) int
 		Origin           func(childComplexity int) int
@@ -114,6 +118,7 @@ type ComplexityRoot struct {
 
 	HasMetadata struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Key           func(childComplexity int) int
@@ -127,6 +132,7 @@ type ComplexityRoot struct {
 		Algorithm            func(childComplexity int) int
 		Collector            func(childComplexity int) int
 		Digest               func(childComplexity int) int
+		DocumentRef          func(childComplexity int) int
 		DownloadLocation     func(childComplexity int) int
 		ID                   func(childComplexity int) int
 		IncludedDependencies func(childComplexity int) int
@@ -146,6 +152,7 @@ type ComplexityRoot struct {
 
 	HasSourceAt struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		KnownSince    func(childComplexity int) int
@@ -157,6 +164,7 @@ type ComplexityRoot struct {
 	HashEqual struct {
 		Artifacts     func(childComplexity int) int
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
@@ -166,6 +174,7 @@ type ComplexityRoot struct {
 		Collector         func(childComplexity int) int
 		DependencyPackage func(childComplexity int) int
 		DependencyType    func(childComplexity int) int
+		DocumentRef       func(childComplexity int) int
 		ID                func(childComplexity int) int
 		Justification     func(childComplexity int) int
 		Origin            func(childComplexity int) int
@@ -176,6 +185,7 @@ type ComplexityRoot struct {
 	IsOccurrence struct {
 		Artifact      func(childComplexity int) int
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
@@ -278,6 +288,7 @@ type ComplexityRoot struct {
 
 	PkgEqual struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Justification func(childComplexity int) int
 		Origin        func(childComplexity int) int
@@ -286,6 +297,7 @@ type ComplexityRoot struct {
 
 	PointOfContact struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		Email         func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Info          func(childComplexity int) int
@@ -331,6 +343,7 @@ type ComplexityRoot struct {
 		BuiltBy       func(childComplexity int) int
 		BuiltFrom     func(childComplexity int) int
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		FinishedOn    func(childComplexity int) int
 		Origin        func(childComplexity int) int
 		SlsaPredicate func(childComplexity int) int
@@ -347,6 +360,7 @@ type ComplexityRoot struct {
 		Collector      func(childComplexity int) int
 		DbURI          func(childComplexity int) int
 		DbVersion      func(childComplexity int) int
+		DocumentRef    func(childComplexity int) int
 		Origin         func(childComplexity int) int
 		ScannerURI     func(childComplexity int) int
 		ScannerVersion func(childComplexity int) int
@@ -357,6 +371,7 @@ type ComplexityRoot struct {
 		AggregateScore   func(childComplexity int) int
 		Checks           func(childComplexity int) int
 		Collector        func(childComplexity int) int
+		DocumentRef      func(childComplexity int) int
 		Origin           func(childComplexity int) int
 		ScorecardCommit  func(childComplexity int) int
 		ScorecardVersion func(childComplexity int) int
@@ -395,6 +410,7 @@ type ComplexityRoot struct {
 
 	VulnEqual struct {
 		Collector       func(childComplexity int) int
+		DocumentRef     func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Justification   func(childComplexity int) int
 		Origin          func(childComplexity int) int
@@ -419,6 +435,7 @@ type ComplexityRoot struct {
 
 	VulnerabilityMetadata struct {
 		Collector     func(childComplexity int) int
+		DocumentRef   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		Origin        func(childComplexity int) int
 		ScoreType     func(childComplexity int) int
@@ -489,6 +506,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CertifyBad.Collector(childComplexity), true
 
+	case "CertifyBad.documentRef":
+		if e.complexity.CertifyBad.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.CertifyBad.DocumentRef(childComplexity), true
+
 	case "CertifyBad.id":
 		if e.complexity.CertifyBad.ID == nil {
 			break
@@ -530,6 +554,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CertifyGood.Collector(childComplexity), true
+
+	case "CertifyGood.documentRef":
+		if e.complexity.CertifyGood.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.CertifyGood.DocumentRef(childComplexity), true
 
 	case "CertifyGood.id":
 		if e.complexity.CertifyGood.ID == nil {
@@ -608,6 +639,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CertifyLegal.DiscoveredLicenses(childComplexity), true
 
+	case "CertifyLegal.documentRef":
+		if e.complexity.CertifyLegal.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.CertifyLegal.DocumentRef(childComplexity), true
+
 	case "CertifyLegal.id":
 		if e.complexity.CertifyLegal.ID == nil {
 			break
@@ -670,6 +708,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CertifyVEXStatement.Collector(childComplexity), true
+
+	case "CertifyVEXStatement.documentRef":
+		if e.complexity.CertifyVEXStatement.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.CertifyVEXStatement.DocumentRef(childComplexity), true
 
 	case "CertifyVEXStatement.id":
 		if e.complexity.CertifyVEXStatement.ID == nil {
@@ -769,6 +814,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.HasMetadata.Collector(childComplexity), true
 
+	case "HasMetadata.documentRef":
+		if e.complexity.HasMetadata.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.HasMetadata.DocumentRef(childComplexity), true
+
 	case "HasMetadata.id":
 		if e.complexity.HasMetadata.ID == nil {
 			break
@@ -838,6 +890,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.HasSBOM.Digest(childComplexity), true
+
+	case "HasSBOM.documentRef":
+		if e.complexity.HasSBOM.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.HasSBOM.DocumentRef(childComplexity), true
 
 	case "HasSBOM.downloadLocation":
 		if e.complexity.HasSBOM.DownloadLocation == nil {
@@ -930,6 +989,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.HasSourceAt.Collector(childComplexity), true
 
+	case "HasSourceAt.documentRef":
+		if e.complexity.HasSourceAt.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.HasSourceAt.DocumentRef(childComplexity), true
+
 	case "HasSourceAt.id":
 		if e.complexity.HasSourceAt.ID == nil {
 			break
@@ -986,6 +1052,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.HashEqual.Collector(childComplexity), true
 
+	case "HashEqual.documentRef":
+		if e.complexity.HashEqual.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.HashEqual.DocumentRef(childComplexity), true
+
 	case "HashEqual.id":
 		if e.complexity.HashEqual.ID == nil {
 			break
@@ -1027,6 +1100,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IsDependency.DependencyType(childComplexity), true
+
+	case "IsDependency.documentRef":
+		if e.complexity.IsDependency.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.IsDependency.DocumentRef(childComplexity), true
 
 	case "IsDependency.id":
 		if e.complexity.IsDependency.ID == nil {
@@ -1076,6 +1156,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IsOccurrence.Collector(childComplexity), true
+
+	case "IsOccurrence.documentRef":
+		if e.complexity.IsOccurrence.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.IsOccurrence.DocumentRef(childComplexity), true
 
 	case "IsOccurrence.id":
 		if e.complexity.IsOccurrence.ID == nil {
@@ -1832,6 +1919,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PkgEqual.Collector(childComplexity), true
 
+	case "PkgEqual.documentRef":
+		if e.complexity.PkgEqual.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.PkgEqual.DocumentRef(childComplexity), true
+
 	case "PkgEqual.id":
 		if e.complexity.PkgEqual.ID == nil {
 			break
@@ -1866,6 +1960,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PointOfContact.Collector(childComplexity), true
+
+	case "PointOfContact.documentRef":
+		if e.complexity.PointOfContact.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.PointOfContact.DocumentRef(childComplexity), true
 
 	case "PointOfContact.email":
 		if e.complexity.PointOfContact.Email == nil {
@@ -2280,6 +2381,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SLSA.Collector(childComplexity), true
 
+	case "SLSA.documentRef":
+		if e.complexity.SLSA.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.SLSA.DocumentRef(childComplexity), true
+
 	case "SLSA.finishedOn":
 		if e.complexity.SLSA.FinishedOn == nil {
 			break
@@ -2350,6 +2458,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ScanMetadata.DbVersion(childComplexity), true
 
+	case "ScanMetadata.documentRef":
+		if e.complexity.ScanMetadata.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.ScanMetadata.DocumentRef(childComplexity), true
+
 	case "ScanMetadata.origin":
 		if e.complexity.ScanMetadata.Origin == nil {
 			break
@@ -2398,6 +2513,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Scorecard.Collector(childComplexity), true
+
+	case "Scorecard.documentRef":
+		if e.complexity.Scorecard.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.Scorecard.DocumentRef(childComplexity), true
 
 	case "Scorecard.origin":
 		if e.complexity.Scorecard.Origin == nil {
@@ -2539,6 +2661,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.VulnEqual.Collector(childComplexity), true
 
+	case "VulnEqual.documentRef":
+		if e.complexity.VulnEqual.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.VulnEqual.DocumentRef(childComplexity), true
+
 	case "VulnEqual.id":
 		if e.complexity.VulnEqual.ID == nil {
 			break
@@ -2622,6 +2751,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.VulnerabilityMetadata.Collector(childComplexity), true
+
+	case "VulnerabilityMetadata.documentRef":
+		if e.complexity.VulnerabilityMetadata.DocumentRef == nil {
+			break
+		}
+
+		return e.complexity.VulnerabilityMetadata.DocumentRef(childComplexity), true
 
 	case "VulnerabilityMetadata.id":
 		if e.complexity.VulnerabilityMetadata.ID == nil {
@@ -3055,11 +3191,18 @@ SourceName.
 """
 type CertifyBad {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "The justification for the subject being certified bad"
   justification: String!
-  origin: String!
-  collector: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   knownSince: Time!
+  "Document from which this attestation is generated from"
+  origin: String!
+  "GUAC collector for the document"
+  collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3080,9 +3223,10 @@ input CertifyBadSpec {
   id: ID
   subject: PackageSourceOrArtifactSpec
   justification: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
 }
 
 """
@@ -3091,9 +3235,10 @@ evidence.
 """
 input CertifyBadInputSpec {
   justification: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 """
@@ -3164,11 +3309,18 @@ SourceName.
 """
 type CertifyGood {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "The justification for the subject being certified good"
   justification: String!
-  origin: String!
-  collector: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   knownSince: Time!
+  "Document from which this attestation is generated from"
+  origin: String!
+  "GUAC collector for the document"
+  collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3189,9 +3341,10 @@ input CertifyGoodSpec {
   id: ID
   subject: PackageSourceOrArtifactSpec
   justification: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
 }
 
 """
@@ -3199,9 +3352,10 @@ CertifyGoodInputSpec represents the mutation input to ingest a CertifyGood evide
 """
 input CertifyGoodInputSpec {
   justification: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 extend type Query {
@@ -3281,6 +3435,8 @@ type CertifyLegal {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3302,6 +3458,7 @@ input CertifyLegalSpec {
   timeScanned: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -3316,6 +3473,7 @@ input CertifyLegalInputSpec {
   timeScanned: Time!
   origin: String!
   collector: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -3392,6 +3550,8 @@ type Scorecard {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3426,6 +3586,7 @@ input CertifyScorecardSpec {
   scorecardCommit: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input."
@@ -3443,6 +3604,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."
@@ -3561,6 +3723,8 @@ type CertifyVEXStatement {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3582,6 +3746,7 @@ input CertifyVEXStatementSpec {
   knownSince: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 "VexStatementInputSpec represents the input to ingest VEX statements."
@@ -3593,6 +3758,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -3673,6 +3839,8 @@ type ScanMetadata {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3696,6 +3864,7 @@ input CertifyVulnSpec {
   scannerVersion: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -3710,6 +3879,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -3774,13 +3944,22 @@ reference to the contact details.
 """
 type PointOfContact {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "Email for the POC"
   email: String!
+  "Generic info for the POC"
   info: String!
+  "Timestamp when the certification for POC was created (in RFC 3339 format)"
   since: Time!
+  "The justification for the POC attestation"
   justification: String!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -3805,6 +3984,7 @@ input PointOfContactSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -3817,6 +3997,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -3875,12 +4056,14 @@ type HasSBOM {
   digest: String!
   "Location from which the SBOM can be downloaded"
   downloadLocation: String!
+  "Timestamp for SBOM creation"
+  knownSince: Time!
   "Document from which this attestation is generated from"
   origin: String!
   "GUAC collector for the document"
   collector: String!
-  "Timestamp for SBOM creation"
-  knownSince: Time!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -3904,9 +4087,10 @@ input HasSBOMSpec {
   algorithm: String
   digest: String
   downloadLocation: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
   includedSoftware: [PackageOrArtifactSpec!]
   includedDependencies: [IsDependencySpec!]
   includedOccurrences: [IsOccurrenceSpec!]
@@ -3925,9 +4109,10 @@ input HasSBOMInputSpec {
   algorithm: String!
   digest: String!
   downloadLocation: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 extend type Query {
@@ -4007,6 +4192,8 @@ type SLSA {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -4054,6 +4241,7 @@ input HasSLSASpec {
   finishedOn: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 "SLSAPredicateSpec is the same as SLSAPredicate, but usable as query input."
@@ -4071,6 +4259,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."
@@ -4135,6 +4324,8 @@ type HasSourceAt {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -4146,6 +4337,7 @@ input HasSourceAtSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "HasSourceAtInputSpec is the same as HasSourceAt but for mutation input."
@@ -4154,6 +4346,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -4208,6 +4401,8 @@ type HashEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -4223,6 +4418,7 @@ input HashEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "HashEqualInputSpec represents the input to certify that packages are similar."
@@ -4230,6 +4426,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -4298,6 +4495,8 @@ type IsDependency {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -4317,6 +4516,7 @@ input IsDependencySpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "IsDependencyInputSpec is the input to record a new dependency."
@@ -4327,6 +4527,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -4419,6 +4620,8 @@ type IsOccurrence {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -4432,6 +4635,7 @@ input IsOccurrenceSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "IsOccurrenceInputSpec represents the input to record an artifact's origin."
@@ -4439,6 +4643,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -4595,13 +4800,22 @@ SourceName.
 """
 type HasMetadata {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "Key in the key value pair"
   key: String!
+  "Value in the key value pair"
   value: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   timestamp: Time!
+  "The justification for the metadata"
   justification: String!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -4626,6 +4840,7 @@ input HasMetadataSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -4638,6 +4853,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -5104,6 +5320,8 @@ type PkgEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -5119,6 +5337,7 @@ input PkgEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "PkgEqualInputSpec represents the input to certify that packages are similar."
@@ -5126,6 +5345,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -5358,6 +5578,8 @@ type VulnEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -5370,6 +5592,7 @@ input VulnEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "VulnEqualInputSpec represents the input to link vulnerabilities to each other."
@@ -5377,6 +5600,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {
@@ -5464,12 +5688,20 @@ The timestamp is used to determine when the score was evaluated for the specific
 """
 type VulnerabilityMetadata {
   id: ID!
+  "The subject vulnerability that the metadata applies to"
   vulnerability: Vulnerability!
+  "The specific score type for the score value"
   scoreType: VulnerabilityScoreType!
+  "The score value based on the score type"
   scoreValue: Float!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   timestamp: Time!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -5490,6 +5722,7 @@ input VulnerabilityMetadataSpec {
   timestamp: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -5501,6 +5734,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3202,7 +3202,7 @@ type CertifyBad {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3238,7 +3238,7 @@ input CertifyBadInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3320,7 +3320,7 @@ type CertifyGood {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3355,7 +3355,7 @@ input CertifyGoodInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -3436,7 +3436,7 @@ type CertifyLegal {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3551,7 +3551,7 @@ type Scorecard {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3604,7 +3604,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."
@@ -3724,7 +3724,7 @@ type CertifyVEXStatement {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3758,7 +3758,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -3840,7 +3840,7 @@ type ScanMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3879,7 +3879,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -3959,7 +3959,7 @@ type PointOfContact {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -3997,7 +3997,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4063,7 +4063,7 @@ type HasSBOM {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -4112,7 +4112,7 @@ input HasSBOMInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4193,7 +4193,7 @@ type SLSA {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -4259,7 +4259,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."
@@ -4325,7 +4325,7 @@ type HasSourceAt {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -4346,7 +4346,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4402,7 +4402,7 @@ type HashEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -4426,7 +4426,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4496,7 +4496,7 @@ type IsDependency {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -4527,7 +4527,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4621,7 +4621,7 @@ type IsOccurrence {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -4643,7 +4643,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -4815,7 +4815,7 @@ type HasMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -4853,7 +4853,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -5321,7 +5321,7 @@ type PkgEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -5345,7 +5345,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -5579,7 +5579,7 @@ type VulnEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -5600,7 +5600,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {
@@ -5701,7 +5701,7 @@ type VulnerabilityMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -5734,7 +5734,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/generated/vulnEqual.generated.go
+++ b/pkg/assembler/graphql/generated/vulnEqual.generated.go
@@ -242,6 +242,47 @@ func (ec *executionContext) fieldContext_VulnEqual_collector(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _VulnEqual_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.VulnEqual) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VulnEqual_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VulnEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VulnEqual",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -253,7 +294,7 @@ func (ec *executionContext) unmarshalInputVulnEqualInputSpec(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -281,6 +322,13 @@ func (ec *executionContext) unmarshalInputVulnEqualInputSpec(ctx context.Context
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -294,7 +342,7 @@ func (ec *executionContext) unmarshalInputVulnEqualSpec(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "vulnerabilities", "justification", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "vulnerabilities", "justification", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -336,6 +384,13 @@ func (ec *executionContext) unmarshalInputVulnEqualSpec(ctx context.Context, obj
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -383,6 +438,11 @@ func (ec *executionContext) _VulnEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "collector":
 			out.Values[i] = ec._VulnEqual_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._VulnEqual_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/generated/vulnEqual.generated.go
+++ b/pkg/assembler/graphql/generated/vulnEqual.generated.go
@@ -260,14 +260,11 @@ func (ec *executionContext) _VulnEqual_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VulnEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -324,7 +321,7 @@ func (ec *executionContext) unmarshalInputVulnEqualInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -443,9 +440,6 @@ func (ec *executionContext) _VulnEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._VulnEqual_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/vulnMetadata.generated.go
+++ b/pkg/assembler/graphql/generated/vulnMetadata.generated.go
@@ -343,14 +343,11 @@ func (ec *executionContext) _VulnerabilityMetadata_documentRef(ctx context.Conte
 	})
 
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VulnerabilityMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -421,7 +418,7 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataInputSpec(ctx con
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -571,9 +568,6 @@ func (ec *executionContext) _VulnerabilityMetadata(ctx context.Context, sel ast.
 			}
 		case "documentRef":
 			out.Values[i] = ec._VulnerabilityMetadata_documentRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/vulnMetadata.generated.go
+++ b/pkg/assembler/graphql/generated/vulnMetadata.generated.go
@@ -325,6 +325,47 @@ func (ec *executionContext) fieldContext_VulnerabilityMetadata_collector(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _VulnerabilityMetadata_documentRef(ctx context.Context, field graphql.CollectedField, obj *model.VulnerabilityMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VulnerabilityMetadata_documentRef(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DocumentRef, nil
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VulnerabilityMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VulnerabilityMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -336,7 +377,7 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataInputSpec(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"scoreType", "scoreValue", "timestamp", "origin", "collector"}
+	fieldsInOrder := [...]string{"scoreType", "scoreValue", "timestamp", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -378,6 +419,13 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataInputSpec(ctx con
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -391,7 +439,7 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataSpec(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "vulnerability", "scoreType", "scoreValue", "comparator", "timestamp", "origin", "collector"}
+	fieldsInOrder := [...]string{"id", "vulnerability", "scoreType", "scoreValue", "comparator", "timestamp", "origin", "collector", "documentRef"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -454,6 +502,13 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataSpec(ctx context.
 				return it, err
 			}
 			it.Collector = data
+		case "documentRef":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentRef = data
 		}
 	}
 
@@ -511,6 +566,11 @@ func (ec *executionContext) _VulnerabilityMetadata(ctx context.Context, sel ast.
 			}
 		case "collector":
 			out.Values[i] = ec._VulnerabilityMetadata_collector(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "documentRef":
+			out.Values[i] = ec._VulnerabilityMetadata_documentRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -102,12 +102,19 @@ type BuilderSpec struct {
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type CertifyBad struct {
-	ID            string                  `json:"id"`
-	Subject       PackageSourceOrArtifact `json:"subject"`
-	Justification string                  `json:"justification"`
-	Origin        string                  `json:"origin"`
-	Collector     string                  `json:"collector"`
-	KnownSince    time.Time               `json:"knownSince"`
+	ID string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject PackageSourceOrArtifact `json:"subject"`
+	// The justification for the subject being certified bad
+	Justification string `json:"justification"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	KnownSince time.Time `json:"knownSince"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyBad) IsNode() {}
@@ -116,9 +123,10 @@ func (CertifyBad) IsNode() {}
 // evidence.
 type CertifyBadInputSpec struct {
 	Justification string    `json:"justification"`
+	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	KnownSince    time.Time `json:"knownSince"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -137,9 +145,10 @@ type CertifyBadSpec struct {
 	ID            *string                      `json:"id,omitempty"`
 	Subject       *PackageSourceOrArtifactSpec `json:"subject,omitempty"`
 	Justification *string                      `json:"justification,omitempty"`
+	KnownSince    *time.Time                   `json:"knownSince,omitempty"`
 	Origin        *string                      `json:"origin,omitempty"`
 	Collector     *string                      `json:"collector,omitempty"`
-	KnownSince    *time.Time                   `json:"knownSince,omitempty"`
+	DocumentRef   *string                      `json:"documentRef,omitempty"`
 }
 
 // CertifyGood is an attestation that a package, source, or artifact is considered
@@ -154,12 +163,19 @@ type CertifyBadSpec struct {
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type CertifyGood struct {
-	ID            string                  `json:"id"`
-	Subject       PackageSourceOrArtifact `json:"subject"`
-	Justification string                  `json:"justification"`
-	Origin        string                  `json:"origin"`
-	Collector     string                  `json:"collector"`
-	KnownSince    time.Time               `json:"knownSince"`
+	ID string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject PackageSourceOrArtifact `json:"subject"`
+	// The justification for the subject being certified good
+	Justification string `json:"justification"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	KnownSince time.Time `json:"knownSince"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyGood) IsNode() {}
@@ -167,9 +183,10 @@ func (CertifyGood) IsNode() {}
 // CertifyGoodInputSpec represents the mutation input to ingest a CertifyGood evidence.
 type CertifyGoodInputSpec struct {
 	Justification string    `json:"justification"`
+	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	KnownSince    time.Time `json:"knownSince"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -188,9 +205,10 @@ type CertifyGoodSpec struct {
 	ID            *string                      `json:"id,omitempty"`
 	Subject       *PackageSourceOrArtifactSpec `json:"subject,omitempty"`
 	Justification *string                      `json:"justification,omitempty"`
+	KnownSince    *time.Time                   `json:"knownSince,omitempty"`
 	Origin        *string                      `json:"origin,omitempty"`
 	Collector     *string                      `json:"collector,omitempty"`
-	KnownSince    *time.Time                   `json:"knownSince,omitempty"`
+	DocumentRef   *string                      `json:"documentRef,omitempty"`
 }
 
 // CertifyLegal is an attestation to attach legal information to a package or source.
@@ -229,6 +247,8 @@ type CertifyLegal struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyLegal) IsNode() {}
@@ -243,6 +263,7 @@ type CertifyLegalInputSpec struct {
 	TimeScanned       time.Time `json:"timeScanned"`
 	Origin            string    `json:"origin"`
 	Collector         string    `json:"collector"`
+	DocumentRef       *string   `json:"documentRef,omitempty"`
 }
 
 // CertifyLegalSpec allows filtering the list of legal certifications to
@@ -262,6 +283,7 @@ type CertifyLegalSpec struct {
 	TimeScanned        *time.Time           `json:"timeScanned,omitempty"`
 	Origin             *string              `json:"origin,omitempty"`
 	Collector          *string              `json:"collector,omitempty"`
+	DocumentRef        *string              `json:"documentRef,omitempty"`
 }
 
 // CertifyScorecard is an attestation to attach a Scorecard analysis to a
@@ -287,6 +309,7 @@ type CertifyScorecardSpec struct {
 	ScorecardCommit  *string               `json:"scorecardCommit,omitempty"`
 	Origin           *string               `json:"origin,omitempty"`
 	Collector        *string               `json:"collector,omitempty"`
+	DocumentRef      *string               `json:"documentRef,omitempty"`
 }
 
 // CertifyVEXStatement is an attestation to attach VEX statements to a package or
@@ -311,6 +334,8 @@ type CertifyVEXStatement struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyVEXStatement) IsNode() {}
@@ -332,6 +357,7 @@ type CertifyVEXStatementSpec struct {
 	KnownSince       *time.Time             `json:"knownSince,omitempty"`
 	Origin           *string                `json:"origin,omitempty"`
 	Collector        *string                `json:"collector,omitempty"`
+	DocumentRef      *string                `json:"documentRef,omitempty"`
 }
 
 // CertifyVuln is an attestation to attach vulnerability information to a package.
@@ -370,6 +396,7 @@ type CertifyVulnSpec struct {
 	ScannerVersion *string            `json:"scannerVersion,omitempty"`
 	Origin         *string            `json:"origin,omitempty"`
 	Collector      *string            `json:"collector,omitempty"`
+	DocumentRef    *string            `json:"documentRef,omitempty"`
 }
 
 // HasMetadata is an attestation that a package, source, or artifact has a certain
@@ -387,14 +414,23 @@ type CertifyVulnSpec struct {
 // PackageVersion. If the attestation targets a source, it must target a
 // SourceName.
 type HasMetadata struct {
-	ID            string                  `json:"id"`
-	Subject       PackageSourceOrArtifact `json:"subject"`
-	Key           string                  `json:"key"`
-	Value         string                  `json:"value"`
-	Timestamp     time.Time               `json:"timestamp"`
-	Justification string                  `json:"justification"`
-	Origin        string                  `json:"origin"`
-	Collector     string                  `json:"collector"`
+	ID string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject PackageSourceOrArtifact `json:"subject"`
+	// Key in the key value pair
+	Key string `json:"key"`
+	// Value in the key value pair
+	Value string `json:"value"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	Timestamp time.Time `json:"timestamp"`
+	// The justification for the metadata
+	Justification string `json:"justification"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HasMetadata) IsNode() {}
@@ -407,6 +443,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // HasMetadataSpec allows filtering the list of HasMetadata evidence to return in a
@@ -429,6 +466,7 @@ type HasMetadataSpec struct {
 	Justification *string                      `json:"justification,omitempty"`
 	Origin        *string                      `json:"origin,omitempty"`
 	Collector     *string                      `json:"collector,omitempty"`
+	DocumentRef   *string                      `json:"documentRef,omitempty"`
 }
 
 type HasSbom struct {
@@ -443,12 +481,14 @@ type HasSbom struct {
 	Digest string `json:"digest"`
 	// Location from which the SBOM can be downloaded
 	DownloadLocation string `json:"downloadLocation"`
+	// Timestamp for SBOM creation
+	KnownSince time.Time `json:"knownSince"`
 	// Document from which this attestation is generated from
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
-	// Timestamp for SBOM creation
-	KnownSince time.Time `json:"knownSince"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 	// Included packages and artifacts
 	IncludedSoftware []PackageOrArtifact `json:"includedSoftware"`
 	// Included dependencies
@@ -472,9 +512,10 @@ type HasSBOMInputSpec struct {
 	Algorithm        string    `json:"algorithm"`
 	Digest           string    `json:"digest"`
 	DownloadLocation string    `json:"downloadLocation"`
+	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	KnownSince       time.Time `json:"knownSince"`
+	DocumentRef      string    `json:"documentRef"`
 }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
@@ -490,9 +531,10 @@ type HasSBOMSpec struct {
 	Algorithm            *string                  `json:"algorithm,omitempty"`
 	Digest               *string                  `json:"digest,omitempty"`
 	DownloadLocation     *string                  `json:"downloadLocation,omitempty"`
+	KnownSince           *time.Time               `json:"knownSince,omitempty"`
 	Origin               *string                  `json:"origin,omitempty"`
 	Collector            *string                  `json:"collector,omitempty"`
-	KnownSince           *time.Time               `json:"knownSince,omitempty"`
+	DocumentRef          *string                  `json:"documentRef,omitempty"`
 	IncludedSoftware     []*PackageOrArtifactSpec `json:"includedSoftware,omitempty"`
 	IncludedDependencies []*IsDependencySpec      `json:"includedDependencies,omitempty"`
 	IncludedOccurrences  []*IsOccurrenceSpec      `json:"includedOccurrences,omitempty"`
@@ -522,6 +564,7 @@ type HasSLSASpec struct {
 	FinishedOn  *time.Time           `json:"finishedOn,omitempty"`
 	Origin      *string              `json:"origin,omitempty"`
 	Collector   *string              `json:"collector,omitempty"`
+	DocumentRef *string              `json:"documentRef,omitempty"`
 }
 
 // HasSourceAt records that a package's repository is a given source.
@@ -539,6 +582,8 @@ type HasSourceAt struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HasSourceAt) IsNode() {}
@@ -549,6 +594,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // HasSourceAtSpec allows filtering the list of HasSourceAt to return.
@@ -560,6 +606,7 @@ type HasSourceAtSpec struct {
 	Justification *string     `json:"justification,omitempty"`
 	Origin        *string     `json:"origin,omitempty"`
 	Collector     *string     `json:"collector,omitempty"`
+	DocumentRef   *string     `json:"documentRef,omitempty"`
 }
 
 // HashEqual is an attestation that a set of artifacts are identical.
@@ -573,6 +620,8 @@ type HashEqual struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HashEqual) IsNode() {}
@@ -582,6 +631,7 @@ type HashEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // HashEqualSpec allows filtering the list of artifact equality statements to
@@ -595,6 +645,7 @@ type HashEqualSpec struct {
 	Justification *string         `json:"justification,omitempty"`
 	Origin        *string         `json:"origin,omitempty"`
 	Collector     *string         `json:"collector,omitempty"`
+	DocumentRef   *string         `json:"documentRef,omitempty"`
 }
 
 // IDorArtifactInput allows for specifying either the artifact ID or the ArtifactInputSpec.
@@ -680,6 +731,8 @@ type IsDependency struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (IsDependency) IsNode() {}
@@ -692,6 +745,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
+	DocumentRef    string         `json:"documentRef"`
 }
 
 // IsDependencySpec allows filtering the list of dependencies to return.
@@ -709,6 +763,7 @@ type IsDependencySpec struct {
 	Justification     *string         `json:"justification,omitempty"`
 	Origin            *string         `json:"origin,omitempty"`
 	Collector         *string         `json:"collector,omitempty"`
+	DocumentRef       *string         `json:"documentRef,omitempty"`
 }
 
 // IsOccurrence is an attestation to link an artifact to a package or source.
@@ -726,6 +781,8 @@ type IsOccurrence struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (IsOccurrence) IsNode() {}
@@ -735,6 +792,7 @@ type IsOccurrenceInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
@@ -746,6 +804,7 @@ type IsOccurrenceSpec struct {
 	Justification *string              `json:"justification,omitempty"`
 	Origin        *string              `json:"origin,omitempty"`
 	Collector     *string              `json:"collector,omitempty"`
+	DocumentRef   *string              `json:"documentRef,omitempty"`
 }
 
 // License represents a particular license. If the license is found on the SPDX
@@ -1018,6 +1077,8 @@ type PkgEqual struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (PkgEqual) IsNode() {}
@@ -1027,6 +1088,7 @@ type PkgEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // PkgEqualSpec allows filtering the list of package equality statements to return
@@ -1040,6 +1102,7 @@ type PkgEqualSpec struct {
 	Justification *string    `json:"justification,omitempty"`
 	Origin        *string    `json:"origin,omitempty"`
 	Collector     *string    `json:"collector,omitempty"`
+	DocumentRef   *string    `json:"documentRef,omitempty"`
 }
 
 // PkgInputSpec specifies a package for mutations.
@@ -1103,14 +1166,23 @@ type PkgSpec struct {
 // hierarchy. However, until the use case arises, PointOfContact will be a flat
 // reference to the contact details.
 type PointOfContact struct {
-	ID            string                  `json:"id"`
-	Subject       PackageSourceOrArtifact `json:"subject"`
-	Email         string                  `json:"email"`
-	Info          string                  `json:"info"`
-	Since         time.Time               `json:"since"`
-	Justification string                  `json:"justification"`
-	Origin        string                  `json:"origin"`
-	Collector     string                  `json:"collector"`
+	ID string `json:"id"`
+	// The package, source or artifact that is attested
+	Subject PackageSourceOrArtifact `json:"subject"`
+	// Email for the POC
+	Email string `json:"email"`
+	// Generic info for the POC
+	Info string `json:"info"`
+	// Timestamp when the certification for POC was created (in RFC 3339 format)
+	Since time.Time `json:"since"`
+	// The justification for the POC attestation
+	Justification string `json:"justification"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (PointOfContact) IsNode() {}
@@ -1123,6 +1195,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // PointOfContactSpec allows filtering the list of PointOfContact evidence to return in a
@@ -1145,6 +1218,7 @@ type PointOfContactSpec struct {
 	Justification *string                      `json:"justification,omitempty"`
 	Origin        *string                      `json:"origin,omitempty"`
 	Collector     *string                      `json:"collector,omitempty"`
+	DocumentRef   *string                      `json:"documentRef,omitempty"`
 }
 
 type Query struct {
@@ -1177,6 +1251,8 @@ type Slsa struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
@@ -1188,6 +1264,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time                `json:"finishedOn,omitempty"`
 	Origin        string                    `json:"origin"`
 	Collector     string                    `json:"collector"`
+	DocumentRef   string                    `json:"documentRef"`
 }
 
 // SLSAPredicate are the values from the SLSA predicate in key-value pair form.
@@ -1252,6 +1329,8 @@ type ScanMetadata struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 // ScanMetadataInput represents the input for certifying vulnerability
@@ -1264,6 +1343,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
+	DocumentRef    string    `json:"documentRef"`
 }
 
 // Scorecard contains all of the fields present in a Scorecard attestation.
@@ -1286,6 +1366,8 @@ type Scorecard struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 // ScorecardCheck are the individual checks from scorecard and their values as a
@@ -1330,6 +1412,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                     `json:"scorecardCommit"`
 	Origin           string                     `json:"origin"`
 	Collector        string                     `json:"collector"`
+	DocumentRef      string                     `json:"documentRef"`
 }
 
 // Source represents the root of the source trie/tree.
@@ -1428,6 +1511,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
+	DocumentRef      string           `json:"documentRef"`
 }
 
 // VulnEqual is an attestation to link two vulnerabilities together as being equal"
@@ -1443,6 +1527,8 @@ type VulnEqual struct {
 	Origin string `json:"origin"`
 	// GUAC collector for the document
 	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (VulnEqual) IsNode() {}
@@ -1452,6 +1538,7 @@ type VulnEqualInputSpec struct {
 	Justification string `json:"justification"`
 	Origin        string `json:"origin"`
 	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // VulnEqualSpec allows filtering the list of vulnerability links to return
@@ -1462,6 +1549,7 @@ type VulnEqualSpec struct {
 	Justification   *string              `json:"justification,omitempty"`
 	Origin          *string              `json:"origin,omitempty"`
 	Collector       *string              `json:"collector,omitempty"`
+	DocumentRef     *string              `json:"documentRef,omitempty"`
 }
 
 // Vulnerability represents the root of the vulnerability trie/tree.
@@ -1544,24 +1632,33 @@ type VulnerabilityInputSpec struct {
 //
 // The timestamp is used to determine when the score was evaluated for the specific vulnerability.
 type VulnerabilityMetadata struct {
-	ID            string                 `json:"id"`
-	Vulnerability *Vulnerability         `json:"vulnerability"`
-	ScoreType     VulnerabilityScoreType `json:"scoreType"`
-	ScoreValue    float64                `json:"scoreValue"`
-	Timestamp     time.Time              `json:"timestamp"`
-	Origin        string                 `json:"origin"`
-	Collector     string                 `json:"collector"`
+	ID string `json:"id"`
+	// The subject vulnerability that the metadata applies to
+	Vulnerability *Vulnerability `json:"vulnerability"`
+	// The specific score type for the score value
+	ScoreType VulnerabilityScoreType `json:"scoreType"`
+	// The score value based on the score type
+	ScoreValue float64 `json:"scoreValue"`
+	// Timestamp when the certification was created (in RFC 3339 format)
+	Timestamp time.Time `json:"timestamp"`
+	// Document from which this attestation is generated from
+	Origin string `json:"origin"`
+	// GUAC collector for the document
+	Collector string `json:"collector"`
+	// Reference location of the document in the persistent blob store (if that is configured)
+	DocumentRef string `json:"documentRef"`
 }
 
 func (VulnerabilityMetadata) IsNode() {}
 
 // VulnerabilityMetadataInputSpec represents the mutation input to ingest a vulnerability metadata.
 type VulnerabilityMetadataInputSpec struct {
-	ScoreType  VulnerabilityScoreType `json:"scoreType"`
-	ScoreValue float64                `json:"scoreValue"`
-	Timestamp  time.Time              `json:"timestamp"`
-	Origin     string                 `json:"origin"`
-	Collector  string                 `json:"collector"`
+	ScoreType   VulnerabilityScoreType `json:"scoreType"`
+	ScoreValue  float64                `json:"scoreValue"`
+	Timestamp   time.Time              `json:"timestamp"`
+	Origin      string                 `json:"origin"`
+	Collector   string                 `json:"collector"`
+	DocumentRef string                 `json:"documentRef"`
 }
 
 // VulnerabilityMetadataSpec allows filtering the list of VulnerabilityMetadata evidence
@@ -1580,6 +1677,7 @@ type VulnerabilityMetadataSpec struct {
 	Timestamp     *time.Time              `json:"timestamp,omitempty"`
 	Origin        *string                 `json:"origin,omitempty"`
 	Collector     *string                 `json:"collector,omitempty"`
+	DocumentRef   *string                 `json:"documentRef,omitempty"`
 }
 
 // VulnerabilitySpec allows filtering the list of vulnerabilities to return in a query.

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -114,7 +114,7 @@ type CertifyBad struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (CertifyBad) IsNode() {}
@@ -126,7 +126,7 @@ type CertifyBadInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef,omitempty"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -175,7 +175,7 @@ type CertifyGood struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (CertifyGood) IsNode() {}
@@ -186,7 +186,7 @@ type CertifyGoodInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef,omitempty"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -248,7 +248,7 @@ type CertifyLegal struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (CertifyLegal) IsNode() {}
@@ -335,7 +335,7 @@ type CertifyVEXStatement struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (CertifyVEXStatement) IsNode() {}
@@ -430,7 +430,7 @@ type HasMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (HasMetadata) IsNode() {}
@@ -443,7 +443,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef,omitempty"`
 }
 
 // HasMetadataSpec allows filtering the list of HasMetadata evidence to return in a
@@ -488,7 +488,7 @@ type HasSbom struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 	// Included packages and artifacts
 	IncludedSoftware []PackageOrArtifact `json:"includedSoftware"`
 	// Included dependencies
@@ -515,7 +515,7 @@ type HasSBOMInputSpec struct {
 	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	DocumentRef      string    `json:"documentRef"`
+	DocumentRef      *string   `json:"documentRef,omitempty"`
 }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
@@ -583,7 +583,7 @@ type HasSourceAt struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (HasSourceAt) IsNode() {}
@@ -594,7 +594,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef,omitempty"`
 }
 
 // HasSourceAtSpec allows filtering the list of HasSourceAt to return.
@@ -621,17 +621,17 @@ type HashEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (HashEqual) IsNode() {}
 
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef,omitempty"`
 }
 
 // HashEqualSpec allows filtering the list of artifact equality statements to
@@ -732,7 +732,7 @@ type IsDependency struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (IsDependency) IsNode() {}
@@ -745,7 +745,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
-	DocumentRef    string         `json:"documentRef"`
+	DocumentRef    *string        `json:"documentRef,omitempty"`
 }
 
 // IsDependencySpec allows filtering the list of dependencies to return.
@@ -782,17 +782,17 @@ type IsOccurrence struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (IsOccurrence) IsNode() {}
 
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef,omitempty"`
 }
 
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
@@ -1078,17 +1078,17 @@ type PkgEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (PkgEqual) IsNode() {}
 
 // PkgEqualInputSpec represents the input to certify that packages are similar.
 type PkgEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef,omitempty"`
 }
 
 // PkgEqualSpec allows filtering the list of package equality statements to return
@@ -1182,7 +1182,7 @@ type PointOfContact struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (PointOfContact) IsNode() {}
@@ -1195,7 +1195,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   string    `json:"documentRef"`
+	DocumentRef   *string   `json:"documentRef,omitempty"`
 }
 
 // PointOfContactSpec allows filtering the list of PointOfContact evidence to return in a
@@ -1252,7 +1252,7 @@ type Slsa struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
@@ -1264,7 +1264,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time                `json:"finishedOn,omitempty"`
 	Origin        string                    `json:"origin"`
 	Collector     string                    `json:"collector"`
-	DocumentRef   string                    `json:"documentRef"`
+	DocumentRef   *string                   `json:"documentRef,omitempty"`
 }
 
 // SLSAPredicate are the values from the SLSA predicate in key-value pair form.
@@ -1330,7 +1330,7 @@ type ScanMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 // ScanMetadataInput represents the input for certifying vulnerability
@@ -1343,7 +1343,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
-	DocumentRef    string    `json:"documentRef"`
+	DocumentRef    *string   `json:"documentRef,omitempty"`
 }
 
 // Scorecard contains all of the fields present in a Scorecard attestation.
@@ -1367,7 +1367,7 @@ type Scorecard struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 // ScorecardCheck are the individual checks from scorecard and their values as a
@@ -1412,7 +1412,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                     `json:"scorecardCommit"`
 	Origin           string                     `json:"origin"`
 	Collector        string                     `json:"collector"`
-	DocumentRef      string                     `json:"documentRef"`
+	DocumentRef      *string                    `json:"documentRef,omitempty"`
 }
 
 // Source represents the root of the source trie/tree.
@@ -1511,7 +1511,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
-	DocumentRef      string           `json:"documentRef"`
+	DocumentRef      *string          `json:"documentRef,omitempty"`
 }
 
 // VulnEqual is an attestation to link two vulnerabilities together as being equal"
@@ -1528,17 +1528,17 @@ type VulnEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (VulnEqual) IsNode() {}
 
 // VulnEqualInputSpec represents the input to link vulnerabilities to each other.
 type VulnEqualInputSpec struct {
-	Justification string `json:"justification"`
-	Origin        string `json:"origin"`
-	Collector     string `json:"collector"`
-	DocumentRef   string `json:"documentRef"`
+	Justification string  `json:"justification"`
+	Origin        string  `json:"origin"`
+	Collector     string  `json:"collector"`
+	DocumentRef   *string `json:"documentRef,omitempty"`
 }
 
 // VulnEqualSpec allows filtering the list of vulnerability links to return
@@ -1646,7 +1646,7 @@ type VulnerabilityMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef string `json:"documentRef"`
+	DocumentRef *string `json:"documentRef,omitempty"`
 }
 
 func (VulnerabilityMetadata) IsNode() {}
@@ -1658,7 +1658,7 @@ type VulnerabilityMetadataInputSpec struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Origin      string                 `json:"origin"`
 	Collector   string                 `json:"collector"`
-	DocumentRef string                 `json:"documentRef"`
+	DocumentRef *string                `json:"documentRef,omitempty"`
 }
 
 // VulnerabilityMetadataSpec allows filtering the list of VulnerabilityMetadata evidence

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -82,7 +82,7 @@ type CertifyBad {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -118,7 +118,7 @@ input CertifyBadInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 """

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -71,11 +71,18 @@ SourceName.
 """
 type CertifyBad {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "The justification for the subject being certified bad"
   justification: String!
-  origin: String!
-  collector: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   knownSince: Time!
+  "Document from which this attestation is generated from"
+  origin: String!
+  "GUAC collector for the document"
+  collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -96,9 +103,10 @@ input CertifyBadSpec {
   id: ID
   subject: PackageSourceOrArtifactSpec
   justification: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
 }
 
 """
@@ -107,9 +115,10 @@ evidence.
 """
 input CertifyBadInputSpec {
   justification: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 """

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -32,11 +32,18 @@ SourceName.
 """
 type CertifyGood {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "The justification for the subject being certified good"
   justification: String!
-  origin: String!
-  collector: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   knownSince: Time!
+  "Document from which this attestation is generated from"
+  origin: String!
+  "GUAC collector for the document"
+  collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -57,9 +64,10 @@ input CertifyGoodSpec {
   id: ID
   subject: PackageSourceOrArtifactSpec
   justification: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
 }
 
 """
@@ -67,9 +75,10 @@ CertifyGoodInputSpec represents the mutation input to ingest a CertifyGood evide
 """
 input CertifyGoodInputSpec {
   justification: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -43,7 +43,7 @@ type CertifyGood {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -78,7 +78,7 @@ input CertifyGoodInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -56,7 +56,7 @@ type CertifyLegal {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -55,6 +55,8 @@ type CertifyLegal {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -76,6 +78,7 @@ input CertifyLegalSpec {
   timeScanned: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -90,6 +93,7 @@ input CertifyLegalInputSpec {
   timeScanned: Time!
   origin: String!
   collector: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -60,6 +60,8 @@ type Scorecard {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -94,6 +96,7 @@ input CertifyScorecardSpec {
   scorecardCommit: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "ScorecardCheckSpec is the same as ScorecardCheck, but usable as query input."
@@ -111,6 +114,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -61,7 +61,7 @@ type Scorecard {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -114,7 +114,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -94,7 +94,7 @@ type CertifyVEXStatement {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -128,7 +128,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -93,6 +93,8 @@ type CertifyVEXStatement {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -114,6 +116,7 @@ input CertifyVEXStatementSpec {
   knownSince: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 "VexStatementInputSpec represents the input to ingest VEX statements."
@@ -125,6 +128,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -54,6 +54,8 @@ type ScanMetadata {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -77,6 +79,7 @@ input CertifyVulnSpec {
   scannerVersion: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -91,6 +94,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -55,7 +55,7 @@ type ScanMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -94,7 +94,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -55,7 +55,7 @@ type PointOfContact {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -93,7 +93,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -40,13 +40,22 @@ reference to the contact details.
 """
 type PointOfContact {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "Email for the POC"
   email: String!
+  "Generic info for the POC"
   info: String!
+  "Timestamp when the certification for POC was created (in RFC 3339 format)"
   since: Time!
+  "The justification for the POC attestation"
   justification: String!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -71,6 +80,7 @@ input PointOfContactSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -83,6 +93,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -29,12 +29,14 @@ type HasSBOM {
   digest: String!
   "Location from which the SBOM can be downloaded"
   downloadLocation: String!
+  "Timestamp for SBOM creation"
+  knownSince: Time!
   "Document from which this attestation is generated from"
   origin: String!
   "GUAC collector for the document"
   collector: String!
-  "Timestamp for SBOM creation"
-  knownSince: Time!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -58,9 +60,10 @@ input HasSBOMSpec {
   algorithm: String
   digest: String
   downloadLocation: String
+  knownSince: Time
   origin: String
   collector: String
-  knownSince: Time
+  documentRef: String
   includedSoftware: [PackageOrArtifactSpec!]
   includedDependencies: [IsDependencySpec!]
   includedOccurrences: [IsOccurrenceSpec!]
@@ -79,9 +82,10 @@ input HasSBOMInputSpec {
   algorithm: String!
   digest: String!
   downloadLocation: String!
+  knownSince: Time!
   origin: String!
   collector: String!
-  knownSince: Time!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -36,7 +36,7 @@ type HasSBOM {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -85,7 +85,7 @@ input HasSBOMInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -56,7 +56,7 @@ type SLSA {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -122,7 +122,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -55,6 +55,8 @@ type SLSA {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -102,6 +104,7 @@ input HasSLSASpec {
   finishedOn: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 "SLSAPredicateSpec is the same as SLSAPredicate, but usable as query input."
@@ -119,6 +122,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -33,7 +33,7 @@ type HasSourceAt {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -54,7 +54,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -32,6 +32,8 @@ type HasSourceAt {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -43,6 +45,7 @@ input HasSourceAtSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "HasSourceAtInputSpec is the same as HasSourceAt but for mutation input."
@@ -51,6 +54,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -29,7 +29,7 @@ type HashEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -53,7 +53,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -28,6 +28,8 @@ type HashEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -43,6 +45,7 @@ input HashEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "HashEqualInputSpec represents the input to certify that packages are similar."
@@ -50,6 +53,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -44,6 +44,8 @@ type IsDependency {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -63,6 +65,7 @@ input IsDependencySpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "IsDependencyInputSpec is the input to record a new dependency."
@@ -73,6 +76,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -45,7 +45,7 @@ type IsDependency {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -76,7 +76,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -67,7 +67,7 @@ type IsOccurrence {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -89,7 +89,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -66,6 +66,8 @@ type IsOccurrence {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -79,6 +81,7 @@ input IsOccurrenceSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "IsOccurrenceInputSpec represents the input to record an artifact's origin."
@@ -86,6 +89,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -35,13 +35,22 @@ SourceName.
 """
 type HasMetadata {
   id: ID!
+  "The package, source or artifact that is attested"
   subject: PackageSourceOrArtifact!
+  "Key in the key value pair"
   key: String!
+  "Value in the key value pair"
   value: String!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   timestamp: Time!
+  "The justification for the metadata"
   justification: String!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -66,6 +75,7 @@ input HasMetadataSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -78,6 +88,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -50,7 +50,7 @@ type HasMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -88,7 +88,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -28,6 +28,8 @@ type PkgEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -43,6 +45,7 @@ input PkgEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "PkgEqualInputSpec represents the input to certify that packages are similar."
@@ -50,6 +53,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -29,7 +29,7 @@ type PkgEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -53,7 +53,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -32,6 +32,8 @@ type VulnEqual {
   origin: String!
   "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -44,6 +46,7 @@ input VulnEqualSpec {
   justification: String
   origin: String
   collector: String
+  documentRef: String
 }
 
 "VulnEqualInputSpec represents the input to link vulnerabilities to each other."
@@ -51,6 +54,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -33,7 +33,7 @@ type VulnEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -54,7 +54,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnMetadata.graphql
+++ b/pkg/assembler/graphql/schema/vulnMetadata.graphql
@@ -76,7 +76,7 @@ type VulnerabilityMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String!
+  documentRef: String
 }
 
 """
@@ -109,7 +109,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
-  documentRef: String!
+  documentRef: String
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnMetadata.graphql
+++ b/pkg/assembler/graphql/schema/vulnMetadata.graphql
@@ -63,12 +63,20 @@ The timestamp is used to determine when the score was evaluated for the specific
 """
 type VulnerabilityMetadata {
   id: ID!
+  "The subject vulnerability that the metadata applies to"
   vulnerability: Vulnerability!
+  "The specific score type for the score value"
   scoreType: VulnerabilityScoreType!
+  "The score value based on the score type"
   scoreValue: Float!
+  "Timestamp when the certification was created (in RFC 3339 format)"
   timestamp: Time!
+  "Document from which this attestation is generated from"
   origin: String!
+  "GUAC collector for the document"
   collector: String!
+  "Reference location of the document in the persistent blob store (if that is configured)"
+  documentRef: String!
 }
 
 """
@@ -89,6 +97,7 @@ input VulnerabilityMetadataSpec {
   timestamp: Time
   origin: String
   collector: String
+  documentRef: String
 }
 
 """
@@ -100,6 +109,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
+  documentRef: String!
 }
 
 extend type Query {


### PR DESCRIPTION
# Description of the PR

Update graphQL schema to add `documentRef` field to all verbs.

Subsequent PRs will include update to the `processor.Document`, parsers, and backend databases.

Updates the graphQL schema based on issue: https://github.com/guacsec/guac/issues/1833

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
