### PR TITLE
Update gql, parser and backends to add new `documentRef` field

### DIFF
--- a/internal/testing/backend/arango_test.go
+++ b/internal/testing/backend/arango_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/arango_test.go
+++ b/internal/testing/backend/arango_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/artifact_test.go
+++ b/internal/testing/backend/artifact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/artifact_test.go
+++ b/internal/testing/backend/artifact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/builder_test.go
+++ b/internal/testing/backend/builder_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/builder_test.go
+++ b/internal/testing/backend/builder_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyBad_test.go
+++ b/internal/testing/backend/certifyBad_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyBad_test.go
+++ b/internal/testing/backend/certifyBad_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyBad_test.go
+++ b/internal/testing/backend/certifyBad_test.go
@@ -747,6 +747,32 @@ func TestCertifyBad(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: &model.CertifyBadInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpCB: []*model.CertifyBad{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -988,8 +1014,7 @@ func TestIngestCertifyBads(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
-		},
-		{
+		}, {
 			Name:  "Query on Source",
 			InPkg: []*model.PkgInputSpec{testdata.P1},
 			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S2},
@@ -1075,6 +1100,33 @@ func TestIngestCertifyBads(t *testing.T) {
 				{
 					Subject:       testdata.A2out,
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:  "docRef",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{{PackageInput: testdata.P1}},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CB: []*model.CertifyBadInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.CertifyBadSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpCB: []*model.CertifyBad{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/certifyGood_test.go
+++ b/internal/testing/backend/certifyGood_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyGood_test.go
+++ b/internal/testing/backend/certifyGood_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyGood_test.go
+++ b/internal/testing/backend/certifyGood_test.go
@@ -599,6 +599,31 @@ func TestCertifyGood(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: &model.CertifyGoodInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpCG: []*model.CertifyGood{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -754,8 +779,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
-		},
-		{
+		}, {
 			Name:  "Ingest same twice",
 			InPkg: []*model.PkgInputSpec{testdata.P1},
 			Calls: []call{
@@ -789,8 +813,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
-		},
-		{
+		}, {
 			Name:  "Query on Package",
 			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
 			InSrc: []*model.SourceInputSpec{testdata.S1},
@@ -839,8 +862,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
-		},
-		{
+		}, {
 			Name:  "Query on Source",
 			InPkg: []*model.PkgInputSpec{testdata.P1},
 			InSrc: []*model.SourceInputSpec{testdata.S1, testdata.S2},
@@ -885,8 +907,7 @@ func TestIngestCertifyGoods(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
-		},
-		{
+		}, {
 			Name:  "Query on Artifact",
 			InSrc: []*model.SourceInputSpec{testdata.S1},
 			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
@@ -926,6 +947,33 @@ func TestIngestCertifyGoods(t *testing.T) {
 				{
 					Subject:       testdata.A2out,
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					CG: []*model.CertifyGoodInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.CertifyGoodSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpCG: []*model.CertifyGood{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/certifyLegal_test.go
+++ b/internal/testing/backend/certifyLegal_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyLegal_test.go
+++ b/internal/testing/backend/certifyLegal_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyLegal_test.go
+++ b/internal/testing/backend/certifyLegal_test.go
@@ -486,6 +486,31 @@ func TestLegal(t *testing.T) {
 					Justification:    "test justification special",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InLic: []*model.LicenseInputSpec{testdata.L1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Dec: []*model.IDorLicenseInput{{LicenseInput: testdata.L1}},
+					Legal: &model.CertifyLegalInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpLegal: []*model.CertifyLegal{
+				{
+					Subject:          testdata.P1out,
+					DeclaredLicenses: []*model.License{testdata.L1out},
+					DocumentRef:      "test",
+				},
+			},
 		},
 		// {
 		// 	Name: "Ingest without Package",
@@ -619,6 +644,34 @@ func TestLegals(t *testing.T) {
 					Subject:          testdata.P2out,
 					DeclaredLicenses: []*model.License{testdata.L1out},
 					Justification:    "test justification",
+				},
+			},
+		},
+		{
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			InLic: []*model.LicenseInputSpec{testdata.L1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInputs{
+						Packages: []*model.IDorPkgInput{{PackageInput: testdata.P1}, {PackageInput: testdata.P2}},
+					},
+					Dec: [][]*model.IDorLicenseInput{{{LicenseInput: testdata.L1}}, {{LicenseInput: testdata.L1}}},
+					Dis: [][]*model.IDorLicenseInput{{}, {}},
+					Legal: []*model.CertifyLegalInputSpec{
+						{Justification: "test justification"},
+						{DocumentRef: "test"},
+					},
+				},
+			},
+			Query: &model.CertifyLegalSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpLegal: []*model.CertifyLegal{
+				{
+					Subject:          testdata.P2out,
+					DeclaredLicenses: []*model.License{testdata.L1out},
+					DocumentRef:      "test",
 				},
 			},
 		},

--- a/internal/testing/backend/certifyScorecard_test.go
+++ b/internal/testing/backend/certifyScorecard_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyScorecard_test.go
+++ b/internal/testing/backend/certifyScorecard_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyScorecard_test.go
+++ b/internal/testing/backend/certifyScorecard_test.go
@@ -476,6 +476,29 @@ func TestCertifyScorecard(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			Name:  "docref",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Src: testdata.S1,
+					SC: &model.ScorecardInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: testdata.S1out,
+					Scorecard: &model.Scorecard{
+						Checks:      []*model.ScorecardCheck{},
+						DocumentRef: "test",
+					},
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -686,6 +709,31 @@ func TestIngestScorecards(t *testing.T) {
 					Scorecard: &model.Scorecard{
 						Checks: []*model.ScorecardCheck{},
 						Origin: "test origin",
+					},
+				},
+			},
+		}, {
+			Name:  "docref",
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Src: []*model.IDorSourceInput{{SourceInput: testdata.S1}},
+					SC: []*model.ScorecardInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.CertifyScorecardSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpSC: []*model.CertifyScorecard{
+				{
+					Source: testdata.S1out,
+					Scorecard: &model.Scorecard{
+						Checks:      []*model.ScorecardCheck{},
+						DocumentRef: "test",
 					},
 				},
 			},

--- a/internal/testing/backend/certifyVEXStatement_test.go
+++ b/internal/testing/backend/certifyVEXStatement_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyVEXStatement_test.go
+++ b/internal/testing/backend/certifyVEXStatement_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyVEXStatement_test.go
+++ b/internal/testing/backend/certifyVEXStatement_test.go
@@ -836,6 +836,38 @@ func TestVEX(t *testing.T) {
 					KnownSince:       time.Unix(1e9, 0),
 				},
 			},
+		}, {
+			Name:   "docref",
+			InPkg:  []*model.PkgInputSpec{testdata.P1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Vuln: testdata.O1,
+					In: &model.VexStatementInputSpec{
+						VexJustification: "test justification",
+						KnownSince:       time.Unix(1e9, 0),
+						DocumentRef:      "test",
+					},
+				},
+			},
+			Query: &model.CertifyVEXStatementSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVEX: []*model.CertifyVEXStatement{
+				{
+					Subject: testdata.P1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "osv",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+					},
+					VexJustification: "test justification",
+					KnownSince:       time.Unix(1e9, 0),
+					DocumentRef:      "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -1252,6 +1284,40 @@ func TestVEXBulkIngest(t *testing.T) {
 					},
 					VexJustification: "test justification two",
 					KnownSince:       time.Unix(1e9, 0),
+				},
+			},
+		}, {
+			Name:   "docref",
+			InPkg:  []*model.PkgInputSpec{testdata.P1},
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1},
+			Calls: []call{
+				{
+					Subs: model.PackageOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					},
+					Vulns: []*model.IDorVulnerabilityInput{{VulnerabilityInput: testdata.O1}},
+					Vexs: []*model.VexStatementInputSpec{
+						{
+							VexJustification: "test justification",
+							KnownSince:       time.Unix(1e9, 0),
+							DocumentRef:      "test",
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVEXStatementSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVEX: []*model.CertifyVEXStatement{
+				{
+					Subject: testdata.P1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "osv",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+					},
+					VexJustification: "test justification",
+					KnownSince:       time.Unix(1e9, 0),
+					DocumentRef:      "test",
 				},
 			},
 		},

--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -917,6 +917,49 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 					Metadata: vmd1,
 				},
 			},
+		}, {
+			Name:   "docref",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.C1},
+			InPkg:  []*model.IDorPkgInput{{PackageInput: testdata.P2}},
+			Calls: []call{
+				{
+					Pkg:  testdata.P2,
+					Vuln: testdata.C1,
+					CertifyVuln: &model.ScanMetadataInput{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+						DocumentRef:    "test",
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					ID:      "1",
+					Package: testdata.P2out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.C1out},
+					},
+					Metadata: &model.ScanMetadata{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+						DocumentRef:    "test",
+					},
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -1364,6 +1407,60 @@ func TestIngestCertifyVulns(t *testing.T) {
 						VulnerabilityIDs: []*model.VulnerabilityID{testdata.NoVulnOut},
 					},
 					Metadata: vmd1,
+				},
+			},
+		}, {
+			Name:   "HappyPath",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.C1, testdata.C2},
+			InPkg:  []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					Pkgs:  []*model.IDorPkgInput{{PackageInput: testdata.P2}, {PackageInput: testdata.P1}},
+					Vulns: []*model.IDorVulnerabilityInput{{VulnerabilityInput: testdata.C1}, {VulnerabilityInput: testdata.C2}},
+					CertifyVulns: []*model.ScanMetadataInput{
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    testdata.T1,
+						},
+						{
+							Collector:      "test collector",
+							Origin:         "test origin",
+							ScannerVersion: "v1.0.0",
+							ScannerURI:     "test scanner uri",
+							DbVersion:      "2023.01.01",
+							DbURI:          "test db uri",
+							TimeScanned:    testdata.T1,
+							DocumentRef:    "test",
+						},
+					},
+				},
+			},
+			Query: &model.CertifyVulnSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVuln: []*model.CertifyVuln{
+				{
+					ID:      "10",
+					Package: testdata.P1out,
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.C2out},
+					},
+					Metadata: &model.ScanMetadata{
+						Collector:      "test collector",
+						Origin:         "test origin",
+						ScannerVersion: "v1.0.0",
+						ScannerURI:     "test scanner uri",
+						DbVersion:      "2023.01.01",
+						DbURI:          "test db uri",
+						TimeScanned:    testdata.T1,
+						DocumentRef:    "test",
+					},
 				},
 			},
 		},

--- a/internal/testing/backend/ent_test.go
+++ b/internal/testing/backend/ent_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/ent_test.go
+++ b/internal/testing/backend/ent_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hasMetadata_test.go
+++ b/internal/testing/backend/hasMetadata_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/hasMetadata_test.go
+++ b/internal/testing/backend/hasMetadata_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hasMetadata_test.go
+++ b/internal/testing/backend/hasMetadata_test.go
@@ -728,6 +728,37 @@ func TestHasMetadata(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:         "key1",
+						Value:       "value1",
+						Timestamp:   time.Unix(1e9, 0),
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:     testdata.P1out,
+					Key:         "key1",
+					Value:       "value1",
+					Timestamp:   time.Unix(1e9, 0),
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -1058,6 +1089,33 @@ func TestIngestBulkHasMetadata(t *testing.T) {
 				{
 					Subject:       testdata.A2out,
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: []*model.HasMetadataInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/hasSBOM_test.go
+++ b/internal/testing/backend/hasSBOM_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSBOM_test.go
+++ b/internal/testing/backend/hasSBOM_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSBOM_test.go
+++ b/internal/testing/backend/hasSBOM_test.go
@@ -2654,6 +2654,32 @@ func TestHasSBOM(t *testing.T) {
 			}},
 			Query: &model.HasSBOMSpec{IncludedOccurrences: []*model.IsOccurrenceSpec{{Collector: ptrfrom.String("invalid_collector")}}},
 			ExpHS: nil,
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+			},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					HS: &model.HasSBOMInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.HasSBOMSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHS: []*model.HasSbom{
+				{
+					Subject:          testdata.P1out,
+					DocumentRef:      "test",
+					IncludedSoftware: []model.PackageOrArtifact{testdata.P1out},
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -3028,6 +3054,34 @@ func TestIngestHasSBOMs(t *testing.T) {
 						Artifact:      testdata.A2out,
 						Justification: "test justification",
 					}},
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			PkgArt: &model.PackageOrArtifactInputs{
+				Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+			},
+			Calls: []call{
+				{
+					Sub: model.PackageOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					},
+					HS: []*model.HasSBOMInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.HasSBOMSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHS: []*model.HasSbom{
+				{
+					Subject:          testdata.P1out,
+					DocumentRef:      "test",
+					IncludedSoftware: []model.PackageOrArtifact{testdata.P1out},
 				},
 			},
 		},

--- a/internal/testing/backend/hasSLSA_test.go
+++ b/internal/testing/backend/hasSLSA_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSLSA_test.go
+++ b/internal/testing/backend/hasSLSA_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSLSA_test.go
+++ b/internal/testing/backend/hasSLSA_test.go
@@ -579,6 +579,35 @@ func TestHasSLSA(t *testing.T) {
 				},
 			},
 			ExpHS: nil,
+		}, {
+			Name:  "docref",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			InBld: []*model.BuilderInputSpec{testdata.B1},
+			Calls: []call{
+				{
+					Sub: testdata.A1,
+					BF:  []*model.IDorArtifactInput{&model.IDorArtifactInput{ArtifactInput: testdata.A2}},
+					BB:  testdata.B1,
+					SLSA: &model.SLSAInputSpec{
+						BuildType:   "test type",
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHS: []*model.HasSlsa{
+				{
+					Subject: testdata.A1out,
+					Slsa: &model.Slsa{
+						BuiltBy:     testdata.B1out,
+						BuiltFrom:   []*model.Artifact{testdata.A2out},
+						BuildType:   "test type",
+						DocumentRef: "test",
+					},
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -812,6 +841,37 @@ func TestIngestHasSLSAs(t *testing.T) {
 					Slsa: &model.Slsa{
 						BuiltBy:   testdata.B1out,
 						BuiltFrom: []*model.Artifact{testdata.A4out},
+					},
+				},
+			},
+		}, {
+			Name:  "docref",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			InBld: []*model.BuilderInputSpec{testdata.B1},
+			Calls: []call{
+				{
+					Sub: []*model.IDorArtifactInput{{ArtifactInput: testdata.A1}},
+					BF:  [][]*model.IDorArtifactInput{{{ArtifactInput: testdata.A2}}},
+					BB:  []*model.IDorBuilderInput{{BuilderInput: testdata.B1}},
+					SLSA: []*model.SLSAInputSpec{
+						{
+							BuildType:   "test type",
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.HasSLSASpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHS: []*model.HasSlsa{
+				{
+					Subject: testdata.A1out,
+					Slsa: &model.Slsa{
+						BuiltBy:     testdata.B1out,
+						BuiltFrom:   []*model.Artifact{testdata.A2out},
+						BuildType:   "test type",
+						DocumentRef: "test",
 					},
 				},
 			},

--- a/internal/testing/backend/hasSourceAt_test.go
+++ b/internal/testing/backend/hasSourceAt_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSourceAt_test.go
+++ b/internal/testing/backend/hasSourceAt_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hasSourceAt_test.go
+++ b/internal/testing/backend/hasSourceAt_test.go
@@ -542,6 +542,32 @@ func TestHasSourceAt(t *testing.T) {
 					Source:  testdata.S4out,
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkg: testdata.P1,
+					Src: testdata.S1,
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSA: &model.HasSourceAtInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:     testdata.P1out,
+					Source:      testdata.S1out,
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -824,6 +850,34 @@ func TestIngestHasSourceAts(t *testing.T) {
 					Package:    testdata.P1out,
 					Source:     testdata.S1out,
 					KnownSince: testTime,
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InSrc: []*model.SourceInputSpec{testdata.S1},
+			Calls: []call{
+				{
+					Pkgs: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					Srcs: []*model.IDorSourceInput{&model.IDorSourceInput{SourceInput: testdata.S1}},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HSAs: []*model.HasSourceAtInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.HasSourceAtSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHSA: []*model.HasSourceAt{
+				{
+					Package:     testdata.P1out,
+					Source:      testdata.S1out,
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/hashEqual_test.go
+++ b/internal/testing/backend/hashEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/hashEqual_test.go
+++ b/internal/testing/backend/hashEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/hashEqual_test.go
+++ b/internal/testing/backend/hashEqual_test.go
@@ -430,6 +430,27 @@ func TestHashEqual(t *testing.T) {
 					Artifacts: []*model.Artifact{testdata.A1out, testdata.A3out},
 				},
 			},
+		}, {
+			Name:  "docref",
+			InArt: []*model.IDorArtifactInput{{ArtifactInput: testdata.A1}, {ArtifactInput: testdata.A2}},
+			Calls: []call{
+				{
+					A1: testdata.A1,
+					A2: testdata.A2,
+					HE: &model.HashEqualInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.HashEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHE: []*model.HashEqual{
+				{
+					Artifacts:   []*model.Artifact{testdata.A1out, testdata.A2out},
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -743,6 +764,29 @@ func TestIngestHashEquals(t *testing.T) {
 			ExpHE: []*model.HashEqual{
 				{
 					Artifacts: []*model.Artifact{testdata.A2out, testdata.A3out},
+				},
+			},
+		}, {
+			Name:  "docref",
+			InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+			Calls: []call{
+				{
+					A1: []*model.IDorArtifactInput{{ArtifactInput: testdata.A1}},
+					A2: []*model.IDorArtifactInput{{ArtifactInput: testdata.A2}},
+					HE: []*model.HashEqualInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.HashEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHE: []*model.HashEqual{
+				{
+					Artifacts:   []*model.Artifact{testdata.A1out, testdata.A2out},
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/helpers_test.go
+++ b/internal/testing/backend/helpers_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/helpers_test.go
+++ b/internal/testing/backend/helpers_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (
@@ -84,6 +86,10 @@ func certifyVexLess(e1, e2 *model.CertifyVEXStatement) bool {
 
 	if e1.VexJustification != e2.VexJustification {
 		return e1.VexJustification < e2.VexJustification
+	}
+
+	if e1.Vulnerability.Type != e2.Vulnerability.Type {
+		return e1.Vulnerability.Type < e2.Vulnerability.Type
 	}
 
 	ap, oka := e1.Subject.(*model.Package)

--- a/internal/testing/backend/isDependency_test.go
+++ b/internal/testing/backend/isDependency_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/isDependency_test.go
+++ b/internal/testing/backend/isDependency_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/isDependency_test.go
+++ b/internal/testing/backend/isDependency_test.go
@@ -813,6 +813,29 @@ func TestIsDependency(t *testing.T) {
 					DependencyPackage: testdata.P4out,
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P2,
+					MF: mAll,
+					ID: &model.IsDependencyInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.IsDependencySpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpID: []*model.IsDependency{
+				{
+					Package:           testdata.P1out,
+					DependencyPackage: testdata.P2outName,
+					DocumentRef:       "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -927,6 +950,29 @@ func TestIsDependencies(t *testing.T) {
 					Package:           testdata.P1out,
 					DependencyPackage: testdata.P2out,
 					Justification:     "test justification",
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2, testdata.P3, testdata.P4},
+			Calls: []call{{
+				P1s: []*model.IDorPkgInput{{PackageInput: testdata.P1}, {PackageInput: testdata.P2}},
+				P2s: []*model.IDorPkgInput{{PackageInput: testdata.P2}, {PackageInput: testdata.P4}},
+				MF:  mAll,
+				IDs: []*model.IsDependencyInputSpec{
+					{
+						DocumentRef: "test",
+					},
+					{
+						Justification: "test justification",
+					},
+				},
+			}},
+			ExpID: []*model.IsDependency{
+				{
+					Package:           testdata.P1out,
+					DependencyPackage: testdata.P2outName,
+					DocumentRef:       "test",
 				},
 			},
 		},

--- a/internal/testing/backend/isOccurrence_test.go
+++ b/internal/testing/backend/isOccurrence_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/isOccurrence_test.go
+++ b/internal/testing/backend/isOccurrence_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/isOccurrence_test.go
+++ b/internal/testing/backend/isOccurrence_test.go
@@ -449,6 +449,31 @@ func TestOccurrence(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			InArt: []*model.ArtifactInputSpec{testdata.A1},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Artifact: testdata.A1,
+					Occurrence: &model.IsOccurrenceInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.IsOccurrenceSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpOcc: []*model.IsOccurrence{
+				{
+					Subject:     testdata.P1out,
+					Artifact:    testdata.A1out,
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -586,6 +611,30 @@ func TestIngestOccurrences(t *testing.T) {
 				Subject:       testdata.S1out,
 				Artifact:      testdata.A1out,
 				Justification: "test justification",
+			},
+		},
+	}, {
+		Name:  "docref",
+		InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+		InArt: []*model.ArtifactInputSpec{testdata.A1, testdata.A2},
+		Calls: []call{
+			{
+				PkgSrcs: model.PackageOrSourceInputs{
+					Packages: []*model.IDorPkgInput{{PackageInput: testdata.P1}, {PackageInput: testdata.P2}},
+				},
+				Artifacts: []*model.IDorArtifactInput{{ArtifactInput: testdata.A1}, {ArtifactInput: testdata.A2}},
+				Occurrences: []*model.IsOccurrenceInputSpec{{
+					DocumentRef: "test",
+				}, {
+					Justification: "test justification",
+				}},
+			},
+		},
+		ExpOcc: []*model.IsOccurrence{
+			{
+				Subject:     testdata.P1out,
+				Artifact:    testdata.A1out,
+				DocumentRef: "test",
 			},
 		},
 	}}

--- a/internal/testing/backend/license_test.go
+++ b/internal/testing/backend/license_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/license_test.go
+++ b/internal/testing/backend/license_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (
@@ -67,11 +69,11 @@ type backend interface {
 }
 
 var testBackends = map[string]backend{
-	// memmap: newMemMap(),
-	// arango: newArango(),
-	// redis:  newRedis(),
-	ent: newEnt(),
-	// tikv:   newTikv(),
+	memmap: newMemMap(),
+	arango: newArango(),
+	redis:  newRedis(),
+	ent:    newEnt(),
+	tikv:   newTikv(),
 }
 
 var currentBackend string

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (
@@ -69,11 +67,11 @@ type backend interface {
 }
 
 var testBackends = map[string]backend{
-	memmap: newMemMap(),
-	arango: newArango(),
-	redis:  newRedis(),
-	ent:    newEnt(),
-	tikv:   newTikv(),
+	// memmap: newMemMap(),
+	// arango: newArango(),
+	// redis:  newRedis(),
+	ent: newEnt(),
+	// tikv:   newTikv(),
 }
 
 var currentBackend string

--- a/internal/testing/backend/memmap_test.go
+++ b/internal/testing/backend/memmap_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/memmap_test.go
+++ b/internal/testing/backend/memmap_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/path_test.go
+++ b/internal/testing/backend/path_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/path_test.go
+++ b/internal/testing/backend/path_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/pkgEqual_test.go
+++ b/internal/testing/backend/pkgEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/pkgEqual_test.go
+++ b/internal/testing/backend/pkgEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/pkgEqual_test.go
+++ b/internal/testing/backend/pkgEqual_test.go
@@ -524,6 +524,27 @@ func TestPkgEqual(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					P1: testdata.P1,
+					P2: testdata.P2,
+					HE: &model.PkgEqualInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.PkgEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHE: []*model.PkgEqual{
+				{
+					Packages:    []*model.Package{testdata.P1out, testdata.P2out},
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -750,6 +771,32 @@ func TestIngestPkgEquals(t *testing.T) {
 				{
 					Packages:      []*model.Package{testdata.P1out, testdata.P3out},
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2},
+			Calls: []call{
+				{
+					P1: []*model.IDorPkgInput{{PackageInput: testdata.P1}, {PackageInput: testdata.P1}},
+					P2: []*model.IDorPkgInput{{PackageInput: testdata.P2}, {PackageInput: testdata.P2}},
+					PE: []*model.PkgEqualInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.PkgEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpHE: []*model.PkgEqual{
+				{
+					Packages:    []*model.Package{testdata.P1out, testdata.P2out},
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/pkg_test.go
+++ b/internal/testing/backend/pkg_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/pkg_test.go
+++ b/internal/testing/backend/pkg_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/pointOfContact_test.go
+++ b/internal/testing/backend/pointOfContact_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/pointOfContact_test.go
+++ b/internal/testing/backend/pointOfContact_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/pointOfContact_test.go
+++ b/internal/testing/backend/pointOfContact_test.go
@@ -739,6 +739,37 @@ func TestPointOfContact(t *testing.T) {
 					Justification: "test justification",
 				},
 			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					POC: &model.PointOfContactInputSpec{
+						Email:       "a@b.com",
+						Info:        "info1",
+						Since:       time.Unix(1e9, 0),
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpPoc: []*model.PointOfContact{
+				{
+					Subject:     testdata.P1out,
+					Email:       "a@b.com",
+					Info:        "info1",
+					Since:       time.Unix(1e9, 0),
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -1069,6 +1100,33 @@ func TestIngestPointOfContacts(t *testing.T) {
 				{
 					Subject:       testdata.A2out,
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:  "docref",
+			InPkg: []*model.PkgInputSpec{testdata.P1},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInputs{
+						Packages: []*model.IDorPkgInput{&model.IDorPkgInput{PackageInput: testdata.P1}},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					PC: []*model.PointOfContactInputSpec{
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.PointOfContactSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpPC: []*model.PointOfContact{
+				{
+					Subject:     testdata.P1out,
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/search_test.go
+++ b/internal/testing/backend/search_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/search_test.go
+++ b/internal/testing/backend/search_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/src_test.go
+++ b/internal/testing/backend/src_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/src_test.go
+++ b/internal/testing/backend/src_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnEqual_test.go
+++ b/internal/testing/backend/vulnEqual_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnEqual_test.go
+++ b/internal/testing/backend/vulnEqual_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnEqual_test.go
+++ b/internal/testing/backend/vulnEqual_test.go
@@ -559,6 +559,36 @@ func TestVulnEqual(t *testing.T) {
 			},
 			ExpVulnEqual: nil,
 			ExpQueryErr:  false,
+		}, {
+			Name:   "docref",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1, testdata.C1},
+			Calls: []call{
+				{
+					Vuln:      testdata.O1,
+					OtherVuln: testdata.C1,
+					In: &model.VulnEqualInputSpec{
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.VulnEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVulnEqual: []*model.VulnEqual{
+				{
+					Vulnerabilities: []*model.Vulnerability{
+						{
+							Type:             "osv",
+							VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+						},
+						{
+							Type:             "cve",
+							VulnerabilityIDs: []*model.VulnerabilityID{testdata.C1out},
+						},
+					},
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -764,6 +794,41 @@ func TestIngestVulnEquals(t *testing.T) {
 						},
 					},
 					Justification: "test justification",
+				},
+			},
+		}, {
+			Name:   "docref",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.O1, testdata.C1, testdata.O1, testdata.C2},
+			Calls: []call{
+				{
+					Vulns:      []*model.IDorVulnerabilityInput{{VulnerabilityInput: testdata.O1}, {VulnerabilityInput: testdata.O1}},
+					OtherVulns: []*model.IDorVulnerabilityInput{{VulnerabilityInput: testdata.C1}, {VulnerabilityInput: testdata.C2}},
+					Ins: []*model.VulnEqualInputSpec{
+						{
+							Justification: "test justification",
+						},
+						{
+							DocumentRef: "test",
+						},
+					},
+				},
+			},
+			Query: &model.VulnEqualSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVulnEqual: []*model.VulnEqual{
+				{
+					Vulnerabilities: []*model.Vulnerability{
+						{
+							Type:             "cve",
+							VulnerabilityIDs: []*model.VulnerabilityID{testdata.C2out},
+						},
+						{
+							Type:             "osv",
+							VulnerabilityIDs: []*model.VulnerabilityID{testdata.O1out},
+						},
+					},
+					DocumentRef: "test",
 				},
 			},
 		},

--- a/internal/testing/backend/vulnMetadata_test.go
+++ b/internal/testing/backend/vulnMetadata_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnMetadata_test.go
+++ b/internal/testing/backend/vulnMetadata_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnMetadata_test.go
+++ b/internal/testing/backend/vulnMetadata_test.go
@@ -968,6 +968,40 @@ func TestIngestVulnMetadata(t *testing.T) {
 					Origin:     "test origin",
 				},
 			},
+		}, {
+			Name:   "docref",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.C1},
+			Calls: []call{
+				{
+					Vuln: testdata.C1,
+					VulnMetadata: &model.VulnerabilityMetadataInputSpec{
+						ScoreType:   model.VulnerabilityScoreTypeCVSSv2,
+						ScoreValue:  8.9,
+						Timestamp:   testdata.T1,
+						Collector:   "test collector",
+						Origin:      "test origin",
+						DocumentRef: "test",
+					},
+				},
+			},
+			Query: &model.VulnerabilityMetadataSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVuln: []*model.VulnerabilityMetadata{
+				{
+					ID: "1",
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.C1out},
+					},
+					ScoreType:   model.VulnerabilityScoreTypeCVSSv2,
+					ScoreValue:  8.9,
+					Timestamp:   testdata.T1,
+					Collector:   "test collector",
+					Origin:      "test origin",
+					DocumentRef: "test",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -1278,6 +1312,47 @@ func TestIngestVulnMetadatas(t *testing.T) {
 				},
 			},
 			ExpVuln: nil,
+		}, {
+			Name:   "docref",
+			InVuln: []*model.VulnerabilityInputSpec{testdata.C1, testdata.C2},
+			Calls: []call{
+				{
+					Vulns: []*model.IDorVulnerabilityInput{{VulnerabilityInput: testdata.C1}, {VulnerabilityInput: testdata.C2}},
+					VulnMetadatas: []*model.VulnerabilityMetadataInputSpec{
+						{
+							ScoreType:  model.VulnerabilityScoreTypeCVSSv3,
+							ScoreValue: 7.9,
+							Timestamp:  testdata.T1,
+							Collector:  "test collector",
+							Origin:     "test origin",
+						},
+						{
+							ScoreType:   model.VulnerabilityScoreTypeCVSSv2,
+							ScoreValue:  8.9,
+							Timestamp:   testdata.T1,
+							DocumentRef: "test",
+							Origin:      "test origin",
+						},
+					},
+				},
+			},
+			Query: &model.VulnerabilityMetadataSpec{
+				DocumentRef: ptrfrom.String("test"),
+			},
+			ExpVuln: []*model.VulnerabilityMetadata{
+				{
+					ID: "10",
+					Vulnerability: &model.Vulnerability{
+						Type:             "cve",
+						VulnerabilityIDs: []*model.VulnerabilityID{testdata.C2out},
+					},
+					ScoreType:   model.VulnerabilityScoreTypeCVSSv2,
+					ScoreValue:  8.9,
+					Timestamp:   testdata.T1,
+					DocumentRef: "test",
+					Origin:      "test origin",
+				},
+			},
 		},
 	}
 	for _, test := range tests {

--- a/internal/testing/backend/vulnerability_test.go
+++ b/internal/testing/backend/vulnerability_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package backend_test
 
 import (

--- a/internal/testing/backend/vulnerability_test.go
+++ b/internal/testing/backend/vulnerability_test.go
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package backend_test
 
 import (

--- a/internal/testing/dochelper/dochelper_test.go
+++ b/internal/testing/dochelper/dochelper_test.go
@@ -50,7 +50,7 @@ func TestStringTree(t *testing.T) {
 				},
 				makeOverflow: false,
 			},
-			want: " { doc: {\"a\":\"b\"}, , test2, { }}\n- { doc: {\"c\":\"d\"}, , test, { }}",
+			want: " { doc: {\"a\":\"b\"}, , test2, {  }}\n- { doc: {\"c\":\"d\"}, , test, {  }}",
 		},
 		{
 			name: "stack overflow",
@@ -71,7 +71,7 @@ func TestStringTree(t *testing.T) {
 				},
 				makeOverflow: true,
 			},
-			want: " { doc: {\"a\":\"b\"}, , test1, { }}\n- { doc: {\"c\":\"d\"}, , test2, { }}",
+			want: " { doc: {\"a\":\"b\"}, , test1, {  }}\n- { doc: {\"c\":\"d\"}, , test2, {  }}",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -570,82 +570,82 @@ func getCollectionIndexMap() map[string][]index {
 	}
 
 	collectionIndexMap[isDependenciesStr] = []index{
-		initIndex("byPkgIDDepPkgIDversionRangeOrigin", []string{"packageID", "depPackageID", "versionRange", "origin"}, false),
+		initIndex("byPkgIDDepPkgIDversionRangeOrigin", []string{"packageID", "depPackageID", "versionRange", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[isOccurrencesStr] = []index{
-		initIndex("byPkgIDArtIDOriginJust", []string{"packageID", "artifactID", "justification", "origin"}, true),
+		initIndex("byPkgIDArtIDOriginJust", []string{"packageID", "artifactID", "justification", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[certifyBadsStr] = []index{
-		initIndex("certifyBadArtifactID", []string{"artifactID", "justification", "knownSince"}, false),
-		initIndex("certifyBadPackageID", []string{"packageID", "justification", "knownSince"}, false),
-		initIndex("certifyBadSourceID", []string{"sourceID", "justification", "knownSince"}, false),
+		initIndex("certifyBadArtifactID", []string{"artifactID", "justification", "knownSince", docRef}, false),
+		initIndex("certifyBadPackageID", []string{"packageID", "justification", "knownSince", docRef}, false),
+		initIndex("certifyBadSourceID", []string{"sourceID", "justification", "knownSince", docRef}, false),
 	}
 
 	collectionIndexMap[certifyGoodsStr] = []index{
-		initIndex("certifyGoodArtifactID", []string{"artifactID", "justification", "knownSince"}, false),
-		initIndex("certifyGoodPackageID", []string{"packageID", "justification", "knownSince"}, false),
-		initIndex("certifyGoodSourceID", []string{"sourceID", "justification", "knownSince"}, false),
+		initIndex("certifyGoodArtifactID", []string{"artifactID", "justification", "knownSince", docRef}, false),
+		initIndex("certifyGoodPackageID", []string{"packageID", "justification", "knownSince", docRef}, false),
+		initIndex("certifyGoodSourceID", []string{"sourceID", "justification", "knownSince", docRef}, false),
 	}
 
 	collectionIndexMap[certifyLegalsStr] = []index{
-		initIndex("certifyLegalPackageID", []string{"packageID", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin"}, false),
-		initIndex("certifyLegalSourceID", []string{"sourceID", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin"}, false),
+		initIndex("certifyLegalPackageID", []string{"packageID", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin", docRef}, false),
+		initIndex("certifyLegalSourceID", []string{"sourceID", "declaredLicense", "declaredLicenses", "discoveredLicense", "discoveredLicenses", "attribution", "justification", "timeScanned", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[scorecardStr] = []index{
-		initIndex("certifyScorecard", []string{"sourceID", "checks", "aggregateScore", "timeScanned", "origin"}, true),
+		initIndex("certifyScorecard", []string{"sourceID", "checks", "aggregateScore", "timeScanned", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[certifyVEXsStr] = []index{
-		initIndex("certifyVexPackageID", []string{"packageID", "vulnerabilityID", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin"}, false),
-		initIndex("certifyVexArtifactID", []string{"artifactID", "vulnerabilityID", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin"}, false),
+		initIndex("certifyVexPackageID", []string{"packageID", "vulnerabilityID", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", docRef}, false),
+		initIndex("certifyVexArtifactID", []string{"artifactID", "vulnerabilityID", "status", "vexJustification", "statement", "statusNotes", "knownSince", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[certifyVulnsStr] = []index{
-		initIndex("certifyVuln", []string{"packageID", "vulnerabilityID", "ScannerVersion", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "timeScanned", "origin"}, true),
+		initIndex("certifyVuln", []string{"packageID", "vulnerabilityID", "ScannerVersion", "dbUri", "dbVersion", "scannerUri", "scannerVersion", "timeScanned", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[hashEqualsStr] = []index{
-		initIndex("hashEquals", []string{"artifactID", "equalArtifactID", "justification", "origin"}, true),
+		initIndex("hashEquals", []string{"artifactID", "equalArtifactID", "justification", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[hasMetadataStr] = []index{
-		initIndex("hashMetadataArtifactID", []string{"artifactID", "key", "value", "timestamp", "justification", "origin"}, false),
-		initIndex("hashMetadataPackageID", []string{"packageID", "key", "value", "timestamp", "justification", "origin"}, false),
-		initIndex("hashMetadataSourceID", []string{"sourceID", "key", "value", "timestamp", "justification", "origin"}, false),
+		initIndex("hashMetadataArtifactID", []string{"artifactID", "key", "value", "timestamp", "justification", "origin", docRef}, false),
+		initIndex("hashMetadataPackageID", []string{"packageID", "key", "value", "timestamp", "justification", "origin", docRef}, false),
+		initIndex("hashMetadataSourceID", []string{"sourceID", "key", "value", "timestamp", "justification", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[hasSBOMsStr] = []index{
-		initIndex("hasSbomArtifactID", []string{"artifactID", "uri", "algorithm", "digest", "knownSince", "downloadLocation", "origin"}, false),
-		initIndex("hasSbomPackageID", []string{"packageID", "uri", "algorithm", "digest", "knownSince", "downloadLocation", "origin"}, false),
+		initIndex("hasSbomArtifactID", []string{"artifactID", "uri", "algorithm", "digest", "knownSince", "downloadLocation", "origin", docRef}, false),
+		initIndex("hasSbomPackageID", []string{"packageID", "uri", "algorithm", "digest", "knownSince", "downloadLocation", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[hasSLSAsStr] = []index{
-		initIndex("hasSlsa", []string{"subjectID", "builtByID", "buildType", "builtFrom", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin"}, true),
+		initIndex("hasSlsa", []string{"subjectID", "builtByID", "buildType", "builtFrom", "slsaPredicate", "slsaVersion", "startedOn", "finishedOn", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[hasSourceAtsStr] = []index{
-		initIndex("hasSourceAt", []string{"packageID", "sourceID", "justification", "knownSince", "origin"}, true),
+		initIndex("hasSourceAt", []string{"packageID", "sourceID", "justification", "knownSince", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[pkgEqualsStr] = []index{
-		initIndex("pkgEqual", []string{"packageID", "equalPackageID", "justification", "origin"}, true),
+		initIndex("pkgEqual", []string{"packageID", "equalPackageID", "justification", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[pointOfContactStr] = []index{
-		initIndex("pointOfContactArtifactID", []string{"artifactID", "email", "info", "since", "justification", "origin"}, false),
-		initIndex("pointOfContactPackageID", []string{"packageID", "email", "info", "since", "justification", "origin"}, false),
-		initIndex("pointOfContactSourceID", []string{"sourceID", "email", "info", "since", "justification", "origin"}, false),
+		initIndex("pointOfContactArtifactID", []string{"artifactID", "email", "info", "since", "justification", "origin", docRef}, false),
+		initIndex("pointOfContactPackageID", []string{"packageID", "email", "info", "since", "justification", "origin", docRef}, false),
+		initIndex("pointOfContactSourceID", []string{"sourceID", "email", "info", "since", "justification", "origin", docRef}, false),
 	}
 
 	collectionIndexMap[vulnEqualsStr] = []index{
-		initIndex("vulnEqual", []string{"vulnerabilityID", "equalVulnerabilityID", "justification", "origin"}, true),
+		initIndex("vulnEqual", []string{"vulnerabilityID", "equalVulnerabilityID", "justification", "origin", docRef}, true),
 	}
 
 	collectionIndexMap[vulnMetadataStr] = []index{
-		initIndex("vulnMetadata", []string{"vulnerabilityID", "scoreType", "scoreValue", "timestamp", "origin"}, true),
+		initIndex("vulnMetadata", []string{"vulnerabilityID", "scoreType", "scoreValue", "timestamp", "origin", docRef}, true),
 	}
 
 	return collectionIndexMap

--- a/pkg/assembler/backends/arangodb/certifyGood.go
+++ b/pkg/assembler/backends/arangodb/certifyGood.go
@@ -175,7 +175,8 @@ func getSrcCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 		'justification': certifyGood.justification,
 		'collector': certifyGood.collector,
 		'knownSince': certifyGood.knownSince,
-		'origin': certifyGood.origin
+		'origin': certifyGood.origin,
+		'documentRef': certifyGood.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "certifyGood")
@@ -199,7 +200,8 @@ func getArtCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 		'justification': certifyGood.justification,
 		'collector': certifyGood.collector,
 		'knownSince': certifyGood.knownSince,
-		'origin': certifyGood.origin
+		'origin': certifyGood.origin,
+		'documentRef': certifyGood.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "certifyGood")
@@ -231,7 +233,8 @@ func getPkgCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'justification': certifyGood.justification,
 			'collector': certifyGood.collector,
 			'knownSince': certifyGood.knownSince,
-			'origin': certifyGood.origin
+			'origin': certifyGood.origin,
+			'documentRef': certifyGood.documentRef
 		  }`)
 
 	} else {
@@ -249,7 +252,8 @@ func getPkgCertifyGoodForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'justification': certifyGood.justification,
 			'collector': certifyGood.collector,
 			'knownSince': certifyGood.knownSince,
-			'origin': certifyGood.origin
+			'origin': certifyGood.origin,
+			'documentRef': certifyGood.documentRef
 		  }`)
 	}
 
@@ -278,6 +282,10 @@ func setCertifyGoodMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyGo
 	if certifyGoodSpec.Collector != nil {
 		arangoQueryBuilder.filter("certifyGood", collector, "==", "@"+collector)
 		queryValues[collector] = *certifyGoodSpec.Collector
+	}
+	if certifyGoodSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("certifyGood", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *certifyGoodSpec.DocumentRef
 	}
 	if certifyGoodSpec.KnownSince != nil {
 		certifyGoodKnownSince := *certifyGoodSpec.KnownSince
@@ -308,6 +316,7 @@ func getCertifyGoodQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Matc
 	values["origin"] = certifyGood.Origin
 	values["collector"] = certifyGood.Collector
 	values["knownSince"] = certifyGood.KnownSince.UTC()
+	values[docRef] = certifyGood.DocumentRef
 
 	return values
 }
@@ -328,8 +337,8 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 		)
 
 		  LET certifyGood = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
-				  INSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
+			  UPSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
+				  INSERT {  packageID:firstPkg.version_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
 				  UPDATE {} IN certifyGoods
 				  RETURN {
 					'_id': NEW._id,
@@ -360,8 +369,8 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 			)
 
 			  LET certifyGood = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
-					  INSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
+				  UPSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
+					  INSERT {  packageID:firstPkg.name_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
 					  UPDATE {} IN certifyGoods
 					  RETURN {
 						'_id': NEW._id,
@@ -386,8 +395,8 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
 
 		LET certifyGood = FIRST(
-			UPSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
-				INSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
+			UPSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
+				INSERT { artifactID:artifact._id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
 				UPDATE {} IN certifyGoods
 				RETURN {
 					'_id': NEW._id,
@@ -418,8 +427,8 @@ func (c *arangoClient) IngestCertifyGood(ctx context.Context, subject model.Pack
 		)
 
 		LET certifyGood = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
-				INSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin, knownSince:@knownSince }
+			UPSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
+				INSERT { sourceID:firstSrc.name_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef, knownSince:@knownSince }
 				UPDATE {} IN certifyGoods
 				RETURN {
 					'_id': NEW._id,
@@ -502,8 +511,8 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 		)
 		  
 		  LET certifyGood = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
-				  INSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+			  UPSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
+				  INSERT {  packageID:firstPkg.version_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
 				  UPDATE {} IN certifyGoods
 				  RETURN {
 					'_id': NEW._id,
@@ -536,8 +545,8 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 			)
 			  
 			  LET certifyGood = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
-					  INSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+				  UPSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
+					  INSERT {  packageID:firstPkg.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
 					  UPDATE {} IN certifyGoods
 					  RETURN {
 						'_id': NEW._id,
@@ -596,8 +605,8 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 		  
 		LET certifyGood = FIRST(
-			UPSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
-				INSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+			UPSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
+				INSERT { artifactID:artifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
 				UPDATE {} IN certifyGoods
 				RETURN {
 					'_id': NEW._id,
@@ -663,8 +672,8 @@ func (c *arangoClient) IngestCertifyGoods(ctx context.Context, subjects model.Pa
 		)
 		  
 		LET certifyGood = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
-				INSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, knownSince:doc.knownSince } 
+			UPSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
+				INSERT { sourceID:firstSrc.name_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef, knownSince:doc.knownSince } 
 				UPDATE {} IN certifyGoods
 				RETURN {
 					'_id': NEW._id,
@@ -711,6 +720,7 @@ func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 		Collector     string          `json:"collector"`
 		KnownSince    time.Time       `json:"knownSince"`
 		Origin        string          `json:"origin"`
+		DocumentRef   string          `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -745,6 +755,7 @@ func getCertifyGoodFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 			Origin:        createdValue.Collector,
 			Collector:     createdValue.Origin,
 			KnownSince:    createdValue.KnownSince,
+			DocumentRef:   createdValue.DocumentRef,
 		}
 		if pkg != nil {
 			certifyGood.Subject = pkg
@@ -809,6 +820,7 @@ func (c *arangoClient) queryCertifyGoodNodeByID(ctx context.Context, filter *mod
 		Justification string  `json:"justification"`
 		Collector     string  `json:"collector"`
 		Origin        string  `json:"origin"`
+		DocumentRef   string  `json:"documentRef"`
 	}
 
 	var collectedValues []dbCertifyGood
@@ -835,6 +847,7 @@ func (c *arangoClient) queryCertifyGoodNodeByID(ctx context.Context, filter *mod
 		Justification: collectedValues[0].Justification,
 		Origin:        collectedValues[0].Origin,
 		Collector:     collectedValues[0].Collector,
+		DocumentRef:   collectedValues[0].DocumentRef,
 	}
 
 	if collectedValues[0].PackageID != nil {

--- a/pkg/assembler/backends/arangodb/certifyLegal.go
+++ b/pkg/assembler/backends/arangodb/certifyLegal.go
@@ -132,7 +132,8 @@ func getSrcCertifyLegalForQuery(ctx context.Context, c *arangoClient,
   'justification': certifyLegal.justification,
   'timeScanned': certifyLegal.timeScanned,
   'collector': certifyLegal.collector,
-  'origin': certifyLegal.origin
+  'origin': certifyLegal.origin,
+  'documentRef': certifyLegal.documentRef
 }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, aqb.string(), values, "CertifyLegal")
@@ -170,7 +171,8 @@ func getPkgCertifyLegalForQuery(ctx context.Context, c *arangoClient,
   'justification': certifyLegal.justification,
   'timeScanned': certifyLegal.timeScanned,
   'collector': certifyLegal.collector,
-  'origin': certifyLegal.origin
+  'origin': certifyLegal.origin,
+  'documentRef': certifyLegal.documentRef
 }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, aqb.string(), values, "CertifyLegal")
@@ -202,6 +204,10 @@ func setCertifyLegalMatchValues(aqb *arangoQueryBuilder, certifyLegalSpec *model
 	if certifyLegalSpec.Justification != nil {
 		aqb.filter("certifyLegal", justification, "==", "@"+justification)
 		queryValues[justification] = *certifyLegalSpec.Justification
+	}
+	if certifyLegalSpec.DocumentRef != nil {
+		aqb.filter("certifyLegal", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *certifyLegalSpec.DocumentRef
 	}
 	if certifyLegalSpec.TimeScanned != nil {
 		aqb.filter("certifyLegal", "timeScanned", "==", "@timeScanned")
@@ -256,6 +262,7 @@ func getCertifyLegalQueryValues(pkg *model.PkgInputSpec, source *model.SourceInp
 	values["timeScanned"] = certifyLegal.TimeScanned.UTC()
 	values["origin"] = certifyLegal.Origin
 	values["collector"] = certifyLegal.Collector
+	values[docRef] = certifyLegal.DocumentRef
 
 	return values
 }
@@ -299,7 +306,8 @@ LET certifyLegal = FIRST(
     justification:@justification,
     timeScanned:@timeScanned,
     collector:@collector,
-    origin:@origin
+    origin:@origin,
+	documentRef:@documentRef
   }
   INSERT {
     packageID:firstPkg.version_id,
@@ -311,7 +319,8 @@ LET certifyLegal = FIRST(
     justification:@justification,
     timeScanned:@timeScanned,
     collector:@collector,
-    origin:@origin
+    origin:@origin,
+	documentRef:@documentRef
   }
   UPDATE {} IN certifyLegals
   RETURN {
@@ -373,7 +382,8 @@ LET certifyLegal = FIRST(
     justification:@justification,
     timeScanned:@timeScanned,
     collector:@collector,
-    origin:@origin
+    origin:@origin,
+	documentRef:@documentRef
   }
   INSERT {
     sourceID:firstSrc.name_id,
@@ -385,7 +395,8 @@ LET certifyLegal = FIRST(
     justification:@justification,
     timeScanned:@timeScanned,
     collector:@collector,
-    origin:@origin
+    origin:@origin,
+	documentRef:@documentRef
   }
   UPDATE {} IN certifyLegals
   RETURN {
@@ -494,7 +505,8 @@ LET certifyLegal = FIRST(
     justification:doc.justification,
     timeScanned:doc.timeScanned,
     collector:doc.collector,
-    origin:doc.origin
+    origin:doc.origin,
+	documentRef:doc.documentRef
   }
   INSERT {
     packageID:firstPkg.version_id,
@@ -506,7 +518,8 @@ LET certifyLegal = FIRST(
     justification:doc.justification,
     timeScanned:doc.timeScanned,
     collector:doc.collector,
-    origin:doc.origin
+    origin:doc.origin,
+	documentRef:doc.documentRef
   }
   UPDATE {} IN certifyLegals
   RETURN {
@@ -609,7 +622,8 @@ LET certifyLegal = FIRST(
     justification:doc.justification,
     timeScanned:doc.timeScanned,
     collector:doc.collector,
-    origin:doc.origin
+    origin:doc.origin,
+	documentRef:doc.documentRef
   }
   INSERT {
     sourceID:firstSrc.name_id,
@@ -621,7 +635,8 @@ LET certifyLegal = FIRST(
     justification:doc.justification,
     timeScanned:doc.timeScanned,
     collector:doc.collector,
-    origin:doc.origin
+    origin:doc.origin,
+	documentRef:doc.documentRef
   }
   UPDATE {} IN certifyLegals
   RETURN {
@@ -683,6 +698,7 @@ func (c *arangoClient) getCertifyLegalFromCursor(ctx context.Context,
 		TimeScanned        time.Time     `json:"timeScanned"`
 		Collector          string        `json:"collector"`
 		Origin             string        `json:"origin"`
+		DocumentRef        string        `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -737,6 +753,7 @@ func (c *arangoClient) getCertifyLegalFromCursor(ctx context.Context,
 			TimeScanned:       createdValue.TimeScanned,
 			Origin:            createdValue.Origin,
 			Collector:         createdValue.Collector,
+			DocumentRef:       createdValue.DocumentRef,
 		}
 
 		dec, err := c.getLicensesByID(ctx, createdValue.DeclaredLicenses)
@@ -823,6 +840,7 @@ func (c *arangoClient) queryCertifyLegalNodeByID(ctx context.Context, filter *mo
 		TimeScanned        time.Time `json:"timeScanned"`
 		Collector          string    `json:"collector"`
 		Origin             string    `json:"origin"`
+		DocumentRef        string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbCertifyLegal
@@ -853,6 +871,7 @@ func (c *arangoClient) queryCertifyLegalNodeByID(ctx context.Context, filter *mo
 		TimeScanned:       collectedValues[0].TimeScanned,
 		Origin:            collectedValues[0].Origin,
 		Collector:         collectedValues[0].Collector,
+		DocumentRef:       collectedValues[0].DocumentRef,
 	}
 
 	dec, err := c.getLicensesByID(ctx, collectedValues[0].DeclaredLicenses)

--- a/pkg/assembler/backends/arangodb/certifyVEXStatement.go
+++ b/pkg/assembler/backends/arangodb/certifyVEXStatement.go
@@ -136,7 +136,8 @@ func getPkgVexForQuery(ctx context.Context, c *arangoClient, arangoQueryBuilder 
 		'statusNotes': certifyVex.statusNotes,
 		'knownSince': certifyVex.knownSince,
 		'collector': certifyVex.collector,
-		'origin': certifyVex.origin  
+		'origin': certifyVex.origin,
+		'documentRef': certifyVex.documentRef  
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyVEXStatement")
@@ -169,7 +170,8 @@ func getArtifactVexForQuery(ctx context.Context, c *arangoClient, arangoQueryBui
 		'statusNotes': certifyVex.statusNotes,
 		'knownSince': certifyVex.knownSince,
 		'collector': certifyVex.collector,
-		'origin': certifyVex.origin  
+		'origin': certifyVex.origin,
+		'documentRef': certifyVex.documentRef  
 	}`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyVEXStatement")
@@ -214,6 +216,10 @@ func setVexMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyVexSpec *m
 		arangoQueryBuilder.filter("certifyVex", collector, "==", "@"+collector)
 		queryValues[collector] = *certifyVexSpec.Collector
 	}
+	if certifyVexSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("certifyVex", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *certifyVexSpec.DocumentRef
+	}
 	if certifyVexSpec.Vulnerability != nil {
 		arangoQueryBuilder.forOutBound(certifyVexVulnEdgesStr, "vVulnID", "certifyVex")
 		if certifyVexSpec.Vulnerability.ID != nil {
@@ -256,6 +262,7 @@ func getVEXStatementQueryValues(pkg *model.PkgInputSpec, artifact *model.Artifac
 	values[knownSinceStr] = vexStatement.KnownSince.UTC()
 	values[origin] = vexStatement.Origin
 	values[collector] = vexStatement.Collector
+	values[docRef] = vexStatement.DocumentRef
 
 	return values
 }
@@ -302,8 +309,8 @@ func (c *arangoClient) IngestVEXStatements(ctx context.Context, subjects model.P
 		)
 		  
 		LET certifyVex = FIRST(
-			UPSERT { artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin } 
-				INSERT {artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin } 
+			UPSERT { artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT {artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN certifyVEXs
 				RETURN {
 					'_id': NEW._id,
@@ -385,8 +392,8 @@ func (c *arangoClient) IngestVEXStatements(ctx context.Context, subjects model.P
 		)
 		  
 		LET certifyVex = FIRST(
-			UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin } 
-				INSERT {packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin } 
+			UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT {packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:doc.status, vexJustification:doc.vexJustification, statement:doc.statement, statusNotes:doc.statusNotes, knownSince:doc.knownSince, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN certifyVEXs
 				RETURN {
 					'_id': NEW._id,
@@ -440,8 +447,8 @@ func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.Pac
 		  )
 		  
 		  LET certifyVex = FIRST(
-			  UPSERT { artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
-				  INSERT {artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+			  UPSERT { artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				  INSERT {artifactID:artifact._id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				  UPDATE {} IN certifyVEXs
 				  RETURN {
 					'_id': NEW._id,
@@ -490,8 +497,8 @@ func (c *arangoClient) IngestVEXStatement(ctx context.Context, subject model.Pac
 		)
 		  
 		LET certifyVex = FIRST(
-			UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
-				INSERT {packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin } 
+			UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				INSERT {packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, status:@status, vexJustification:@vexJustification, statement:@statement, statusNotes:@statusNotes, knownSince:@knownSince, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				UPDATE {} IN certifyVEXs
 				RETURN {
 					'_id': NEW._id,
@@ -537,6 +544,7 @@ func getCertifyVexFromCursor(ctx context.Context, cursor driver.Cursor, ingestio
 		KnownSince       time.Time       `json:"knownSince"`
 		Collector        string          `json:"collector"`
 		Origin           string          `json:"origin"`
+		DocumentRef      string          `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -571,6 +579,7 @@ func getCertifyVexFromCursor(ctx context.Context, cursor driver.Cursor, ingestio
 			KnownSince:       createdValue.KnownSince,
 			Origin:           createdValue.Origin,
 			Collector:        createdValue.Collector,
+			DocumentRef:      createdValue.DocumentRef,
 		}
 		if pkg != nil {
 			certifyVex.Subject = pkg
@@ -656,6 +665,7 @@ func (c *arangoClient) queryCertifyVexNodeByID(ctx context.Context, filter *mode
 		KnownSince       time.Time `json:"knownSince"`
 		Collector        string    `json:"collector"`
 		Origin           string    `json:"origin"`
+		DocumentRef      string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbVex
@@ -685,6 +695,7 @@ func (c *arangoClient) queryCertifyVexNodeByID(ctx context.Context, filter *mode
 		KnownSince:       collectedValues[0].KnownSince,
 		Origin:           collectedValues[0].Origin,
 		Collector:        collectedValues[0].Collector,
+		DocumentRef:      collectedValues[0].DocumentRef,
 	}
 
 	builtVuln, err := c.buildVulnResponseByID(ctx, collectedValues[0].VulnerabilityID, filter.Vulnerability)

--- a/pkg/assembler/backends/arangodb/certifyVuln.go
+++ b/pkg/assembler/backends/arangodb/certifyVuln.go
@@ -95,7 +95,8 @@ func getPkgCertifyVulnForQuery(ctx context.Context, c *arangoClient, arangoQuery
 		'scannerUri': certifyVuln.scannerUri,
 		'scannerVersion': certifyVuln.scannerVersion,
 		'collector': certifyVuln.collector,
-		'origin': certifyVuln.origin
+		'origin': certifyVuln.origin,
+		'documentRef': certifyVuln.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "CertifyVuln")
@@ -139,6 +140,10 @@ func setCertifyVulnMatchValues(arangoQueryBuilder *arangoQueryBuilder, certifyVu
 	if certifyVulnSpec.Collector != nil {
 		arangoQueryBuilder.filter("certifyVuln", collector, "==", "@"+collector)
 		queryValues[collector] = *certifyVulnSpec.Collector
+	}
+	if certifyVulnSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("certifyVuln", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *certifyVulnSpec.DocumentRef
 	}
 	if certifyVulnSpec.Vulnerability != nil {
 
@@ -186,6 +191,7 @@ func getCertifyVulnQueryValues(pkg *model.PkgInputSpec, vulnerability *model.Vul
 	values[scannerVersionStr] = certifyVuln.ScannerVersion
 	values[origin] = certifyVuln.Origin
 	values[collector] = certifyVuln.Collector
+	values[docRef] = certifyVuln.DocumentRef
 
 	return values
 }
@@ -239,8 +245,8 @@ func (c *arangoClient) IngestCertifyVulns(ctx context.Context, pkgs []*model.IDo
 		)
 		  
 		  LET certifyVuln = FIRST(
-			  UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin } 
-				  INSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin } 
+			  UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				  INSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:doc.timeScanned, dbUri:doc.dbUri, dbVersion:doc.dbVersion, scannerUri:doc.scannerUri, scannerVersion:doc.scannerVersion, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				  UPDATE {} IN certifyVulns
 				RETURN {
 					'_id': NEW._id,
@@ -295,8 +301,8 @@ func (c *arangoClient) IngestCertifyVuln(ctx context.Context, pkg model.IDorPkgI
 		)
 		  
 		  LET certifyVuln = FIRST(
-			  UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin } 
-				  INSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin } 
+			  UPSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				  INSERT { packageID:firstPkg.version_id, vulnerabilityID:firstVuln.vuln_id, timeScanned:@timeScanned, dbUri:@dbUri, dbVersion:@dbVersion, scannerUri:@scannerUri, scannerVersion:@scannerVersion, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				  UPDATE {} IN certifyVulns
 				  RETURN {
 					'_id': NEW._id,
@@ -339,6 +345,7 @@ func geCertifyVulnFromCursor(ctx context.Context, cursor driver.Cursor, ingestio
 		ScannerVersion string        `json:"scannerVersion"`
 		Collector      string        `json:"collector"`
 		Origin         string        `json:"origin"`
+		DocumentRef    string        `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -368,6 +375,7 @@ func geCertifyVulnFromCursor(ctx context.Context, cursor driver.Cursor, ingestio
 				ScannerVersion: createdValue.ScannerVersion,
 				Origin:         createdValue.Origin,
 				Collector:      createdValue.Collector,
+				DocumentRef:    createdValue.DocumentRef,
 			},
 		}
 		if createdValue.PkgVersion != nil {
@@ -451,6 +459,7 @@ func (c *arangoClient) queryCertifyVulnNodeByID(ctx context.Context, filter *mod
 		ScannerVersion  string    `json:"scannerVersion"`
 		Collector       string    `json:"collector"`
 		Origin          string    `json:"origin"`
+		DocumentRef     string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbVuln
@@ -482,6 +491,7 @@ func (c *arangoClient) queryCertifyVulnNodeByID(ctx context.Context, filter *mod
 			ScannerVersion: collectedValues[0].ScannerVersion,
 			Origin:         collectedValues[0].Origin,
 			Collector:      collectedValues[0].Collector,
+			DocumentRef:    collectedValues[0].DocumentRef,
 		},
 	}
 

--- a/pkg/assembler/backends/arangodb/edgeCollections.go
+++ b/pkg/assembler/backends/arangodb/edgeCollections.go
@@ -16,6 +16,7 @@ const (
 	vulnerabilityID string        = "vulnerabilityIDs"
 	origin          string        = "origin"
 	collector       string        = "collector"
+	docRef          string        = "documentRef"
 	justification   string        = "justification"
 	knownSince      string        = "knownSince"
 	maxRetires      int           = 100

--- a/pkg/assembler/backends/arangodb/hasMetadata.go
+++ b/pkg/assembler/backends/arangodb/hasMetadata.go
@@ -182,7 +182,8 @@ func getSrcHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQuery
 		'timestamp': hasMetadata.timestamp,
 		'justification': hasMetadata.justification,
 		'collector': hasMetadata.collector,
-		'origin': hasMetadata.origin  
+		'origin': hasMetadata.origin,
+		'documentRef': hasMetadata.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasMetadata")
@@ -208,7 +209,8 @@ func getArtHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQuery
 		'timestamp': hasMetadata.timestamp,
 		'justification': hasMetadata.justification,
 		'collector': hasMetadata.collector,
-		'origin': hasMetadata.origin
+		'origin': hasMetadata.origin,
+		'documentRef': hasMetadata.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasMetadata")
@@ -242,7 +244,8 @@ func getPkgHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'timestamp': hasMetadata.timestamp,
 			'justification': hasMetadata.justification,
 			'collector': hasMetadata.collector,
-			'origin': hasMetadata.origin
+			'origin': hasMetadata.origin,
+			'documentRef': hasMetadata.documentRef
 		  }`)
 	} else {
 		arangoQueryBuilder.query.WriteString("\n")
@@ -261,7 +264,8 @@ func getPkgHasMetadataForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'timestamp': hasMetadata.timestamp,
 			'justification': hasMetadata.justification,
 			'collector': hasMetadata.collector,
-			'origin': hasMetadata.origin
+			'origin': hasMetadata.origin,
+			'documentRef': hasMetadata.documentRef
 		  }`)
 	}
 
@@ -303,6 +307,10 @@ func setHasMetadataMatchValues(arangoQueryBuilder *arangoQueryBuilder, hasMetada
 		arangoQueryBuilder.filter("hasMetadata", collector, "==", "@"+collector)
 		queryValues[collector] = *hasMetadataSpec.Collector
 	}
+	if hasMetadataSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("hasMetadata", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *hasMetadataSpec.DocumentRef
+	}
 }
 
 func getHasMetadataQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.MatchFlags, artifact *model.ArtifactInputSpec, source *model.SourceInputSpec, hasMetadata *model.HasMetadataInputSpec) map[string]any {
@@ -329,6 +337,7 @@ func getHasMetadataQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Matc
 	values[justification] = hasMetadata.Justification
 	values[origin] = hasMetadata.Origin
 	values[collector] = hasMetadata.Collector
+	values[docRef] = hasMetadata.DocumentRef
 
 	return values
 }
@@ -349,8 +358,8 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 		)
 		  
 		  LET hasMetadata = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
-				  INSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+			  UPSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				  INSERT {  packageID:firstPkg.version_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				  UPDATE {} IN hasMetadataCollection
 				  RETURN {
 					'_id': NEW._id,
@@ -382,8 +391,8 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 			)
 			  
 			  LET hasMetadata = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
-					  INSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+				  UPSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+					  INSERT {  packageID:firstPkg.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 					  UPDATE {} IN hasMetadataCollection
 					  RETURN {
 						'_id': NEW._id,
@@ -407,8 +416,8 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
 		  
 		LET hasMetadata = FIRST(
-			UPSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
-				INSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+			UPSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				INSERT { artifactID:artifact._id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				UPDATE {} IN hasMetadataCollection
 				RETURN {
 					'_id': NEW._id,
@@ -439,8 +448,8 @@ func (c *arangoClient) IngestHasMetadata(ctx context.Context, subject model.Pack
 		)
 		  
 		LET hasMetadata = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
-				INSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin } 
+			UPSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				INSERT { sourceID:firstSrc.name_id, key:@key, value:@value, timestamp:@timestamp, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				UPDATE {} IN hasMetadataCollection
 				RETURN {
 					'_id': NEW._id,
@@ -519,8 +528,8 @@ func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model
 			)
 			  
 			  LET hasMetadata = FIRST(
-				  UPSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-					  INSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+					  INSERT {  packageID:firstPkg.version_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 					  UPDATE {} IN hasMetadataCollection
 					  RETURN {
 						'_id': NEW._id,
@@ -554,8 +563,8 @@ func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model
 			)
 			  
 			  LET hasMetadata = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-					  INSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+					  INSERT {  packageID:firstPkg.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 					  UPDATE {} IN hasMetadataCollection
 					  RETURN {
 						'_id': NEW._id,
@@ -609,8 +618,8 @@ func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 		  
 		LET hasMetadata = FIRST(
-			UPSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				INSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			UPSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT { artifactID:artifact._id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN hasMetadataCollection
 				RETURN {
 					'_id': NEW._id,
@@ -671,8 +680,8 @@ func (c *arangoClient) IngestBulkHasMetadata(ctx context.Context, subjects model
 		)
 		  
 		LET hasMetadata = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				INSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			UPSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT { sourceID:firstSrc.name_id, key:doc.key, value:doc.value, timestamp:doc.timestamp, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN hasMetadataCollection
 				RETURN {
 					'_id': NEW._id,
@@ -722,6 +731,7 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 		Justification string          `json:"justification"`
 		Collector     string          `json:"collector"`
 		Origin        string          `json:"origin"`
+		DocumentRef   string          `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -759,6 +769,7 @@ func getHasMetadataFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 			Justification: createdValue.Justification,
 			Origin:        createdValue.Origin,
 			Collector:     createdValue.Collector,
+			DocumentRef:   createdValue.DocumentRef,
 		}
 
 		if pkg != nil {
@@ -827,6 +838,7 @@ func (c *arangoClient) queryHasMetadataNodeByID(ctx context.Context, filter *mod
 		Justification string    `json:"justification"`
 		Collector     string    `json:"collector"`
 		Origin        string    `json:"origin"`
+		DocumentRef   string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbHasMetadata
@@ -856,6 +868,7 @@ func (c *arangoClient) queryHasMetadataNodeByID(ctx context.Context, filter *mod
 		Justification: collectedValues[0].Justification,
 		Origin:        collectedValues[0].Origin,
 		Collector:     collectedValues[0].Collector,
+		DocumentRef:   collectedValues[0].DocumentRef,
 	}
 
 	if collectedValues[0].PackageID != nil {

--- a/pkg/assembler/backends/arangodb/hasSLSA.go
+++ b/pkg/assembler/backends/arangodb/hasSLSA.go
@@ -83,7 +83,7 @@ func (c *arangoClient) HasSlsa(ctx context.Context, hasSLSASpec *model.HasSLSASp
 		'finishedOn': hasSLSA.finishedOn,
 		'collector': hasSLSA.collector,
 		'origin': hasSLSA.origin,
-		'documentRef': hashEqual.documentRef
+		'documentRef': hasSLSA.documentRef
 	}`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "HasSlsa")

--- a/pkg/assembler/backends/arangodb/hasSourceAt.go
+++ b/pkg/assembler/backends/arangodb/hasSourceAt.go
@@ -136,7 +136,8 @@ func getPkgHasSourceAtForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'knownSince': hasSourceAt.knownSince,
 			'justification': hasSourceAt.justification,
 			'collector': hasSourceAt.collector,
-			'origin': hasSourceAt.origin
+			'origin': hasSourceAt.origin,
+			'documentRef': hasSourceAt.documentRef
 		  }`)
 	} else {
 		arangoQueryBuilder.query.WriteString("\n")
@@ -163,7 +164,8 @@ func getPkgHasSourceAtForQuery(ctx context.Context, c *arangoClient, arangoQuery
 			'knownSince': hasSourceAt.knownSince,
 			'justification': hasSourceAt.justification,
 			'collector': hasSourceAt.collector,
-			'origin': hasSourceAt.origin
+			'origin': hasSourceAt.origin,
+			'documentRef': hasSourceAt.documentRef
 		  }`)
 	}
 
@@ -196,6 +198,10 @@ func queryHasSourceAtBasedOnFilter(arangoQueryBuilder *arangoQueryBuilder, hasSo
 	if hasSourceAtSpec.Collector != nil {
 		arangoQueryBuilder.filter("hasSourceAt", collector, "==", "@"+collector)
 		queryValues[collector] = *hasSourceAtSpec.Collector
+	}
+	if hasSourceAtSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("hasSourceAt", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *hasSourceAtSpec.DocumentRef
 	}
 }
 
@@ -253,6 +259,7 @@ func getHasSourceAtQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.Matc
 	values[justification] = hasSourceAt.Justification
 	values[origin] = hasSourceAt.Origin
 	values[collector] = hasSourceAt.Collector
+	values[docRef] = hasSourceAt.DocumentRef
 
 	return values
 }
@@ -281,8 +288,8 @@ func (c *arangoClient) IngestHasSourceAt(ctx context.Context, pkg model.IDorPkgI
 		)
 		  
 		  LET hasSourceAt = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
-				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				  UPDATE {} IN hasSourceAts
 				  RETURN {
 					'_id': NEW._id,
@@ -321,8 +328,8 @@ func (c *arangoClient) IngestHasSourceAt(ctx context.Context, pkg model.IDorPkgI
 			)
 			  
 			  LET hasSourceAt = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
-					  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin } 
+				  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+					  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:@knownSince, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 					  UPDATE {} IN hasSourceAts
 					  RETURN {
 						'_id': NEW._id,
@@ -405,8 +412,8 @@ func (c *arangoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.IDo
 		)
 		  
 		  LET hasSourceAt = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			  UPSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				  INSERT {  packageID:firstPkg.version_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				  UPDATE {} IN hasSourceAts
 				  RETURN {
 					'_id': NEW._id,
@@ -448,8 +455,8 @@ func (c *arangoClient) IngestHasSourceAts(ctx context.Context, pkgs []*model.IDo
 		)
 		  
 		  LET hasSourceAt = FIRST(
-			  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			  UPSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				  INSERT {  packageID:firstPkg.name_id, sourceID:firstSrc.name_id, knownSince:doc.knownSince, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				  UPDATE {} IN hasSourceAts
 				  RETURN {
 					'_id': NEW._id,
@@ -492,6 +499,7 @@ func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 		Justification string        `json:"justification"`
 		Collector     string        `json:"collector"`
 		Origin        string        `json:"origin"`
+		DocumentRef   string        `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -526,6 +534,7 @@ func getHasSourceAtFromCursor(ctx context.Context, cursor driver.Cursor, ingesti
 				Justification: createdValue.Justification,
 				Origin:        createdValue.Origin,
 				Collector:     createdValue.Collector,
+				DocumentRef:   createdValue.DocumentRef,
 			}
 		} else {
 			hasSourceAt = &model.HasSourceAt{ID: createdValue.HasSourceAtID}
@@ -582,6 +591,7 @@ func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *mod
 		Justification string    `json:"justification"`
 		Collector     string    `json:"collector"`
 		Origin        string    `json:"origin"`
+		DocumentRef   string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbHasSourceAt
@@ -620,6 +630,7 @@ func (c *arangoClient) queryHasSourceAtNodeByID(ctx context.Context, filter *mod
 		KnownSince:    collectedValues[0].KnownSince,
 		Justification: collectedValues[0].Justification,
 		Origin:        collectedValues[0].Origin,
+		DocumentRef:   collectedValues[0].DocumentRef,
 	}, nil
 }
 

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -216,7 +216,7 @@ func (c *arangoClient) IngestHashEquals(ctx context.Context, artifacts []*model.
 	LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 	LET equalArtifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.equal_algorithm FILTER art.digest == doc.equal_digest RETURN art)
 	LET hashEqual = FIRST(
-		UPSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+		UPSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:do.origin, documentRef:doc.documentRef } 
 			INSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 			UPDATE {} IN hashEquals
 			RETURN {

--- a/pkg/assembler/backends/arangodb/hashEqual.go
+++ b/pkg/assembler/backends/arangodb/hashEqual.go
@@ -216,7 +216,7 @@ func (c *arangoClient) IngestHashEquals(ctx context.Context, artifacts []*model.
 	LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 	LET equalArtifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.equal_algorithm FILTER art.digest == doc.equal_digest RETURN art)
 	LET hashEqual = FIRST(
-		UPSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:do.origin, documentRef:doc.documentRef } 
+		UPSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 			INSERT { artifactID:artifact._id, equalArtifactID:equalArtifact._id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 			UPDATE {} IN hashEquals
 			RETURN {

--- a/pkg/assembler/backends/arangodb/isDependency.go
+++ b/pkg/assembler/backends/arangodb/isDependency.go
@@ -171,7 +171,8 @@ func getDependencyForQuery(ctx context.Context, c *arangoClient, arangoQueryBuil
 			'dependencyType': isDependency.dependencyType,
 			'justification': isDependency.justification,
 			'collector': isDependency.collector,
-			'origin': isDependency.origin
+			'origin': isDependency.origin,
+			'documentRef': isDependency.documentRef
 		}`)
 	} else {
 		arangoQueryBuilder.query.WriteString("\n")
@@ -201,7 +202,8 @@ func getDependencyForQuery(ctx context.Context, c *arangoClient, arangoQueryBuil
 			'dependencyType': isDependency.dependencyType,
 			'justification': isDependency.justification,
 			'collector': isDependency.collector,
-			'origin': isDependency.origin
+			'origin': isDependency.origin,
+			'documentRef': isDependency.documentRef
 		}`)
 	}
 
@@ -238,6 +240,10 @@ func queryIsDependencyBasedOnFilter(arangoQueryBuilder *arangoQueryBuilder, isDe
 	if isDependencySpec.Collector != nil {
 		arangoQueryBuilder.filter("isDependency", collector, "==", "@"+collector)
 		queryValues[collector] = *isDependencySpec.Collector
+	}
+	if isDependencySpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("isDependency", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *isDependencySpec.DocumentRef
 	}
 }
 
@@ -342,6 +348,7 @@ func getDependencyQueryValues(pkg *model.PkgInputSpec, depPkg *model.PkgInputSpe
 	values[justification] = dependency.Justification
 	values[origin] = dependency.Origin
 	values[collector] = dependency.Collector
+	values[docRef] = dependency.DocumentRef
 
 	return values
 }
@@ -399,8 +406,8 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.IDo
     )
 		
 	LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin }
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+			INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef }
 			UPDATE {} IN isDependencies
 			RETURN {
 			   '_id': NEW._id,
@@ -435,8 +442,8 @@ func (c *arangoClient) IngestDependencies(ctx context.Context, pkgs []*model.IDo
     )
 		
 	LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin }
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+			INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:doc.versionRange, dependencyType:doc.dependencyType, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef }
 			UPDATE {} IN isDependencies
 			RETURN {
 				'_id': NEW._id,
@@ -494,8 +501,8 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.IDorPkgIn
     )
 	  
 	  LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
-			  INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+			  INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.name_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 			  UPDATE {} IN isDependencies
 			  RETURN {
 				'_id': NEW._id,
@@ -531,8 +538,8 @@ func (c *arangoClient) IngestDependency(ctx context.Context, pkg model.IDorPkgIn
 
 	  
 	  LET isDependency = FIRST(
-		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
-			  INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin } 
+		  UPSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+			  INSERT { packageID:firstPkg.version_id, depPackageID:secondPkg.version_id, versionRange:@versionRange, dependencyType:@dependencyType, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 			  UPDATE {} IN isDependencies
 			  RETURN {
 				'_id': NEW._id,
@@ -573,6 +580,7 @@ func getIsDependencyFromCursor(ctx context.Context, cursor driver.Cursor, ingest
 		Justification  string        `json:"justification"`
 		Collector      string        `json:"collector"`
 		Origin         string        `json:"origin"`
+		DocumentRef    string        `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -608,6 +616,7 @@ func getIsDependencyFromCursor(ctx context.Context, cursor driver.Cursor, ingest
 				Justification:     createdValue.Justification,
 				Origin:            createdValue.Origin,
 				Collector:         createdValue.Collector,
+				DocumentRef:       createdValue.DocumentRef,
 			}
 
 			if depType, ok := dependencyTypeToEnum[createdValue.DependencyType]; ok {
@@ -672,6 +681,7 @@ func (c *arangoClient) queryIsDependencyNodeByID(ctx context.Context, filter *mo
 		Justification  string `json:"justification"`
 		Collector      string `json:"collector"`
 		Origin         string `json:"origin"`
+		DocumentRef    string `json:"documentRef"`
 	}
 
 	var collectedValues []dbIsDependency
@@ -719,6 +729,7 @@ func (c *arangoClient) queryIsDependencyNodeByID(ctx context.Context, filter *mo
 		Justification:     collectedValues[0].Justification,
 		Origin:            collectedValues[0].Origin,
 		Collector:         collectedValues[0].Collector,
+		DocumentRef:       collectedValues[0].DocumentRef,
 	}, nil
 }
 

--- a/pkg/assembler/backends/arangodb/pointOfContact.go
+++ b/pkg/assembler/backends/arangodb/pointOfContact.go
@@ -183,7 +183,8 @@ func getSrcPointOfContactForQuery(ctx context.Context, c *arangoClient, arangoQu
 		'since': pointOfContact.since,
 		'justification': pointOfContact.justification,
 		'collector': pointOfContact.collector,
-		'origin': pointOfContact.origin
+		'origin': pointOfContact.origin,
+		'documentRef': pointOfContact.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "PointOfContact")
@@ -209,7 +210,8 @@ func getArtPointOfContactForQuery(ctx context.Context, c *arangoClient, arangoQu
 		'since': pointOfContact.since,
 		'justification': pointOfContact.justification,
 		'collector': pointOfContact.collector,
-		'origin': pointOfContact.origin
+		'origin': pointOfContact.origin,
+		'documentRef': pointOfContact.documentRef
 	  }`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "PointOfContact")
@@ -243,7 +245,8 @@ func getPkgPointOfContactForQuery(ctx context.Context, c *arangoClient, arangoQu
 			'since': pointOfContact.since,
 			'justification': pointOfContact.justification,
 			'collector': pointOfContact.collector,
-			'origin': pointOfContact.origin
+			'origin': pointOfContact.origin,
+			'documentRef': pointOfContact.documentRef
 		  }`)
 	} else {
 		arangoQueryBuilder.query.WriteString("\n")
@@ -262,7 +265,8 @@ func getPkgPointOfContactForQuery(ctx context.Context, c *arangoClient, arangoQu
 			'since': pointOfContact.since,
 			'justification': pointOfContact.justification,
 			'collector': pointOfContact.collector,
-			'origin': pointOfContact.origin
+			'origin': pointOfContact.origin,
+			'documentRef': pointOfContact.documentRef
 		  }`)
 	}
 
@@ -275,34 +279,38 @@ func getPkgPointOfContactForQuery(ctx context.Context, c *arangoClient, arangoQu
 	return getPointOfContactFromCursor(ctx, cursor, false)
 }
 
-func setPointOfContactMatchValues(arangoQueryBuilder *arangoQueryBuilder, PointOfContactSpec *model.PointOfContactSpec, queryValues map[string]any) {
-	if PointOfContactSpec.ID != nil {
+func setPointOfContactMatchValues(arangoQueryBuilder *arangoQueryBuilder, pointOfContactSpec *model.PointOfContactSpec, queryValues map[string]any) {
+	if pointOfContactSpec.ID != nil {
 		arangoQueryBuilder.filter("pointOfContact", "_id", "==", "@id")
-		queryValues["id"] = *PointOfContactSpec.ID
+		queryValues["id"] = *pointOfContactSpec.ID
 	}
-	if PointOfContactSpec.Email != nil {
+	if pointOfContactSpec.Email != nil {
 		arangoQueryBuilder.filter("pointOfContact", emailStr, "==", "@"+emailStr)
-		queryValues[emailStr] = *PointOfContactSpec.Email
+		queryValues[emailStr] = *pointOfContactSpec.Email
 	}
-	if PointOfContactSpec.Info != nil {
+	if pointOfContactSpec.Info != nil {
 		arangoQueryBuilder.filter("pointOfContact", infoStr, "==", "@"+infoStr)
-		queryValues[infoStr] = *PointOfContactSpec.Info
+		queryValues[infoStr] = *pointOfContactSpec.Info
 	}
-	if PointOfContactSpec.Since != nil {
+	if pointOfContactSpec.Since != nil {
 		arangoQueryBuilder.filter("pointOfContact", sinceStr, ">=", "@"+sinceStr)
-		queryValues[sinceStr] = PointOfContactSpec.Since.UTC()
+		queryValues[sinceStr] = pointOfContactSpec.Since.UTC()
 	}
-	if PointOfContactSpec.Justification != nil {
+	if pointOfContactSpec.Justification != nil {
 		arangoQueryBuilder.filter("pointOfContact", justification, "==", "@"+justification)
-		queryValues[justification] = *PointOfContactSpec.Justification
+		queryValues[justification] = *pointOfContactSpec.Justification
 	}
-	if PointOfContactSpec.Origin != nil {
+	if pointOfContactSpec.Origin != nil {
 		arangoQueryBuilder.filter("pointOfContact", origin, "==", "@"+origin)
-		queryValues[origin] = *PointOfContactSpec.Origin
+		queryValues[origin] = *pointOfContactSpec.Origin
 	}
-	if PointOfContactSpec.Collector != nil {
+	if pointOfContactSpec.Collector != nil {
 		arangoQueryBuilder.filter("pointOfContact", collector, "==", "@"+collector)
-		queryValues[collector] = *PointOfContactSpec.Collector
+		queryValues[collector] = *pointOfContactSpec.Collector
+	}
+	if pointOfContactSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("pointOfContact", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *pointOfContactSpec.DocumentRef
 	}
 }
 
@@ -330,6 +338,7 @@ func getPointOfContactQueryValues(pkg *model.PkgInputSpec, pkgMatchType *model.M
 	values[justification] = pointOfContact.Justification
 	values[origin] = pointOfContact.Origin
 	values[collector] = pointOfContact.Collector
+	values[docRef] = pointOfContact.DocumentRef
 
 	return values
 }
@@ -350,8 +359,8 @@ func (c *arangoClient) IngestPointOfContact(ctx context.Context, subject model.P
 		)
 		  
 		  LET pointOfContact = FIRST(
-			  UPSERT {  packageID:firstPkg.version_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
-				  INSERT {  packageID:firstPkg.version_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
+			  UPSERT {  packageID:firstPkg.version_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				  INSERT {  packageID:firstPkg.version_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				  UPDATE {} IN pointOfContacts
 				  RETURN {
 					'_id': NEW._id,
@@ -382,8 +391,8 @@ func (c *arangoClient) IngestPointOfContact(ctx context.Context, subject model.P
 			)
 			  
 			  LET pointOfContact = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
-					  INSERT {  packageID:firstPkg.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
+				  UPSERT {  packageID:firstPkg.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+					  INSERT {  packageID:firstPkg.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 					  UPDATE {} IN pointOfContacts
 					  RETURN {
 						'_id': NEW._id,
@@ -408,8 +417,8 @@ func (c *arangoClient) IngestPointOfContact(ctx context.Context, subject model.P
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == @art_algorithm FILTER art.digest == @art_digest RETURN art)
 		  
 		LET pointOfContact = FIRST(
-			UPSERT { artifactID:artifact._id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
-				INSERT { artifactID:artifact._id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
+			UPSERT { artifactID:artifact._id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				INSERT { artifactID:artifact._id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				UPDATE {} IN pointOfContacts
 				RETURN {
 					'_id': NEW._id,
@@ -440,8 +449,8 @@ func (c *arangoClient) IngestPointOfContact(ctx context.Context, subject model.P
 		)
 		  
 		LET pointOfContact = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
-				INSERT { sourceID:firstSrc.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin } 
+			UPSERT { sourceID:firstSrc.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+				INSERT { sourceID:firstSrc.name_id, email:@email, info:@info, since:@since, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 				UPDATE {} IN pointOfContacts
 				RETURN {
 					'_id': NEW._id,
@@ -519,8 +528,8 @@ func (c *arangoClient) IngestPointOfContacts(ctx context.Context, subjects model
 			)
 			  
 			  LET pointOfContact = FIRST(
-				  UPSERT {  packageID:firstPkg.version_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-					  INSERT {  packageID:firstPkg.version_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPSERT {  packageID:firstPkg.version_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+					  INSERT {  packageID:firstPkg.version_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 					  UPDATE {} IN pointOfContacts
 					  RETURN {
 						'_id': NEW._id,
@@ -553,8 +562,8 @@ func (c *arangoClient) IngestPointOfContacts(ctx context.Context, subjects model
 			)
 			  
 			  LET pointOfContact = FIRST(
-				  UPSERT {  packageID:firstPkg.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-					  INSERT {  packageID:firstPkg.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+				  UPSERT {  packageID:firstPkg.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+					  INSERT {  packageID:firstPkg.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 					  UPDATE {} IN pointOfContacts
 					  RETURN {
 						'_id': NEW._id,
@@ -609,8 +618,8 @@ func (c *arangoClient) IngestPointOfContacts(ctx context.Context, subjects model
 		query := `LET artifact = FIRST(FOR art IN artifacts FILTER art.algorithm == doc.art_algorithm FILTER art.digest == doc.art_digest RETURN art)
 		  
 		LET pointOfContact = FIRST(
-			UPSERT { artifactID:artifact._id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				INSERT { artifactID:artifact._id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			UPSERT { artifactID:artifact._id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT { artifactID:artifact._id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN pointOfContacts
 				RETURN {
 					'_id': NEW._id,
@@ -671,8 +680,8 @@ func (c *arangoClient) IngestPointOfContacts(ctx context.Context, subjects model
 		)
 		  
 		LET pointOfContact = FIRST(
-			UPSERT { sourceID:firstSrc.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-				INSERT { sourceID:firstSrc.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+			UPSERT { sourceID:firstSrc.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+				INSERT { sourceID:firstSrc.name_id, email:doc.email, info:doc.info, since:doc.since, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 				UPDATE {} IN pointOfContacts
 				RETURN {
 					'_id': NEW._id,
@@ -721,6 +730,7 @@ func getPointOfContactFromCursor(ctx context.Context, cursor driver.Cursor, inge
 		Justification    string          `json:"justification"`
 		Collector        string          `json:"collector"`
 		Origin           string          `json:"origin"`
+		DocumentRef      string          `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -758,6 +768,7 @@ func getPointOfContactFromCursor(ctx context.Context, cursor driver.Cursor, inge
 			Justification: createdValue.Justification,
 			Origin:        createdValue.Origin,
 			Collector:     createdValue.Collector,
+			DocumentRef:   createdValue.DocumentRef,
 		}
 
 		if pkg != nil {
@@ -826,6 +837,7 @@ func (c *arangoClient) queryPointOfContactNodeByID(ctx context.Context, filter *
 		Justification    string    `json:"justification"`
 		Collector        string    `json:"collector"`
 		Origin           string    `json:"origin"`
+		DocumentRef      string    `json:"documentRef"`
 	}
 
 	var collectedValues []dbPointOfContact
@@ -855,6 +867,7 @@ func (c *arangoClient) queryPointOfContactNodeByID(ctx context.Context, filter *
 		Justification: collectedValues[0].Justification,
 		Origin:        collectedValues[0].Origin,
 		Collector:     collectedValues[0].Collector,
+		DocumentRef:   collectedValues[0].DocumentRef,
 	}
 
 	if collectedValues[0].PackageID != nil {

--- a/pkg/assembler/backends/arangodb/vulnEqual.go
+++ b/pkg/assembler/backends/arangodb/vulnEqual.go
@@ -153,7 +153,8 @@ func getVulnEqualForQuery(ctx context.Context, c *arangoClient, arangoQueryBuild
 		'vulnEqual_id': vulnEqual._id,
 		'justification': vulnEqual.justification,
 		'collector': vulnEqual.collector,
-		'origin': vulnEqual.origin
+		'origin': vulnEqual.origin,
+		'documentRef': vulnEqual.documentRef
 	}`)
 
 	cursor, err := executeQueryWithRetry(ctx, c.db, arangoQueryBuilder.string(), values, "vulnEqual")
@@ -182,6 +183,10 @@ func setVulnEqualMatchValues(arangoQueryBuilder *arangoQueryBuilder, vulnEqualSp
 		arangoQueryBuilder.filter("vulnEqual", collector, "==", "@"+collector)
 		queryValues[collector] = *vulnEqualSpec.Collector
 	}
+	if vulnEqualSpec.DocumentRef != nil {
+		arangoQueryBuilder.filter("vulnEqual", docRef, "==", "@"+docRef)
+		queryValues[docRef] = *vulnEqualSpec.DocumentRef
+	}
 }
 
 func getVulnEqualQueryValues(vulnerability *model.VulnerabilityInputSpec, otherVulnerability *model.VulnerabilityInputSpec, vulnEqual *model.VulnEqualInputSpec) map[string]any {
@@ -201,6 +206,7 @@ func getVulnEqualQueryValues(vulnerability *model.VulnerabilityInputSpec, otherV
 	values[justification] = vulnEqual.Justification
 	values[origin] = vulnEqual.Origin
 	values[collector] = vulnEqual.Collector
+	values[docRef] = vulnEqual.DocumentRef
 
 	return values
 }
@@ -255,8 +261,8 @@ func (c *arangoClient) IngestVulnEquals(ctx context.Context, vulnerabilities []*
 	)
 	
 	LET vulnEqual = FIRST(
-		UPSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
-			INSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:doc.justification, collector:doc.collector, origin:doc.origin } 
+		UPSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
+			INSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:doc.justification, collector:doc.collector, origin:doc.origin, documentRef:doc.documentRef } 
 			UPDATE {} IN vulnEquals
 			RETURN {
 				'_id': NEW._id,
@@ -311,8 +317,8 @@ func (c *arangoClient) IngestVulnEqual(ctx context.Context, vulnerability model.
 	)
 	
 	LET vulnEqual = FIRST(
-		UPSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:@justification, collector:@collector, origin:@origin } 
-			INSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:@justification, collector:@collector, origin:@origin } 
+		UPSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
+			INSERT { vulnerabilityID:firstVuln.vuln_id, equalVulnerabilityID:equalVuln.vuln_id, justification:@justification, collector:@collector, origin:@origin, documentRef:@documentRef } 
 			UPDATE {} IN vulnEquals
 			RETURN {
 				'_id': NEW._id,
@@ -351,6 +357,7 @@ func getVulnEqualFromCursor(ctx context.Context, cursor driver.Cursor, ingestion
 		Justification      string    `json:"justification"`
 		Collector          string    `json:"collector"`
 		Origin             string    `json:"origin"`
+		DocumentRef        string    `json:"documentRef"`
 	}
 
 	var createdValues []collectedData
@@ -400,6 +407,7 @@ func getVulnEqualFromCursor(ctx context.Context, cursor driver.Cursor, ingestion
 				Justification:   createdValue.Justification,
 				Origin:          createdValue.Origin,
 				Collector:       createdValue.Collector,
+				DocumentRef:     createdValue.DocumentRef,
 			}
 		} else {
 			vulnEqual = &model.VulnEqual{ID: createdValue.VulnEqualId}
@@ -455,6 +463,7 @@ func (c *arangoClient) queryVulnEqualNodeByID(ctx context.Context, filter *model
 		Justification        string `json:"justification"`
 		Collector            string `json:"collector"`
 		Origin               string `json:"origin"`
+		DocumentRef          string `json:"documentRef"`
 	}
 
 	var collectedValues []dbVulnEqual
@@ -491,6 +500,7 @@ func (c *arangoClient) queryVulnEqualNodeByID(ctx context.Context, filter *model
 		Justification:   collectedValues[0].Justification,
 		Origin:          collectedValues[0].Origin,
 		Collector:       collectedValues[0].Collector,
+		DocumentRef:     collectedValues[0].DocumentRef,
 	}, nil
 }
 

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -256,16 +256,16 @@ func generateCertifyCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgIn
 		certifyCreate.
 			SetType(certification.TypeBAD).
 			SetJustification(cb.Justification).
+			SetKnownSince(cb.KnownSince.UTC()).
 			SetOrigin(cb.Origin).
-			SetCollector(cb.Collector).
-			SetKnownSince(cb.KnownSince.UTC())
+			SetCollector(cb.Collector)
 	} else if cg != nil {
 		certifyCreate.
 			SetType(certification.TypeGOOD).
 			SetJustification(cg.Justification).
+			SetKnownSince(cg.KnownSince.UTC()).
 			SetOrigin(cg.Origin).
-			SetCollector(cg.Collector).
-			SetKnownSince(cg.KnownSince.UTC())
+			SetCollector(cg.Collector)
 	} else {
 		return nil, fmt.Errorf("must specify either certifyGood or certifyBad")
 	}

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -92,6 +92,7 @@ func queryCertifications(typ certification.Type, filter *model.CertifyBadSpec) p
 		optionalPredicate(filter.Origin, certification.OriginEQ),
 		optionalPredicate(filter.Justification, certification.JustificationEQ),
 		optionalPredicate(filter.KnownSince, certification.KnownSinceEQ),
+		optionalPredicate(filter.DocumentRef, certification.DocumentRef),
 	}
 
 	if filter.Subject != nil {
@@ -175,6 +176,7 @@ func upsertCertification[T certificationInputSpec](ctx context.Context, tx *ent.
 		certification.FieldCollector,
 		certification.FieldOrigin,
 		certification.FieldJustification,
+		certification.FieldDocumentRef,
 		certification.FieldKnownSince,
 	}
 
@@ -258,14 +260,16 @@ func generateCertifyCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgIn
 			SetJustification(cb.Justification).
 			SetKnownSince(cb.KnownSince.UTC()).
 			SetOrigin(cb.Origin).
-			SetCollector(cb.Collector)
+			SetCollector(cb.Collector).
+			SetDocumentRef(cb.DocumentRef)
 	} else if cg != nil {
 		certifyCreate.
 			SetType(certification.TypeGOOD).
 			SetJustification(cg.Justification).
 			SetKnownSince(cg.KnownSince.UTC()).
 			SetOrigin(cg.Origin).
-			SetCollector(cg.Collector)
+			SetCollector(cg.Collector).
+			SetDocumentRef(cg.DocumentRef)
 	} else {
 		return nil, fmt.Errorf("must specify either certifyGood or certifyBad")
 	}
@@ -356,6 +360,7 @@ func upsertBulkCertification[T certificationInputSpec](ctx context.Context, tx *
 		certification.FieldOrigin,
 		certification.FieldJustification,
 		certification.FieldKnownSince,
+		certification.FieldDocumentRef,
 	}
 
 	switch {
@@ -506,6 +511,7 @@ func toModelCertifyBad(v *ent.Certification) *model.CertifyBad {
 		Justification: v.Justification,
 		Origin:        v.Origin,
 		Collector:     v.Collector,
+		DocumentRef:   v.DocumentRef,
 		Subject:       sub,
 		KnownSince:    v.KnownSince,
 	}
@@ -533,6 +539,7 @@ func toModelCertifyGood(v *ent.Certification) *model.CertifyGood {
 		Justification: v.Justification,
 		Origin:        v.Origin,
 		Collector:     v.Collector,
+		DocumentRef:   v.DocumentRef,
 		Subject:       sub,
 		KnownSince:    v.KnownSince,
 	}

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -168,10 +168,8 @@ func (b *EntBackend) IngestCertifyGoods(ctx context.Context, subjects model.Pack
 	return toGlobalIDs(certifyGoodString, *ids), nil
 }
 
-func upsertCertification[T certificationInputSpec](ctx context.Context, tx *ent.Tx, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, spec T) (*string, error) {
-	var conflictWhere *sql.Predicate
-
-	conflictColumns := []string{
+func certifyConflictColumns() []string {
+	return []string{
 		certification.FieldType,
 		certification.FieldCollector,
 		certification.FieldOrigin,
@@ -179,6 +177,12 @@ func upsertCertification[T certificationInputSpec](ctx context.Context, tx *ent.
 		certification.FieldDocumentRef,
 		certification.FieldKnownSince,
 	}
+}
+
+func upsertCertification[T certificationInputSpec](ctx context.Context, tx *ent.Tx, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, spec T) (*string, error) {
+	var conflictWhere *sql.Predicate
+
+	conflictColumns := certifyConflictColumns()
 
 	switch {
 	case subject.Artifact != nil:
@@ -354,14 +358,7 @@ func upsertBulkCertification[T certificationInputSpec](ctx context.Context, tx *
 
 	var conflictWhere *sql.Predicate
 
-	conflictColumns := []string{
-		certification.FieldType,
-		certification.FieldCollector,
-		certification.FieldOrigin,
-		certification.FieldJustification,
-		certification.FieldKnownSince,
-		certification.FieldDocumentRef,
-	}
+	conflictColumns := certifyConflictColumns()
 
 	switch {
 	case len(subjects.Artifacts) > 0:

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -76,23 +76,27 @@ func (b *EntBackend) IngestCertifyLegals(ctx context.Context, subjects model.Pac
 	return toGlobalIDs(certifylegal.Table, *ids), nil
 }
 
+func certifyLegalConflictColumns() []string {
+	return []string{
+		certifylegal.FieldDeclaredLicense,
+		certifylegal.FieldDiscoveredLicense,
+		certifylegal.FieldAttribution,
+		certifylegal.FieldJustification,
+		certifylegal.FieldTimeScanned,
+		certifylegal.FieldOrigin,
+		certifylegal.FieldCollector,
+		certifylegal.FieldDocumentRef,
+		certifylegal.FieldDeclaredLicensesHash,
+		certifylegal.FieldDiscoveredLicensesHash,
+	}
+}
+
 func (b *EntBackend) IngestCertifyLegal(ctx context.Context, subject model.PackageOrSourceInput, declaredLicenses []*model.IDorLicenseInput, discoveredLicenses []*model.IDorLicenseInput, spec *model.CertifyLegalInputSpec) (string, error) {
 
 	recordID, txErr := WithinTX(ctx, b.client, func(ctx context.Context) (*string, error) {
 		tx := ent.TxFromContext(ctx)
 
-		certifyLegalConflictColumns := []string{
-			certifylegal.FieldDeclaredLicense,
-			certifylegal.FieldDiscoveredLicense,
-			certifylegal.FieldAttribution,
-			certifylegal.FieldJustification,
-			certifylegal.FieldTimeScanned,
-			certifylegal.FieldOrigin,
-			certifylegal.FieldCollector,
-			certifylegal.FieldDocumentRef,
-			certifylegal.FieldDeclaredLicensesHash,
-			certifylegal.FieldDiscoveredLicensesHash,
-		}
+		certifyLegalConflictColumns := certifyLegalConflictColumns()
 		var conflictWhere *sql.Predicate
 
 		if subject.Package != nil {
@@ -262,18 +266,7 @@ func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.Certi
 func upsertBulkCertifyLegal(ctx context.Context, tx *ent.Tx, subjects model.PackageOrSourceInputs, declaredLicensesList [][]*model.IDorLicenseInput, discoveredLicensesList [][]*model.IDorLicenseInput, certifyLegals []*model.CertifyLegalInputSpec) (*[]string, error) {
 	ids := make([]string, 0)
 
-	certifyLegalConflictColumns := []string{
-		certifylegal.FieldDeclaredLicense,
-		certifylegal.FieldDiscoveredLicense,
-		certifylegal.FieldAttribution,
-		certifylegal.FieldJustification,
-		certifylegal.FieldTimeScanned,
-		certifylegal.FieldOrigin,
-		certifylegal.FieldCollector,
-		certifylegal.FieldDocumentRef,
-		certifylegal.FieldDeclaredLicensesHash,
-		certifylegal.FieldDiscoveredLicensesHash,
-	}
+	certifyLegalConflictColumns := certifyLegalConflictColumns()
 
 	var conflictWhere *sql.Predicate
 
@@ -381,7 +374,7 @@ func certifyLegalQuery(filter model.CertifyLegalSpec) predicate.CertifyLegal {
 }
 
 func canonicalCertifyLegalString(cl *model.CertifyLegalInputSpec) string {
-	return fmt.Sprintf("%s::%s::%s::%s::%s::%s::%s", cl.DeclaredLicense, cl.DiscoveredLicense, cl.Attribution, cl.Justification, cl.TimeScanned.UTC(), cl.Origin, cl.Collector)
+	return fmt.Sprintf("%s::%s::%s::%s::%s::%s::%s:%s", cl.DeclaredLicense, cl.DiscoveredLicense, cl.Attribution, cl.Justification, cl.TimeScanned.UTC(), cl.Origin, cl.Collector, cl.DocumentRef)
 }
 
 // guacCertifyLegalKey generates an uuid based on the hash of the inputspec and inputs. certifyLegal ID has to be set for bulk ingestion

--- a/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
+++ b/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
@@ -337,9 +337,7 @@ func certifyVexPredicate(filter model.CertifyVEXStatementSpec) predicate.Certify
 		} else {
 			predicates = append(predicates,
 				certifyvex.HasVulnerabilityWith(
-					optionalPredicate(filter.Vulnerability.ID, IDEQ),
-					optionalPredicate(filter.Vulnerability.VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold),
-					optionalPredicate(filter.Vulnerability.Type, vulnerabilityid.TypeEqualFold),
+					vulnerabilityQueryPredicates(*filter.Vulnerability)...,
 				),
 			)
 		}

--- a/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
+++ b/pkg/assembler/backends/ent/backend/certifyVEXStatement.go
@@ -31,21 +31,26 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+func certifyVexConflictColumns() []string {
+	return []string{
+		certifyvex.FieldKnownSince,
+		certifyvex.FieldStatus,
+		certifyvex.FieldStatement,
+		certifyvex.FieldStatusNotes,
+		certifyvex.FieldJustification,
+		certifyvex.FieldOrigin,
+		certifyvex.FieldCollector,
+		certifyvex.FieldDocumentRef,
+		certifyvex.FieldVulnerabilityID,
+	}
+}
+
 func (b *EntBackend) IngestVEXStatement(ctx context.Context, subject model.PackageOrArtifactInput, vulnerability model.IDorVulnerabilityInput, vexStatement model.VexStatementInputSpec) (string, error) {
 	funcName := "IngestVEXStatement"
 
 	recordID, txErr := WithinTX(ctx, b.client, func(ctx context.Context) (*string, error) {
 		tx := ent.TxFromContext(ctx)
-		conflictColumns := []string{
-			certifyvex.FieldKnownSince,
-			certifyvex.FieldStatus,
-			certifyvex.FieldStatement,
-			certifyvex.FieldStatusNotes,
-			certifyvex.FieldJustification,
-			certifyvex.FieldOrigin,
-			certifyvex.FieldCollector,
-			certifyvex.FieldVulnerabilityID,
-		}
+		conflictColumns := certifyVexConflictColumns()
 
 		var conflictWhere *sql.Predicate
 
@@ -187,7 +192,8 @@ func generateVexCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgInput,
 		SetStatusNotes(vexStatement.StatusNotes).
 		SetJustification(vexStatement.VexJustification.String()).
 		SetOrigin(vexStatement.Origin).
-		SetCollector(vexStatement.Collector)
+		SetCollector(vexStatement.Collector).
+		SetDocumentRef(vexStatement.DocumentRef)
 
 	return certifyVexCreate, nil
 }
@@ -195,16 +201,7 @@ func generateVexCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgInput,
 func upsertBulkVEX(ctx context.Context, tx *ent.Tx, subjects model.PackageOrArtifactInputs, vulnerabilities []*model.IDorVulnerabilityInput, vexStatements []*model.VexStatementInputSpec) (*[]string, error) {
 	ids := make([]string, 0)
 
-	conflictColumns := []string{
-		certifyvex.FieldKnownSince,
-		certifyvex.FieldStatus,
-		certifyvex.FieldStatement,
-		certifyvex.FieldStatusNotes,
-		certifyvex.FieldJustification,
-		certifyvex.FieldOrigin,
-		certifyvex.FieldCollector,
-		certifyvex.FieldVulnerabilityID,
-	}
+	conflictColumns := certifyVexConflictColumns()
 
 	var conflictWhere *sql.Predicate
 
@@ -301,6 +298,7 @@ func toModelCertifyVEXStatement(record *ent.CertifyVex) *model.CertifyVEXStateme
 		VexJustification: model.VexJustification(record.Justification),
 		Origin:           record.Origin,
 		Collector:        record.Collector,
+		DocumentRef:      record.DocumentRef,
 	}
 
 }
@@ -313,6 +311,7 @@ func certifyVexPredicate(filter model.CertifyVEXStatementSpec) predicate.Certify
 		optionalPredicate(filter.StatusNotes, certifyvex.StatusNotesEQ),
 		optionalPredicate(filter.Collector, certifyvex.CollectorEQ),
 		optionalPredicate(filter.Origin, certifyvex.OriginEQ),
+		optionalPredicate(filter.DocumentRef, certifyvex.DocumentRefEQ),
 	}
 	if filter.Status != nil {
 		status := filter.Status.String()

--- a/pkg/assembler/backends/ent/backend/certifyVuln.go
+++ b/pkg/assembler/backends/ent/backend/certifyVuln.go
@@ -230,23 +230,6 @@ func certifyVulnPredicate(spec model.CertifyVulnSpec) predicate.CertifyVuln {
 			)
 		}),
 	}
-
-	// if spec.Vulnerability != nil &&
-	// 	spec.Vulnerability.NoVuln != nil {
-	// 	if *spec.Vulnerability.NoVuln {
-	// 		predicates = append(predicates,
-	// 			certifyvuln.HasVulnerabilityWith(
-	// 				vulnerabilityid.TypeEqualFold(NoVuln),
-	// 			),
-	// 		)
-	// 	} else {
-	// 		predicates = append(predicates,
-	// 			certifyvuln.HasVulnerabilityWith(
-	// 				vulnerabilityid.TypeNEQ(NoVuln),
-	// 			),
-	// 		)
-	// 	}
-	// }
 	return certifyvuln.And(predicates...)
 }
 

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -26,7 +26,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/occurrence"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
-	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcename"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -323,12 +322,7 @@ func isOccurrenceQuery(filter *model.IsOccurrenceSpec) predicate.Occurrence {
 		} else if filter.Subject.Source != nil {
 			predicates = append(predicates,
 				occurrence.HasSourceWith(
-					optionalPredicate(filter.Subject.Source.ID, IDEQ),
-					optionalPredicate(filter.Subject.Source.Namespace, sourcename.NamespaceEQ),
-					optionalPredicate(filter.Subject.Source.Type, sourcename.TypeEQ),
-					optionalPredicate(filter.Subject.Source.Name, sourcename.NameEQ),
-					optionalPredicate(filter.Subject.Source.Commit, sourcename.CommitEQ),
-					optionalPredicate(filter.Subject.Source.Tag, sourcename.TagEQ),
+					sourceQuery(filter.Subject.Source),
 				),
 			)
 		}

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
-	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/occurrence"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
@@ -74,15 +73,20 @@ func (b *EntBackend) IngestOccurrences(ctx context.Context, subjects model.Packa
 	return toGlobalIDs(occurrence.Table, *ids), nil
 }
 
-func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.PackageOrSourceInputs, artifacts []*model.IDorArtifactInput, occurrences []*model.IsOccurrenceInputSpec) (*[]string, error) {
-	ids := make([]string, 0)
-
-	occurrenceConflictColumns := []string{
+func occurrenceConflictColumns() []string {
+	return []string{
 		occurrence.FieldArtifactID,
 		occurrence.FieldJustification,
 		occurrence.FieldOrigin,
 		occurrence.FieldCollector,
+		occurrence.FieldDocumentRef,
 	}
+}
+
+func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.PackageOrSourceInputs, artifacts []*model.IDorArtifactInput, occurrences []*model.IsOccurrenceInputSpec) (*[]string, error) {
+	ids := make([]string, 0)
+
+	occurrenceConflictColumns := occurrenceConflictColumns()
 
 	var conflictWhere *sql.Predicate
 
@@ -176,7 +180,8 @@ func generateOccurrenceCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPk
 		SetArtifactID(artID).
 		SetJustification(occur.Justification).
 		SetOrigin(occur.Origin).
-		SetCollector(occur.Collector)
+		SetCollector(occur.Collector).
+		SetDocumentRef(occur.DocumentRef)
 
 	var isOccurrenceID *uuid.UUID
 	if pkg != nil {
@@ -244,12 +249,7 @@ func (b *EntBackend) IngestOccurrence(ctx context.Context,
 	recordID, txErr := WithinTX(ctx, b.client, func(ctx context.Context) (*string, error) {
 		tx := ent.TxFromContext(ctx)
 
-		occurrenceConflictColumns := []string{
-			occurrence.FieldArtifactID,
-			occurrence.FieldJustification,
-			occurrence.FieldOrigin,
-			occurrence.FieldCollector,
-		}
+		occurrenceConflictColumns := occurrenceConflictColumns()
 
 		var conflictWhere *sql.Predicate
 
@@ -302,17 +302,12 @@ func isOccurrenceQuery(filter *model.IsOccurrenceSpec) predicate.Occurrence {
 		optionalPredicate(filter.Justification, occurrence.JustificationEQ),
 		optionalPredicate(filter.Origin, occurrence.OriginEQ),
 		optionalPredicate(filter.Collector, occurrence.CollectorEQ),
+		optionalPredicate(filter.DocumentRef, occurrence.DocumentRef),
 	}
 
 	if filter.Artifact != nil {
 		predicates = append(predicates,
-			occurrence.HasArtifactWith(func(s *sql.Selector) {
-				if filter.Artifact != nil {
-					optionalPredicate(filter.Artifact.Digest, artifact.DigestEQ)(s)
-					optionalPredicate(filter.Artifact.Algorithm, artifact.AlgorithmEQ)(s)
-					optionalPredicate(filter.Artifact.ID, IDEQ)(s)
-				}
-			}),
+			occurrence.HasArtifactWith(artifactQueryPredicates(filter.Artifact)),
 		)
 	}
 
@@ -331,7 +326,7 @@ func isOccurrenceQuery(filter *model.IsOccurrenceSpec) predicate.Occurrence {
 }
 
 func canonicalOccurrenceString(occur model.IsOccurrenceInputSpec) string {
-	return fmt.Sprintf("%s::%s::%s", occur.Justification, occur.Origin, occur.Collector)
+	return fmt.Sprintf("%s::%s::%s:%s", occur.Justification, occur.Origin, occur.Collector, occur.DocumentRef)
 }
 
 func guacOccurrenceKey(pkgVersionID *string, srcNameID *string, artID *string, occur model.IsOccurrenceInputSpec) (*uuid.UUID, error) {

--- a/pkg/assembler/backends/ent/backend/pointOfContact.go
+++ b/pkg/assembler/backends/ent/backend/pointOfContact.go
@@ -93,6 +93,7 @@ func pointOfContactPredicate(filter *model.PointOfContactSpec) predicate.PointOf
 		optionalPredicate(filter.Justification, pointofcontact.JustificationEQ),
 		optionalPredicate(filter.Origin, pointofcontact.OriginEQ),
 		optionalPredicate(filter.Collector, pointofcontact.CollectorEQ),
+		optionalPredicate(filter.DocumentRef, pointofcontact.DocumentRefEQ),
 	}
 
 	if filter.Subject != nil {
@@ -111,17 +112,22 @@ func pointOfContactPredicate(filter *model.PointOfContactSpec) predicate.PointOf
 	return pointofcontact.And(predicates...)
 }
 
-func upsertBulkPointOfContact(ctx context.Context, tx *ent.Tx, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, pointOfContactList []*model.PointOfContactInputSpec) (*[]string, error) {
-	ids := make([]string, 0)
-
-	conflictColumns := []string{
+func pocConflictColumns() []string {
+	return []string{
 		pointofcontact.FieldEmail,
 		pointofcontact.FieldInfo,
 		pointofcontact.FieldSince,
 		pointofcontact.FieldJustification,
 		pointofcontact.FieldOrigin,
 		pointofcontact.FieldCollector,
+		pointofcontact.FieldDocumentRef,
 	}
+}
+
+func upsertBulkPointOfContact(ctx context.Context, tx *ent.Tx, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, pointOfContactList []*model.PointOfContactInputSpec) (*[]string, error) {
+	ids := make([]string, 0)
+
+	conflictColumns := pocConflictColumns()
 	var conflictWhere *sql.Predicate
 
 	switch {
@@ -216,7 +222,8 @@ func generatePointOfContactCreate(ctx context.Context, tx *ent.Tx, pkg *model.ID
 		SetSince(poc.Since.UTC()).
 		SetJustification(poc.Justification).
 		SetOrigin(poc.Origin).
-		SetCollector(poc.Collector)
+		SetCollector(poc.Collector).
+		SetDocumentRef(poc.DocumentRef)
 
 	switch {
 	case art != nil:
@@ -295,14 +302,8 @@ func generatePointOfContactCreate(ctx context.Context, tx *ent.Tx, pkg *model.ID
 
 func upsertPointOfContact(ctx context.Context, tx *ent.Tx, subject model.PackageSourceOrArtifactInput, pkgMatchType *model.MatchFlags, spec model.PointOfContactInputSpec) (*string, error) {
 
-	conflictColumns := []string{
-		pointofcontact.FieldEmail,
-		pointofcontact.FieldInfo,
-		pointofcontact.FieldSince,
-		pointofcontact.FieldJustification,
-		pointofcontact.FieldOrigin,
-		pointofcontact.FieldCollector,
-	}
+	conflictColumns := pocConflictColumns()
+
 	var conflictWhere *sql.Predicate
 
 	switch {
@@ -387,6 +388,7 @@ func toModelPointOfContact(v *ent.PointOfContact) *model.PointOfContact {
 		Justification: v.Justification,
 		Origin:        v.Origin,
 		Collector:     v.Collector,
+		DocumentRef:   v.DocumentRef,
 	}
 }
 

--- a/pkg/assembler/backends/ent/backend/slsa.go
+++ b/pkg/assembler/backends/ent/backend/slsa.go
@@ -177,7 +177,7 @@ func generateSLSACreate(ctx context.Context, tx *ent.Tx, subject *model.IDorArti
 		SetBuildType(slsa.BuildType).
 		SetCollector(slsa.Collector).
 		SetOrigin(slsa.Origin).
-		SetDocumentRef(slsa.Origin).
+		SetDocumentRef(slsa.DocumentRef).
 		SetSlsaVersion(slsa.SlsaVersion).
 		SetSlsaPredicate(toSLSAInputPredicate(slsa.SlsaPredicate)).
 		SetStartedOn(setDefaultTime(slsa.StartedOn)).

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -493,6 +493,7 @@ func toModelHasSourceAt(record *ent.HasSourceAt) *model.HasSourceAt {
 		Justification: record.Justification,
 		Origin:        record.Origin,
 		Collector:     record.Collector,
+		DocumentRef:   record.DocumentRef,
 	}
 }
 

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -62,6 +62,7 @@ func hasSourceAtQuery(filter model.HasSourceAtSpec) predicate.HasSourceAt {
 		optionalPredicate(filter.ID, IDEQ),
 		optionalPredicate(filter.Collector, hassourceat.CollectorEQ),
 		optionalPredicate(filter.Origin, hassourceat.OriginEQ),
+		optionalPredicate(filter.DocumentRef, hassourceat.DocumentRefEQ),
 		optionalPredicate(filter.Justification, hassourceat.JustificationEQ),
 		optionalPredicate(filter.KnownSince, hassourceat.KnownSinceEQ),
 	}
@@ -117,16 +118,21 @@ func (b *EntBackend) IngestHasSourceAts(ctx context.Context, pkgs []*model.IDorP
 	return toGlobalIDs(hassourceat.Table, *ids), nil
 }
 
-func upsertBulkHasSourceAts(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPkgInput, pkgMatchType *model.MatchFlags, sources []*model.IDorSourceInput, hasSourceAts []*model.HasSourceAtInputSpec) (*[]string, error) {
-	ids := make([]string, 0)
-
-	conflictColumns := []string{
+func hasSourceAtConflictColumns() []string {
+	return []string{
 		hassourceat.FieldSourceID,
 		hassourceat.FieldJustification,
 		hassourceat.FieldKnownSince,
 		hassourceat.FieldCollector,
 		hassourceat.FieldOrigin,
+		hassourceat.FieldDocumentRef,
 	}
+}
+
+func upsertBulkHasSourceAts(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPkgInput, pkgMatchType *model.MatchFlags, sources []*model.IDorSourceInput, hasSourceAts []*model.HasSourceAtInputSpec) (*[]string, error) {
+	ids := make([]string, 0)
+
+	conflictColumns := hasSourceAtConflictColumns()
 	var conflictWhere *sql.Predicate
 
 	if pkgMatchType.Pkg == model.PkgMatchTypeAllVersions {
@@ -194,6 +200,7 @@ func generateHasSourceAtCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorP
 	hasSourceAtCreate.
 		SetCollector(hs.Collector).
 		SetOrigin(hs.Origin).
+		SetDocumentRef(hs.DocumentRef).
 		SetJustification(hs.Justification).
 		SetKnownSince(hs.KnownSince.UTC()).
 		SetSourceID(sourceID)
@@ -241,13 +248,8 @@ func generateHasSourceAtCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorP
 }
 
 func upsertHasSourceAt(ctx context.Context, tx *ent.Tx, pkg model.IDorPkgInput, pkgMatchType model.MatchFlags, source model.IDorSourceInput, spec model.HasSourceAtInputSpec) (*string, error) {
-	conflictColumns := []string{
-		hassourceat.FieldSourceID,
-		hassourceat.FieldJustification,
-		hassourceat.FieldKnownSince,
-		hassourceat.FieldCollector,
-		hassourceat.FieldOrigin,
-	}
+	conflictColumns := hasSourceAtConflictColumns()
+
 	// conflictWhere MUST match the IndexWhere() defined on the index we plan to use for this query
 	var conflictWhere *sql.Predicate
 

--- a/pkg/assembler/backends/ent/backend/transforms.go
+++ b/pkg/assembler/backends/ent/backend/transforms.go
@@ -127,6 +127,7 @@ func toModelIsOccurrenceWithSubject(o *ent.Occurrence) *model.IsOccurrence {
 		Justification: o.Justification,
 		Origin:        o.Origin,
 		Collector:     o.Collector,
+		DocumentRef:   o.DocumentRef,
 	}
 }
 
@@ -195,6 +196,7 @@ func toModelIsDependency(id *ent.Dependency, backrefs bool) *model.IsDependency 
 		Justification:     id.Justification,
 		Origin:            id.Origin,
 		Collector:         id.Collector,
+		DocumentRef:       id.DocumentRef,
 	}
 }
 
@@ -219,6 +221,7 @@ func toModelHasSBOM(sbom *ent.BillOfMaterials) *model.HasSbom {
 		DownloadLocation:     sbom.DownloadLocation,
 		Origin:               sbom.Origin,
 		Collector:            sbom.Collector,
+		DocumentRef:          sbom.DocumentRef,
 		KnownSince:           sbom.KnownSince,
 		IncludedSoftware:     toIncludedSoftware(sbom.Edges.IncludedSoftwarePackages, sbom.Edges.IncludedSoftwareArtifacts),
 		IncludedDependencies: collect(sbom.Edges.IncludedDependencies, toModelIsDependencyWithBackrefs),
@@ -278,6 +281,7 @@ func toModelCertifyLegal(cl *ent.CertifyLegal) *model.CertifyLegal {
 		TimeScanned:        cl.TimeScanned,
 		Origin:             cl.Origin,
 		Collector:          cl.Collector,
+		DocumentRef:        cl.DocumentRef,
 	}
 }
 

--- a/pkg/assembler/backends/ent/backend/vulnEqual.go
+++ b/pkg/assembler/backends/ent/backend/vulnEqual.go
@@ -92,22 +92,6 @@ func vulnEqualQuery(filter *model.VulnEqualSpec) predicate.VulnEqual {
 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[1])...),
 			vulnequal.HasVulnerabilityBWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[1])...)))
 
-		// if filter.Vulnerabilities[0].NoVuln != nil {
-		// 	if *filter.Vulnerabilities[0].NoVuln {
-		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
-		// 	} else {
-		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
-		// 	}
-
-		// }
-
-		// if filter.Vulnerabilities[1].NoVuln != nil {
-		// 	if *filter.Vulnerabilities[1].NoVuln {
-		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
-		// 	} else {
-		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
-		// 	}
-		// }
 	}
 
 	return vulnequal.And(where...)

--- a/pkg/assembler/backends/ent/backend/vulnEqual.go
+++ b/pkg/assembler/backends/ent/backend/vulnEqual.go
@@ -74,8 +74,8 @@ func vulnEqualQuery(filter *model.VulnEqualSpec) predicate.VulnEqual {
 	}
 
 	if len(filter.Vulnerabilities) == 1 {
-		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(optionalPredicate(filter.Vulnerabilities[0].ID, IDEQ), optionalPredicate(filter.Vulnerabilities[0].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[0].Type, vulnerabilityid.TypeEqualFold)),
-			vulnequal.HasVulnerabilityBWith(optionalPredicate(filter.Vulnerabilities[0].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[0].Type, vulnerabilityid.TypeEqualFold))))
+		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[0])...),
+			vulnequal.HasVulnerabilityBWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[0])...)))
 
 		if filter.Vulnerabilities[0].NoVuln != nil {
 			if *filter.Vulnerabilities[0].NoVuln {
@@ -85,28 +85,28 @@ func vulnEqualQuery(filter *model.VulnEqualSpec) predicate.VulnEqual {
 			}
 		}
 	} else if len(filter.Vulnerabilities) == 2 {
-		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(optionalPredicate(filter.Vulnerabilities[0].ID, IDEQ), optionalPredicate(filter.Vulnerabilities[0].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[0].Type, vulnerabilityid.TypeEqualFold)),
-			vulnequal.HasVulnerabilityBWith(optionalPredicate(filter.Vulnerabilities[0].ID, IDEQ), optionalPredicate(filter.Vulnerabilities[0].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[0].Type, vulnerabilityid.TypeEqualFold))))
+		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[0])...),
+			vulnequal.HasVulnerabilityBWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[0])...)))
 
-		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(optionalPredicate(filter.Vulnerabilities[1].ID, IDEQ), optionalPredicate(filter.Vulnerabilities[1].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[1].Type, vulnerabilityid.TypeEqualFold)),
-			vulnequal.HasVulnerabilityBWith(optionalPredicate(filter.Vulnerabilities[1].ID, IDEQ), optionalPredicate(filter.Vulnerabilities[1].VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold), optionalPredicate(filter.Vulnerabilities[1].Type, vulnerabilityid.TypeEqualFold))))
+		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[1])...),
+			vulnequal.HasVulnerabilityBWith(vulnerabilityQueryPredicates(*filter.Vulnerabilities[1])...)))
 
-		if filter.Vulnerabilities[0].NoVuln != nil {
-			if *filter.Vulnerabilities[0].NoVuln {
-				where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
-			} else {
-				where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
-			}
+		// if filter.Vulnerabilities[0].NoVuln != nil {
+		// 	if *filter.Vulnerabilities[0].NoVuln {
+		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
+		// 	} else {
+		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
+		// 	}
 
-		}
+		// }
 
-		if filter.Vulnerabilities[1].NoVuln != nil {
-			if *filter.Vulnerabilities[1].NoVuln {
-				where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
-			} else {
-				where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
-			}
-		}
+		// if filter.Vulnerabilities[1].NoVuln != nil {
+		// 	if *filter.Vulnerabilities[1].NoVuln {
+		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeEqualFold(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeEqualFold(NoVuln))))
+		// 	} else {
+		// 		where = append(where, vulnequal.Or(vulnequal.HasVulnerabilityAWith(vulnerabilityid.TypeNEQ(NoVuln)), vulnequal.HasVulnerabilityBWith(vulnerabilityid.TypeNEQ(NoVuln))))
+		// 	}
+		// }
 	}
 
 	return vulnequal.And(where...)

--- a/pkg/assembler/backends/ent/backend/vulnEqual.go
+++ b/pkg/assembler/backends/ent/backend/vulnEqual.go
@@ -71,6 +71,7 @@ func vulnEqualQuery(filter *model.VulnEqualSpec) predicate.VulnEqual {
 		optionalPredicate(filter.Justification, vulnequal.JustificationEQ),
 		optionalPredicate(filter.Origin, vulnequal.OriginEQ),
 		optionalPredicate(filter.Collector, vulnequal.CollectorEQ),
+		optionalPredicate(filter.DocumentRef, vulnequal.DocumentRefEQ),
 	}
 
 	if len(filter.Vulnerabilities) == 1 {
@@ -142,17 +143,20 @@ func (b *EntBackend) IngestVulnEqual(ctx context.Context, vulnerability model.ID
 	return toGlobalID(vulnequal.Table, *id), nil
 }
 
-func upsertBulkVulnEquals(ctx context.Context, tx *ent.Tx, vulnerabilities []*model.IDorVulnerabilityInput, otherVulnerabilities []*model.IDorVulnerabilityInput, vulnEquals []*model.VulnEqualInputSpec) (*[]string, error) {
-	ids := make([]string, 0)
-
-	conflictColumns := []string{
+func vulnEqualConflictColumns() []string {
+	return []string{
 		vulnequal.FieldVulnerabilitiesHash,
 		vulnequal.FieldVulnID,
 		vulnequal.FieldEqualVulnID,
 		vulnequal.FieldOrigin,
 		vulnequal.FieldCollector,
 		vulnequal.FieldJustification,
+		vulnequal.FieldDocumentRef,
 	}
+}
+
+func upsertBulkVulnEquals(ctx context.Context, tx *ent.Tx, vulnerabilities []*model.IDorVulnerabilityInput, otherVulnerabilities []*model.IDorVulnerabilityInput, vulnEquals []*model.VulnEqualInputSpec) (*[]string, error) {
+	ids := make([]string, 0)
 
 	batches := chunk(vulnEquals, MaxBatchSize)
 
@@ -172,7 +176,7 @@ func upsertBulkVulnEquals(ctx context.Context, tx *ent.Tx, vulnerabilities []*mo
 
 		err := tx.VulnEqual.CreateBulk(creates...).
 			OnConflict(
-				sql.ConflictColumns(conflictColumns...),
+				sql.ConflictColumns(vulnEqualConflictColumns()...),
 			).
 			DoNothing().
 			Exec(ctx)
@@ -195,7 +199,8 @@ func generateVulnEqualCreate(ctx context.Context, tx *ent.Tx, vulnerability *mod
 	vulnEqualCreate := tx.VulnEqual.Create().
 		SetCollector(ve.Collector).
 		SetJustification(ve.Justification).
-		SetOrigin(ve.Origin)
+		SetOrigin(ve.Origin).
+		SetDocumentRef(ve.DocumentRef)
 
 	if vulnerability.VulnerabilityNodeID == nil {
 		foundVulnID, err := tx.VulnerabilityID.Query().
@@ -265,14 +270,7 @@ func upsertVulnEquals(ctx context.Context, tx *ent.Tx, vulnerability model.IDorV
 
 	if id, err := vulnEqualCreate.
 		OnConflict(
-			sql.ConflictColumns(
-				vulnequal.FieldVulnerabilitiesHash,
-				vulnequal.FieldVulnID,
-				vulnequal.FieldEqualVulnID,
-				vulnequal.FieldOrigin,
-				vulnequal.FieldCollector,
-				vulnequal.FieldJustification,
-			),
+			sql.ConflictColumns(vulnEqualConflictColumns()...),
 		).
 		Ignore().
 		ID(ctx); err != nil {
@@ -307,6 +305,7 @@ func toModelVulnEqual(record *ent.VulnEqual) *model.VulnEqual {
 		Justification:   record.Justification,
 		Origin:          record.Origin,
 		Collector:       record.Collector,
+		DocumentRef:     record.DocumentRef,
 	}
 }
 
@@ -319,7 +318,7 @@ func toModelVulnerabilityFromVulnerabilityID(vulnID *ent.VulnerabilityID) *model
 }
 
 func canonicalVulnEqualString(ve *model.VulnEqualInputSpec) string {
-	return fmt.Sprintf("%s::%s::%s", ve.Justification, ve.Origin, ve.Collector)
+	return fmt.Sprintf("%s::%s::%s:%s", ve.Justification, ve.Origin, ve.Collector, ve.DocumentRef)
 }
 
 // guacVulnEqualKey generates an uuid based on the hash of the inputspec and inputs. vulnEqual ID has to be set for bulk ingestion

--- a/pkg/assembler/backends/ent/backend/vulnMetadata.go
+++ b/pkg/assembler/backends/ent/backend/vulnMetadata.go
@@ -130,13 +130,6 @@ func vulnerabilityMetadataPredicate(filter *model.VulnerabilityMetadataSpec) (pr
 				vulnerabilityQueryPredicates(*filter.Vulnerability)...,
 			),
 		)
-		// if filter.Vulnerability.NoVuln != nil && *filter.Vulnerability.NoVuln {
-		// 	predicates = append(predicates,
-		// 		vulnerabilitymetadata.HasVulnerabilityIDWith(
-		// 			vulnerabilityid.TypeEqualFold(NoVuln),
-		// 		),
-		// 	)
-		// }
 	}
 	return vulnerabilitymetadata.And(predicates...), nil
 }

--- a/pkg/assembler/backends/ent/backend/vulnMetadata.go
+++ b/pkg/assembler/backends/ent/backend/vulnMetadata.go
@@ -126,18 +126,16 @@ func vulnerabilityMetadataPredicate(filter *model.VulnerabilityMetadataSpec) (pr
 	if filter.Vulnerability != nil {
 		predicates = append(predicates,
 			vulnerabilitymetadata.HasVulnerabilityIDWith(
-				optionalPredicate(filter.Vulnerability.VulnerabilityID, vulnerabilityid.VulnerabilityIDEqualFold),
-				optionalPredicate(filter.Vulnerability.ID, IDEQ),
-				optionalPredicate(filter.Vulnerability.Type, vulnerabilityid.TypeEqualFold),
+				vulnerabilityQueryPredicates(*filter.Vulnerability)...,
 			),
 		)
-		if filter.Vulnerability.NoVuln != nil && *filter.Vulnerability.NoVuln {
-			predicates = append(predicates,
-				vulnerabilitymetadata.HasVulnerabilityIDWith(
-					vulnerabilityid.TypeEqualFold(NoVuln),
-				),
-			)
-		}
+		// if filter.Vulnerability.NoVuln != nil && *filter.Vulnerability.NoVuln {
+		// 	predicates = append(predicates,
+		// 		vulnerabilitymetadata.HasVulnerabilityIDWith(
+		// 			vulnerabilityid.TypeEqualFold(NoVuln),
+		// 		),
+		// 	)
+		// }
 	}
 	return vulnerabilitymetadata.And(predicates...), nil
 }

--- a/pkg/assembler/backends/ent/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials.go
@@ -36,6 +36,8 @@ type BillOfMaterials struct {
 	Origin string `json:"origin,omitempty"`
 	// GUAC collector for the document
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// KnownSince holds the value of the "known_since" field.
 	KnownSince time.Time `json:"known_since,omitempty"`
 	// An opaque hash of the included packages
@@ -147,7 +149,7 @@ func (*BillOfMaterials) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case billofmaterials.FieldPackageID, billofmaterials.FieldArtifactID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case billofmaterials.FieldURI, billofmaterials.FieldAlgorithm, billofmaterials.FieldDigest, billofmaterials.FieldDownloadLocation, billofmaterials.FieldOrigin, billofmaterials.FieldCollector, billofmaterials.FieldIncludedPackagesHash, billofmaterials.FieldIncludedArtifactsHash, billofmaterials.FieldIncludedDependenciesHash, billofmaterials.FieldIncludedOccurrencesHash:
+		case billofmaterials.FieldURI, billofmaterials.FieldAlgorithm, billofmaterials.FieldDigest, billofmaterials.FieldDownloadLocation, billofmaterials.FieldOrigin, billofmaterials.FieldCollector, billofmaterials.FieldDocumentRef, billofmaterials.FieldIncludedPackagesHash, billofmaterials.FieldIncludedArtifactsHash, billofmaterials.FieldIncludedDependenciesHash, billofmaterials.FieldIncludedOccurrencesHash:
 			values[i] = new(sql.NullString)
 		case billofmaterials.FieldKnownSince:
 			values[i] = new(sql.NullTime)
@@ -223,6 +225,12 @@ func (bom *BillOfMaterials) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				bom.Collector = value.String
+			}
+		case billofmaterials.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				bom.DocumentRef = value.String
 			}
 		case billofmaterials.FieldKnownSince:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -347,6 +355,9 @@ func (bom *BillOfMaterials) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(bom.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(bom.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("known_since=")
 	builder.WriteString(bom.KnownSince.Format(time.ANSIC))

--- a/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
+++ b/pkg/assembler/backends/ent/billofmaterials/billofmaterials.go
@@ -29,6 +29,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldKnownSince holds the string denoting the known_since field in the database.
 	FieldKnownSince = "known_since"
 	// FieldIncludedPackagesHash holds the string denoting the included_packages_hash field in the database.
@@ -100,6 +102,7 @@ var Columns = []string{
 	FieldDownloadLocation,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldKnownSince,
 	FieldIncludedPackagesHash,
 	FieldIncludedArtifactsHash,
@@ -183,6 +186,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByKnownSince orders the results by the known_since field.

--- a/pkg/assembler/backends/ent/billofmaterials/where.go
+++ b/pkg/assembler/backends/ent/billofmaterials/where.go
@@ -96,6 +96,11 @@ func Collector(v string) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // KnownSince applies equality check predicate on the "known_since" field. It's identical to KnownSinceEQ.
 func KnownSince(v time.Time) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.FieldEQ(FieldKnownSince, v))
@@ -569,6 +574,71 @@ func CollectorEqualFold(v string) predicate.BillOfMaterials {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.BillOfMaterials {
 	return predicate.BillOfMaterials(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.BillOfMaterials {
+	return predicate.BillOfMaterials(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // KnownSinceEQ applies the EQ predicate on the "known_since" field.

--- a/pkg/assembler/backends/ent/billofmaterials_create.go
+++ b/pkg/assembler/backends/ent/billofmaterials_create.go
@@ -92,6 +92,12 @@ func (bomc *BillOfMaterialsCreate) SetCollector(s string) *BillOfMaterialsCreate
 	return bomc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (bomc *BillOfMaterialsCreate) SetDocumentRef(s string) *BillOfMaterialsCreate {
+	bomc.mutation.SetDocumentRef(s)
+	return bomc
+}
+
 // SetKnownSince sets the "known_since" field.
 func (bomc *BillOfMaterialsCreate) SetKnownSince(t time.Time) *BillOfMaterialsCreate {
 	bomc.mutation.SetKnownSince(t)
@@ -267,6 +273,9 @@ func (bomc *BillOfMaterialsCreate) check() error {
 	if _, ok := bomc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "BillOfMaterials.collector"`)}
 	}
+	if _, ok := bomc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "BillOfMaterials.document_ref"`)}
+	}
 	if _, ok := bomc.mutation.KnownSince(); !ok {
 		return &ValidationError{Name: "known_since", err: errors.New(`ent: missing required field "BillOfMaterials.known_since"`)}
 	}
@@ -341,6 +350,10 @@ func (bomc *BillOfMaterialsCreate) createSpec() (*BillOfMaterials, *sqlgraph.Cre
 	if value, ok := bomc.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := bomc.mutation.DocumentRef(); ok {
+		_spec.SetField(billofmaterials.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := bomc.mutation.KnownSince(); ok {
 		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)
@@ -620,6 +633,18 @@ func (u *BillOfMaterialsUpsert) UpdateCollector() *BillOfMaterialsUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *BillOfMaterialsUpsert) SetDocumentRef(v string) *BillOfMaterialsUpsert {
+	u.Set(billofmaterials.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsert) UpdateDocumentRef() *BillOfMaterialsUpsert {
+	u.SetExcluded(billofmaterials.FieldDocumentRef)
+	return u
+}
+
 // SetKnownSince sets the "known_since" field.
 func (u *BillOfMaterialsUpsert) SetKnownSince(v time.Time) *BillOfMaterialsUpsert {
 	u.Set(billofmaterials.FieldKnownSince, v)
@@ -851,6 +876,20 @@ func (u *BillOfMaterialsUpsertOne) SetCollector(v string) *BillOfMaterialsUpsert
 func (u *BillOfMaterialsUpsertOne) UpdateCollector() *BillOfMaterialsUpsertOne {
 	return u.Update(func(s *BillOfMaterialsUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *BillOfMaterialsUpsertOne) SetDocumentRef(v string) *BillOfMaterialsUpsertOne {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsertOne) UpdateDocumentRef() *BillOfMaterialsUpsertOne {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1262,6 +1301,20 @@ func (u *BillOfMaterialsUpsertBulk) SetCollector(v string) *BillOfMaterialsUpser
 func (u *BillOfMaterialsUpsertBulk) UpdateCollector() *BillOfMaterialsUpsertBulk {
 	return u.Update(func(s *BillOfMaterialsUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *BillOfMaterialsUpsertBulk) SetDocumentRef(v string) *BillOfMaterialsUpsertBulk {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *BillOfMaterialsUpsertBulk) UpdateDocumentRef() *BillOfMaterialsUpsertBulk {
+	return u.Update(func(s *BillOfMaterialsUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/billofmaterials_update.go
+++ b/pkg/assembler/backends/ent/billofmaterials_update.go
@@ -157,6 +157,20 @@ func (bomu *BillOfMaterialsUpdate) SetNillableCollector(s *string) *BillOfMateri
 	return bomu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (bomu *BillOfMaterialsUpdate) SetDocumentRef(s string) *BillOfMaterialsUpdate {
+	bomu.mutation.SetDocumentRef(s)
+	return bomu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (bomu *BillOfMaterialsUpdate) SetNillableDocumentRef(s *string) *BillOfMaterialsUpdate {
+	if s != nil {
+		bomu.SetDocumentRef(*s)
+	}
+	return bomu
+}
+
 // SetKnownSince sets the "known_since" field.
 func (bomu *BillOfMaterialsUpdate) SetKnownSince(t time.Time) *BillOfMaterialsUpdate {
 	bomu.mutation.SetKnownSince(t)
@@ -451,6 +465,9 @@ func (bomu *BillOfMaterialsUpdate) sqlSave(ctx context.Context) (n int, err erro
 	}
 	if value, ok := bomu.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := bomu.mutation.DocumentRef(); ok {
+		_spec.SetField(billofmaterials.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := bomu.mutation.KnownSince(); ok {
 		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)
@@ -849,6 +866,20 @@ func (bomuo *BillOfMaterialsUpdateOne) SetNillableCollector(s *string) *BillOfMa
 	return bomuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (bomuo *BillOfMaterialsUpdateOne) SetDocumentRef(s string) *BillOfMaterialsUpdateOne {
+	bomuo.mutation.SetDocumentRef(s)
+	return bomuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (bomuo *BillOfMaterialsUpdateOne) SetNillableDocumentRef(s *string) *BillOfMaterialsUpdateOne {
+	if s != nil {
+		bomuo.SetDocumentRef(*s)
+	}
+	return bomuo
+}
+
 // SetKnownSince sets the "known_since" field.
 func (bomuo *BillOfMaterialsUpdateOne) SetKnownSince(t time.Time) *BillOfMaterialsUpdateOne {
 	bomuo.mutation.SetKnownSince(t)
@@ -1173,6 +1204,9 @@ func (bomuo *BillOfMaterialsUpdateOne) sqlSave(ctx context.Context) (_node *Bill
 	}
 	if value, ok := bomuo.mutation.Collector(); ok {
 		_spec.SetField(billofmaterials.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := bomuo.mutation.DocumentRef(); ok {
+		_spec.SetField(billofmaterials.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := bomuo.mutation.KnownSince(); ok {
 		_spec.SetField(billofmaterials.FieldKnownSince, field.TypeTime, value)

--- a/pkg/assembler/backends/ent/certification.go
+++ b/pkg/assembler/backends/ent/certification.go
@@ -34,12 +34,14 @@ type Certification struct {
 	Type certification.Type `json:"type,omitempty"`
 	// Justification holds the value of the "justification" field.
 	Justification string `json:"justification,omitempty"`
+	// KnownSince holds the value of the "known_since" field.
+	KnownSince time.Time `json:"known_since,omitempty"`
 	// Origin holds the value of the "origin" field.
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
-	// KnownSince holds the value of the "known_since" field.
-	KnownSince time.Time `json:"known_since,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CertificationQuery when eager-loading is set.
 	Edges        CertificationEdges `json:"edges"`
@@ -122,7 +124,7 @@ func (*Certification) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case certification.FieldSourceID, certification.FieldPackageVersionID, certification.FieldPackageNameID, certification.FieldArtifactID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case certification.FieldType, certification.FieldJustification, certification.FieldOrigin, certification.FieldCollector:
+		case certification.FieldType, certification.FieldJustification, certification.FieldOrigin, certification.FieldCollector, certification.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case certification.FieldKnownSince:
 			values[i] = new(sql.NullTime)
@@ -189,6 +191,12 @@ func (c *Certification) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				c.Justification = value.String
 			}
+		case certification.FieldKnownSince:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field known_since", values[i])
+			} else if value.Valid {
+				c.KnownSince = value.Time
+			}
 		case certification.FieldOrigin:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field origin", values[i])
@@ -201,11 +209,11 @@ func (c *Certification) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				c.Collector = value.String
 			}
-		case certification.FieldKnownSince:
-			if value, ok := values[i].(*sql.NullTime); !ok {
-				return fmt.Errorf("unexpected type %T for field known_since", values[i])
+		case certification.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
 			} else if value.Valid {
-				c.KnownSince = value.Time
+				c.DocumentRef = value.String
 			}
 		default:
 			c.selectValues.Set(columns[i], values[i])
@@ -289,14 +297,17 @@ func (c *Certification) String() string {
 	builder.WriteString("justification=")
 	builder.WriteString(c.Justification)
 	builder.WriteString(", ")
+	builder.WriteString("known_since=")
+	builder.WriteString(c.KnownSince.Format(time.ANSIC))
+	builder.WriteString(", ")
 	builder.WriteString("origin=")
 	builder.WriteString(c.Origin)
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(c.Collector)
 	builder.WriteString(", ")
-	builder.WriteString("known_since=")
-	builder.WriteString(c.KnownSince.Format(time.ANSIC))
+	builder.WriteString("document_ref=")
+	builder.WriteString(c.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/certification/certification.go
+++ b/pkg/assembler/backends/ent/certification/certification.go
@@ -29,12 +29,14 @@ const (
 	FieldType = "type"
 	// FieldJustification holds the string denoting the justification field in the database.
 	FieldJustification = "justification"
+	// FieldKnownSince holds the string denoting the known_since field in the database.
+	FieldKnownSince = "known_since"
 	// FieldOrigin holds the string denoting the origin field in the database.
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
-	// FieldKnownSince holds the string denoting the known_since field in the database.
-	FieldKnownSince = "known_since"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgeSource holds the string denoting the source edge name in mutations.
 	EdgeSource = "source"
 	// EdgePackageVersion holds the string denoting the package_version edge name in mutations.
@@ -84,9 +86,10 @@ var Columns = []string{
 	FieldArtifactID,
 	FieldType,
 	FieldJustification,
+	FieldKnownSince,
 	FieldOrigin,
 	FieldCollector,
-	FieldKnownSince,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -168,6 +171,11 @@ func ByJustification(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldJustification, opts...).ToFunc()
 }
 
+// ByKnownSince orders the results by the known_since field.
+func ByKnownSince(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKnownSince, opts...).ToFunc()
+}
+
 // ByOrigin orders the results by the origin field.
 func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOrigin, opts...).ToFunc()
@@ -178,9 +186,9 @@ func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
 }
 
-// ByKnownSince orders the results by the known_since field.
-func ByKnownSince(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldKnownSince, opts...).ToFunc()
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // BySourceField orders the results by source field.

--- a/pkg/assembler/backends/ent/certification/where.go
+++ b/pkg/assembler/backends/ent/certification/where.go
@@ -81,6 +81,11 @@ func Justification(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldEQ(FieldJustification, v))
 }
 
+// KnownSince applies equality check predicate on the "known_since" field. It's identical to KnownSinceEQ.
+func KnownSince(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
+}
+
 // Origin applies equality check predicate on the "origin" field. It's identical to OriginEQ.
 func Origin(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldEQ(FieldOrigin, v))
@@ -91,9 +96,9 @@ func Collector(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldEQ(FieldCollector, v))
 }
 
-// KnownSince applies equality check predicate on the "known_since" field. It's identical to KnownSinceEQ.
-func KnownSince(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldDocumentRef, v))
 }
 
 // SourceIDEQ applies the EQ predicate on the "source_id" field.
@@ -301,6 +306,46 @@ func JustificationContainsFold(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldContainsFold(FieldJustification, v))
 }
 
+// KnownSinceEQ applies the EQ predicate on the "known_since" field.
+func KnownSinceEQ(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
+}
+
+// KnownSinceNEQ applies the NEQ predicate on the "known_since" field.
+func KnownSinceNEQ(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldNEQ(FieldKnownSince, v))
+}
+
+// KnownSinceIn applies the In predicate on the "known_since" field.
+func KnownSinceIn(vs ...time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceNotIn applies the NotIn predicate on the "known_since" field.
+func KnownSinceNotIn(vs ...time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldNotIn(FieldKnownSince, vs...))
+}
+
+// KnownSinceGT applies the GT predicate on the "known_since" field.
+func KnownSinceGT(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldGT(FieldKnownSince, v))
+}
+
+// KnownSinceGTE applies the GTE predicate on the "known_since" field.
+func KnownSinceGTE(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldGTE(FieldKnownSince, v))
+}
+
+// KnownSinceLT applies the LT predicate on the "known_since" field.
+func KnownSinceLT(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldLT(FieldKnownSince, v))
+}
+
+// KnownSinceLTE applies the LTE predicate on the "known_since" field.
+func KnownSinceLTE(v time.Time) predicate.Certification {
+	return predicate.Certification(sql.FieldLTE(FieldKnownSince, v))
+}
+
 // OriginEQ applies the EQ predicate on the "origin" field.
 func OriginEQ(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldEQ(FieldOrigin, v))
@@ -431,44 +476,69 @@ func CollectorContainsFold(v string) predicate.Certification {
 	return predicate.Certification(sql.FieldContainsFold(FieldCollector, v))
 }
 
-// KnownSinceEQ applies the EQ predicate on the "known_since" field.
-func KnownSinceEQ(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldEQ(FieldKnownSince, v))
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldEQ(FieldDocumentRef, v))
 }
 
-// KnownSinceNEQ applies the NEQ predicate on the "known_since" field.
-func KnownSinceNEQ(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldNEQ(FieldKnownSince, v))
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldNEQ(FieldDocumentRef, v))
 }
 
-// KnownSinceIn applies the In predicate on the "known_since" field.
-func KnownSinceIn(vs ...time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldIn(FieldKnownSince, vs...))
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.Certification {
+	return predicate.Certification(sql.FieldIn(FieldDocumentRef, vs...))
 }
 
-// KnownSinceNotIn applies the NotIn predicate on the "known_since" field.
-func KnownSinceNotIn(vs ...time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldNotIn(FieldKnownSince, vs...))
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.Certification {
+	return predicate.Certification(sql.FieldNotIn(FieldDocumentRef, vs...))
 }
 
-// KnownSinceGT applies the GT predicate on the "known_since" field.
-func KnownSinceGT(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldGT(FieldKnownSince, v))
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldGT(FieldDocumentRef, v))
 }
 
-// KnownSinceGTE applies the GTE predicate on the "known_since" field.
-func KnownSinceGTE(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldGTE(FieldKnownSince, v))
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldGTE(FieldDocumentRef, v))
 }
 
-// KnownSinceLT applies the LT predicate on the "known_since" field.
-func KnownSinceLT(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldLT(FieldKnownSince, v))
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldLT(FieldDocumentRef, v))
 }
 
-// KnownSinceLTE applies the LTE predicate on the "known_since" field.
-func KnownSinceLTE(v time.Time) predicate.Certification {
-	return predicate.Certification(sql.FieldLTE(FieldKnownSince, v))
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.Certification {
+	return predicate.Certification(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasSource applies the HasEdge predicate on the "source" edge.

--- a/pkg/assembler/backends/ent/certification_create.go
+++ b/pkg/assembler/backends/ent/certification_create.go
@@ -104,6 +104,12 @@ func (cc *CertificationCreate) SetJustification(s string) *CertificationCreate {
 	return cc
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cc *CertificationCreate) SetKnownSince(t time.Time) *CertificationCreate {
+	cc.mutation.SetKnownSince(t)
+	return cc
+}
+
 // SetOrigin sets the "origin" field.
 func (cc *CertificationCreate) SetOrigin(s string) *CertificationCreate {
 	cc.mutation.SetOrigin(s)
@@ -116,9 +122,9 @@ func (cc *CertificationCreate) SetCollector(s string) *CertificationCreate {
 	return cc
 }
 
-// SetKnownSince sets the "known_since" field.
-func (cc *CertificationCreate) SetKnownSince(t time.Time) *CertificationCreate {
-	cc.mutation.SetKnownSince(t)
+// SetDocumentRef sets the "document_ref" field.
+func (cc *CertificationCreate) SetDocumentRef(s string) *CertificationCreate {
+	cc.mutation.SetDocumentRef(s)
 	return cc
 }
 
@@ -228,14 +234,17 @@ func (cc *CertificationCreate) check() error {
 	if _, ok := cc.mutation.Justification(); !ok {
 		return &ValidationError{Name: "justification", err: errors.New(`ent: missing required field "Certification.justification"`)}
 	}
+	if _, ok := cc.mutation.KnownSince(); !ok {
+		return &ValidationError{Name: "known_since", err: errors.New(`ent: missing required field "Certification.known_since"`)}
+	}
 	if _, ok := cc.mutation.Origin(); !ok {
 		return &ValidationError{Name: "origin", err: errors.New(`ent: missing required field "Certification.origin"`)}
 	}
 	if _, ok := cc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "Certification.collector"`)}
 	}
-	if _, ok := cc.mutation.KnownSince(); !ok {
-		return &ValidationError{Name: "known_since", err: errors.New(`ent: missing required field "Certification.known_since"`)}
+	if _, ok := cc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "Certification.document_ref"`)}
 	}
 	return nil
 }
@@ -281,6 +290,10 @@ func (cc *CertificationCreate) createSpec() (*Certification, *sqlgraph.CreateSpe
 		_spec.SetField(certification.FieldJustification, field.TypeString, value)
 		_node.Justification = value
 	}
+	if value, ok := cc.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+		_node.KnownSince = value
+	}
 	if value, ok := cc.mutation.Origin(); ok {
 		_spec.SetField(certification.FieldOrigin, field.TypeString, value)
 		_node.Origin = value
@@ -289,9 +302,9 @@ func (cc *CertificationCreate) createSpec() (*Certification, *sqlgraph.CreateSpe
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
 		_node.Collector = value
 	}
-	if value, ok := cc.mutation.KnownSince(); ok {
-		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
-		_node.KnownSince = value
+	if value, ok := cc.mutation.DocumentRef(); ok {
+		_spec.SetField(certification.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := cc.mutation.SourceIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -509,6 +522,18 @@ func (u *CertificationUpsert) UpdateJustification() *CertificationUpsert {
 	return u
 }
 
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsert) SetKnownSince(v time.Time) *CertificationUpsert {
+	u.Set(certification.FieldKnownSince, v)
+	return u
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsert) UpdateKnownSince() *CertificationUpsert {
+	u.SetExcluded(certification.FieldKnownSince)
+	return u
+}
+
 // SetOrigin sets the "origin" field.
 func (u *CertificationUpsert) SetOrigin(v string) *CertificationUpsert {
 	u.Set(certification.FieldOrigin, v)
@@ -533,15 +558,15 @@ func (u *CertificationUpsert) UpdateCollector() *CertificationUpsert {
 	return u
 }
 
-// SetKnownSince sets the "known_since" field.
-func (u *CertificationUpsert) SetKnownSince(v time.Time) *CertificationUpsert {
-	u.Set(certification.FieldKnownSince, v)
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertificationUpsert) SetDocumentRef(v string) *CertificationUpsert {
+	u.Set(certification.FieldDocumentRef, v)
 	return u
 }
 
-// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
-func (u *CertificationUpsert) UpdateKnownSince() *CertificationUpsert {
-	u.SetExcluded(certification.FieldKnownSince)
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertificationUpsert) UpdateDocumentRef() *CertificationUpsert {
+	u.SetExcluded(certification.FieldDocumentRef)
 	return u
 }
 
@@ -705,6 +730,20 @@ func (u *CertificationUpsertOne) UpdateJustification() *CertificationUpsertOne {
 	})
 }
 
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsertOne) SetKnownSince(v time.Time) *CertificationUpsertOne {
+	return u.Update(func(s *CertificationUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsertOne) UpdateKnownSince() *CertificationUpsertOne {
+	return u.Update(func(s *CertificationUpsert) {
+		s.UpdateKnownSince()
+	})
+}
+
 // SetOrigin sets the "origin" field.
 func (u *CertificationUpsertOne) SetOrigin(v string) *CertificationUpsertOne {
 	return u.Update(func(s *CertificationUpsert) {
@@ -733,17 +772,17 @@ func (u *CertificationUpsertOne) UpdateCollector() *CertificationUpsertOne {
 	})
 }
 
-// SetKnownSince sets the "known_since" field.
-func (u *CertificationUpsertOne) SetKnownSince(v time.Time) *CertificationUpsertOne {
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertificationUpsertOne) SetDocumentRef(v string) *CertificationUpsertOne {
 	return u.Update(func(s *CertificationUpsert) {
-		s.SetKnownSince(v)
+		s.SetDocumentRef(v)
 	})
 }
 
-// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
-func (u *CertificationUpsertOne) UpdateKnownSince() *CertificationUpsertOne {
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertificationUpsertOne) UpdateDocumentRef() *CertificationUpsertOne {
 	return u.Update(func(s *CertificationUpsert) {
-		s.UpdateKnownSince()
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1074,6 +1113,20 @@ func (u *CertificationUpsertBulk) UpdateJustification() *CertificationUpsertBulk
 	})
 }
 
+// SetKnownSince sets the "known_since" field.
+func (u *CertificationUpsertBulk) SetKnownSince(v time.Time) *CertificationUpsertBulk {
+	return u.Update(func(s *CertificationUpsert) {
+		s.SetKnownSince(v)
+	})
+}
+
+// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
+func (u *CertificationUpsertBulk) UpdateKnownSince() *CertificationUpsertBulk {
+	return u.Update(func(s *CertificationUpsert) {
+		s.UpdateKnownSince()
+	})
+}
+
 // SetOrigin sets the "origin" field.
 func (u *CertificationUpsertBulk) SetOrigin(v string) *CertificationUpsertBulk {
 	return u.Update(func(s *CertificationUpsert) {
@@ -1102,17 +1155,17 @@ func (u *CertificationUpsertBulk) UpdateCollector() *CertificationUpsertBulk {
 	})
 }
 
-// SetKnownSince sets the "known_since" field.
-func (u *CertificationUpsertBulk) SetKnownSince(v time.Time) *CertificationUpsertBulk {
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertificationUpsertBulk) SetDocumentRef(v string) *CertificationUpsertBulk {
 	return u.Update(func(s *CertificationUpsert) {
-		s.SetKnownSince(v)
+		s.SetDocumentRef(v)
 	})
 }
 
-// UpdateKnownSince sets the "known_since" field to the value that was provided on create.
-func (u *CertificationUpsertBulk) UpdateKnownSince() *CertificationUpsertBulk {
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertificationUpsertBulk) UpdateDocumentRef() *CertificationUpsertBulk {
 	return u.Update(func(s *CertificationUpsert) {
-		s.UpdateKnownSince()
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certification_update.go
+++ b/pkg/assembler/backends/ent/certification_update.go
@@ -141,6 +141,20 @@ func (cu *CertificationUpdate) SetNillableJustification(s *string) *Certificatio
 	return cu
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cu *CertificationUpdate) SetKnownSince(t time.Time) *CertificationUpdate {
+	cu.mutation.SetKnownSince(t)
+	return cu
+}
+
+// SetNillableKnownSince sets the "known_since" field if the given value is not nil.
+func (cu *CertificationUpdate) SetNillableKnownSince(t *time.Time) *CertificationUpdate {
+	if t != nil {
+		cu.SetKnownSince(*t)
+	}
+	return cu
+}
+
 // SetOrigin sets the "origin" field.
 func (cu *CertificationUpdate) SetOrigin(s string) *CertificationUpdate {
 	cu.mutation.SetOrigin(s)
@@ -169,16 +183,16 @@ func (cu *CertificationUpdate) SetNillableCollector(s *string) *CertificationUpd
 	return cu
 }
 
-// SetKnownSince sets the "known_since" field.
-func (cu *CertificationUpdate) SetKnownSince(t time.Time) *CertificationUpdate {
-	cu.mutation.SetKnownSince(t)
+// SetDocumentRef sets the "document_ref" field.
+func (cu *CertificationUpdate) SetDocumentRef(s string) *CertificationUpdate {
+	cu.mutation.SetDocumentRef(s)
 	return cu
 }
 
-// SetNillableKnownSince sets the "known_since" field if the given value is not nil.
-func (cu *CertificationUpdate) SetNillableKnownSince(t *time.Time) *CertificationUpdate {
-	if t != nil {
-		cu.SetKnownSince(*t)
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cu *CertificationUpdate) SetNillableDocumentRef(s *string) *CertificationUpdate {
+	if s != nil {
+		cu.SetDocumentRef(*s)
 	}
 	return cu
 }
@@ -301,14 +315,17 @@ func (cu *CertificationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := cu.mutation.Justification(); ok {
 		_spec.SetField(certification.FieldJustification, field.TypeString, value)
 	}
+	if value, ok := cu.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+	}
 	if value, ok := cu.mutation.Origin(); ok {
 		_spec.SetField(certification.FieldOrigin, field.TypeString, value)
 	}
 	if value, ok := cu.mutation.Collector(); ok {
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
 	}
-	if value, ok := cu.mutation.KnownSince(); ok {
-		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+	if value, ok := cu.mutation.DocumentRef(); ok {
+		_spec.SetField(certification.FieldDocumentRef, field.TypeString, value)
 	}
 	if cu.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -554,6 +571,20 @@ func (cuo *CertificationUpdateOne) SetNillableJustification(s *string) *Certific
 	return cuo
 }
 
+// SetKnownSince sets the "known_since" field.
+func (cuo *CertificationUpdateOne) SetKnownSince(t time.Time) *CertificationUpdateOne {
+	cuo.mutation.SetKnownSince(t)
+	return cuo
+}
+
+// SetNillableKnownSince sets the "known_since" field if the given value is not nil.
+func (cuo *CertificationUpdateOne) SetNillableKnownSince(t *time.Time) *CertificationUpdateOne {
+	if t != nil {
+		cuo.SetKnownSince(*t)
+	}
+	return cuo
+}
+
 // SetOrigin sets the "origin" field.
 func (cuo *CertificationUpdateOne) SetOrigin(s string) *CertificationUpdateOne {
 	cuo.mutation.SetOrigin(s)
@@ -582,16 +613,16 @@ func (cuo *CertificationUpdateOne) SetNillableCollector(s *string) *Certificatio
 	return cuo
 }
 
-// SetKnownSince sets the "known_since" field.
-func (cuo *CertificationUpdateOne) SetKnownSince(t time.Time) *CertificationUpdateOne {
-	cuo.mutation.SetKnownSince(t)
+// SetDocumentRef sets the "document_ref" field.
+func (cuo *CertificationUpdateOne) SetDocumentRef(s string) *CertificationUpdateOne {
+	cuo.mutation.SetDocumentRef(s)
 	return cuo
 }
 
-// SetNillableKnownSince sets the "known_since" field if the given value is not nil.
-func (cuo *CertificationUpdateOne) SetNillableKnownSince(t *time.Time) *CertificationUpdateOne {
-	if t != nil {
-		cuo.SetKnownSince(*t)
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cuo *CertificationUpdateOne) SetNillableDocumentRef(s *string) *CertificationUpdateOne {
+	if s != nil {
+		cuo.SetDocumentRef(*s)
 	}
 	return cuo
 }
@@ -744,14 +775,17 @@ func (cuo *CertificationUpdateOne) sqlSave(ctx context.Context) (_node *Certific
 	if value, ok := cuo.mutation.Justification(); ok {
 		_spec.SetField(certification.FieldJustification, field.TypeString, value)
 	}
+	if value, ok := cuo.mutation.KnownSince(); ok {
+		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+	}
 	if value, ok := cuo.mutation.Origin(); ok {
 		_spec.SetField(certification.FieldOrigin, field.TypeString, value)
 	}
 	if value, ok := cuo.mutation.Collector(); ok {
 		_spec.SetField(certification.FieldCollector, field.TypeString, value)
 	}
-	if value, ok := cuo.mutation.KnownSince(); ok {
-		_spec.SetField(certification.FieldKnownSince, field.TypeTime, value)
+	if value, ok := cuo.mutation.DocumentRef(); ok {
+		_spec.SetField(certification.FieldDocumentRef, field.TypeString, value)
 	}
 	if cuo.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/certifylegal.go
+++ b/pkg/assembler/backends/ent/certifylegal.go
@@ -38,6 +38,8 @@ type CertifyLegal struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// An opaque hash of the declared license IDs to ensure uniqueness
 	DeclaredLicensesHash string `json:"declared_licenses_hash,omitempty"`
 	// An opaque hash of the discovered license IDs to ensure uniqueness
@@ -119,7 +121,7 @@ func (*CertifyLegal) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case certifylegal.FieldPackageID, certifylegal.FieldSourceID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case certifylegal.FieldDeclaredLicense, certifylegal.FieldDiscoveredLicense, certifylegal.FieldAttribution, certifylegal.FieldJustification, certifylegal.FieldOrigin, certifylegal.FieldCollector, certifylegal.FieldDeclaredLicensesHash, certifylegal.FieldDiscoveredLicensesHash:
+		case certifylegal.FieldDeclaredLicense, certifylegal.FieldDiscoveredLicense, certifylegal.FieldAttribution, certifylegal.FieldJustification, certifylegal.FieldOrigin, certifylegal.FieldCollector, certifylegal.FieldDocumentRef, certifylegal.FieldDeclaredLicensesHash, certifylegal.FieldDiscoveredLicensesHash:
 			values[i] = new(sql.NullString)
 		case certifylegal.FieldTimeScanned:
 			values[i] = new(sql.NullTime)
@@ -201,6 +203,12 @@ func (cl *CertifyLegal) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				cl.Collector = value.String
+			}
+		case certifylegal.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				cl.DocumentRef = value.String
 			}
 		case certifylegal.FieldDeclaredLicensesHash:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -300,6 +308,9 @@ func (cl *CertifyLegal) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(cl.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(cl.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("declared_licenses_hash=")
 	builder.WriteString(cl.DeclaredLicensesHash)

--- a/pkg/assembler/backends/ent/certifylegal/certifylegal.go
+++ b/pkg/assembler/backends/ent/certifylegal/certifylegal.go
@@ -31,6 +31,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldDeclaredLicensesHash holds the string denoting the declared_licenses_hash field in the database.
 	FieldDeclaredLicensesHash = "declared_licenses_hash"
 	// FieldDiscoveredLicensesHash holds the string denoting the discovered_licenses_hash field in the database.
@@ -83,6 +85,7 @@ var Columns = []string{
 	FieldTimeScanned,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldDeclaredLicensesHash,
 	FieldDiscoveredLicensesHash,
 }
@@ -162,6 +165,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByDeclaredLicensesHash orders the results by the declared_licenses_hash field.

--- a/pkg/assembler/backends/ent/certifylegal/where.go
+++ b/pkg/assembler/backends/ent/certifylegal/where.go
@@ -101,6 +101,11 @@ func Collector(v string) predicate.CertifyLegal {
 	return predicate.CertifyLegal(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // DeclaredLicensesHash applies equality check predicate on the "declared_licenses_hash" field. It's identical to DeclaredLicensesHashEQ.
 func DeclaredLicensesHash(v string) predicate.CertifyLegal {
 	return predicate.CertifyLegal(sql.FieldEQ(FieldDeclaredLicensesHash, v))
@@ -599,6 +604,71 @@ func CollectorEqualFold(v string) predicate.CertifyLegal {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.CertifyLegal {
 	return predicate.CertifyLegal(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.CertifyLegal {
+	return predicate.CertifyLegal(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // DeclaredLicensesHashEQ applies the EQ predicate on the "declared_licenses_hash" field.

--- a/pkg/assembler/backends/ent/certifylegal_create.go
+++ b/pkg/assembler/backends/ent/certifylegal_create.go
@@ -97,6 +97,12 @@ func (clc *CertifyLegalCreate) SetCollector(s string) *CertifyLegalCreate {
 	return clc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (clc *CertifyLegalCreate) SetDocumentRef(s string) *CertifyLegalCreate {
+	clc.mutation.SetDocumentRef(s)
+	return clc
+}
+
 // SetDeclaredLicensesHash sets the "declared_licenses_hash" field.
 func (clc *CertifyLegalCreate) SetDeclaredLicensesHash(s string) *CertifyLegalCreate {
 	clc.mutation.SetDeclaredLicensesHash(s)
@@ -227,6 +233,9 @@ func (clc *CertifyLegalCreate) check() error {
 	if _, ok := clc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "CertifyLegal.collector"`)}
 	}
+	if _, ok := clc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyLegal.document_ref"`)}
+	}
 	if _, ok := clc.mutation.DeclaredLicensesHash(); !ok {
 		return &ValidationError{Name: "declared_licenses_hash", err: errors.New(`ent: missing required field "CertifyLegal.declared_licenses_hash"`)}
 	}
@@ -296,6 +305,10 @@ func (clc *CertifyLegalCreate) createSpec() (*CertifyLegal, *sqlgraph.CreateSpec
 	if value, ok := clc.mutation.Collector(); ok {
 		_spec.SetField(certifylegal.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := clc.mutation.DocumentRef(); ok {
+		_spec.SetField(certifylegal.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := clc.mutation.DeclaredLicensesHash(); ok {
 		_spec.SetField(certifylegal.FieldDeclaredLicensesHash, field.TypeString, value)
@@ -543,6 +556,18 @@ func (u *CertifyLegalUpsert) UpdateCollector() *CertifyLegalUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyLegalUpsert) SetDocumentRef(v string) *CertifyLegalUpsert {
+	u.Set(certifylegal.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyLegalUpsert) UpdateDocumentRef() *CertifyLegalUpsert {
+	u.SetExcluded(certifylegal.FieldDocumentRef)
+	return u
+}
+
 // SetDeclaredLicensesHash sets the "declared_licenses_hash" field.
 func (u *CertifyLegalUpsert) SetDeclaredLicensesHash(v string) *CertifyLegalUpsert {
 	u.Set(certifylegal.FieldDeclaredLicensesHash, v)
@@ -752,6 +777,20 @@ func (u *CertifyLegalUpsertOne) SetCollector(v string) *CertifyLegalUpsertOne {
 func (u *CertifyLegalUpsertOne) UpdateCollector() *CertifyLegalUpsertOne {
 	return u.Update(func(s *CertifyLegalUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyLegalUpsertOne) SetDocumentRef(v string) *CertifyLegalUpsertOne {
+	return u.Update(func(s *CertifyLegalUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyLegalUpsertOne) UpdateDocumentRef() *CertifyLegalUpsertOne {
+	return u.Update(func(s *CertifyLegalUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1135,6 +1174,20 @@ func (u *CertifyLegalUpsertBulk) SetCollector(v string) *CertifyLegalUpsertBulk 
 func (u *CertifyLegalUpsertBulk) UpdateCollector() *CertifyLegalUpsertBulk {
 	return u.Update(func(s *CertifyLegalUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyLegalUpsertBulk) SetDocumentRef(v string) *CertifyLegalUpsertBulk {
+	return u.Update(func(s *CertifyLegalUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyLegalUpsertBulk) UpdateDocumentRef() *CertifyLegalUpsertBulk {
+	return u.Update(func(s *CertifyLegalUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certifylegal_update.go
+++ b/pkg/assembler/backends/ent/certifylegal_update.go
@@ -170,6 +170,20 @@ func (clu *CertifyLegalUpdate) SetNillableCollector(s *string) *CertifyLegalUpda
 	return clu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (clu *CertifyLegalUpdate) SetDocumentRef(s string) *CertifyLegalUpdate {
+	clu.mutation.SetDocumentRef(s)
+	return clu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (clu *CertifyLegalUpdate) SetNillableDocumentRef(s *string) *CertifyLegalUpdate {
+	if s != nil {
+		clu.SetDocumentRef(*s)
+	}
+	return clu
+}
+
 // SetDeclaredLicensesHash sets the "declared_licenses_hash" field.
 func (clu *CertifyLegalUpdate) SetDeclaredLicensesHash(s string) *CertifyLegalUpdate {
 	clu.mutation.SetDeclaredLicensesHash(s)
@@ -353,6 +367,9 @@ func (clu *CertifyLegalUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := clu.mutation.Collector(); ok {
 		_spec.SetField(certifylegal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := clu.mutation.DocumentRef(); ok {
+		_spec.SetField(certifylegal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := clu.mutation.DeclaredLicensesHash(); ok {
 		_spec.SetField(certifylegal.FieldDeclaredLicensesHash, field.TypeString, value)
@@ -666,6 +683,20 @@ func (cluo *CertifyLegalUpdateOne) SetNillableCollector(s *string) *CertifyLegal
 	return cluo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cluo *CertifyLegalUpdateOne) SetDocumentRef(s string) *CertifyLegalUpdateOne {
+	cluo.mutation.SetDocumentRef(s)
+	return cluo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cluo *CertifyLegalUpdateOne) SetNillableDocumentRef(s *string) *CertifyLegalUpdateOne {
+	if s != nil {
+		cluo.SetDocumentRef(*s)
+	}
+	return cluo
+}
+
 // SetDeclaredLicensesHash sets the "declared_licenses_hash" field.
 func (cluo *CertifyLegalUpdateOne) SetDeclaredLicensesHash(s string) *CertifyLegalUpdateOne {
 	cluo.mutation.SetDeclaredLicensesHash(s)
@@ -879,6 +910,9 @@ func (cluo *CertifyLegalUpdateOne) sqlSave(ctx context.Context) (_node *CertifyL
 	}
 	if value, ok := cluo.mutation.Collector(); ok {
 		_spec.SetField(certifylegal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cluo.mutation.DocumentRef(); ok {
+		_spec.SetField(certifylegal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := cluo.mutation.DeclaredLicensesHash(); ok {
 		_spec.SetField(certifylegal.FieldDeclaredLicensesHash, field.TypeString, value)

--- a/pkg/assembler/backends/ent/certifyscorecard.go
+++ b/pkg/assembler/backends/ent/certifyscorecard.go
@@ -37,6 +37,8 @@ type CertifyScorecard struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// A SHA1 of the checks fields after sorting keys, used to ensure uniqueness of scorecard records.
 	ChecksHash string `json:"checks_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -78,7 +80,7 @@ func (*CertifyScorecard) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case certifyscorecard.FieldAggregateScore:
 			values[i] = new(sql.NullFloat64)
-		case certifyscorecard.FieldScorecardVersion, certifyscorecard.FieldScorecardCommit, certifyscorecard.FieldOrigin, certifyscorecard.FieldCollector, certifyscorecard.FieldChecksHash:
+		case certifyscorecard.FieldScorecardVersion, certifyscorecard.FieldScorecardCommit, certifyscorecard.FieldOrigin, certifyscorecard.FieldCollector, certifyscorecard.FieldDocumentRef, certifyscorecard.FieldChecksHash:
 			values[i] = new(sql.NullString)
 		case certifyscorecard.FieldTimeScanned:
 			values[i] = new(sql.NullTime)
@@ -155,6 +157,12 @@ func (cs *CertifyScorecard) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				cs.Collector = value.String
 			}
+		case certifyscorecard.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				cs.DocumentRef = value.String
+			}
 		case certifyscorecard.FieldChecksHash:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field checks_hash", values[i])
@@ -225,6 +233,9 @@ func (cs *CertifyScorecard) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(cs.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(cs.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("checks_hash=")
 	builder.WriteString(cs.ChecksHash)

--- a/pkg/assembler/backends/ent/certifyscorecard/certifyscorecard.go
+++ b/pkg/assembler/backends/ent/certifyscorecard/certifyscorecard.go
@@ -31,6 +31,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldChecksHash holds the string denoting the checks_hash field in the database.
 	FieldChecksHash = "checks_hash"
 	// EdgeSource holds the string denoting the source edge name in mutations.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldScorecardCommit,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldChecksHash,
 }
 
@@ -120,6 +123,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByChecksHash orders the results by the checks_hash field.

--- a/pkg/assembler/backends/ent/certifyscorecard/where.go
+++ b/pkg/assembler/backends/ent/certifyscorecard/where.go
@@ -91,6 +91,11 @@ func Collector(v string) predicate.CertifyScorecard {
 	return predicate.CertifyScorecard(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // ChecksHash applies equality check predicate on the "checks_hash" field. It's identical to ChecksHashEQ.
 func ChecksHash(v string) predicate.CertifyScorecard {
 	return predicate.CertifyScorecard(sql.FieldEQ(FieldChecksHash, v))
@@ -454,6 +459,71 @@ func CollectorEqualFold(v string) predicate.CertifyScorecard {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.CertifyScorecard {
 	return predicate.CertifyScorecard(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.CertifyScorecard {
+	return predicate.CertifyScorecard(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // ChecksHashEQ applies the EQ predicate on the "checks_hash" field.

--- a/pkg/assembler/backends/ent/certifyscorecard_create.go
+++ b/pkg/assembler/backends/ent/certifyscorecard_create.go
@@ -90,6 +90,12 @@ func (csc *CertifyScorecardCreate) SetCollector(s string) *CertifyScorecardCreat
 	return csc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (csc *CertifyScorecardCreate) SetDocumentRef(s string) *CertifyScorecardCreate {
+	csc.mutation.SetDocumentRef(s)
+	return csc
+}
+
 // SetChecksHash sets the "checks_hash" field.
 func (csc *CertifyScorecardCreate) SetChecksHash(s string) *CertifyScorecardCreate {
 	csc.mutation.SetChecksHash(s)
@@ -190,6 +196,9 @@ func (csc *CertifyScorecardCreate) check() error {
 	if _, ok := csc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "CertifyScorecard.collector"`)}
 	}
+	if _, ok := csc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyScorecard.document_ref"`)}
+	}
 	if _, ok := csc.mutation.ChecksHash(); !ok {
 		return &ValidationError{Name: "checks_hash", err: errors.New(`ent: missing required field "CertifyScorecard.checks_hash"`)}
 	}
@@ -259,6 +268,10 @@ func (csc *CertifyScorecardCreate) createSpec() (*CertifyScorecard, *sqlgraph.Cr
 	if value, ok := csc.mutation.Collector(); ok {
 		_spec.SetField(certifyscorecard.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := csc.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyscorecard.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := csc.mutation.ChecksHash(); ok {
 		_spec.SetField(certifyscorecard.FieldChecksHash, field.TypeString, value)
@@ -432,6 +445,18 @@ func (u *CertifyScorecardUpsert) SetCollector(v string) *CertifyScorecardUpsert 
 // UpdateCollector sets the "collector" field to the value that was provided on create.
 func (u *CertifyScorecardUpsert) UpdateCollector() *CertifyScorecardUpsert {
 	u.SetExcluded(certifyscorecard.FieldCollector)
+	return u
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyScorecardUpsert) SetDocumentRef(v string) *CertifyScorecardUpsert {
+	u.Set(certifyscorecard.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyScorecardUpsert) UpdateDocumentRef() *CertifyScorecardUpsert {
+	u.SetExcluded(certifyscorecard.FieldDocumentRef)
 	return u
 }
 
@@ -611,6 +636,20 @@ func (u *CertifyScorecardUpsertOne) SetCollector(v string) *CertifyScorecardUpse
 func (u *CertifyScorecardUpsertOne) UpdateCollector() *CertifyScorecardUpsertOne {
 	return u.Update(func(s *CertifyScorecardUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyScorecardUpsertOne) SetDocumentRef(v string) *CertifyScorecardUpsertOne {
+	return u.Update(func(s *CertifyScorecardUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyScorecardUpsertOne) UpdateDocumentRef() *CertifyScorecardUpsertOne {
+	return u.Update(func(s *CertifyScorecardUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -959,6 +998,20 @@ func (u *CertifyScorecardUpsertBulk) SetCollector(v string) *CertifyScorecardUps
 func (u *CertifyScorecardUpsertBulk) UpdateCollector() *CertifyScorecardUpsertBulk {
 	return u.Update(func(s *CertifyScorecardUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyScorecardUpsertBulk) SetDocumentRef(v string) *CertifyScorecardUpsertBulk {
+	return u.Update(func(s *CertifyScorecardUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyScorecardUpsertBulk) UpdateDocumentRef() *CertifyScorecardUpsertBulk {
+	return u.Update(func(s *CertifyScorecardUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certifyscorecard_update.go
+++ b/pkg/assembler/backends/ent/certifyscorecard_update.go
@@ -149,6 +149,20 @@ func (csu *CertifyScorecardUpdate) SetNillableCollector(s *string) *CertifyScore
 	return csu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (csu *CertifyScorecardUpdate) SetDocumentRef(s string) *CertifyScorecardUpdate {
+	csu.mutation.SetDocumentRef(s)
+	return csu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (csu *CertifyScorecardUpdate) SetNillableDocumentRef(s *string) *CertifyScorecardUpdate {
+	if s != nil {
+		csu.SetDocumentRef(*s)
+	}
+	return csu
+}
+
 // SetChecksHash sets the "checks_hash" field.
 func (csu *CertifyScorecardUpdate) SetChecksHash(s string) *CertifyScorecardUpdate {
 	csu.mutation.SetChecksHash(s)
@@ -254,6 +268,9 @@ func (csu *CertifyScorecardUpdate) sqlSave(ctx context.Context) (n int, err erro
 	}
 	if value, ok := csu.mutation.Collector(); ok {
 		_spec.SetField(certifyscorecard.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := csu.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyscorecard.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := csu.mutation.ChecksHash(); ok {
 		_spec.SetField(certifyscorecard.FieldChecksHash, field.TypeString, value)
@@ -424,6 +441,20 @@ func (csuo *CertifyScorecardUpdateOne) SetNillableCollector(s *string) *CertifyS
 	return csuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (csuo *CertifyScorecardUpdateOne) SetDocumentRef(s string) *CertifyScorecardUpdateOne {
+	csuo.mutation.SetDocumentRef(s)
+	return csuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (csuo *CertifyScorecardUpdateOne) SetNillableDocumentRef(s *string) *CertifyScorecardUpdateOne {
+	if s != nil {
+		csuo.SetDocumentRef(*s)
+	}
+	return csuo
+}
+
 // SetChecksHash sets the "checks_hash" field.
 func (csuo *CertifyScorecardUpdateOne) SetChecksHash(s string) *CertifyScorecardUpdateOne {
 	csuo.mutation.SetChecksHash(s)
@@ -559,6 +590,9 @@ func (csuo *CertifyScorecardUpdateOne) sqlSave(ctx context.Context) (_node *Cert
 	}
 	if value, ok := csuo.mutation.Collector(); ok {
 		_spec.SetField(certifyscorecard.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := csuo.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyscorecard.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := csuo.mutation.ChecksHash(); ok {
 		_spec.SetField(certifyscorecard.FieldChecksHash, field.TypeString, value)

--- a/pkg/assembler/backends/ent/certifyvex.go
+++ b/pkg/assembler/backends/ent/certifyvex.go
@@ -41,6 +41,8 @@ type CertifyVex struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CertifyVexQuery when eager-loading is set.
 	Edges        CertifyVexEdges `json:"edges"`
@@ -108,7 +110,7 @@ func (*CertifyVex) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case certifyvex.FieldPackageID, certifyvex.FieldArtifactID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case certifyvex.FieldStatus, certifyvex.FieldStatement, certifyvex.FieldStatusNotes, certifyvex.FieldJustification, certifyvex.FieldOrigin, certifyvex.FieldCollector:
+		case certifyvex.FieldStatus, certifyvex.FieldStatement, certifyvex.FieldStatusNotes, certifyvex.FieldJustification, certifyvex.FieldOrigin, certifyvex.FieldCollector, certifyvex.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case certifyvex.FieldKnownSince:
 			values[i] = new(sql.NullTime)
@@ -197,6 +199,12 @@ func (cv *CertifyVex) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				cv.Collector = value.String
 			}
+		case certifyvex.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				cv.DocumentRef = value.String
+			}
 		default:
 			cv.selectValues.Set(columns[i], values[i])
 		}
@@ -281,6 +289,9 @@ func (cv *CertifyVex) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(cv.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(cv.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/certifyvex/certifyvex.go
+++ b/pkg/assembler/backends/ent/certifyvex/certifyvex.go
@@ -33,6 +33,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgePackage holds the string denoting the package edge name in mutations.
 	EdgePackage = "package"
 	// EdgeArtifact holds the string denoting the artifact edge name in mutations.
@@ -77,6 +79,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -150,6 +153,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByPackageField orders the results by package field.

--- a/pkg/assembler/backends/ent/certifyvex/where.go
+++ b/pkg/assembler/backends/ent/certifyvex/where.go
@@ -106,6 +106,11 @@ func Collector(v string) predicate.CertifyVex {
 	return predicate.CertifyVex(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // PackageIDEQ applies the EQ predicate on the "package_id" field.
 func PackageIDEQ(v uuid.UUID) predicate.CertifyVex {
 	return predicate.CertifyVex(sql.FieldEQ(FieldPackageID, v))
@@ -614,6 +619,71 @@ func CollectorEqualFold(v string) predicate.CertifyVex {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.CertifyVex {
 	return predicate.CertifyVex(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.CertifyVex {
+	return predicate.CertifyVex(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasPackage applies the HasEdge predicate on the "package" edge.

--- a/pkg/assembler/backends/ent/certifyvex_create.go
+++ b/pkg/assembler/backends/ent/certifyvex_create.go
@@ -103,6 +103,12 @@ func (cvc *CertifyVexCreate) SetCollector(s string) *CertifyVexCreate {
 	return cvc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvc *CertifyVexCreate) SetDocumentRef(s string) *CertifyVexCreate {
+	cvc.mutation.SetDocumentRef(s)
+	return cvc
+}
+
 // SetID sets the "id" field.
 func (cvc *CertifyVexCreate) SetID(u uuid.UUID) *CertifyVexCreate {
 	cvc.mutation.SetID(u)
@@ -199,6 +205,9 @@ func (cvc *CertifyVexCreate) check() error {
 	if _, ok := cvc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "CertifyVex.collector"`)}
 	}
+	if _, ok := cvc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyVex.document_ref"`)}
+	}
 	if _, ok := cvc.mutation.VulnerabilityID(); !ok {
 		return &ValidationError{Name: "vulnerability", err: errors.New(`ent: missing required edge "CertifyVex.vulnerability"`)}
 	}
@@ -265,6 +274,10 @@ func (cvc *CertifyVexCreate) createSpec() (*CertifyVex, *sqlgraph.CreateSpec) {
 	if value, ok := cvc.mutation.Collector(); ok {
 		_spec.SetField(certifyvex.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := cvc.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvex.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := cvc.mutation.PackageIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -501,6 +514,18 @@ func (u *CertifyVexUpsert) UpdateCollector() *CertifyVexUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVexUpsert) SetDocumentRef(v string) *CertifyVexUpsert {
+	u.Set(certifyvex.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVexUpsert) UpdateDocumentRef() *CertifyVexUpsert {
+	u.SetExcluded(certifyvex.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -700,6 +725,20 @@ func (u *CertifyVexUpsertOne) SetCollector(v string) *CertifyVexUpsertOne {
 func (u *CertifyVexUpsertOne) UpdateCollector() *CertifyVexUpsertOne {
 	return u.Update(func(s *CertifyVexUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVexUpsertOne) SetDocumentRef(v string) *CertifyVexUpsertOne {
+	return u.Update(func(s *CertifyVexUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVexUpsertOne) UpdateDocumentRef() *CertifyVexUpsertOne {
+	return u.Update(func(s *CertifyVexUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1069,6 +1108,20 @@ func (u *CertifyVexUpsertBulk) SetCollector(v string) *CertifyVexUpsertBulk {
 func (u *CertifyVexUpsertBulk) UpdateCollector() *CertifyVexUpsertBulk {
 	return u.Update(func(s *CertifyVexUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVexUpsertBulk) SetDocumentRef(v string) *CertifyVexUpsertBulk {
+	return u.Update(func(s *CertifyVexUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVexUpsertBulk) UpdateDocumentRef() *CertifyVexUpsertBulk {
+	return u.Update(func(s *CertifyVexUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certifyvex_update.go
+++ b/pkg/assembler/backends/ent/certifyvex_update.go
@@ -184,6 +184,20 @@ func (cvu *CertifyVexUpdate) SetNillableCollector(s *string) *CertifyVexUpdate {
 	return cvu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvu *CertifyVexUpdate) SetDocumentRef(s string) *CertifyVexUpdate {
+	cvu.mutation.SetDocumentRef(s)
+	return cvu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cvu *CertifyVexUpdate) SetNillableDocumentRef(s *string) *CertifyVexUpdate {
+	if s != nil {
+		cvu.SetDocumentRef(*s)
+	}
+	return cvu
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (cvu *CertifyVexUpdate) SetPackage(p *PackageVersion) *CertifyVexUpdate {
 	return cvu.SetPackageID(p.ID)
@@ -289,6 +303,9 @@ func (cvu *CertifyVexUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := cvu.mutation.Collector(); ok {
 		_spec.SetField(certifyvex.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cvu.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvex.FieldDocumentRef, field.TypeString, value)
 	}
 	if cvu.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -549,6 +566,20 @@ func (cvuo *CertifyVexUpdateOne) SetNillableCollector(s *string) *CertifyVexUpda
 	return cvuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvuo *CertifyVexUpdateOne) SetDocumentRef(s string) *CertifyVexUpdateOne {
+	cvuo.mutation.SetDocumentRef(s)
+	return cvuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cvuo *CertifyVexUpdateOne) SetNillableDocumentRef(s *string) *CertifyVexUpdateOne {
+	if s != nil {
+		cvuo.SetDocumentRef(*s)
+	}
+	return cvuo
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (cvuo *CertifyVexUpdateOne) SetPackage(p *PackageVersion) *CertifyVexUpdateOne {
 	return cvuo.SetPackageID(p.ID)
@@ -684,6 +715,9 @@ func (cvuo *CertifyVexUpdateOne) sqlSave(ctx context.Context) (_node *CertifyVex
 	}
 	if value, ok := cvuo.mutation.Collector(); ok {
 		_spec.SetField(certifyvex.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cvuo.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvex.FieldDocumentRef, field.TypeString, value)
 	}
 	if cvuo.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/certifyvuln.go
+++ b/pkg/assembler/backends/ent/certifyvuln.go
@@ -38,6 +38,8 @@ type CertifyVuln struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CertifyVulnQuery when eager-loading is set.
 	Edges        CertifyVulnEdges `json:"edges"`
@@ -88,7 +90,7 @@ func (*CertifyVuln) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case certifyvuln.FieldDbURI, certifyvuln.FieldDbVersion, certifyvuln.FieldScannerURI, certifyvuln.FieldScannerVersion, certifyvuln.FieldOrigin, certifyvuln.FieldCollector:
+		case certifyvuln.FieldDbURI, certifyvuln.FieldDbVersion, certifyvuln.FieldScannerURI, certifyvuln.FieldScannerVersion, certifyvuln.FieldOrigin, certifyvuln.FieldCollector, certifyvuln.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case certifyvuln.FieldTimeScanned:
 			values[i] = new(sql.NullTime)
@@ -169,6 +171,12 @@ func (cv *CertifyVuln) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				cv.Collector = value.String
 			}
+		case certifyvuln.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				cv.DocumentRef = value.String
+			}
 		default:
 			cv.selectValues.Set(columns[i], values[i])
 		}
@@ -241,6 +249,9 @@ func (cv *CertifyVuln) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(cv.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(cv.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/certifyvuln/certifyvuln.go
+++ b/pkg/assembler/backends/ent/certifyvuln/certifyvuln.go
@@ -31,6 +31,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgeVulnerability holds the string denoting the vulnerability edge name in mutations.
 	EdgeVulnerability = "vulnerability"
 	// EdgePackage holds the string denoting the package edge name in mutations.
@@ -65,6 +67,7 @@ var Columns = []string{
 	FieldScannerVersion,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -133,6 +136,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByVulnerabilityField orders the results by vulnerability field.

--- a/pkg/assembler/backends/ent/certifyvuln/where.go
+++ b/pkg/assembler/backends/ent/certifyvuln/where.go
@@ -101,6 +101,11 @@ func Collector(v string) predicate.CertifyVuln {
 	return predicate.CertifyVuln(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // VulnerabilityIDEQ applies the EQ predicate on the "vulnerability_id" field.
 func VulnerabilityIDEQ(v uuid.UUID) predicate.CertifyVuln {
 	return predicate.CertifyVuln(sql.FieldEQ(FieldVulnerabilityID, v))
@@ -569,6 +574,71 @@ func CollectorEqualFold(v string) predicate.CertifyVuln {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.CertifyVuln {
 	return predicate.CertifyVuln(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.CertifyVuln {
+	return predicate.CertifyVuln(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasVulnerability applies the HasEdge predicate on the "vulnerability" edge.

--- a/pkg/assembler/backends/ent/certifyvuln_create.go
+++ b/pkg/assembler/backends/ent/certifyvuln_create.go
@@ -80,6 +80,12 @@ func (cvc *CertifyVulnCreate) SetCollector(s string) *CertifyVulnCreate {
 	return cvc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvc *CertifyVulnCreate) SetDocumentRef(s string) *CertifyVulnCreate {
+	cvc.mutation.SetDocumentRef(s)
+	return cvc
+}
+
 // SetID sets the "id" field.
 func (cvc *CertifyVulnCreate) SetID(u uuid.UUID) *CertifyVulnCreate {
 	cvc.mutation.SetID(u)
@@ -174,6 +180,9 @@ func (cvc *CertifyVulnCreate) check() error {
 	if _, ok := cvc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "CertifyVuln.collector"`)}
 	}
+	if _, ok := cvc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyVuln.document_ref"`)}
+	}
 	if _, ok := cvc.mutation.VulnerabilityID(); !ok {
 		return &ValidationError{Name: "vulnerability", err: errors.New(`ent: missing required edge "CertifyVuln.vulnerability"`)}
 	}
@@ -243,6 +252,10 @@ func (cvc *CertifyVulnCreate) createSpec() (*CertifyVuln, *sqlgraph.CreateSpec) 
 	if value, ok := cvc.mutation.Collector(); ok {
 		_spec.SetField(certifyvuln.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := cvc.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvuln.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := cvc.mutation.VulnerabilityIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -438,6 +451,18 @@ func (u *CertifyVulnUpsert) UpdateCollector() *CertifyVulnUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVulnUpsert) SetDocumentRef(v string) *CertifyVulnUpsert {
+	u.Set(certifyvuln.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVulnUpsert) UpdateDocumentRef() *CertifyVulnUpsert {
+	u.SetExcluded(certifyvuln.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -609,6 +634,20 @@ func (u *CertifyVulnUpsertOne) SetCollector(v string) *CertifyVulnUpsertOne {
 func (u *CertifyVulnUpsertOne) UpdateCollector() *CertifyVulnUpsertOne {
 	return u.Update(func(s *CertifyVulnUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVulnUpsertOne) SetDocumentRef(v string) *CertifyVulnUpsertOne {
+	return u.Update(func(s *CertifyVulnUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVulnUpsertOne) UpdateDocumentRef() *CertifyVulnUpsertOne {
+	return u.Update(func(s *CertifyVulnUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -950,6 +989,20 @@ func (u *CertifyVulnUpsertBulk) SetCollector(v string) *CertifyVulnUpsertBulk {
 func (u *CertifyVulnUpsertBulk) UpdateCollector() *CertifyVulnUpsertBulk {
 	return u.Update(func(s *CertifyVulnUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *CertifyVulnUpsertBulk) SetDocumentRef(v string) *CertifyVulnUpsertBulk {
+	return u.Update(func(s *CertifyVulnUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *CertifyVulnUpsertBulk) UpdateDocumentRef() *CertifyVulnUpsertBulk {
+	return u.Update(func(s *CertifyVulnUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/certifyvuln_update.go
+++ b/pkg/assembler/backends/ent/certifyvuln_update.go
@@ -157,6 +157,20 @@ func (cvu *CertifyVulnUpdate) SetNillableCollector(s *string) *CertifyVulnUpdate
 	return cvu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvu *CertifyVulnUpdate) SetDocumentRef(s string) *CertifyVulnUpdate {
+	cvu.mutation.SetDocumentRef(s)
+	return cvu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cvu *CertifyVulnUpdate) SetNillableDocumentRef(s *string) *CertifyVulnUpdate {
+	if s != nil {
+		cvu.SetDocumentRef(*s)
+	}
+	return cvu
+}
+
 // SetVulnerability sets the "vulnerability" edge to the VulnerabilityID entity.
 func (cvu *CertifyVulnUpdate) SetVulnerability(v *VulnerabilityID) *CertifyVulnUpdate {
 	return cvu.SetVulnerabilityID(v.ID)
@@ -254,6 +268,9 @@ func (cvu *CertifyVulnUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := cvu.mutation.Collector(); ok {
 		_spec.SetField(certifyvuln.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cvu.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvuln.FieldDocumentRef, field.TypeString, value)
 	}
 	if cvu.mutation.VulnerabilityCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -459,6 +476,20 @@ func (cvuo *CertifyVulnUpdateOne) SetNillableCollector(s *string) *CertifyVulnUp
 	return cvuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (cvuo *CertifyVulnUpdateOne) SetDocumentRef(s string) *CertifyVulnUpdateOne {
+	cvuo.mutation.SetDocumentRef(s)
+	return cvuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (cvuo *CertifyVulnUpdateOne) SetNillableDocumentRef(s *string) *CertifyVulnUpdateOne {
+	if s != nil {
+		cvuo.SetDocumentRef(*s)
+	}
+	return cvuo
+}
+
 // SetVulnerability sets the "vulnerability" edge to the VulnerabilityID entity.
 func (cvuo *CertifyVulnUpdateOne) SetVulnerability(v *VulnerabilityID) *CertifyVulnUpdateOne {
 	return cvuo.SetVulnerabilityID(v.ID)
@@ -586,6 +617,9 @@ func (cvuo *CertifyVulnUpdateOne) sqlSave(ctx context.Context) (_node *CertifyVu
 	}
 	if value, ok := cvuo.mutation.Collector(); ok {
 		_spec.SetField(certifyvuln.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := cvuo.mutation.DocumentRef(); ok {
+		_spec.SetField(certifyvuln.FieldDocumentRef, field.TypeString, value)
 	}
 	if cvuo.mutation.VulnerabilityCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/dependency.go
+++ b/pkg/assembler/backends/ent/dependency.go
@@ -35,6 +35,8 @@ type Dependency struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DependencyQuery when eager-loading is set.
 	Edges        DependencyEdges `json:"edges"`
@@ -113,7 +115,7 @@ func (*Dependency) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case dependency.FieldVersionRange, dependency.FieldDependencyType, dependency.FieldJustification, dependency.FieldOrigin, dependency.FieldCollector:
+		case dependency.FieldVersionRange, dependency.FieldDependencyType, dependency.FieldJustification, dependency.FieldOrigin, dependency.FieldCollector, dependency.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case dependency.FieldID, dependency.FieldPackageID, dependency.FieldDependentPackageNameID, dependency.FieldDependentPackageVersionID:
 			values[i] = new(uuid.UUID)
@@ -185,6 +187,12 @@ func (d *Dependency) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				d.Collector = value.String
+			}
+		case dependency.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				d.DocumentRef = value.String
 			}
 		default:
 			d.selectValues.Set(columns[i], values[i])
@@ -265,6 +273,9 @@ func (d *Dependency) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(d.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(d.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/dependency/dependency.go
+++ b/pkg/assembler/backends/ent/dependency/dependency.go
@@ -33,6 +33,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgePackage holds the string denoting the package edge name in mutations.
 	EdgePackage = "package"
 	// EdgeDependentPackageName holds the string denoting the dependent_package_name edge name in mutations.
@@ -82,6 +84,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 var (
@@ -175,6 +178,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByPackageField orders the results by package field.

--- a/pkg/assembler/backends/ent/dependency/where.go
+++ b/pkg/assembler/backends/ent/dependency/where.go
@@ -89,6 +89,11 @@ func Collector(v string) predicate.Dependency {
 	return predicate.Dependency(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // PackageIDEQ applies the EQ predicate on the "package_id" field.
 func PackageIDEQ(v uuid.UUID) predicate.Dependency {
 	return predicate.Dependency(sql.FieldEQ(FieldPackageID, v))
@@ -447,6 +452,71 @@ func CollectorEqualFold(v string) predicate.Dependency {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.Dependency {
 	return predicate.Dependency(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.Dependency {
+	return predicate.Dependency(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasPackage applies the HasEdge predicate on the "package" edge.

--- a/pkg/assembler/backends/ent/dependency_create.go
+++ b/pkg/assembler/backends/ent/dependency_create.go
@@ -90,6 +90,12 @@ func (dc *DependencyCreate) SetCollector(s string) *DependencyCreate {
 	return dc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (dc *DependencyCreate) SetDocumentRef(s string) *DependencyCreate {
+	dc.mutation.SetDocumentRef(s)
+	return dc
+}
+
 // SetID sets the "id" field.
 func (dc *DependencyCreate) SetID(u uuid.UUID) *DependencyCreate {
 	dc.mutation.SetID(u)
@@ -200,6 +206,9 @@ func (dc *DependencyCreate) check() error {
 	if _, ok := dc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "Dependency.collector"`)}
 	}
+	if _, ok := dc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "Dependency.document_ref"`)}
+	}
 	if _, ok := dc.mutation.PackageID(); !ok {
 		return &ValidationError{Name: "package", err: errors.New(`ent: missing required edge "Dependency.package"`)}
 	}
@@ -258,6 +267,10 @@ func (dc *DependencyCreate) createSpec() (*Dependency, *sqlgraph.CreateSpec) {
 	if value, ok := dc.mutation.Collector(); ok {
 		_spec.SetField(dependency.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := dc.mutation.DocumentRef(); ok {
+		_spec.SetField(dependency.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := dc.mutation.PackageIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -486,6 +499,18 @@ func (u *DependencyUpsert) UpdateCollector() *DependencyUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *DependencyUpsert) SetDocumentRef(v string) *DependencyUpsert {
+	u.Set(dependency.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *DependencyUpsert) UpdateDocumentRef() *DependencyUpsert {
+	u.SetExcluded(dependency.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -657,6 +682,20 @@ func (u *DependencyUpsertOne) SetCollector(v string) *DependencyUpsertOne {
 func (u *DependencyUpsertOne) UpdateCollector() *DependencyUpsertOne {
 	return u.Update(func(s *DependencyUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *DependencyUpsertOne) SetDocumentRef(v string) *DependencyUpsertOne {
+	return u.Update(func(s *DependencyUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *DependencyUpsertOne) UpdateDocumentRef() *DependencyUpsertOne {
+	return u.Update(func(s *DependencyUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -998,6 +1037,20 @@ func (u *DependencyUpsertBulk) SetCollector(v string) *DependencyUpsertBulk {
 func (u *DependencyUpsertBulk) UpdateCollector() *DependencyUpsertBulk {
 	return u.Update(func(s *DependencyUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *DependencyUpsertBulk) SetDocumentRef(v string) *DependencyUpsertBulk {
+	return u.Update(func(s *DependencyUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *DependencyUpsertBulk) UpdateDocumentRef() *DependencyUpsertBulk {
+	return u.Update(func(s *DependencyUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/dependency_update.go
+++ b/pkg/assembler/backends/ent/dependency_update.go
@@ -155,6 +155,20 @@ func (du *DependencyUpdate) SetNillableCollector(s *string) *DependencyUpdate {
 	return du
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (du *DependencyUpdate) SetDocumentRef(s string) *DependencyUpdate {
+	du.mutation.SetDocumentRef(s)
+	return du
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (du *DependencyUpdate) SetNillableDocumentRef(s *string) *DependencyUpdate {
+	if s != nil {
+		du.SetDocumentRef(*s)
+	}
+	return du
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (du *DependencyUpdate) SetPackage(p *PackageVersion) *DependencyUpdate {
 	return du.SetPackageID(p.ID)
@@ -295,6 +309,9 @@ func (du *DependencyUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := du.mutation.Collector(); ok {
 		_spec.SetField(dependency.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := du.mutation.DocumentRef(); ok {
+		_spec.SetField(dependency.FieldDocumentRef, field.TypeString, value)
 	}
 	if du.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -572,6 +589,20 @@ func (duo *DependencyUpdateOne) SetNillableCollector(s *string) *DependencyUpdat
 	return duo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (duo *DependencyUpdateOne) SetDocumentRef(s string) *DependencyUpdateOne {
+	duo.mutation.SetDocumentRef(s)
+	return duo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (duo *DependencyUpdateOne) SetNillableDocumentRef(s *string) *DependencyUpdateOne {
+	if s != nil {
+		duo.SetDocumentRef(*s)
+	}
+	return duo
+}
+
 // SetPackage sets the "package" edge to the PackageVersion entity.
 func (duo *DependencyUpdateOne) SetPackage(p *PackageVersion) *DependencyUpdateOne {
 	return duo.SetPackageID(p.ID)
@@ -742,6 +773,9 @@ func (duo *DependencyUpdateOne) sqlSave(ctx context.Context) (_node *Dependency,
 	}
 	if value, ok := duo.mutation.Collector(); ok {
 		_spec.SetField(dependency.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := duo.mutation.DocumentRef(); ok {
+		_spec.SetField(dependency.FieldDocumentRef, field.TypeString, value)
 	}
 	if duo.mutation.PackageCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -616,6 +616,11 @@ func (c *CertificationQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, certification.FieldJustification)
 				fieldSeen[certification.FieldJustification] = struct{}{}
 			}
+		case "knownSince":
+			if _, ok := fieldSeen[certification.FieldKnownSince]; !ok {
+				selectedFields = append(selectedFields, certification.FieldKnownSince)
+				fieldSeen[certification.FieldKnownSince] = struct{}{}
+			}
 		case "origin":
 			if _, ok := fieldSeen[certification.FieldOrigin]; !ok {
 				selectedFields = append(selectedFields, certification.FieldOrigin)
@@ -626,10 +631,10 @@ func (c *CertificationQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, certification.FieldCollector)
 				fieldSeen[certification.FieldCollector] = struct{}{}
 			}
-		case "knownSince":
-			if _, ok := fieldSeen[certification.FieldKnownSince]; !ok {
-				selectedFields = append(selectedFields, certification.FieldKnownSince)
-				fieldSeen[certification.FieldKnownSince] = struct{}{}
+		case "documentRef":
+			if _, ok := fieldSeen[certification.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, certification.FieldDocumentRef)
+				fieldSeen[certification.FieldDocumentRef] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -370,6 +370,11 @@ func (bom *BillOfMaterialsQuery) collectField(ctx context.Context, opCtx *graphq
 				selectedFields = append(selectedFields, billofmaterials.FieldCollector)
 				fieldSeen[billofmaterials.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[billofmaterials.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, billofmaterials.FieldDocumentRef)
+				fieldSeen[billofmaterials.FieldDocumentRef] = struct{}{}
+			}
 		case "knownSince":
 			if _, ok := fieldSeen[billofmaterials.FieldKnownSince]; !ok {
 				selectedFields = append(selectedFields, billofmaterials.FieldKnownSince)
@@ -792,6 +797,11 @@ func (cl *CertifyLegalQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, certifylegal.FieldCollector)
 				fieldSeen[certifylegal.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[certifylegal.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, certifylegal.FieldDocumentRef)
+				fieldSeen[certifylegal.FieldDocumentRef] = struct{}{}
+			}
 		case "declaredLicensesHash":
 			if _, ok := fieldSeen[certifylegal.FieldDeclaredLicensesHash]; !ok {
 				selectedFields = append(selectedFields, certifylegal.FieldDeclaredLicensesHash)
@@ -914,6 +924,11 @@ func (cs *CertifyScorecardQuery) collectField(ctx context.Context, opCtx *graphq
 			if _, ok := fieldSeen[certifyscorecard.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, certifyscorecard.FieldCollector)
 				fieldSeen[certifyscorecard.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[certifyscorecard.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, certifyscorecard.FieldDocumentRef)
+				fieldSeen[certifyscorecard.FieldDocumentRef] = struct{}{}
 			}
 		case "checksHash":
 			if _, ok := fieldSeen[certifyscorecard.FieldChecksHash]; !ok {
@@ -1071,6 +1086,11 @@ func (cv *CertifyVexQuery) collectField(ctx context.Context, opCtx *graphql.Oper
 				selectedFields = append(selectedFields, certifyvex.FieldCollector)
 				fieldSeen[certifyvex.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[certifyvex.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, certifyvex.FieldDocumentRef)
+				fieldSeen[certifyvex.FieldDocumentRef] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -1202,6 +1222,11 @@ func (cv *CertifyVulnQuery) collectField(ctx context.Context, opCtx *graphql.Ope
 			if _, ok := fieldSeen[certifyvuln.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, certifyvuln.FieldCollector)
 				fieldSeen[certifyvuln.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[certifyvuln.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, certifyvuln.FieldDocumentRef)
+				fieldSeen[certifyvuln.FieldDocumentRef] = struct{}{}
 			}
 		case "id":
 		case "__typename":
@@ -1355,6 +1380,11 @@ func (d *DependencyQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 			if _, ok := fieldSeen[dependency.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, dependency.FieldCollector)
 				fieldSeen[dependency.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[dependency.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, dependency.FieldDocumentRef)
+				fieldSeen[dependency.FieldDocumentRef] = struct{}{}
 			}
 		case "id":
 		case "__typename":
@@ -1521,6 +1551,11 @@ func (hm *HasMetadataQuery) collectField(ctx context.Context, opCtx *graphql.Ope
 				selectedFields = append(selectedFields, hasmetadata.FieldCollector)
 				fieldSeen[hasmetadata.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[hasmetadata.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, hasmetadata.FieldDocumentRef)
+				fieldSeen[hasmetadata.FieldDocumentRef] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -1657,6 +1692,11 @@ func (hsa *HasSourceAtQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, hassourceat.FieldCollector)
 				fieldSeen[hassourceat.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[hassourceat.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, hassourceat.FieldDocumentRef)
+				fieldSeen[hassourceat.FieldDocumentRef] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -1768,6 +1808,11 @@ func (he *HashEqualQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 			if _, ok := fieldSeen[hashequal.FieldJustification]; !ok {
 				selectedFields = append(selectedFields, hashequal.FieldJustification)
 				fieldSeen[hashequal.FieldJustification] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[hashequal.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, hashequal.FieldDocumentRef)
+				fieldSeen[hashequal.FieldDocumentRef] = struct{}{}
 			}
 		case "artifactsHash":
 			if _, ok := fieldSeen[hashequal.FieldArtifactsHash]; !ok {
@@ -2004,6 +2049,11 @@ func (o *OccurrenceQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 			if _, ok := fieldSeen[occurrence.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, occurrence.FieldCollector)
 				fieldSeen[occurrence.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[occurrence.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, occurrence.FieldDocumentRef)
+				fieldSeen[occurrence.FieldDocumentRef] = struct{}{}
 			}
 		case "sourceID":
 			if _, ok := fieldSeen[occurrence.FieldSourceID]; !ok {
@@ -2534,6 +2584,11 @@ func (pe *PkgEqualQuery) collectField(ctx context.Context, opCtx *graphql.Operat
 				selectedFields = append(selectedFields, pkgequal.FieldCollector)
 				fieldSeen[pkgequal.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[pkgequal.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, pkgequal.FieldDocumentRef)
+				fieldSeen[pkgequal.FieldDocumentRef] = struct{}{}
+			}
 		case "justification":
 			if _, ok := fieldSeen[pkgequal.FieldJustification]; !ok {
 				selectedFields = append(selectedFields, pkgequal.FieldJustification)
@@ -2709,6 +2764,11 @@ func (poc *PointOfContactQuery) collectField(ctx context.Context, opCtx *graphql
 				selectedFields = append(selectedFields, pointofcontact.FieldCollector)
 				fieldSeen[pointofcontact.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[pointofcontact.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, pointofcontact.FieldDocumentRef)
+				fieldSeen[pointofcontact.FieldDocumentRef] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -2852,6 +2912,11 @@ func (sa *SLSAAttestationQuery) collectField(ctx context.Context, opCtx *graphql
 			if _, ok := fieldSeen[slsaattestation.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, slsaattestation.FieldCollector)
 				fieldSeen[slsaattestation.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[slsaattestation.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, slsaattestation.FieldDocumentRef)
+				fieldSeen[slsaattestation.FieldDocumentRef] = struct{}{}
 			}
 		case "builtFromHash":
 			if _, ok := fieldSeen[slsaattestation.FieldBuiltFromHash]; !ok {
@@ -3138,6 +3203,11 @@ func (ve *VulnEqualQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				selectedFields = append(selectedFields, vulnequal.FieldCollector)
 				fieldSeen[vulnequal.FieldCollector] = struct{}{}
 			}
+		case "documentRef":
+			if _, ok := fieldSeen[vulnequal.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, vulnequal.FieldDocumentRef)
+				fieldSeen[vulnequal.FieldDocumentRef] = struct{}{}
+			}
 		case "vulnerabilitiesHash":
 			if _, ok := fieldSeen[vulnequal.FieldVulnerabilitiesHash]; !ok {
 				selectedFields = append(selectedFields, vulnequal.FieldVulnerabilitiesHash)
@@ -3374,6 +3444,11 @@ func (vm *VulnerabilityMetadataQuery) collectField(ctx context.Context, opCtx *g
 			if _, ok := fieldSeen[vulnerabilitymetadata.FieldCollector]; !ok {
 				selectedFields = append(selectedFields, vulnerabilitymetadata.FieldCollector)
 				fieldSeen[vulnerabilitymetadata.FieldCollector] = struct{}{}
+			}
+		case "documentRef":
+			if _, ok := fieldSeen[vulnerabilitymetadata.FieldDocumentRef]; !ok {
+				selectedFields = append(selectedFields, vulnerabilitymetadata.FieldDocumentRef)
+				fieldSeen[vulnerabilitymetadata.FieldDocumentRef] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/pkg/assembler/backends/ent/hashequal.go
+++ b/pkg/assembler/backends/ent/hashequal.go
@@ -28,6 +28,8 @@ type HashEqual struct {
 	Collector string `json:"collector,omitempty"`
 	// Justification holds the value of the "justification" field.
 	Justification string `json:"justification,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// An opaque hash of the artifact IDs that are equal
 	ArtifactsHash string `json:"artifacts_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -80,7 +82,7 @@ func (*HashEqual) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case hashequal.FieldOrigin, hashequal.FieldCollector, hashequal.FieldJustification, hashequal.FieldArtifactsHash:
+		case hashequal.FieldOrigin, hashequal.FieldCollector, hashequal.FieldJustification, hashequal.FieldDocumentRef, hashequal.FieldArtifactsHash:
 			values[i] = new(sql.NullString)
 		case hashequal.FieldID, hashequal.FieldArtID, hashequal.FieldEqualArtID:
 			values[i] = new(uuid.UUID)
@@ -134,6 +136,12 @@ func (he *HashEqual) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field justification", values[i])
 			} else if value.Valid {
 				he.Justification = value.String
+			}
+		case hashequal.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				he.DocumentRef = value.String
 			}
 		case hashequal.FieldArtifactsHash:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -201,6 +209,9 @@ func (he *HashEqual) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("justification=")
 	builder.WriteString(he.Justification)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(he.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("artifacts_hash=")
 	builder.WriteString(he.ArtifactsHash)

--- a/pkg/assembler/backends/ent/hashequal/hashequal.go
+++ b/pkg/assembler/backends/ent/hashequal/hashequal.go
@@ -23,6 +23,8 @@ const (
 	FieldCollector = "collector"
 	// FieldJustification holds the string denoting the justification field in the database.
 	FieldJustification = "justification"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldArtifactsHash holds the string denoting the artifacts_hash field in the database.
 	FieldArtifactsHash = "artifacts_hash"
 	// EdgeArtifactA holds the string denoting the artifact_a edge name in mutations.
@@ -55,6 +57,7 @@ var Columns = []string{
 	FieldOrigin,
 	FieldCollector,
 	FieldJustification,
+	FieldDocumentRef,
 	FieldArtifactsHash,
 }
 
@@ -104,6 +107,11 @@ func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 // ByJustification orders the results by the justification field.
 func ByJustification(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldJustification, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByArtifactsHash orders the results by the artifacts_hash field.

--- a/pkg/assembler/backends/ent/hashequal/where.go
+++ b/pkg/assembler/backends/ent/hashequal/where.go
@@ -79,6 +79,11 @@ func Justification(v string) predicate.HashEqual {
 	return predicate.HashEqual(sql.FieldEQ(FieldJustification, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // ArtifactsHash applies equality check predicate on the "artifacts_hash" field. It's identical to ArtifactsHashEQ.
 func ArtifactsHash(v string) predicate.HashEqual {
 	return predicate.HashEqual(sql.FieldEQ(FieldArtifactsHash, v))
@@ -317,6 +322,71 @@ func JustificationEqualFold(v string) predicate.HashEqual {
 // JustificationContainsFold applies the ContainsFold predicate on the "justification" field.
 func JustificationContainsFold(v string) predicate.HashEqual {
 	return predicate.HashEqual(sql.FieldContainsFold(FieldJustification, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.HashEqual {
+	return predicate.HashEqual(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // ArtifactsHashEQ applies the EQ predicate on the "artifacts_hash" field.

--- a/pkg/assembler/backends/ent/hashequal_create.go
+++ b/pkg/assembler/backends/ent/hashequal_create.go
@@ -54,6 +54,12 @@ func (hec *HashEqualCreate) SetJustification(s string) *HashEqualCreate {
 	return hec
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hec *HashEqualCreate) SetDocumentRef(s string) *HashEqualCreate {
+	hec.mutation.SetDocumentRef(s)
+	return hec
+}
+
 // SetArtifactsHash sets the "artifacts_hash" field.
 func (hec *HashEqualCreate) SetArtifactsHash(s string) *HashEqualCreate {
 	hec.mutation.SetArtifactsHash(s)
@@ -154,6 +160,9 @@ func (hec *HashEqualCreate) check() error {
 	if _, ok := hec.mutation.Justification(); !ok {
 		return &ValidationError{Name: "justification", err: errors.New(`ent: missing required field "HashEqual.justification"`)}
 	}
+	if _, ok := hec.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "HashEqual.document_ref"`)}
+	}
 	if _, ok := hec.mutation.ArtifactsHash(); !ok {
 		return &ValidationError{Name: "artifacts_hash", err: errors.New(`ent: missing required field "HashEqual.artifacts_hash"`)}
 	}
@@ -210,6 +219,10 @@ func (hec *HashEqualCreate) createSpec() (*HashEqual, *sqlgraph.CreateSpec) {
 	if value, ok := hec.mutation.Justification(); ok {
 		_spec.SetField(hashequal.FieldJustification, field.TypeString, value)
 		_node.Justification = value
+	}
+	if value, ok := hec.mutation.DocumentRef(); ok {
+		_spec.SetField(hashequal.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := hec.mutation.ArtifactsHash(); ok {
 		_spec.SetField(hashequal.FieldArtifactsHash, field.TypeString, value)
@@ -361,6 +374,18 @@ func (u *HashEqualUpsert) UpdateJustification() *HashEqualUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *HashEqualUpsert) SetDocumentRef(v string) *HashEqualUpsert {
+	u.Set(hashequal.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HashEqualUpsert) UpdateDocumentRef() *HashEqualUpsert {
+	u.SetExcluded(hashequal.FieldDocumentRef)
+	return u
+}
+
 // SetArtifactsHash sets the "artifacts_hash" field.
 func (u *HashEqualUpsert) SetArtifactsHash(v string) *HashEqualUpsert {
 	u.Set(hashequal.FieldArtifactsHash, v)
@@ -488,6 +513,20 @@ func (u *HashEqualUpsertOne) SetJustification(v string) *HashEqualUpsertOne {
 func (u *HashEqualUpsertOne) UpdateJustification() *HashEqualUpsertOne {
 	return u.Update(func(s *HashEqualUpsert) {
 		s.UpdateJustification()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HashEqualUpsertOne) SetDocumentRef(v string) *HashEqualUpsertOne {
+	return u.Update(func(s *HashEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HashEqualUpsertOne) UpdateDocumentRef() *HashEqualUpsertOne {
+	return u.Update(func(s *HashEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -787,6 +826,20 @@ func (u *HashEqualUpsertBulk) SetJustification(v string) *HashEqualUpsertBulk {
 func (u *HashEqualUpsertBulk) UpdateJustification() *HashEqualUpsertBulk {
 	return u.Update(func(s *HashEqualUpsert) {
 		s.UpdateJustification()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HashEqualUpsertBulk) SetDocumentRef(v string) *HashEqualUpsertBulk {
+	return u.Update(func(s *HashEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HashEqualUpsertBulk) UpdateDocumentRef() *HashEqualUpsertBulk {
+	return u.Update(func(s *HashEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/hashequal_update.go
+++ b/pkg/assembler/backends/ent/hashequal_update.go
@@ -99,6 +99,20 @@ func (heu *HashEqualUpdate) SetNillableJustification(s *string) *HashEqualUpdate
 	return heu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (heu *HashEqualUpdate) SetDocumentRef(s string) *HashEqualUpdate {
+	heu.mutation.SetDocumentRef(s)
+	return heu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (heu *HashEqualUpdate) SetNillableDocumentRef(s *string) *HashEqualUpdate {
+	if s != nil {
+		heu.SetDocumentRef(*s)
+	}
+	return heu
+}
+
 // SetArtifactsHash sets the "artifacts_hash" field.
 func (heu *HashEqualUpdate) SetArtifactsHash(s string) *HashEqualUpdate {
 	heu.mutation.SetArtifactsHash(s)
@@ -210,6 +224,9 @@ func (heu *HashEqualUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := heu.mutation.Justification(); ok {
 		_spec.SetField(hashequal.FieldJustification, field.TypeString, value)
+	}
+	if value, ok := heu.mutation.DocumentRef(); ok {
+		_spec.SetField(hashequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := heu.mutation.ArtifactsHash(); ok {
 		_spec.SetField(hashequal.FieldArtifactsHash, field.TypeString, value)
@@ -362,6 +379,20 @@ func (heuo *HashEqualUpdateOne) SetNillableJustification(s *string) *HashEqualUp
 	return heuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (heuo *HashEqualUpdateOne) SetDocumentRef(s string) *HashEqualUpdateOne {
+	heuo.mutation.SetDocumentRef(s)
+	return heuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (heuo *HashEqualUpdateOne) SetNillableDocumentRef(s *string) *HashEqualUpdateOne {
+	if s != nil {
+		heuo.SetDocumentRef(*s)
+	}
+	return heuo
+}
+
 // SetArtifactsHash sets the "artifacts_hash" field.
 func (heuo *HashEqualUpdateOne) SetArtifactsHash(s string) *HashEqualUpdateOne {
 	heuo.mutation.SetArtifactsHash(s)
@@ -503,6 +534,9 @@ func (heuo *HashEqualUpdateOne) sqlSave(ctx context.Context) (_node *HashEqual, 
 	}
 	if value, ok := heuo.mutation.Justification(); ok {
 		_spec.SetField(hashequal.FieldJustification, field.TypeString, value)
+	}
+	if value, ok := heuo.mutation.DocumentRef(); ok {
+		_spec.SetField(hashequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := heuo.mutation.ArtifactsHash(); ok {
 		_spec.SetField(hashequal.FieldArtifactsHash, field.TypeString, value)

--- a/pkg/assembler/backends/ent/hasmetadata.go
+++ b/pkg/assembler/backends/ent/hasmetadata.go
@@ -42,6 +42,8 @@ type HasMetadata struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the HasMetadataQuery when eager-loading is set.
 	Edges        HasMetadataEdges `json:"edges"`
@@ -124,7 +126,7 @@ func (*HasMetadata) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case hasmetadata.FieldSourceID, hasmetadata.FieldPackageVersionID, hasmetadata.FieldPackageNameID, hasmetadata.FieldArtifactID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case hasmetadata.FieldKey, hasmetadata.FieldValue, hasmetadata.FieldJustification, hasmetadata.FieldOrigin, hasmetadata.FieldCollector:
+		case hasmetadata.FieldKey, hasmetadata.FieldValue, hasmetadata.FieldJustification, hasmetadata.FieldOrigin, hasmetadata.FieldCollector, hasmetadata.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case hasmetadata.FieldTimestamp:
 			values[i] = new(sql.NullTime)
@@ -214,6 +216,12 @@ func (hm *HasMetadata) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				hm.Collector = value.String
+			}
+		case hasmetadata.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				hm.DocumentRef = value.String
 			}
 		default:
 			hm.selectValues.Set(columns[i], values[i])
@@ -308,6 +316,9 @@ func (hm *HasMetadata) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(hm.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(hm.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/hasmetadata/hasmetadata.go
+++ b/pkg/assembler/backends/ent/hasmetadata/hasmetadata.go
@@ -33,6 +33,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgeSource holds the string denoting the source edge name in mutations.
 	EdgeSource = "source"
 	// EdgePackageVersion holds the string denoting the package_version edge name in mutations.
@@ -86,6 +88,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -159,6 +162,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // BySourceField orders the results by source field.

--- a/pkg/assembler/backends/ent/hasmetadata/where.go
+++ b/pkg/assembler/backends/ent/hasmetadata/where.go
@@ -106,6 +106,11 @@ func Collector(v string) predicate.HasMetadata {
 	return predicate.HasMetadata(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // SourceIDEQ applies the EQ predicate on the "source_id" field.
 func SourceIDEQ(v uuid.UUID) predicate.HasMetadata {
 	return predicate.HasMetadata(sql.FieldEQ(FieldSourceID, v))
@@ -589,6 +594,71 @@ func CollectorEqualFold(v string) predicate.HasMetadata {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.HasMetadata {
 	return predicate.HasMetadata(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.HasMetadata {
+	return predicate.HasMetadata(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasSource applies the HasEdge predicate on the "source" edge.

--- a/pkg/assembler/backends/ent/hasmetadata_create.go
+++ b/pkg/assembler/backends/ent/hasmetadata_create.go
@@ -120,6 +120,12 @@ func (hmc *HasMetadataCreate) SetCollector(s string) *HasMetadataCreate {
 	return hmc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hmc *HasMetadataCreate) SetDocumentRef(s string) *HasMetadataCreate {
+	hmc.mutation.SetDocumentRef(s)
+	return hmc
+}
+
 // SetID sets the "id" field.
 func (hmc *HasMetadataCreate) SetID(u uuid.UUID) *HasMetadataCreate {
 	hmc.mutation.SetID(u)
@@ -229,6 +235,9 @@ func (hmc *HasMetadataCreate) check() error {
 	if _, ok := hmc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "HasMetadata.collector"`)}
 	}
+	if _, ok := hmc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "HasMetadata.document_ref"`)}
+	}
 	return nil
 }
 
@@ -288,6 +297,10 @@ func (hmc *HasMetadataCreate) createSpec() (*HasMetadata, *sqlgraph.CreateSpec) 
 	if value, ok := hmc.mutation.Collector(); ok {
 		_spec.SetField(hasmetadata.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := hmc.mutation.DocumentRef(); ok {
+		_spec.SetField(hasmetadata.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := hmc.mutation.SourceIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -553,6 +566,18 @@ func (u *HasMetadataUpsert) UpdateCollector() *HasMetadataUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasMetadataUpsert) SetDocumentRef(v string) *HasMetadataUpsert {
+	u.Set(hasmetadata.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasMetadataUpsert) UpdateDocumentRef() *HasMetadataUpsert {
+	u.SetExcluded(hasmetadata.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -766,6 +791,20 @@ func (u *HasMetadataUpsertOne) SetCollector(v string) *HasMetadataUpsertOne {
 func (u *HasMetadataUpsertOne) UpdateCollector() *HasMetadataUpsertOne {
 	return u.Update(func(s *HasMetadataUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasMetadataUpsertOne) SetDocumentRef(v string) *HasMetadataUpsertOne {
+	return u.Update(func(s *HasMetadataUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasMetadataUpsertOne) UpdateDocumentRef() *HasMetadataUpsertOne {
+	return u.Update(func(s *HasMetadataUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1149,6 +1188,20 @@ func (u *HasMetadataUpsertBulk) SetCollector(v string) *HasMetadataUpsertBulk {
 func (u *HasMetadataUpsertBulk) UpdateCollector() *HasMetadataUpsertBulk {
 	return u.Update(func(s *HasMetadataUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasMetadataUpsertBulk) SetDocumentRef(v string) *HasMetadataUpsertBulk {
+	return u.Update(func(s *HasMetadataUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasMetadataUpsertBulk) UpdateDocumentRef() *HasMetadataUpsertBulk {
+	return u.Update(func(s *HasMetadataUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/hasmetadata_update.go
+++ b/pkg/assembler/backends/ent/hasmetadata_update.go
@@ -197,6 +197,20 @@ func (hmu *HasMetadataUpdate) SetNillableCollector(s *string) *HasMetadataUpdate
 	return hmu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hmu *HasMetadataUpdate) SetDocumentRef(s string) *HasMetadataUpdate {
+	hmu.mutation.SetDocumentRef(s)
+	return hmu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (hmu *HasMetadataUpdate) SetNillableDocumentRef(s *string) *HasMetadataUpdate {
+	if s != nil {
+		hmu.SetDocumentRef(*s)
+	}
+	return hmu
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (hmu *HasMetadataUpdate) SetSource(s *SourceName) *HasMetadataUpdate {
 	return hmu.SetSourceID(s.ID)
@@ -313,6 +327,9 @@ func (hmu *HasMetadataUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := hmu.mutation.Collector(); ok {
 		_spec.SetField(hasmetadata.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := hmu.mutation.DocumentRef(); ok {
+		_spec.SetField(hasmetadata.FieldDocumentRef, field.TypeString, value)
 	}
 	if hmu.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -614,6 +631,20 @@ func (hmuo *HasMetadataUpdateOne) SetNillableCollector(s *string) *HasMetadataUp
 	return hmuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hmuo *HasMetadataUpdateOne) SetDocumentRef(s string) *HasMetadataUpdateOne {
+	hmuo.mutation.SetDocumentRef(s)
+	return hmuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (hmuo *HasMetadataUpdateOne) SetNillableDocumentRef(s *string) *HasMetadataUpdateOne {
+	if s != nil {
+		hmuo.SetDocumentRef(*s)
+	}
+	return hmuo
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (hmuo *HasMetadataUpdateOne) SetSource(s *SourceName) *HasMetadataUpdateOne {
 	return hmuo.SetSourceID(s.ID)
@@ -760,6 +791,9 @@ func (hmuo *HasMetadataUpdateOne) sqlSave(ctx context.Context) (_node *HasMetada
 	}
 	if value, ok := hmuo.mutation.Collector(); ok {
 		_spec.SetField(hasmetadata.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := hmuo.mutation.DocumentRef(); ok {
+		_spec.SetField(hasmetadata.FieldDocumentRef, field.TypeString, value)
 	}
 	if hmuo.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/hassourceat.go
+++ b/pkg/assembler/backends/ent/hassourceat.go
@@ -35,6 +35,8 @@ type HasSourceAt struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the HasSourceAtQuery when eager-loading is set.
 	Edges        HasSourceAtEdges `json:"edges"`
@@ -102,7 +104,7 @@ func (*HasSourceAt) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case hassourceat.FieldPackageVersionID, hassourceat.FieldPackageNameID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case hassourceat.FieldJustification, hassourceat.FieldOrigin, hassourceat.FieldCollector:
+		case hassourceat.FieldJustification, hassourceat.FieldOrigin, hassourceat.FieldCollector, hassourceat.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case hassourceat.FieldKnownSince:
 			values[i] = new(sql.NullTime)
@@ -172,6 +174,12 @@ func (hsa *HasSourceAt) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				hsa.Collector = value.String
+			}
+		case hassourceat.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				hsa.DocumentRef = value.String
 			}
 		default:
 			hsa.selectValues.Set(columns[i], values[i])
@@ -248,6 +256,9 @@ func (hsa *HasSourceAt) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(hsa.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(hsa.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/hassourceat/hassourceat.go
+++ b/pkg/assembler/backends/ent/hassourceat/hassourceat.go
@@ -27,6 +27,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgePackageVersion holds the string denoting the package_version edge name in mutations.
 	EdgePackageVersion = "package_version"
 	// EdgeAllVersions holds the string denoting the all_versions edge name in mutations.
@@ -68,6 +70,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -126,6 +129,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByPackageVersionField orders the results by package_version field.

--- a/pkg/assembler/backends/ent/hassourceat/where.go
+++ b/pkg/assembler/backends/ent/hassourceat/where.go
@@ -91,6 +91,11 @@ func Collector(v string) predicate.HasSourceAt {
 	return predicate.HasSourceAt(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // PackageVersionIDEQ applies the EQ predicate on the "package_version_id" field.
 func PackageVersionIDEQ(v uuid.UUID) predicate.HasSourceAt {
 	return predicate.HasSourceAt(sql.FieldEQ(FieldPackageVersionID, v))
@@ -404,6 +409,71 @@ func CollectorEqualFold(v string) predicate.HasSourceAt {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.HasSourceAt {
 	return predicate.HasSourceAt(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.HasSourceAt {
+	return predicate.HasSourceAt(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasPackageVersion applies the HasEdge predicate on the "package_version" edge.

--- a/pkg/assembler/backends/ent/hassourceat_create.go
+++ b/pkg/assembler/backends/ent/hassourceat_create.go
@@ -85,6 +85,12 @@ func (hsac *HasSourceAtCreate) SetCollector(s string) *HasSourceAtCreate {
 	return hsac
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hsac *HasSourceAtCreate) SetDocumentRef(s string) *HasSourceAtCreate {
+	hsac.mutation.SetDocumentRef(s)
+	return hsac
+}
+
 // SetID sets the "id" field.
 func (hsac *HasSourceAtCreate) SetID(u uuid.UUID) *HasSourceAtCreate {
 	hsac.mutation.SetID(u)
@@ -186,6 +192,9 @@ func (hsac *HasSourceAtCreate) check() error {
 	if _, ok := hsac.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "HasSourceAt.collector"`)}
 	}
+	if _, ok := hsac.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "HasSourceAt.document_ref"`)}
+	}
 	if _, ok := hsac.mutation.SourceID(); !ok {
 		return &ValidationError{Name: "source", err: errors.New(`ent: missing required edge "HasSourceAt.source"`)}
 	}
@@ -240,6 +249,10 @@ func (hsac *HasSourceAtCreate) createSpec() (*HasSourceAt, *sqlgraph.CreateSpec)
 	if value, ok := hsac.mutation.Collector(); ok {
 		_spec.SetField(hassourceat.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := hsac.mutation.DocumentRef(); ok {
+		_spec.SetField(hassourceat.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := hsac.mutation.PackageVersionIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -440,6 +453,18 @@ func (u *HasSourceAtUpsert) UpdateCollector() *HasSourceAtUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasSourceAtUpsert) SetDocumentRef(v string) *HasSourceAtUpsert {
+	u.Set(hassourceat.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasSourceAtUpsert) UpdateDocumentRef() *HasSourceAtUpsert {
+	u.SetExcluded(hassourceat.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -597,6 +622,20 @@ func (u *HasSourceAtUpsertOne) SetCollector(v string) *HasSourceAtUpsertOne {
 func (u *HasSourceAtUpsertOne) UpdateCollector() *HasSourceAtUpsertOne {
 	return u.Update(func(s *HasSourceAtUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasSourceAtUpsertOne) SetDocumentRef(v string) *HasSourceAtUpsertOne {
+	return u.Update(func(s *HasSourceAtUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasSourceAtUpsertOne) UpdateDocumentRef() *HasSourceAtUpsertOne {
+	return u.Update(func(s *HasSourceAtUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -924,6 +963,20 @@ func (u *HasSourceAtUpsertBulk) SetCollector(v string) *HasSourceAtUpsertBulk {
 func (u *HasSourceAtUpsertBulk) UpdateCollector() *HasSourceAtUpsertBulk {
 	return u.Update(func(s *HasSourceAtUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *HasSourceAtUpsertBulk) SetDocumentRef(v string) *HasSourceAtUpsertBulk {
+	return u.Update(func(s *HasSourceAtUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *HasSourceAtUpsertBulk) UpdateDocumentRef() *HasSourceAtUpsertBulk {
+	return u.Update(func(s *HasSourceAtUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/hassourceat_update.go
+++ b/pkg/assembler/backends/ent/hassourceat_update.go
@@ -142,6 +142,20 @@ func (hsau *HasSourceAtUpdate) SetNillableCollector(s *string) *HasSourceAtUpdat
 	return hsau
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hsau *HasSourceAtUpdate) SetDocumentRef(s string) *HasSourceAtUpdate {
+	hsau.mutation.SetDocumentRef(s)
+	return hsau
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (hsau *HasSourceAtUpdate) SetNillableDocumentRef(s *string) *HasSourceAtUpdate {
+	if s != nil {
+		hsau.SetDocumentRef(*s)
+	}
+	return hsau
+}
+
 // SetPackageVersion sets the "package_version" edge to the PackageVersion entity.
 func (hsau *HasSourceAtUpdate) SetPackageVersion(p *PackageVersion) *HasSourceAtUpdate {
 	return hsau.SetPackageVersionID(p.ID)
@@ -252,6 +266,9 @@ func (hsau *HasSourceAtUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := hsau.mutation.Collector(); ok {
 		_spec.SetField(hassourceat.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := hsau.mutation.DocumentRef(); ok {
+		_spec.SetField(hassourceat.FieldDocumentRef, field.TypeString, value)
 	}
 	if hsau.mutation.PackageVersionCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -470,6 +487,20 @@ func (hsauo *HasSourceAtUpdateOne) SetNillableCollector(s *string) *HasSourceAtU
 	return hsauo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (hsauo *HasSourceAtUpdateOne) SetDocumentRef(s string) *HasSourceAtUpdateOne {
+	hsauo.mutation.SetDocumentRef(s)
+	return hsauo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (hsauo *HasSourceAtUpdateOne) SetNillableDocumentRef(s *string) *HasSourceAtUpdateOne {
+	if s != nil {
+		hsauo.SetDocumentRef(*s)
+	}
+	return hsauo
+}
+
 // SetPackageVersion sets the "package_version" edge to the PackageVersion entity.
 func (hsauo *HasSourceAtUpdateOne) SetPackageVersion(p *PackageVersion) *HasSourceAtUpdateOne {
 	return hsauo.SetPackageVersionID(p.ID)
@@ -610,6 +641,9 @@ func (hsauo *HasSourceAtUpdateOne) sqlSave(ctx context.Context) (_node *HasSourc
 	}
 	if value, ok := hsauo.mutation.Collector(); ok {
 		_spec.SetField(hassourceat.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := hsauo.mutation.DocumentRef(); ok {
+		_spec.SetField(hassourceat.FieldDocumentRef, field.TypeString, value)
 	}
 	if hsauo.mutation.PackageVersionCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -106,9 +106,10 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"GOOD", "BAD"}, Default: "GOOD"},
 		{Name: "justification", Type: field.TypeString},
+		{Name: "known_since", Type: field.TypeTime},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
-		{Name: "known_since", Type: field.TypeTime},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "source_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_version_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_name_id", Type: field.TypeUUID, Nullable: true},
@@ -122,58 +123,58 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certifications_source_names_source",
-				Columns:    []*schema.Column{CertificationsColumns[6]},
+				Columns:    []*schema.Column{CertificationsColumns[7]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_package_versions_package_version",
-				Columns:    []*schema.Column{CertificationsColumns[7]},
+				Columns:    []*schema.Column{CertificationsColumns[8]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_package_names_all_versions",
-				Columns:    []*schema.Column{CertificationsColumns[8]},
+				Columns:    []*schema.Column{CertificationsColumns[9]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certifications_artifacts_artifact",
-				Columns:    []*schema.Column{CertificationsColumns[9]},
+				Columns:    []*schema.Column{CertificationsColumns[10]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certification_type_justification_origin_collector_source_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_source_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[6], CertificationsColumns[5]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[7], CertificationsColumns[3]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_package_version_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_package_version_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[7], CertificationsColumns[5]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[8], CertificationsColumns[3]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_package_name_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_package_name_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[8], CertificationsColumns[5]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[9], CertificationsColumns[3]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_artifact_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_artifact_id_known_since",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[3], CertificationsColumns[4], CertificationsColumns[9], CertificationsColumns[5]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[10], CertificationsColumns[3]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -37,6 +37,7 @@ var (
 		{Name: "download_location", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "known_since", Type: field.TypeTime},
 		{Name: "included_packages_hash", Type: field.TypeString},
 		{Name: "included_artifacts_hash", Type: field.TypeString},
@@ -53,13 +54,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "bill_of_materials_package_versions_package",
-				Columns:    []*schema.Column{BillOfMaterialsColumns[12]},
+				Columns:    []*schema.Column{BillOfMaterialsColumns[13]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "bill_of_materials_artifacts_artifact",
-				Columns:    []*schema.Column{BillOfMaterialsColumns[13]},
+				Columns:    []*schema.Column{BillOfMaterialsColumns[14]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -68,7 +69,7 @@ var (
 			{
 				Name:    "sbom_unique_package",
 				Unique:  true,
-				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[7], BillOfMaterialsColumns[8], BillOfMaterialsColumns[9], BillOfMaterialsColumns[10], BillOfMaterialsColumns[11], BillOfMaterialsColumns[5], BillOfMaterialsColumns[6], BillOfMaterialsColumns[12]},
+				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[8], BillOfMaterialsColumns[9], BillOfMaterialsColumns[10], BillOfMaterialsColumns[11], BillOfMaterialsColumns[12], BillOfMaterialsColumns[5], BillOfMaterialsColumns[6], BillOfMaterialsColumns[7], BillOfMaterialsColumns[13]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND artifact_id IS NULL",
 				},
@@ -76,7 +77,7 @@ var (
 			{
 				Name:    "sbom_unique_artifact",
 				Unique:  true,
-				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[7], BillOfMaterialsColumns[8], BillOfMaterialsColumns[9], BillOfMaterialsColumns[10], BillOfMaterialsColumns[11], BillOfMaterialsColumns[5], BillOfMaterialsColumns[6], BillOfMaterialsColumns[13]},
+				Columns: []*schema.Column{BillOfMaterialsColumns[2], BillOfMaterialsColumns[3], BillOfMaterialsColumns[1], BillOfMaterialsColumns[4], BillOfMaterialsColumns[8], BillOfMaterialsColumns[9], BillOfMaterialsColumns[10], BillOfMaterialsColumns[11], BillOfMaterialsColumns[12], BillOfMaterialsColumns[5], BillOfMaterialsColumns[6], BillOfMaterialsColumns[7], BillOfMaterialsColumns[14]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND artifact_id IS NOT NULL",
 				},
@@ -148,33 +149,33 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_source_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_source_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[7], CertificationsColumns[3]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[7], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_package_version_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_package_version_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[8], CertificationsColumns[3]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[8], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_package_name_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_package_name_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[9], CertificationsColumns[3]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[9], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_artifact_id_known_since",
+				Name:    "certification_type_justification_origin_collector_document_ref_artifact_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[10], CertificationsColumns[3]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[10], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},
@@ -191,6 +192,7 @@ var (
 		{Name: "time_scanned", Type: field.TypeTime},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "declared_licenses_hash", Type: field.TypeString},
 		{Name: "discovered_licenses_hash", Type: field.TypeString},
 		{Name: "package_id", Type: field.TypeUUID, Nullable: true},
@@ -204,30 +206,30 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certify_legals_package_versions_package",
-				Columns:    []*schema.Column{CertifyLegalsColumns[10]},
+				Columns:    []*schema.Column{CertifyLegalsColumns[11]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certify_legals_source_names_source",
-				Columns:    []*schema.Column{CertifyLegalsColumns[11]},
+				Columns:    []*schema.Column{CertifyLegalsColumns[12]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifylegal_source_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_source_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9]},
+				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
 			},
 			{
-				Name:    "certifylegal_package_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_package_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[10], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9]},
+				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},
@@ -244,6 +246,7 @@ var (
 		{Name: "scorecard_commit", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "checks_hash", Type: field.TypeString},
 		{Name: "source_id", Type: field.TypeUUID},
 	}
@@ -255,16 +258,16 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certify_scorecards_source_names_source",
-				Columns:    []*schema.Column{CertifyScorecardsColumns[9]},
+				Columns:    []*schema.Column{CertifyScorecardsColumns[10]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifyscorecard_source_id_origin_collector_scorecard_version_scorecard_commit_aggregate_score_time_scanned_checks_hash",
+				Name:    "certifyscorecard_source_id_origin_collector_scorecard_version_scorecard_commit_aggregate_score_time_scanned_checks_hash_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyScorecardsColumns[9], CertifyScorecardsColumns[6], CertifyScorecardsColumns[7], CertifyScorecardsColumns[4], CertifyScorecardsColumns[5], CertifyScorecardsColumns[2], CertifyScorecardsColumns[3], CertifyScorecardsColumns[8]},
+				Columns: []*schema.Column{CertifyScorecardsColumns[10], CertifyScorecardsColumns[6], CertifyScorecardsColumns[7], CertifyScorecardsColumns[4], CertifyScorecardsColumns[5], CertifyScorecardsColumns[2], CertifyScorecardsColumns[3], CertifyScorecardsColumns[9], CertifyScorecardsColumns[8]},
 			},
 		},
 	}
@@ -278,6 +281,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "package_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "artifact_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "vulnerability_id", Type: field.TypeUUID},
@@ -290,36 +294,36 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certify_vexes_package_versions_package",
-				Columns:    []*schema.Column{CertifyVexesColumns[8]},
+				Columns:    []*schema.Column{CertifyVexesColumns[9]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certify_vexes_artifacts_artifact",
-				Columns:    []*schema.Column{CertifyVexesColumns[9]},
+				Columns:    []*schema.Column{CertifyVexesColumns[10]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "certify_vexes_vulnerability_ids_vulnerability",
-				Columns:    []*schema.Column{CertifyVexesColumns[10]},
+				Columns:    []*schema.Column{CertifyVexesColumns[11]},
 				RefColumns: []*schema.Column{VulnerabilityIdsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifyvex_known_since_justification_status_statement_status_notes_origin_collector_vulnerability_id_package_id",
+				Name:    "certifyvex_known_since_justification_status_statement_status_notes_origin_collector_document_ref_vulnerability_id_package_id",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyVexesColumns[1], CertifyVexesColumns[5], CertifyVexesColumns[2], CertifyVexesColumns[3], CertifyVexesColumns[4], CertifyVexesColumns[6], CertifyVexesColumns[7], CertifyVexesColumns[10], CertifyVexesColumns[8]},
+				Columns: []*schema.Column{CertifyVexesColumns[1], CertifyVexesColumns[5], CertifyVexesColumns[2], CertifyVexesColumns[3], CertifyVexesColumns[4], CertifyVexesColumns[6], CertifyVexesColumns[7], CertifyVexesColumns[8], CertifyVexesColumns[11], CertifyVexesColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certifyvex_known_since_justification_status_statement_status_notes_origin_collector_vulnerability_id_artifact_id",
+				Name:    "certifyvex_known_since_justification_status_statement_status_notes_origin_collector_document_ref_vulnerability_id_artifact_id",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyVexesColumns[1], CertifyVexesColumns[5], CertifyVexesColumns[2], CertifyVexesColumns[3], CertifyVexesColumns[4], CertifyVexesColumns[6], CertifyVexesColumns[7], CertifyVexesColumns[10], CertifyVexesColumns[9]},
+				Columns: []*schema.Column{CertifyVexesColumns[1], CertifyVexesColumns[5], CertifyVexesColumns[2], CertifyVexesColumns[3], CertifyVexesColumns[4], CertifyVexesColumns[6], CertifyVexesColumns[7], CertifyVexesColumns[8], CertifyVexesColumns[11], CertifyVexesColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL",
 				},
@@ -336,6 +340,7 @@ var (
 		{Name: "scanner_version", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "vulnerability_id", Type: field.TypeUUID},
 		{Name: "package_id", Type: field.TypeUUID},
 	}
@@ -347,22 +352,22 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "certify_vulns_vulnerability_ids_vulnerability",
-				Columns:    []*schema.Column{CertifyVulnsColumns[8]},
+				Columns:    []*schema.Column{CertifyVulnsColumns[9]},
 				RefColumns: []*schema.Column{VulnerabilityIdsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "certify_vulns_package_versions_package",
-				Columns:    []*schema.Column{CertifyVulnsColumns[9]},
+				Columns:    []*schema.Column{CertifyVulnsColumns[10]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_time_scanned_vulnerability_id_package_id",
+				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_time_scanned_document_ref_vulnerability_id_package_id",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[1], CertifyVulnsColumns[8], CertifyVulnsColumns[9]},
+				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[1], CertifyVulnsColumns[8], CertifyVulnsColumns[9], CertifyVulnsColumns[10]},
 			},
 		},
 	}
@@ -374,6 +379,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "package_id", Type: field.TypeUUID},
 		{Name: "dependent_package_name_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "dependent_package_version_id", Type: field.TypeUUID, Nullable: true},
@@ -386,19 +392,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "dependencies_package_versions_package",
-				Columns:    []*schema.Column{DependenciesColumns[6]},
+				Columns:    []*schema.Column{DependenciesColumns[7]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "dependencies_package_names_dependent_package_name",
-				Columns:    []*schema.Column{DependenciesColumns[7]},
+				Columns:    []*schema.Column{DependenciesColumns[8]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "dependencies_package_versions_dependent_package_version",
-				Columns:    []*schema.Column{DependenciesColumns[8]},
+				Columns:    []*schema.Column{DependenciesColumns[9]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -407,7 +413,7 @@ var (
 			{
 				Name:    "dep_package_name",
 				Unique:  true,
-				Columns: []*schema.Column{DependenciesColumns[1], DependenciesColumns[2], DependenciesColumns[3], DependenciesColumns[4], DependenciesColumns[5], DependenciesColumns[6], DependenciesColumns[7]},
+				Columns: []*schema.Column{DependenciesColumns[1], DependenciesColumns[2], DependenciesColumns[3], DependenciesColumns[4], DependenciesColumns[5], DependenciesColumns[6], DependenciesColumns[7], DependenciesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "dependent_package_name_id IS NOT NULL AND dependent_package_version_id IS NULL",
 				},
@@ -415,7 +421,7 @@ var (
 			{
 				Name:    "dep_package_version",
 				Unique:  true,
-				Columns: []*schema.Column{DependenciesColumns[1], DependenciesColumns[2], DependenciesColumns[3], DependenciesColumns[4], DependenciesColumns[5], DependenciesColumns[6], DependenciesColumns[8]},
+				Columns: []*schema.Column{DependenciesColumns[1], DependenciesColumns[2], DependenciesColumns[3], DependenciesColumns[4], DependenciesColumns[5], DependenciesColumns[6], DependenciesColumns[7], DependenciesColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "dependent_package_name_id IS NULL AND dependent_package_version_id IS NOT NULL",
 				},
@@ -431,6 +437,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "source_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_version_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_name_id", Type: field.TypeUUID, Nullable: true},
@@ -444,58 +451,58 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "has_metadata_source_names_source",
-				Columns:    []*schema.Column{HasMetadataColumns[7]},
+				Columns:    []*schema.Column{HasMetadataColumns[8]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "has_metadata_package_versions_package_version",
-				Columns:    []*schema.Column{HasMetadataColumns[8]},
+				Columns:    []*schema.Column{HasMetadataColumns[9]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "has_metadata_package_names_all_versions",
-				Columns:    []*schema.Column{HasMetadataColumns[9]},
+				Columns:    []*schema.Column{HasMetadataColumns[10]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "has_metadata_artifacts_artifact",
-				Columns:    []*schema.Column{HasMetadataColumns[10]},
+				Columns:    []*schema.Column{HasMetadataColumns[11]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_source_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_document_ref_source_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[7]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[7], HasMetadataColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_package_version_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_document_ref_package_version_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[8]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[7], HasMetadataColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_package_name_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_document_ref_package_name_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[9]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[7], HasMetadataColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_artifact_id",
+				Name:    "hasmetadata_key_value_justification_origin_collector_timestamp_document_ref_artifact_id",
 				Unique:  true,
-				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[10]},
+				Columns: []*schema.Column{HasMetadataColumns[2], HasMetadataColumns[3], HasMetadataColumns[4], HasMetadataColumns[5], HasMetadataColumns[6], HasMetadataColumns[1], HasMetadataColumns[7], HasMetadataColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},
@@ -509,6 +516,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "package_version_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_name_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "source_id", Type: field.TypeUUID},
@@ -521,36 +529,36 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "has_source_ats_package_versions_package_version",
-				Columns:    []*schema.Column{HasSourceAtsColumns[5]},
+				Columns:    []*schema.Column{HasSourceAtsColumns[6]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "has_source_ats_package_names_all_versions",
-				Columns:    []*schema.Column{HasSourceAtsColumns[6]},
+				Columns:    []*schema.Column{HasSourceAtsColumns[7]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "has_source_ats_source_names_source",
-				Columns:    []*schema.Column{HasSourceAtsColumns[7]},
+				Columns:    []*schema.Column{HasSourceAtsColumns[8]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hassourceat_source_id_package_version_id_justification_origin_collector_known_since",
+				Name:    "hassourceat_source_id_package_version_id_justification_origin_collector_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{HasSourceAtsColumns[7], HasSourceAtsColumns[5], HasSourceAtsColumns[2], HasSourceAtsColumns[3], HasSourceAtsColumns[4], HasSourceAtsColumns[1]},
+				Columns: []*schema.Column{HasSourceAtsColumns[8], HasSourceAtsColumns[6], HasSourceAtsColumns[2], HasSourceAtsColumns[3], HasSourceAtsColumns[4], HasSourceAtsColumns[1], HasSourceAtsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_version_id IS NOT NULL AND package_name_id IS NULL",
 				},
 			},
 			{
-				Name:    "hassourceat_source_id_package_name_id_justification_origin_collector_known_since",
+				Name:    "hassourceat_source_id_package_name_id_justification_origin_collector_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{HasSourceAtsColumns[7], HasSourceAtsColumns[6], HasSourceAtsColumns[2], HasSourceAtsColumns[3], HasSourceAtsColumns[4], HasSourceAtsColumns[1]},
+				Columns: []*schema.Column{HasSourceAtsColumns[8], HasSourceAtsColumns[7], HasSourceAtsColumns[2], HasSourceAtsColumns[3], HasSourceAtsColumns[4], HasSourceAtsColumns[1], HasSourceAtsColumns[5]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_name_id IS NOT NULL AND package_version_id IS NULL",
 				},
@@ -563,6 +571,7 @@ var (
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
 		{Name: "justification", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "artifacts_hash", Type: field.TypeString},
 		{Name: "art_id", Type: field.TypeUUID},
 		{Name: "equal_art_id", Type: field.TypeUUID},
@@ -575,22 +584,22 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "hash_equals_artifacts_artifact_a",
-				Columns:    []*schema.Column{HashEqualsColumns[5]},
+				Columns:    []*schema.Column{HashEqualsColumns[6]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "hash_equals_artifacts_artifact_b",
-				Columns:    []*schema.Column{HashEqualsColumns[6]},
+				Columns:    []*schema.Column{HashEqualsColumns[7]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "hashequal_art_id_equal_art_id_artifacts_hash_origin_justification_collector",
+				Name:    "hashequal_art_id_equal_art_id_artifacts_hash_origin_justification_collector_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{HashEqualsColumns[5], HashEqualsColumns[6], HashEqualsColumns[4], HashEqualsColumns[1], HashEqualsColumns[3], HashEqualsColumns[2]},
+				Columns: []*schema.Column{HashEqualsColumns[6], HashEqualsColumns[7], HashEqualsColumns[5], HashEqualsColumns[1], HashEqualsColumns[3], HashEqualsColumns[2], HashEqualsColumns[4]},
 			},
 		},
 	}
@@ -620,6 +629,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "artifact_id", Type: field.TypeUUID},
 		{Name: "package_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "source_id", Type: field.TypeUUID, Nullable: true},
@@ -632,19 +642,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "occurrences_artifacts_artifact",
-				Columns:    []*schema.Column{OccurrencesColumns[4]},
+				Columns:    []*schema.Column{OccurrencesColumns[5]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "occurrences_package_versions_package",
-				Columns:    []*schema.Column{OccurrencesColumns[5]},
+				Columns:    []*schema.Column{OccurrencesColumns[6]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "occurrences_source_names_source",
-				Columns:    []*schema.Column{OccurrencesColumns[6]},
+				Columns:    []*schema.Column{OccurrencesColumns[7]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -653,7 +663,7 @@ var (
 			{
 				Name:    "occurrence_unique_package",
 				Unique:  true,
-				Columns: []*schema.Column{OccurrencesColumns[1], OccurrencesColumns[2], OccurrencesColumns[3], OccurrencesColumns[4], OccurrencesColumns[5]},
+				Columns: []*schema.Column{OccurrencesColumns[1], OccurrencesColumns[2], OccurrencesColumns[3], OccurrencesColumns[4], OccurrencesColumns[5], OccurrencesColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},
@@ -661,7 +671,7 @@ var (
 			{
 				Name:    "occurrence_unique_source",
 				Unique:  true,
-				Columns: []*schema.Column{OccurrencesColumns[1], OccurrencesColumns[2], OccurrencesColumns[3], OccurrencesColumns[4], OccurrencesColumns[6]},
+				Columns: []*schema.Column{OccurrencesColumns[1], OccurrencesColumns[2], OccurrencesColumns[3], OccurrencesColumns[4], OccurrencesColumns[5], OccurrencesColumns[7]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
@@ -738,6 +748,7 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "justification", Type: field.TypeString},
 		{Name: "packages_hash", Type: field.TypeString},
 		{Name: "pkg_id", Type: field.TypeUUID},
@@ -751,22 +762,22 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "pkg_equals_package_versions_package_a",
-				Columns:    []*schema.Column{PkgEqualsColumns[5]},
+				Columns:    []*schema.Column{PkgEqualsColumns[6]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "pkg_equals_package_versions_package_b",
-				Columns:    []*schema.Column{PkgEqualsColumns[6]},
+				Columns:    []*schema.Column{PkgEqualsColumns[7]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "pkgequal_pkg_id_equal_pkg_id_packages_hash_origin_justification_collector",
+				Name:    "pkgequal_pkg_id_equal_pkg_id_packages_hash_origin_justification_collector_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{PkgEqualsColumns[5], PkgEqualsColumns[6], PkgEqualsColumns[4], PkgEqualsColumns[1], PkgEqualsColumns[3], PkgEqualsColumns[2]},
+				Columns: []*schema.Column{PkgEqualsColumns[6], PkgEqualsColumns[7], PkgEqualsColumns[5], PkgEqualsColumns[1], PkgEqualsColumns[4], PkgEqualsColumns[2], PkgEqualsColumns[3]},
 			},
 		},
 	}
@@ -779,6 +790,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "source_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_version_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "package_name_id", Type: field.TypeUUID, Nullable: true},
@@ -792,58 +804,58 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "point_of_contacts_source_names_source",
-				Columns:    []*schema.Column{PointOfContactsColumns[7]},
+				Columns:    []*schema.Column{PointOfContactsColumns[8]},
 				RefColumns: []*schema.Column{SourceNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "point_of_contacts_package_versions_package_version",
-				Columns:    []*schema.Column{PointOfContactsColumns[8]},
+				Columns:    []*schema.Column{PointOfContactsColumns[9]},
 				RefColumns: []*schema.Column{PackageVersionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "point_of_contacts_package_names_all_versions",
-				Columns:    []*schema.Column{PointOfContactsColumns[9]},
+				Columns:    []*schema.Column{PointOfContactsColumns[10]},
 				RefColumns: []*schema.Column{PackageNamesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "point_of_contacts_artifacts_artifact",
-				Columns:    []*schema.Column{PointOfContactsColumns[10]},
+				Columns:    []*schema.Column{PointOfContactsColumns[11]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "pointofcontact_since_email_info_justification_origin_collector_source_id",
+				Name:    "pointofcontact_since_email_info_justification_origin_collector_document_ref_source_id",
 				Unique:  true,
-				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[7]},
+				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[7], PointOfContactsColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "pointofcontact_since_email_info_justification_origin_collector_package_version_id",
+				Name:    "pointofcontact_since_email_info_justification_origin_collector_document_ref_package_version_id",
 				Unique:  true,
-				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[8]},
+				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[7], PointOfContactsColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "pointofcontact_since_email_info_justification_origin_collector_package_name_id",
+				Name:    "pointofcontact_since_email_info_justification_origin_collector_document_ref_package_name_id",
 				Unique:  true,
-				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[9]},
+				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[7], PointOfContactsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "pointofcontact_since_email_info_justification_origin_collector_artifact_id",
+				Name:    "pointofcontact_since_email_info_justification_origin_collector_document_ref_artifact_id",
 				Unique:  true,
-				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[10]},
+				Columns: []*schema.Column{PointOfContactsColumns[3], PointOfContactsColumns[1], PointOfContactsColumns[2], PointOfContactsColumns[4], PointOfContactsColumns[5], PointOfContactsColumns[6], PointOfContactsColumns[7], PointOfContactsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},
@@ -860,6 +872,7 @@ var (
 		{Name: "finished_on", Type: field.TypeTime},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "built_from_hash", Type: field.TypeString},
 		{Name: "built_by_id", Type: field.TypeUUID},
 		{Name: "subject_id", Type: field.TypeUUID},
@@ -872,22 +885,22 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "slsa_attestations_builders_built_by",
-				Columns:    []*schema.Column{SlsaAttestationsColumns[9]},
+				Columns:    []*schema.Column{SlsaAttestationsColumns[10]},
 				RefColumns: []*schema.Column{BuildersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "slsa_attestations_artifacts_subject",
-				Columns:    []*schema.Column{SlsaAttestationsColumns[10]},
+				Columns:    []*schema.Column{SlsaAttestationsColumns[11]},
 				RefColumns: []*schema.Column{ArtifactsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "slsaattestation_subject_id_origin_collector_build_type_slsa_version_built_by_id_built_from_hash_started_on_finished_on",
+				Name:    "slsaattestation_subject_id_origin_collector_document_ref_build_type_slsa_version_built_by_id_built_from_hash_started_on_finished_on",
 				Unique:  true,
-				Columns: []*schema.Column{SlsaAttestationsColumns[10], SlsaAttestationsColumns[6], SlsaAttestationsColumns[7], SlsaAttestationsColumns[1], SlsaAttestationsColumns[3], SlsaAttestationsColumns[9], SlsaAttestationsColumns[8], SlsaAttestationsColumns[4], SlsaAttestationsColumns[5]},
+				Columns: []*schema.Column{SlsaAttestationsColumns[11], SlsaAttestationsColumns[6], SlsaAttestationsColumns[7], SlsaAttestationsColumns[8], SlsaAttestationsColumns[1], SlsaAttestationsColumns[3], SlsaAttestationsColumns[10], SlsaAttestationsColumns[9], SlsaAttestationsColumns[4], SlsaAttestationsColumns[5]},
 			},
 		},
 	}
@@ -919,6 +932,7 @@ var (
 		{Name: "justification", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "vulnerabilities_hash", Type: field.TypeString},
 		{Name: "vuln_id", Type: field.TypeUUID},
 		{Name: "equal_vuln_id", Type: field.TypeUUID},
@@ -931,22 +945,22 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "vuln_equals_vulnerability_ids_vulnerability_a",
-				Columns:    []*schema.Column{VulnEqualsColumns[5]},
+				Columns:    []*schema.Column{VulnEqualsColumns[6]},
 				RefColumns: []*schema.Column{VulnerabilityIdsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "vuln_equals_vulnerability_ids_vulnerability_b",
-				Columns:    []*schema.Column{VulnEqualsColumns[6]},
+				Columns:    []*schema.Column{VulnEqualsColumns[7]},
 				RefColumns: []*schema.Column{VulnerabilityIdsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "vulnequal_vuln_id_equal_vuln_id_vulnerabilities_hash_justification_origin_collector",
+				Name:    "vulnequal_vuln_id_equal_vuln_id_vulnerabilities_hash_justification_origin_collector_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{VulnEqualsColumns[5], VulnEqualsColumns[6], VulnEqualsColumns[4], VulnEqualsColumns[1], VulnEqualsColumns[2], VulnEqualsColumns[3]},
+				Columns: []*schema.Column{VulnEqualsColumns[6], VulnEqualsColumns[7], VulnEqualsColumns[5], VulnEqualsColumns[1], VulnEqualsColumns[2], VulnEqualsColumns[3], VulnEqualsColumns[4]},
 			},
 		},
 	}
@@ -977,6 +991,7 @@ var (
 		{Name: "timestamp", Type: field.TypeTime},
 		{Name: "origin", Type: field.TypeString},
 		{Name: "collector", Type: field.TypeString},
+		{Name: "document_ref", Type: field.TypeString},
 		{Name: "vulnerability_id_id", Type: field.TypeUUID},
 	}
 	// VulnerabilityMetadataTable holds the schema information for the "vulnerability_metadata" table.
@@ -987,16 +1002,16 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "vulnerability_metadata_vulnerability_ids_vulnerability_id",
-				Columns:    []*schema.Column{VulnerabilityMetadataColumns[6]},
+				Columns:    []*schema.Column{VulnerabilityMetadataColumns[7]},
 				RefColumns: []*schema.Column{VulnerabilityIdsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "vulnerabilitymetadata_vulnerability_id_id_score_type_score_value_timestamp_origin_collector",
+				Name:    "vulnerabilitymetadata_vulnerability_id_id_score_type_score_value_timestamp_origin_collector_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{VulnerabilityMetadataColumns[6], VulnerabilityMetadataColumns[1], VulnerabilityMetadataColumns[2], VulnerabilityMetadataColumns[3], VulnerabilityMetadataColumns[4], VulnerabilityMetadataColumns[5]},
+				Columns: []*schema.Column{VulnerabilityMetadataColumns[7], VulnerabilityMetadataColumns[1], VulnerabilityMetadataColumns[2], VulnerabilityMetadataColumns[3], VulnerabilityMetadataColumns[4], VulnerabilityMetadataColumns[5], VulnerabilityMetadataColumns[6]},
 			},
 		},
 	}

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -149,33 +149,33 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_source_id_known_since_document_ref",
+				Name:    "certification_type_justification_origin_collector_source_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[7], CertificationsColumns[3], CertificationsColumns[6]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[7], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_package_version_id_known_since_document_ref",
+				Name:    "certification_type_justification_origin_collector_package_version_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[8], CertificationsColumns[3], CertificationsColumns[6]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[8], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_package_name_id_known_since_document_ref",
+				Name:    "certification_type_justification_origin_collector_package_name_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[9], CertificationsColumns[3], CertificationsColumns[6]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[9], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL",
 				},
 			},
 			{
-				Name:    "certification_type_justification_origin_collector_document_ref_artifact_id_known_since_document_ref",
+				Name:    "certification_type_justification_origin_collector_artifact_id_known_since_document_ref",
 				Unique:  true,
-				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[6], CertificationsColumns[10], CertificationsColumns[3], CertificationsColumns[6]},
+				Columns: []*schema.Column{CertificationsColumns[1], CertificationsColumns[2], CertificationsColumns[4], CertificationsColumns[5], CertificationsColumns[10], CertificationsColumns[3], CertificationsColumns[6]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL",
 				},

--- a/pkg/assembler/backends/ent/mutation.go
+++ b/pkg/assembler/backends/ent/mutation.go
@@ -1394,6 +1394,7 @@ type BillOfMaterialsMutation struct {
 	download_location                  *string
 	origin                             *string
 	collector                          *string
+	document_ref                       *string
 	known_since                        *time.Time
 	included_packages_hash             *string
 	included_artifacts_hash            *string
@@ -1837,6 +1838,42 @@ func (m *BillOfMaterialsMutation) OldCollector(ctx context.Context) (v string, e
 // ResetCollector resets all changes to the "collector" field.
 func (m *BillOfMaterialsMutation) ResetCollector() {
 	m.collector = nil
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (m *BillOfMaterialsMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *BillOfMaterialsMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the BillOfMaterials entity.
+// If the BillOfMaterials object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillOfMaterialsMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *BillOfMaterialsMutation) ResetDocumentRef() {
+	m.document_ref = nil
 }
 
 // SetKnownSince sets the "known_since" field.
@@ -2323,7 +2360,7 @@ func (m *BillOfMaterialsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BillOfMaterialsMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 14)
 	if m._package != nil {
 		fields = append(fields, billofmaterials.FieldPackageID)
 	}
@@ -2347,6 +2384,9 @@ func (m *BillOfMaterialsMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, billofmaterials.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, billofmaterials.FieldDocumentRef)
 	}
 	if m.known_since != nil {
 		fields = append(fields, billofmaterials.FieldKnownSince)
@@ -2387,6 +2427,8 @@ func (m *BillOfMaterialsMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case billofmaterials.FieldCollector:
 		return m.Collector()
+	case billofmaterials.FieldDocumentRef:
+		return m.DocumentRef()
 	case billofmaterials.FieldKnownSince:
 		return m.KnownSince()
 	case billofmaterials.FieldIncludedPackagesHash:
@@ -2422,6 +2464,8 @@ func (m *BillOfMaterialsMutation) OldField(ctx context.Context, name string) (en
 		return m.OldOrigin(ctx)
 	case billofmaterials.FieldCollector:
 		return m.OldCollector(ctx)
+	case billofmaterials.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case billofmaterials.FieldKnownSince:
 		return m.OldKnownSince(ctx)
 	case billofmaterials.FieldIncludedPackagesHash:
@@ -2496,6 +2540,13 @@ func (m *BillOfMaterialsMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case billofmaterials.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case billofmaterials.FieldKnownSince:
 		v, ok := value.(time.Time)
@@ -2619,6 +2670,9 @@ func (m *BillOfMaterialsMutation) ResetField(name string) error {
 		return nil
 	case billofmaterials.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case billofmaterials.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case billofmaterials.FieldKnownSince:
 		m.ResetKnownSince()
@@ -4377,6 +4431,7 @@ type CertifyLegalMutation struct {
 	time_scanned               *time.Time
 	origin                     *string
 	collector                  *string
+	document_ref               *string
 	declared_licenses_hash     *string
 	discovered_licenses_hash   *string
 	clearedFields              map[string]struct{}
@@ -4849,6 +4904,42 @@ func (m *CertifyLegalMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *CertifyLegalMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *CertifyLegalMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the CertifyLegal entity.
+// If the CertifyLegal object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertifyLegalMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *CertifyLegalMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetDeclaredLicensesHash sets the "declared_licenses_hash" field.
 func (m *CertifyLegalMutation) SetDeclaredLicensesHash(s string) {
 	m.declared_licenses_hash = &s
@@ -5117,7 +5208,7 @@ func (m *CertifyLegalMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertifyLegalMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m._package != nil {
 		fields = append(fields, certifylegal.FieldPackageID)
 	}
@@ -5144,6 +5235,9 @@ func (m *CertifyLegalMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, certifylegal.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, certifylegal.FieldDocumentRef)
 	}
 	if m.declared_licenses_hash != nil {
 		fields = append(fields, certifylegal.FieldDeclaredLicensesHash)
@@ -5177,6 +5271,8 @@ func (m *CertifyLegalMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case certifylegal.FieldCollector:
 		return m.Collector()
+	case certifylegal.FieldDocumentRef:
+		return m.DocumentRef()
 	case certifylegal.FieldDeclaredLicensesHash:
 		return m.DeclaredLicensesHash()
 	case certifylegal.FieldDiscoveredLicensesHash:
@@ -5208,6 +5304,8 @@ func (m *CertifyLegalMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldOrigin(ctx)
 	case certifylegal.FieldCollector:
 		return m.OldCollector(ctx)
+	case certifylegal.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case certifylegal.FieldDeclaredLicensesHash:
 		return m.OldDeclaredLicensesHash(ctx)
 	case certifylegal.FieldDiscoveredLicensesHash:
@@ -5283,6 +5381,13 @@ func (m *CertifyLegalMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case certifylegal.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case certifylegal.FieldDeclaredLicensesHash:
 		v, ok := value.(string)
@@ -5388,6 +5493,9 @@ func (m *CertifyLegalMutation) ResetField(name string) error {
 		return nil
 	case certifylegal.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case certifylegal.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case certifylegal.FieldDeclaredLicensesHash:
 		m.ResetDeclaredLicensesHash()
@@ -5560,6 +5668,7 @@ type CertifyScorecardMutation struct {
 	scorecard_commit   *string
 	origin             *string
 	collector          *string
+	document_ref       *string
 	checks_hash        *string
 	clearedFields      map[string]struct{}
 	source             *uuid.UUID
@@ -5996,6 +6105,42 @@ func (m *CertifyScorecardMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *CertifyScorecardMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *CertifyScorecardMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the CertifyScorecard entity.
+// If the CertifyScorecard object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertifyScorecardMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *CertifyScorecardMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetChecksHash sets the "checks_hash" field.
 func (m *CertifyScorecardMutation) SetChecksHash(s string) {
 	m.checks_hash = &s
@@ -6093,7 +6238,7 @@ func (m *CertifyScorecardMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertifyScorecardMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.source != nil {
 		fields = append(fields, certifyscorecard.FieldSourceID)
 	}
@@ -6117,6 +6262,9 @@ func (m *CertifyScorecardMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, certifyscorecard.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, certifyscorecard.FieldDocumentRef)
 	}
 	if m.checks_hash != nil {
 		fields = append(fields, certifyscorecard.FieldChecksHash)
@@ -6145,6 +6293,8 @@ func (m *CertifyScorecardMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case certifyscorecard.FieldCollector:
 		return m.Collector()
+	case certifyscorecard.FieldDocumentRef:
+		return m.DocumentRef()
 	case certifyscorecard.FieldChecksHash:
 		return m.ChecksHash()
 	}
@@ -6172,6 +6322,8 @@ func (m *CertifyScorecardMutation) OldField(ctx context.Context, name string) (e
 		return m.OldOrigin(ctx)
 	case certifyscorecard.FieldCollector:
 		return m.OldCollector(ctx)
+	case certifyscorecard.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case certifyscorecard.FieldChecksHash:
 		return m.OldChecksHash(ctx)
 	}
@@ -6238,6 +6390,13 @@ func (m *CertifyScorecardMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case certifyscorecard.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case certifyscorecard.FieldChecksHash:
 		v, ok := value.(string)
@@ -6334,6 +6493,9 @@ func (m *CertifyScorecardMutation) ResetField(name string) error {
 	case certifyscorecard.FieldCollector:
 		m.ResetCollector()
 		return nil
+	case certifyscorecard.FieldDocumentRef:
+		m.ResetDocumentRef()
+		return nil
 	case certifyscorecard.FieldChecksHash:
 		m.ResetChecksHash()
 		return nil
@@ -6428,6 +6590,7 @@ type CertifyVexMutation struct {
 	justification        *string
 	origin               *string
 	collector            *string
+	document_ref         *string
 	clearedFields        map[string]struct{}
 	_package             *uuid.UUID
 	cleared_package      bool
@@ -6930,6 +7093,42 @@ func (m *CertifyVexMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *CertifyVexMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *CertifyVexMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the CertifyVex entity.
+// If the CertifyVex object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertifyVexMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *CertifyVexMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearPackage clears the "package" edge to the PackageVersion entity.
 func (m *CertifyVexMutation) ClearPackage() {
 	m.cleared_package = true
@@ -7045,7 +7244,7 @@ func (m *CertifyVexMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertifyVexMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m._package != nil {
 		fields = append(fields, certifyvex.FieldPackageID)
 	}
@@ -7076,6 +7275,9 @@ func (m *CertifyVexMutation) Fields() []string {
 	if m.collector != nil {
 		fields = append(fields, certifyvex.FieldCollector)
 	}
+	if m.document_ref != nil {
+		fields = append(fields, certifyvex.FieldDocumentRef)
+	}
 	return fields
 }
 
@@ -7104,6 +7306,8 @@ func (m *CertifyVexMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case certifyvex.FieldCollector:
 		return m.Collector()
+	case certifyvex.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -7133,6 +7337,8 @@ func (m *CertifyVexMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldOrigin(ctx)
 	case certifyvex.FieldCollector:
 		return m.OldCollector(ctx)
+	case certifyvex.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown CertifyVex field %s", name)
 }
@@ -7211,6 +7417,13 @@ func (m *CertifyVexMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case certifyvex.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown CertifyVex field %s", name)
@@ -7305,6 +7518,9 @@ func (m *CertifyVexMutation) ResetField(name string) error {
 		return nil
 	case certifyvex.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case certifyvex.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown CertifyVex field %s", name)
@@ -7433,6 +7649,7 @@ type CertifyVulnMutation struct {
 	scanner_version      *string
 	origin               *string
 	collector            *string
+	document_ref         *string
 	clearedFields        map[string]struct{}
 	vulnerability        *uuid.UUID
 	clearedvulnerability bool
@@ -7871,6 +8088,42 @@ func (m *CertifyVulnMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *CertifyVulnMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *CertifyVulnMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the CertifyVuln entity.
+// If the CertifyVuln object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertifyVulnMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *CertifyVulnMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearVulnerability clears the "vulnerability" edge to the VulnerabilityID entity.
 func (m *CertifyVulnMutation) ClearVulnerability() {
 	m.clearedvulnerability = true
@@ -7959,7 +8212,7 @@ func (m *CertifyVulnMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertifyVulnMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.vulnerability != nil {
 		fields = append(fields, certifyvuln.FieldVulnerabilityID)
 	}
@@ -7987,6 +8240,9 @@ func (m *CertifyVulnMutation) Fields() []string {
 	if m.collector != nil {
 		fields = append(fields, certifyvuln.FieldCollector)
 	}
+	if m.document_ref != nil {
+		fields = append(fields, certifyvuln.FieldDocumentRef)
+	}
 	return fields
 }
 
@@ -8013,6 +8269,8 @@ func (m *CertifyVulnMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case certifyvuln.FieldCollector:
 		return m.Collector()
+	case certifyvuln.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -8040,6 +8298,8 @@ func (m *CertifyVulnMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldOrigin(ctx)
 	case certifyvuln.FieldCollector:
 		return m.OldCollector(ctx)
+	case certifyvuln.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown CertifyVuln field %s", name)
 }
@@ -8111,6 +8371,13 @@ func (m *CertifyVulnMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case certifyvuln.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown CertifyVuln field %s", name)
@@ -8187,6 +8454,9 @@ func (m *CertifyVulnMutation) ResetField(name string) error {
 		return nil
 	case certifyvuln.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case certifyvuln.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown CertifyVuln field %s", name)
@@ -8295,6 +8565,7 @@ type DependencyMutation struct {
 	justification                    *string
 	origin                           *string
 	collector                        *string
+	document_ref                     *string
 	clearedFields                    map[string]struct{}
 	_package                         *uuid.UUID
 	cleared_package                  bool
@@ -8728,6 +8999,42 @@ func (m *DependencyMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *DependencyMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *DependencyMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the Dependency entity.
+// If the Dependency object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DependencyMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *DependencyMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearPackage clears the "package" edge to the PackageVersion entity.
 func (m *DependencyMutation) ClearPackage() {
 	m.cleared_package = true
@@ -8897,7 +9204,7 @@ func (m *DependencyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DependencyMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m._package != nil {
 		fields = append(fields, dependency.FieldPackageID)
 	}
@@ -8921,6 +9228,9 @@ func (m *DependencyMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, dependency.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, dependency.FieldDocumentRef)
 	}
 	return fields
 }
@@ -8946,6 +9256,8 @@ func (m *DependencyMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case dependency.FieldCollector:
 		return m.Collector()
+	case dependency.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -8971,6 +9283,8 @@ func (m *DependencyMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldOrigin(ctx)
 	case dependency.FieldCollector:
 		return m.OldCollector(ctx)
+	case dependency.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown Dependency field %s", name)
 }
@@ -9035,6 +9349,13 @@ func (m *DependencyMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case dependency.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Dependency field %s", name)
@@ -9123,6 +9444,9 @@ func (m *DependencyMutation) ResetField(name string) error {
 		return nil
 	case dependency.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case dependency.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown Dependency field %s", name)
@@ -9278,6 +9602,7 @@ type HasMetadataMutation struct {
 	justification          *string
 	origin                 *string
 	collector              *string
+	document_ref           *string
 	clearedFields          map[string]struct{}
 	source                 *uuid.UUID
 	clearedsource          bool
@@ -9808,6 +10133,42 @@ func (m *HasMetadataMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *HasMetadataMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *HasMetadataMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the HasMetadata entity.
+// If the HasMetadata object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HasMetadataMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *HasMetadataMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearSource clears the "source" edge to the SourceName entity.
 func (m *HasMetadataMutation) ClearSource() {
 	m.clearedsource = true
@@ -9963,7 +10324,7 @@ func (m *HasMetadataMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HasMetadataMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.source != nil {
 		fields = append(fields, hasmetadata.FieldSourceID)
 	}
@@ -9994,6 +10355,9 @@ func (m *HasMetadataMutation) Fields() []string {
 	if m.collector != nil {
 		fields = append(fields, hasmetadata.FieldCollector)
 	}
+	if m.document_ref != nil {
+		fields = append(fields, hasmetadata.FieldDocumentRef)
+	}
 	return fields
 }
 
@@ -10022,6 +10386,8 @@ func (m *HasMetadataMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case hasmetadata.FieldCollector:
 		return m.Collector()
+	case hasmetadata.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -10051,6 +10417,8 @@ func (m *HasMetadataMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldOrigin(ctx)
 	case hasmetadata.FieldCollector:
 		return m.OldCollector(ctx)
+	case hasmetadata.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown HasMetadata field %s", name)
 }
@@ -10129,6 +10497,13 @@ func (m *HasMetadataMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case hasmetadata.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown HasMetadata field %s", name)
@@ -10235,6 +10610,9 @@ func (m *HasMetadataMutation) ResetField(name string) error {
 		return nil
 	case hasmetadata.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case hasmetadata.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown HasMetadata field %s", name)
@@ -10378,6 +10756,7 @@ type HasSourceAtMutation struct {
 	justification          *string
 	origin                 *string
 	collector              *string
+	document_ref           *string
 	clearedFields          map[string]struct{}
 	package_version        *uuid.UUID
 	clearedpackage_version bool
@@ -10772,6 +11151,42 @@ func (m *HasSourceAtMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *HasSourceAtMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *HasSourceAtMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the HasSourceAt entity.
+// If the HasSourceAt object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HasSourceAtMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *HasSourceAtMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearPackageVersion clears the "package_version" edge to the PackageVersion entity.
 func (m *HasSourceAtMutation) ClearPackageVersion() {
 	m.clearedpackage_version = true
@@ -10900,7 +11315,7 @@ func (m *HasSourceAtMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HasSourceAtMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 8)
 	if m.package_version != nil {
 		fields = append(fields, hassourceat.FieldPackageVersionID)
 	}
@@ -10921,6 +11336,9 @@ func (m *HasSourceAtMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, hassourceat.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, hassourceat.FieldDocumentRef)
 	}
 	return fields
 }
@@ -10944,6 +11362,8 @@ func (m *HasSourceAtMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case hassourceat.FieldCollector:
 		return m.Collector()
+	case hassourceat.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -10967,6 +11387,8 @@ func (m *HasSourceAtMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldOrigin(ctx)
 	case hassourceat.FieldCollector:
 		return m.OldCollector(ctx)
+	case hassourceat.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown HasSourceAt field %s", name)
 }
@@ -11024,6 +11446,13 @@ func (m *HasSourceAtMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case hassourceat.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown HasSourceAt field %s", name)
@@ -11109,6 +11538,9 @@ func (m *HasSourceAtMutation) ResetField(name string) error {
 		return nil
 	case hassourceat.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case hassourceat.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown HasSourceAt field %s", name)
@@ -11233,6 +11665,7 @@ type HashEqualMutation struct {
 	origin            *string
 	collector         *string
 	justification     *string
+	document_ref      *string
 	artifacts_hash    *string
 	clearedFields     map[string]struct{}
 	artifact_a        *uuid.UUID
@@ -11528,6 +11961,42 @@ func (m *HashEqualMutation) ResetJustification() {
 	m.justification = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *HashEqualMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *HashEqualMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the HashEqual entity.
+// If the HashEqual object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HashEqualMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *HashEqualMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetArtifactsHash sets the "artifacts_hash" field.
 func (m *HashEqualMutation) SetArtifactsHash(s string) {
 	m.artifacts_hash = &s
@@ -11678,7 +12147,7 @@ func (m *HashEqualMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HashEqualMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.artifact_a != nil {
 		fields = append(fields, hashequal.FieldArtID)
 	}
@@ -11693,6 +12162,9 @@ func (m *HashEqualMutation) Fields() []string {
 	}
 	if m.justification != nil {
 		fields = append(fields, hashequal.FieldJustification)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, hashequal.FieldDocumentRef)
 	}
 	if m.artifacts_hash != nil {
 		fields = append(fields, hashequal.FieldArtifactsHash)
@@ -11715,6 +12187,8 @@ func (m *HashEqualMutation) Field(name string) (ent.Value, bool) {
 		return m.Collector()
 	case hashequal.FieldJustification:
 		return m.Justification()
+	case hashequal.FieldDocumentRef:
+		return m.DocumentRef()
 	case hashequal.FieldArtifactsHash:
 		return m.ArtifactsHash()
 	}
@@ -11736,6 +12210,8 @@ func (m *HashEqualMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldCollector(ctx)
 	case hashequal.FieldJustification:
 		return m.OldJustification(ctx)
+	case hashequal.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case hashequal.FieldArtifactsHash:
 		return m.OldArtifactsHash(ctx)
 	}
@@ -11781,6 +12257,13 @@ func (m *HashEqualMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetJustification(v)
+		return nil
+	case hashequal.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case hashequal.FieldArtifactsHash:
 		v, ok := value.(string)
@@ -11852,6 +12335,9 @@ func (m *HashEqualMutation) ResetField(name string) error {
 		return nil
 	case hashequal.FieldJustification:
 		m.ResetJustification()
+		return nil
+	case hashequal.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case hashequal.FieldArtifactsHash:
 		m.ResetArtifactsHash()
@@ -12618,6 +13104,7 @@ type OccurrenceMutation struct {
 	justification            *string
 	origin                   *string
 	collector                *string
+	document_ref             *string
 	clearedFields            map[string]struct{}
 	artifact                 *uuid.UUID
 	clearedartifact          bool
@@ -12879,6 +13366,42 @@ func (m *OccurrenceMutation) OldCollector(ctx context.Context) (v string, err er
 // ResetCollector resets all changes to the "collector" field.
 func (m *OccurrenceMutation) ResetCollector() {
 	m.collector = nil
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (m *OccurrenceMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *OccurrenceMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the Occurrence entity.
+// If the Occurrence object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OccurrenceMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *OccurrenceMutation) ResetDocumentRef() {
+	m.document_ref = nil
 }
 
 // SetSourceID sets the "source_id" field.
@@ -13148,7 +13671,7 @@ func (m *OccurrenceMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OccurrenceMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.artifact != nil {
 		fields = append(fields, occurrence.FieldArtifactID)
 	}
@@ -13160,6 +13683,9 @@ func (m *OccurrenceMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, occurrence.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, occurrence.FieldDocumentRef)
 	}
 	if m.source != nil {
 		fields = append(fields, occurrence.FieldSourceID)
@@ -13183,6 +13709,8 @@ func (m *OccurrenceMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case occurrence.FieldCollector:
 		return m.Collector()
+	case occurrence.FieldDocumentRef:
+		return m.DocumentRef()
 	case occurrence.FieldSourceID:
 		return m.SourceID()
 	case occurrence.FieldPackageID:
@@ -13204,6 +13732,8 @@ func (m *OccurrenceMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldOrigin(ctx)
 	case occurrence.FieldCollector:
 		return m.OldCollector(ctx)
+	case occurrence.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case occurrence.FieldSourceID:
 		return m.OldSourceID(ctx)
 	case occurrence.FieldPackageID:
@@ -13244,6 +13774,13 @@ func (m *OccurrenceMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case occurrence.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case occurrence.FieldSourceID:
 		v, ok := value.(uuid.UUID)
@@ -13334,6 +13871,9 @@ func (m *OccurrenceMutation) ResetField(name string) error {
 		return nil
 	case occurrence.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case occurrence.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case occurrence.FieldSourceID:
 		m.ResetSourceID()
@@ -16244,6 +16784,7 @@ type PkgEqualMutation struct {
 	id               *uuid.UUID
 	origin           *string
 	collector        *string
+	document_ref     *string
 	justification    *string
 	packages_hash    *string
 	clearedFields    map[string]struct{}
@@ -16504,6 +17045,42 @@ func (m *PkgEqualMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *PkgEqualMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *PkgEqualMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the PkgEqual entity.
+// If the PkgEqual object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PkgEqualMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *PkgEqualMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetJustification sets the "justification" field.
 func (m *PkgEqualMutation) SetJustification(s string) {
 	m.justification = &s
@@ -16690,7 +17267,7 @@ func (m *PkgEqualMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PkgEqualMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.package_a != nil {
 		fields = append(fields, pkgequal.FieldPkgID)
 	}
@@ -16702,6 +17279,9 @@ func (m *PkgEqualMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, pkgequal.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, pkgequal.FieldDocumentRef)
 	}
 	if m.justification != nil {
 		fields = append(fields, pkgequal.FieldJustification)
@@ -16725,6 +17305,8 @@ func (m *PkgEqualMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case pkgequal.FieldCollector:
 		return m.Collector()
+	case pkgequal.FieldDocumentRef:
+		return m.DocumentRef()
 	case pkgequal.FieldJustification:
 		return m.Justification()
 	case pkgequal.FieldPackagesHash:
@@ -16746,6 +17328,8 @@ func (m *PkgEqualMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldOrigin(ctx)
 	case pkgequal.FieldCollector:
 		return m.OldCollector(ctx)
+	case pkgequal.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case pkgequal.FieldJustification:
 		return m.OldJustification(ctx)
 	case pkgequal.FieldPackagesHash:
@@ -16786,6 +17370,13 @@ func (m *PkgEqualMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case pkgequal.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case pkgequal.FieldJustification:
 		v, ok := value.(string)
@@ -16861,6 +17452,9 @@ func (m *PkgEqualMutation) ResetField(name string) error {
 		return nil
 	case pkgequal.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case pkgequal.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case pkgequal.FieldJustification:
 		m.ResetJustification()
@@ -16976,6 +17570,7 @@ type PointOfContactMutation struct {
 	justification          *string
 	origin                 *string
 	collector              *string
+	document_ref           *string
 	clearedFields          map[string]struct{}
 	source                 *uuid.UUID
 	clearedsource          bool
@@ -17506,6 +18101,42 @@ func (m *PointOfContactMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *PointOfContactMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *PointOfContactMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the PointOfContact entity.
+// If the PointOfContact object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PointOfContactMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *PointOfContactMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearSource clears the "source" edge to the SourceName entity.
 func (m *PointOfContactMutation) ClearSource() {
 	m.clearedsource = true
@@ -17661,7 +18292,7 @@ func (m *PointOfContactMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PointOfContactMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.source != nil {
 		fields = append(fields, pointofcontact.FieldSourceID)
 	}
@@ -17692,6 +18323,9 @@ func (m *PointOfContactMutation) Fields() []string {
 	if m.collector != nil {
 		fields = append(fields, pointofcontact.FieldCollector)
 	}
+	if m.document_ref != nil {
+		fields = append(fields, pointofcontact.FieldDocumentRef)
+	}
 	return fields
 }
 
@@ -17720,6 +18354,8 @@ func (m *PointOfContactMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case pointofcontact.FieldCollector:
 		return m.Collector()
+	case pointofcontact.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -17749,6 +18385,8 @@ func (m *PointOfContactMutation) OldField(ctx context.Context, name string) (ent
 		return m.OldOrigin(ctx)
 	case pointofcontact.FieldCollector:
 		return m.OldCollector(ctx)
+	case pointofcontact.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown PointOfContact field %s", name)
 }
@@ -17827,6 +18465,13 @@ func (m *PointOfContactMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case pointofcontact.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown PointOfContact field %s", name)
@@ -17933,6 +18578,9 @@ func (m *PointOfContactMutation) ResetField(name string) error {
 		return nil
 	case pointofcontact.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case pointofcontact.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown PointOfContact field %s", name)
@@ -18080,6 +18728,7 @@ type SLSAAttestationMutation struct {
 	finished_on          *time.Time
 	origin               *string
 	collector            *string
+	document_ref         *string
 	built_from_hash      *string
 	clearedFields        map[string]struct{}
 	built_from           map[uuid.UUID]struct{}
@@ -18551,6 +19200,42 @@ func (m *SLSAAttestationMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *SLSAAttestationMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *SLSAAttestationMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the SLSAAttestation entity.
+// If the SLSAAttestation object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SLSAAttestationMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *SLSAAttestationMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetBuiltFromHash sets the "built_from_hash" field.
 func (m *SLSAAttestationMutation) SetBuiltFromHash(s string) {
 	m.built_from_hash = &s
@@ -18729,7 +19414,7 @@ func (m *SLSAAttestationMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SLSAAttestationMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.build_type != nil {
 		fields = append(fields, slsaattestation.FieldBuildType)
 	}
@@ -18756,6 +19441,9 @@ func (m *SLSAAttestationMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, slsaattestation.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, slsaattestation.FieldDocumentRef)
 	}
 	if m.built_from_hash != nil {
 		fields = append(fields, slsaattestation.FieldBuiltFromHash)
@@ -18786,6 +19474,8 @@ func (m *SLSAAttestationMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case slsaattestation.FieldCollector:
 		return m.Collector()
+	case slsaattestation.FieldDocumentRef:
+		return m.DocumentRef()
 	case slsaattestation.FieldBuiltFromHash:
 		return m.BuiltFromHash()
 	}
@@ -18815,6 +19505,8 @@ func (m *SLSAAttestationMutation) OldField(ctx context.Context, name string) (en
 		return m.OldOrigin(ctx)
 	case slsaattestation.FieldCollector:
 		return m.OldCollector(ctx)
+	case slsaattestation.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case slsaattestation.FieldBuiltFromHash:
 		return m.OldBuiltFromHash(ctx)
 	}
@@ -18888,6 +19580,13 @@ func (m *SLSAAttestationMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case slsaattestation.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case slsaattestation.FieldBuiltFromHash:
 		v, ok := value.(string)
@@ -18980,6 +19679,9 @@ func (m *SLSAAttestationMutation) ResetField(name string) error {
 		return nil
 	case slsaattestation.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case slsaattestation.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case slsaattestation.FieldBuiltFromHash:
 		m.ResetBuiltFromHash()
@@ -20297,6 +20999,7 @@ type VulnEqualMutation struct {
 	justification          *string
 	origin                 *string
 	collector              *string
+	document_ref           *string
 	vulnerabilities_hash   *string
 	clearedFields          map[string]struct{}
 	vulnerability_a        *uuid.UUID
@@ -20592,6 +21295,42 @@ func (m *VulnEqualMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *VulnEqualMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *VulnEqualMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the VulnEqual entity.
+// If the VulnEqual object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *VulnEqualMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *VulnEqualMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // SetVulnerabilitiesHash sets the "vulnerabilities_hash" field.
 func (m *VulnEqualMutation) SetVulnerabilitiesHash(s string) {
 	m.vulnerabilities_hash = &s
@@ -20742,7 +21481,7 @@ func (m *VulnEqualMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *VulnEqualMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.vulnerability_a != nil {
 		fields = append(fields, vulnequal.FieldVulnID)
 	}
@@ -20757,6 +21496,9 @@ func (m *VulnEqualMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, vulnequal.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, vulnequal.FieldDocumentRef)
 	}
 	if m.vulnerabilities_hash != nil {
 		fields = append(fields, vulnequal.FieldVulnerabilitiesHash)
@@ -20779,6 +21521,8 @@ func (m *VulnEqualMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case vulnequal.FieldCollector:
 		return m.Collector()
+	case vulnequal.FieldDocumentRef:
+		return m.DocumentRef()
 	case vulnequal.FieldVulnerabilitiesHash:
 		return m.VulnerabilitiesHash()
 	}
@@ -20800,6 +21544,8 @@ func (m *VulnEqualMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldOrigin(ctx)
 	case vulnequal.FieldCollector:
 		return m.OldCollector(ctx)
+	case vulnequal.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	case vulnequal.FieldVulnerabilitiesHash:
 		return m.OldVulnerabilitiesHash(ctx)
 	}
@@ -20845,6 +21591,13 @@ func (m *VulnEqualMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case vulnequal.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	case vulnequal.FieldVulnerabilitiesHash:
 		v, ok := value.(string)
@@ -20916,6 +21669,9 @@ func (m *VulnEqualMutation) ResetField(name string) error {
 		return nil
 	case vulnequal.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case vulnequal.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	case vulnequal.FieldVulnerabilitiesHash:
 		m.ResetVulnerabilitiesHash()
@@ -21839,6 +22595,7 @@ type VulnerabilityMetadataMutation struct {
 	timestamp               *time.Time
 	origin                  *string
 	collector               *string
+	document_ref            *string
 	clearedFields           map[string]struct{}
 	vulnerability_id        *uuid.UUID
 	clearedvulnerability_id bool
@@ -22187,6 +22944,42 @@ func (m *VulnerabilityMetadataMutation) ResetCollector() {
 	m.collector = nil
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (m *VulnerabilityMetadataMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
+}
+
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *VulnerabilityMetadataMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDocumentRef returns the old "document_ref" field's value of the VulnerabilityMetadata entity.
+// If the VulnerabilityMetadata object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *VulnerabilityMetadataMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
+	}
+	return oldValue.DocumentRef, nil
+}
+
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *VulnerabilityMetadataMutation) ResetDocumentRef() {
+	m.document_ref = nil
+}
+
 // ClearVulnerabilityID clears the "vulnerability_id" edge to the VulnerabilityID entity.
 func (m *VulnerabilityMetadataMutation) ClearVulnerabilityID() {
 	m.clearedvulnerability_id = true
@@ -22248,7 +23041,7 @@ func (m *VulnerabilityMetadataMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *VulnerabilityMetadataMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.vulnerability_id != nil {
 		fields = append(fields, vulnerabilitymetadata.FieldVulnerabilityIDID)
 	}
@@ -22266,6 +23059,9 @@ func (m *VulnerabilityMetadataMutation) Fields() []string {
 	}
 	if m.collector != nil {
 		fields = append(fields, vulnerabilitymetadata.FieldCollector)
+	}
+	if m.document_ref != nil {
+		fields = append(fields, vulnerabilitymetadata.FieldDocumentRef)
 	}
 	return fields
 }
@@ -22287,6 +23083,8 @@ func (m *VulnerabilityMetadataMutation) Field(name string) (ent.Value, bool) {
 		return m.Origin()
 	case vulnerabilitymetadata.FieldCollector:
 		return m.Collector()
+	case vulnerabilitymetadata.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -22308,6 +23106,8 @@ func (m *VulnerabilityMetadataMutation) OldField(ctx context.Context, name strin
 		return m.OldOrigin(ctx)
 	case vulnerabilitymetadata.FieldCollector:
 		return m.OldCollector(ctx)
+	case vulnerabilitymetadata.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown VulnerabilityMetadata field %s", name)
 }
@@ -22358,6 +23158,13 @@ func (m *VulnerabilityMetadataMutation) SetField(name string, value ent.Value) e
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCollector(v)
+		return nil
+	case vulnerabilitymetadata.FieldDocumentRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown VulnerabilityMetadata field %s", name)
@@ -22440,6 +23247,9 @@ func (m *VulnerabilityMetadataMutation) ResetField(name string) error {
 		return nil
 	case vulnerabilitymetadata.FieldCollector:
 		m.ResetCollector()
+		return nil
+	case vulnerabilitymetadata.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown VulnerabilityMetadata field %s", name)

--- a/pkg/assembler/backends/ent/mutation.go
+++ b/pkg/assembler/backends/ent/mutation.go
@@ -3270,9 +3270,10 @@ type CertificationMutation struct {
 	id                     *uuid.UUID
 	_type                  *certification.Type
 	justification          *string
+	known_since            *time.Time
 	origin                 *string
 	collector              *string
-	known_since            *time.Time
+	document_ref           *string
 	clearedFields          map[string]struct{}
 	source                 *uuid.UUID
 	clearedsource          bool
@@ -3659,6 +3660,42 @@ func (m *CertificationMutation) ResetJustification() {
 	m.justification = nil
 }
 
+// SetKnownSince sets the "known_since" field.
+func (m *CertificationMutation) SetKnownSince(t time.Time) {
+	m.known_since = &t
+}
+
+// KnownSince returns the value of the "known_since" field in the mutation.
+func (m *CertificationMutation) KnownSince() (r time.Time, exists bool) {
+	v := m.known_since
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKnownSince returns the old "known_since" field's value of the Certification entity.
+// If the Certification object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CertificationMutation) OldKnownSince(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKnownSince is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKnownSince requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKnownSince: %w", err)
+	}
+	return oldValue.KnownSince, nil
+}
+
+// ResetKnownSince resets all changes to the "known_since" field.
+func (m *CertificationMutation) ResetKnownSince() {
+	m.known_since = nil
+}
+
 // SetOrigin sets the "origin" field.
 func (m *CertificationMutation) SetOrigin(s string) {
 	m.origin = &s
@@ -3731,40 +3768,40 @@ func (m *CertificationMutation) ResetCollector() {
 	m.collector = nil
 }
 
-// SetKnownSince sets the "known_since" field.
-func (m *CertificationMutation) SetKnownSince(t time.Time) {
-	m.known_since = &t
+// SetDocumentRef sets the "document_ref" field.
+func (m *CertificationMutation) SetDocumentRef(s string) {
+	m.document_ref = &s
 }
 
-// KnownSince returns the value of the "known_since" field in the mutation.
-func (m *CertificationMutation) KnownSince() (r time.Time, exists bool) {
-	v := m.known_since
+// DocumentRef returns the value of the "document_ref" field in the mutation.
+func (m *CertificationMutation) DocumentRef() (r string, exists bool) {
+	v := m.document_ref
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldKnownSince returns the old "known_since" field's value of the Certification entity.
+// OldDocumentRef returns the old "document_ref" field's value of the Certification entity.
 // If the Certification object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *CertificationMutation) OldKnownSince(ctx context.Context) (v time.Time, err error) {
+func (m *CertificationMutation) OldDocumentRef(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldKnownSince is only allowed on UpdateOne operations")
+		return v, errors.New("OldDocumentRef is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldKnownSince requires an ID field in the mutation")
+		return v, errors.New("OldDocumentRef requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldKnownSince: %w", err)
+		return v, fmt.Errorf("querying old value for OldDocumentRef: %w", err)
 	}
-	return oldValue.KnownSince, nil
+	return oldValue.DocumentRef, nil
 }
 
-// ResetKnownSince resets all changes to the "known_since" field.
-func (m *CertificationMutation) ResetKnownSince() {
-	m.known_since = nil
+// ResetDocumentRef resets all changes to the "document_ref" field.
+func (m *CertificationMutation) ResetDocumentRef() {
+	m.document_ref = nil
 }
 
 // ClearSource clears the "source" edge to the SourceName entity.
@@ -3922,7 +3959,7 @@ func (m *CertificationMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CertificationMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.source != nil {
 		fields = append(fields, certification.FieldSourceID)
 	}
@@ -3941,14 +3978,17 @@ func (m *CertificationMutation) Fields() []string {
 	if m.justification != nil {
 		fields = append(fields, certification.FieldJustification)
 	}
+	if m.known_since != nil {
+		fields = append(fields, certification.FieldKnownSince)
+	}
 	if m.origin != nil {
 		fields = append(fields, certification.FieldOrigin)
 	}
 	if m.collector != nil {
 		fields = append(fields, certification.FieldCollector)
 	}
-	if m.known_since != nil {
-		fields = append(fields, certification.FieldKnownSince)
+	if m.document_ref != nil {
+		fields = append(fields, certification.FieldDocumentRef)
 	}
 	return fields
 }
@@ -3970,12 +4010,14 @@ func (m *CertificationMutation) Field(name string) (ent.Value, bool) {
 		return m.GetType()
 	case certification.FieldJustification:
 		return m.Justification()
+	case certification.FieldKnownSince:
+		return m.KnownSince()
 	case certification.FieldOrigin:
 		return m.Origin()
 	case certification.FieldCollector:
 		return m.Collector()
-	case certification.FieldKnownSince:
-		return m.KnownSince()
+	case certification.FieldDocumentRef:
+		return m.DocumentRef()
 	}
 	return nil, false
 }
@@ -3997,12 +4039,14 @@ func (m *CertificationMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldType(ctx)
 	case certification.FieldJustification:
 		return m.OldJustification(ctx)
+	case certification.FieldKnownSince:
+		return m.OldKnownSince(ctx)
 	case certification.FieldOrigin:
 		return m.OldOrigin(ctx)
 	case certification.FieldCollector:
 		return m.OldCollector(ctx)
-	case certification.FieldKnownSince:
-		return m.OldKnownSince(ctx)
+	case certification.FieldDocumentRef:
+		return m.OldDocumentRef(ctx)
 	}
 	return nil, fmt.Errorf("unknown Certification field %s", name)
 }
@@ -4054,6 +4098,13 @@ func (m *CertificationMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetJustification(v)
 		return nil
+	case certification.FieldKnownSince:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKnownSince(v)
+		return nil
 	case certification.FieldOrigin:
 		v, ok := value.(string)
 		if !ok {
@@ -4068,12 +4119,12 @@ func (m *CertificationMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetCollector(v)
 		return nil
-	case certification.FieldKnownSince:
-		v, ok := value.(time.Time)
+	case certification.FieldDocumentRef:
+		v, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetKnownSince(v)
+		m.SetDocumentRef(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Certification field %s", name)
@@ -4169,14 +4220,17 @@ func (m *CertificationMutation) ResetField(name string) error {
 	case certification.FieldJustification:
 		m.ResetJustification()
 		return nil
+	case certification.FieldKnownSince:
+		m.ResetKnownSince()
+		return nil
 	case certification.FieldOrigin:
 		m.ResetOrigin()
 		return nil
 	case certification.FieldCollector:
 		m.ResetCollector()
 		return nil
-	case certification.FieldKnownSince:
-		m.ResetKnownSince()
+	case certification.FieldDocumentRef:
+		m.ResetDocumentRef()
 		return nil
 	}
 	return fmt.Errorf("unknown Certification field %s", name)

--- a/pkg/assembler/backends/ent/occurrence.go
+++ b/pkg/assembler/backends/ent/occurrence.go
@@ -28,6 +28,8 @@ type Occurrence struct {
 	Origin string `json:"origin,omitempty"`
 	// GUAC collector for the document
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// SourceID holds the value of the "source_id" field.
 	SourceID *uuid.UUID `json:"source_id,omitempty"`
 	// PackageID holds the value of the "package_id" field.
@@ -112,7 +114,7 @@ func (*Occurrence) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case occurrence.FieldSourceID, occurrence.FieldPackageID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case occurrence.FieldJustification, occurrence.FieldOrigin, occurrence.FieldCollector:
+		case occurrence.FieldJustification, occurrence.FieldOrigin, occurrence.FieldCollector, occurrence.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case occurrence.FieldID, occurrence.FieldArtifactID:
 			values[i] = new(uuid.UUID)
@@ -160,6 +162,12 @@ func (o *Occurrence) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				o.Collector = value.String
+			}
+		case occurrence.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				o.DocumentRef = value.String
 			}
 		case occurrence.FieldSourceID:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
@@ -242,6 +250,9 @@ func (o *Occurrence) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(o.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(o.DocumentRef)
 	builder.WriteString(", ")
 	if v := o.SourceID; v != nil {
 		builder.WriteString("source_id=")

--- a/pkg/assembler/backends/ent/occurrence/occurrence.go
+++ b/pkg/assembler/backends/ent/occurrence/occurrence.go
@@ -21,6 +21,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldSourceID holds the string denoting the source_id field in the database.
 	FieldSourceID = "source_id"
 	// FieldPackageID holds the string denoting the package_id field in the database.
@@ -70,6 +72,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldSourceID,
 	FieldPackageID,
 }
@@ -121,6 +124,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // BySourceID orders the results by the source_id field.

--- a/pkg/assembler/backends/ent/occurrence/where.go
+++ b/pkg/assembler/backends/ent/occurrence/where.go
@@ -74,6 +74,11 @@ func Collector(v string) predicate.Occurrence {
 	return predicate.Occurrence(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // SourceID applies equality check predicate on the "source_id" field. It's identical to SourceIDEQ.
 func SourceID(v uuid.UUID) predicate.Occurrence {
 	return predicate.Occurrence(sql.FieldEQ(FieldSourceID, v))
@@ -297,6 +302,71 @@ func CollectorEqualFold(v string) predicate.Occurrence {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.Occurrence {
 	return predicate.Occurrence(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.Occurrence {
+	return predicate.Occurrence(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // SourceIDEQ applies the EQ predicate on the "source_id" field.

--- a/pkg/assembler/backends/ent/occurrence_create.go
+++ b/pkg/assembler/backends/ent/occurrence_create.go
@@ -51,6 +51,12 @@ func (oc *OccurrenceCreate) SetCollector(s string) *OccurrenceCreate {
 	return oc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (oc *OccurrenceCreate) SetDocumentRef(s string) *OccurrenceCreate {
+	oc.mutation.SetDocumentRef(s)
+	return oc
+}
+
 // SetSourceID sets the "source_id" field.
 func (oc *OccurrenceCreate) SetSourceID(u uuid.UUID) *OccurrenceCreate {
 	oc.mutation.SetSourceID(u)
@@ -178,6 +184,9 @@ func (oc *OccurrenceCreate) check() error {
 	if _, ok := oc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "Occurrence.collector"`)}
 	}
+	if _, ok := oc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "Occurrence.document_ref"`)}
+	}
 	if _, ok := oc.mutation.ArtifactID(); !ok {
 		return &ValidationError{Name: "artifact", err: errors.New(`ent: missing required edge "Occurrence.artifact"`)}
 	}
@@ -228,6 +237,10 @@ func (oc *OccurrenceCreate) createSpec() (*Occurrence, *sqlgraph.CreateSpec) {
 	if value, ok := oc.mutation.Collector(); ok {
 		_spec.SetField(occurrence.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := oc.mutation.DocumentRef(); ok {
+		_spec.SetField(occurrence.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := oc.mutation.ArtifactIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -396,6 +409,18 @@ func (u *OccurrenceUpsert) UpdateCollector() *OccurrenceUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *OccurrenceUpsert) SetDocumentRef(v string) *OccurrenceUpsert {
+	u.Set(occurrence.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *OccurrenceUpsert) UpdateDocumentRef() *OccurrenceUpsert {
+	u.SetExcluded(occurrence.FieldDocumentRef)
+	return u
+}
+
 // SetSourceID sets the "source_id" field.
 func (u *OccurrenceUpsert) SetSourceID(v uuid.UUID) *OccurrenceUpsert {
 	u.Set(occurrence.FieldSourceID, v)
@@ -533,6 +558,20 @@ func (u *OccurrenceUpsertOne) SetCollector(v string) *OccurrenceUpsertOne {
 func (u *OccurrenceUpsertOne) UpdateCollector() *OccurrenceUpsertOne {
 	return u.Update(func(s *OccurrenceUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *OccurrenceUpsertOne) SetDocumentRef(v string) *OccurrenceUpsertOne {
+	return u.Update(func(s *OccurrenceUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *OccurrenceUpsertOne) UpdateDocumentRef() *OccurrenceUpsertOne {
+	return u.Update(func(s *OccurrenceUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -846,6 +885,20 @@ func (u *OccurrenceUpsertBulk) SetCollector(v string) *OccurrenceUpsertBulk {
 func (u *OccurrenceUpsertBulk) UpdateCollector() *OccurrenceUpsertBulk {
 	return u.Update(func(s *OccurrenceUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *OccurrenceUpsertBulk) SetDocumentRef(v string) *OccurrenceUpsertBulk {
+	return u.Update(func(s *OccurrenceUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *OccurrenceUpsertBulk) UpdateDocumentRef() *OccurrenceUpsertBulk {
+	return u.Update(func(s *OccurrenceUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/occurrence_update.go
+++ b/pkg/assembler/backends/ent/occurrence_update.go
@@ -88,6 +88,20 @@ func (ou *OccurrenceUpdate) SetNillableCollector(s *string) *OccurrenceUpdate {
 	return ou
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (ou *OccurrenceUpdate) SetDocumentRef(s string) *OccurrenceUpdate {
+	ou.mutation.SetDocumentRef(s)
+	return ou
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (ou *OccurrenceUpdate) SetNillableDocumentRef(s *string) *OccurrenceUpdate {
+	if s != nil {
+		ou.SetDocumentRef(*s)
+	}
+	return ou
+}
+
 // SetSourceID sets the "source_id" field.
 func (ou *OccurrenceUpdate) SetSourceID(u uuid.UUID) *OccurrenceUpdate {
 	ou.mutation.SetSourceID(u)
@@ -257,6 +271,9 @@ func (ou *OccurrenceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := ou.mutation.Collector(); ok {
 		_spec.SetField(occurrence.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := ou.mutation.DocumentRef(); ok {
+		_spec.SetField(occurrence.FieldDocumentRef, field.TypeString, value)
 	}
 	if ou.mutation.ArtifactCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -466,6 +483,20 @@ func (ouo *OccurrenceUpdateOne) SetNillableCollector(s *string) *OccurrenceUpdat
 	return ouo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (ouo *OccurrenceUpdateOne) SetDocumentRef(s string) *OccurrenceUpdateOne {
+	ouo.mutation.SetDocumentRef(s)
+	return ouo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (ouo *OccurrenceUpdateOne) SetNillableDocumentRef(s *string) *OccurrenceUpdateOne {
+	if s != nil {
+		ouo.SetDocumentRef(*s)
+	}
+	return ouo
+}
+
 // SetSourceID sets the "source_id" field.
 func (ouo *OccurrenceUpdateOne) SetSourceID(u uuid.UUID) *OccurrenceUpdateOne {
 	ouo.mutation.SetSourceID(u)
@@ -665,6 +696,9 @@ func (ouo *OccurrenceUpdateOne) sqlSave(ctx context.Context) (_node *Occurrence,
 	}
 	if value, ok := ouo.mutation.Collector(); ok {
 		_spec.SetField(occurrence.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := ouo.mutation.DocumentRef(); ok {
+		_spec.SetField(occurrence.FieldDocumentRef, field.TypeString, value)
 	}
 	if ouo.mutation.ArtifactCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/pkgequal.go
+++ b/pkg/assembler/backends/ent/pkgequal.go
@@ -26,6 +26,8 @@ type PkgEqual struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Justification holds the value of the "justification" field.
 	Justification string `json:"justification,omitempty"`
 	// An opaque hash of the package IDs that are equal
@@ -80,7 +82,7 @@ func (*PkgEqual) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case pkgequal.FieldOrigin, pkgequal.FieldCollector, pkgequal.FieldJustification, pkgequal.FieldPackagesHash:
+		case pkgequal.FieldOrigin, pkgequal.FieldCollector, pkgequal.FieldDocumentRef, pkgequal.FieldJustification, pkgequal.FieldPackagesHash:
 			values[i] = new(sql.NullString)
 		case pkgequal.FieldID, pkgequal.FieldPkgID, pkgequal.FieldEqualPkgID:
 			values[i] = new(uuid.UUID)
@@ -128,6 +130,12 @@ func (pe *PkgEqual) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				pe.Collector = value.String
+			}
+		case pkgequal.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				pe.DocumentRef = value.String
 			}
 		case pkgequal.FieldJustification:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -198,6 +206,9 @@ func (pe *PkgEqual) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(pe.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(pe.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("justification=")
 	builder.WriteString(pe.Justification)

--- a/pkg/assembler/backends/ent/pkgequal/pkgequal.go
+++ b/pkg/assembler/backends/ent/pkgequal/pkgequal.go
@@ -21,6 +21,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldJustification holds the string denoting the justification field in the database.
 	FieldJustification = "justification"
 	// FieldPackagesHash holds the string denoting the packages_hash field in the database.
@@ -54,6 +56,7 @@ var Columns = []string{
 	FieldEqualPkgID,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldJustification,
 	FieldPackagesHash,
 }
@@ -99,6 +102,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByJustification orders the results by the justification field.

--- a/pkg/assembler/backends/ent/pkgequal/where.go
+++ b/pkg/assembler/backends/ent/pkgequal/where.go
@@ -74,6 +74,11 @@ func Collector(v string) predicate.PkgEqual {
 	return predicate.PkgEqual(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // Justification applies equality check predicate on the "justification" field. It's identical to JustificationEQ.
 func Justification(v string) predicate.PkgEqual {
 	return predicate.PkgEqual(sql.FieldEQ(FieldJustification, v))
@@ -252,6 +257,71 @@ func CollectorEqualFold(v string) predicate.PkgEqual {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.PkgEqual {
 	return predicate.PkgEqual(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.PkgEqual {
+	return predicate.PkgEqual(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // JustificationEQ applies the EQ predicate on the "justification" field.

--- a/pkg/assembler/backends/ent/pkgequal_create.go
+++ b/pkg/assembler/backends/ent/pkgequal_create.go
@@ -48,6 +48,12 @@ func (pec *PkgEqualCreate) SetCollector(s string) *PkgEqualCreate {
 	return pec
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (pec *PkgEqualCreate) SetDocumentRef(s string) *PkgEqualCreate {
+	pec.mutation.SetDocumentRef(s)
+	return pec
+}
+
 // SetJustification sets the "justification" field.
 func (pec *PkgEqualCreate) SetJustification(s string) *PkgEqualCreate {
 	pec.mutation.SetJustification(s)
@@ -151,6 +157,9 @@ func (pec *PkgEqualCreate) check() error {
 	if _, ok := pec.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "PkgEqual.collector"`)}
 	}
+	if _, ok := pec.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "PkgEqual.document_ref"`)}
+	}
 	if _, ok := pec.mutation.Justification(); !ok {
 		return &ValidationError{Name: "justification", err: errors.New(`ent: missing required field "PkgEqual.justification"`)}
 	}
@@ -206,6 +215,10 @@ func (pec *PkgEqualCreate) createSpec() (*PkgEqual, *sqlgraph.CreateSpec) {
 	if value, ok := pec.mutation.Collector(); ok {
 		_spec.SetField(pkgequal.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := pec.mutation.DocumentRef(); ok {
+		_spec.SetField(pkgequal.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := pec.mutation.Justification(); ok {
 		_spec.SetField(pkgequal.FieldJustification, field.TypeString, value)
@@ -349,6 +362,18 @@ func (u *PkgEqualUpsert) UpdateCollector() *PkgEqualUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *PkgEqualUpsert) SetDocumentRef(v string) *PkgEqualUpsert {
+	u.Set(pkgequal.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PkgEqualUpsert) UpdateDocumentRef() *PkgEqualUpsert {
+	u.SetExcluded(pkgequal.FieldDocumentRef)
+	return u
+}
+
 // SetJustification sets the "justification" field.
 func (u *PkgEqualUpsert) SetJustification(v string) *PkgEqualUpsert {
 	u.Set(pkgequal.FieldJustification, v)
@@ -474,6 +499,20 @@ func (u *PkgEqualUpsertOne) SetCollector(v string) *PkgEqualUpsertOne {
 func (u *PkgEqualUpsertOne) UpdateCollector() *PkgEqualUpsertOne {
 	return u.Update(func(s *PkgEqualUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *PkgEqualUpsertOne) SetDocumentRef(v string) *PkgEqualUpsertOne {
+	return u.Update(func(s *PkgEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PkgEqualUpsertOne) UpdateDocumentRef() *PkgEqualUpsertOne {
+	return u.Update(func(s *PkgEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -773,6 +812,20 @@ func (u *PkgEqualUpsertBulk) SetCollector(v string) *PkgEqualUpsertBulk {
 func (u *PkgEqualUpsertBulk) UpdateCollector() *PkgEqualUpsertBulk {
 	return u.Update(func(s *PkgEqualUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *PkgEqualUpsertBulk) SetDocumentRef(v string) *PkgEqualUpsertBulk {
+	return u.Update(func(s *PkgEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PkgEqualUpsertBulk) UpdateDocumentRef() *PkgEqualUpsertBulk {
+	return u.Update(func(s *PkgEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/pkgequal_update.go
+++ b/pkg/assembler/backends/ent/pkgequal_update.go
@@ -85,6 +85,20 @@ func (peu *PkgEqualUpdate) SetNillableCollector(s *string) *PkgEqualUpdate {
 	return peu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (peu *PkgEqualUpdate) SetDocumentRef(s string) *PkgEqualUpdate {
+	peu.mutation.SetDocumentRef(s)
+	return peu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (peu *PkgEqualUpdate) SetNillableDocumentRef(s *string) *PkgEqualUpdate {
+	if s != nil {
+		peu.SetDocumentRef(*s)
+	}
+	return peu
+}
+
 // SetJustification sets the "justification" field.
 func (peu *PkgEqualUpdate) SetJustification(s string) *PkgEqualUpdate {
 	peu.mutation.SetJustification(s)
@@ -207,6 +221,9 @@ func (peu *PkgEqualUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := peu.mutation.Collector(); ok {
 		_spec.SetField(pkgequal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := peu.mutation.DocumentRef(); ok {
+		_spec.SetField(pkgequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := peu.mutation.Justification(); ok {
 		_spec.SetField(pkgequal.FieldJustification, field.TypeString, value)
@@ -344,6 +361,20 @@ func (peuo *PkgEqualUpdateOne) SetCollector(s string) *PkgEqualUpdateOne {
 func (peuo *PkgEqualUpdateOne) SetNillableCollector(s *string) *PkgEqualUpdateOne {
 	if s != nil {
 		peuo.SetCollector(*s)
+	}
+	return peuo
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (peuo *PkgEqualUpdateOne) SetDocumentRef(s string) *PkgEqualUpdateOne {
+	peuo.mutation.SetDocumentRef(s)
+	return peuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (peuo *PkgEqualUpdateOne) SetNillableDocumentRef(s *string) *PkgEqualUpdateOne {
+	if s != nil {
+		peuo.SetDocumentRef(*s)
 	}
 	return peuo
 }
@@ -500,6 +531,9 @@ func (peuo *PkgEqualUpdateOne) sqlSave(ctx context.Context) (_node *PkgEqual, er
 	}
 	if value, ok := peuo.mutation.Collector(); ok {
 		_spec.SetField(pkgequal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := peuo.mutation.DocumentRef(); ok {
+		_spec.SetField(pkgequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := peuo.mutation.Justification(); ok {
 		_spec.SetField(pkgequal.FieldJustification, field.TypeString, value)

--- a/pkg/assembler/backends/ent/pointofcontact.go
+++ b/pkg/assembler/backends/ent/pointofcontact.go
@@ -42,6 +42,8 @@ type PointOfContact struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PointOfContactQuery when eager-loading is set.
 	Edges        PointOfContactEdges `json:"edges"`
@@ -124,7 +126,7 @@ func (*PointOfContact) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case pointofcontact.FieldSourceID, pointofcontact.FieldPackageVersionID, pointofcontact.FieldPackageNameID, pointofcontact.FieldArtifactID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case pointofcontact.FieldEmail, pointofcontact.FieldInfo, pointofcontact.FieldJustification, pointofcontact.FieldOrigin, pointofcontact.FieldCollector:
+		case pointofcontact.FieldEmail, pointofcontact.FieldInfo, pointofcontact.FieldJustification, pointofcontact.FieldOrigin, pointofcontact.FieldCollector, pointofcontact.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case pointofcontact.FieldSince:
 			values[i] = new(sql.NullTime)
@@ -214,6 +216,12 @@ func (poc *PointOfContact) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				poc.Collector = value.String
+			}
+		case pointofcontact.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				poc.DocumentRef = value.String
 			}
 		default:
 			poc.selectValues.Set(columns[i], values[i])
@@ -308,6 +316,9 @@ func (poc *PointOfContact) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(poc.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(poc.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/pointofcontact/pointofcontact.go
+++ b/pkg/assembler/backends/ent/pointofcontact/pointofcontact.go
@@ -33,6 +33,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgeSource holds the string denoting the source edge name in mutations.
 	EdgeSource = "source"
 	// EdgePackageVersion holds the string denoting the package_version edge name in mutations.
@@ -86,6 +88,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -159,6 +162,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // BySourceField orders the results by source field.

--- a/pkg/assembler/backends/ent/pointofcontact/where.go
+++ b/pkg/assembler/backends/ent/pointofcontact/where.go
@@ -106,6 +106,11 @@ func Collector(v string) predicate.PointOfContact {
 	return predicate.PointOfContact(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // SourceIDEQ applies the EQ predicate on the "source_id" field.
 func SourceIDEQ(v uuid.UUID) predicate.PointOfContact {
 	return predicate.PointOfContact(sql.FieldEQ(FieldSourceID, v))
@@ -589,6 +594,71 @@ func CollectorEqualFold(v string) predicate.PointOfContact {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.PointOfContact {
 	return predicate.PointOfContact(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.PointOfContact {
+	return predicate.PointOfContact(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasSource applies the HasEdge predicate on the "source" edge.

--- a/pkg/assembler/backends/ent/pointofcontact_create.go
+++ b/pkg/assembler/backends/ent/pointofcontact_create.go
@@ -120,6 +120,12 @@ func (pocc *PointOfContactCreate) SetCollector(s string) *PointOfContactCreate {
 	return pocc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (pocc *PointOfContactCreate) SetDocumentRef(s string) *PointOfContactCreate {
+	pocc.mutation.SetDocumentRef(s)
+	return pocc
+}
+
 // SetID sets the "id" field.
 func (pocc *PointOfContactCreate) SetID(u uuid.UUID) *PointOfContactCreate {
 	pocc.mutation.SetID(u)
@@ -229,6 +235,9 @@ func (pocc *PointOfContactCreate) check() error {
 	if _, ok := pocc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "PointOfContact.collector"`)}
 	}
+	if _, ok := pocc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "PointOfContact.document_ref"`)}
+	}
 	return nil
 }
 
@@ -288,6 +297,10 @@ func (pocc *PointOfContactCreate) createSpec() (*PointOfContact, *sqlgraph.Creat
 	if value, ok := pocc.mutation.Collector(); ok {
 		_spec.SetField(pointofcontact.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := pocc.mutation.DocumentRef(); ok {
+		_spec.SetField(pointofcontact.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := pocc.mutation.SourceIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -553,6 +566,18 @@ func (u *PointOfContactUpsert) UpdateCollector() *PointOfContactUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *PointOfContactUpsert) SetDocumentRef(v string) *PointOfContactUpsert {
+	u.Set(pointofcontact.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PointOfContactUpsert) UpdateDocumentRef() *PointOfContactUpsert {
+	u.SetExcluded(pointofcontact.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -766,6 +791,20 @@ func (u *PointOfContactUpsertOne) SetCollector(v string) *PointOfContactUpsertOn
 func (u *PointOfContactUpsertOne) UpdateCollector() *PointOfContactUpsertOne {
 	return u.Update(func(s *PointOfContactUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *PointOfContactUpsertOne) SetDocumentRef(v string) *PointOfContactUpsertOne {
+	return u.Update(func(s *PointOfContactUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PointOfContactUpsertOne) UpdateDocumentRef() *PointOfContactUpsertOne {
+	return u.Update(func(s *PointOfContactUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1149,6 +1188,20 @@ func (u *PointOfContactUpsertBulk) SetCollector(v string) *PointOfContactUpsertB
 func (u *PointOfContactUpsertBulk) UpdateCollector() *PointOfContactUpsertBulk {
 	return u.Update(func(s *PointOfContactUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *PointOfContactUpsertBulk) SetDocumentRef(v string) *PointOfContactUpsertBulk {
+	return u.Update(func(s *PointOfContactUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *PointOfContactUpsertBulk) UpdateDocumentRef() *PointOfContactUpsertBulk {
+	return u.Update(func(s *PointOfContactUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/pointofcontact_update.go
+++ b/pkg/assembler/backends/ent/pointofcontact_update.go
@@ -197,6 +197,20 @@ func (pocu *PointOfContactUpdate) SetNillableCollector(s *string) *PointOfContac
 	return pocu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (pocu *PointOfContactUpdate) SetDocumentRef(s string) *PointOfContactUpdate {
+	pocu.mutation.SetDocumentRef(s)
+	return pocu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (pocu *PointOfContactUpdate) SetNillableDocumentRef(s *string) *PointOfContactUpdate {
+	if s != nil {
+		pocu.SetDocumentRef(*s)
+	}
+	return pocu
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (pocu *PointOfContactUpdate) SetSource(s *SourceName) *PointOfContactUpdate {
 	return pocu.SetSourceID(s.ID)
@@ -313,6 +327,9 @@ func (pocu *PointOfContactUpdate) sqlSave(ctx context.Context) (n int, err error
 	}
 	if value, ok := pocu.mutation.Collector(); ok {
 		_spec.SetField(pointofcontact.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := pocu.mutation.DocumentRef(); ok {
+		_spec.SetField(pointofcontact.FieldDocumentRef, field.TypeString, value)
 	}
 	if pocu.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -614,6 +631,20 @@ func (pocuo *PointOfContactUpdateOne) SetNillableCollector(s *string) *PointOfCo
 	return pocuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (pocuo *PointOfContactUpdateOne) SetDocumentRef(s string) *PointOfContactUpdateOne {
+	pocuo.mutation.SetDocumentRef(s)
+	return pocuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (pocuo *PointOfContactUpdateOne) SetNillableDocumentRef(s *string) *PointOfContactUpdateOne {
+	if s != nil {
+		pocuo.SetDocumentRef(*s)
+	}
+	return pocuo
+}
+
 // SetSource sets the "source" edge to the SourceName entity.
 func (pocuo *PointOfContactUpdateOne) SetSource(s *SourceName) *PointOfContactUpdateOne {
 	return pocuo.SetSourceID(s.ID)
@@ -760,6 +791,9 @@ func (pocuo *PointOfContactUpdateOne) sqlSave(ctx context.Context) (_node *Point
 	}
 	if value, ok := pocuo.mutation.Collector(); ok {
 		_spec.SetField(pointofcontact.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := pocuo.mutation.DocumentRef(); ok {
+		_spec.SetField(pointofcontact.FieldDocumentRef, field.TypeString, value)
 	}
 	if pocuo.mutation.SourceCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/ent/schema/billofmaterials.go
+++ b/pkg/assembler/backends/ent/schema/billofmaterials.go
@@ -44,6 +44,7 @@ func (BillOfMaterials) Fields() []ent.Field {
 		field.String("download_location"),
 		field.String("origin"),
 		field.String("collector").Comment("GUAC collector for the document"),
+		field.String("document_ref"),
 		field.Time("known_since"),
 		field.String("included_packages_hash").Comment("An opaque hash of the included packages"),
 		field.String("included_artifacts_hash").Comment("An opaque hash of the included artifacts"),
@@ -68,10 +69,10 @@ func (BillOfMaterials) Edges() []ent.Edge {
 func (BillOfMaterials) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("algorithm", "digest", "uri", "download_location", "known_since", "included_packages_hash",
-			"included_artifacts_hash", "included_dependencies_hash", "included_occurrences_hash", "origin", "collector").Edges("package").Unique().
+			"included_artifacts_hash", "included_dependencies_hash", "included_occurrences_hash", "origin", "collector", "document_ref").Edges("package").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND artifact_id IS NULL")).StorageKey("sbom_unique_package"),
 		index.Fields("algorithm", "digest", "uri", "download_location", "known_since", "included_packages_hash",
-			"included_artifacts_hash", "included_dependencies_hash", "included_occurrences_hash", "origin", "collector").Edges("artifact").Unique().
+			"included_artifacts_hash", "included_dependencies_hash", "included_occurrences_hash", "origin", "collector", "document_ref").Edges("artifact").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND artifact_id IS NOT NULL")).StorageKey("sbom_unique_artifact"),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certification.go
+++ b/pkg/assembler/backends/ent/schema/certification.go
@@ -62,9 +62,9 @@ func (Certification) Edges() []ent.Edge {
 
 func (Certification) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "source_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_version_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_name_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "artifact_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("type", "justification", "origin", "collector", "source_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "package_version_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "package_name_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "artifact_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certification.go
+++ b/pkg/assembler/backends/ent/schema/certification.go
@@ -62,9 +62,9 @@ func (Certification) Edges() []ent.Edge {
 
 func (Certification) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "source_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_version_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_name_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "document_ref", "artifact_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "source_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_version_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_name_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "artifact_id", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certification.go
+++ b/pkg/assembler/backends/ent/schema/certification.go
@@ -43,9 +43,10 @@ func (Certification) Fields() []ent.Field {
 		field.UUID("artifact_id", getUUIDv7()).Optional().Nillable(),
 		field.Enum("type").Values("GOOD", "BAD").Default("GOOD"),
 		field.String("justification"),
+		field.Time("known_since"),
 		field.String("origin"),
 		field.String("collector"),
-		field.Time("known_since"),
+		field.String("document_ref"),
 	}
 }
 
@@ -61,9 +62,9 @@ func (Certification) Edges() []ent.Edge {
 
 func (Certification) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("type", "justification", "origin", "collector", "source_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "package_version_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "package_name_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("type", "justification", "origin", "collector", "artifact_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "source_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_version_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "package_name_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("type", "justification", "origin", "collector", "document_ref", "artifact_id", "known_since").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certifylegal.go
+++ b/pkg/assembler/backends/ent/schema/certifylegal.go
@@ -45,6 +45,7 @@ func (CertifyLegal) Fields() []ent.Field {
 		field.Time("time_scanned"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 		field.String("declared_licenses_hash").Comment("An opaque hash of the declared license IDs to ensure uniqueness"),
 		field.String("discovered_licenses_hash").Comment("An opaque hash of the discovered license IDs to ensure uniqueness"),
 	}
@@ -63,11 +64,11 @@ func (CertifyLegal) Edges() []ent.Edge {
 func (CertifyLegal) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("source_id", "declared_license", "discovered_license", "attribution", "justification", "time_scanned",
-			"origin", "collector", "declared_licenses_hash", "discovered_licenses_hash").
+			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")),
 		index.Fields("package_id", "declared_license", "discovered_license", "attribution", "justification", "time_scanned",
-			"origin", "collector", "declared_licenses_hash", "discovered_licenses_hash").
+			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),
 	}

--- a/pkg/assembler/backends/ent/schema/certifyscorecard.go
+++ b/pkg/assembler/backends/ent/schema/certifyscorecard.go
@@ -46,6 +46,7 @@ func (CertifyScorecard) Fields() []ent.Field {
 		field.String("scorecard_commit"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 		field.String("checks_hash").Comment("A SHA1 of the checks fields after sorting keys, used to ensure uniqueness of scorecard records."),
 	}
 }
@@ -58,6 +59,6 @@ func (CertifyScorecard) Edges() []ent.Edge {
 }
 func (CertifyScorecard) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("source_id", "origin", "collector", "scorecard_version", "scorecard_commit", "aggregate_score", "time_scanned", "checks_hash").Unique(),
+		index.Fields("source_id", "origin", "collector", "scorecard_version", "scorecard_commit", "aggregate_score", "time_scanned", "checks_hash", "document_ref").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certifyvex.go
+++ b/pkg/assembler/backends/ent/schema/certifyvex.go
@@ -46,6 +46,7 @@ func (CertifyVex) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -61,7 +62,7 @@ func (CertifyVex) Edges() []ent.Edge {
 // Indexes of the VEX.
 func (CertifyVex) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector").Edges("vulnerability", "package").Unique().Annotations(entsql.IndexWhere("artifact_id IS NULL")),
-		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector").Edges("vulnerability", "artifact").Unique().Annotations(entsql.IndexWhere("package_id IS NULL")),
+		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector", "document_ref").Edges("vulnerability", "package").Unique().Annotations(entsql.IndexWhere("artifact_id IS NULL")),
+		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector", "document_ref").Edges("vulnerability", "artifact").Unique().Annotations(entsql.IndexWhere("package_id IS NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -44,6 +44,7 @@ func (CertifyVuln) Fields() []ent.Field {
 		field.String("scanner_version"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -58,6 +59,6 @@ func (CertifyVuln) Edges() []ent.Edge {
 // Indexes of the Vulnerability.
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned").Edges("vulnerability", "package").Unique(),
+		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned", "document_ref").Edges("vulnerability", "package").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/dependency.go
+++ b/pkg/assembler/backends/ent/schema/dependency.go
@@ -53,6 +53,7 @@ func (Dependency) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -76,11 +77,11 @@ func (Dependency) Edges() []ent.Edge {
 // Indexes of the Dependency.
 func (Dependency) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("version_range", "dependency_type", "justification", "origin", "collector").
+		index.Fields("version_range", "dependency_type", "justification", "origin", "collector", "document_ref").
 			Edges("package", "dependent_package_name").
 			Unique().
 			Annotations(entsql.IndexWhere("dependent_package_name_id IS NOT NULL AND dependent_package_version_id IS NULL")).StorageKey("dep_package_name"),
-		index.Fields("version_range", "dependency_type", "justification", "origin", "collector").
+		index.Fields("version_range", "dependency_type", "justification", "origin", "collector", "document_ref").
 			Edges("package", "dependent_package_version").
 			Unique().
 			Annotations(entsql.IndexWhere("dependent_package_name_id IS NULL AND dependent_package_version_id IS NOT NULL")).StorageKey("dep_package_version"),

--- a/pkg/assembler/backends/ent/schema/hashequal.go
+++ b/pkg/assembler/backends/ent/schema/hashequal.go
@@ -40,6 +40,7 @@ func (HashEqual) Fields() []ent.Field {
 		field.String("origin"),
 		field.String("collector"),
 		field.String("justification"),
+		field.String("document_ref"),
 		field.String("artifacts_hash").Comment("An opaque hash of the artifact IDs that are equal"),
 	}
 }
@@ -55,6 +56,6 @@ func (HashEqual) Edges() []ent.Edge {
 // Indexes of the HashEqual.
 func (HashEqual) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("art_id", "equal_art_id", "artifacts_hash", "origin", "justification", "collector").Unique(),
+		index.Fields("art_id", "equal_art_id", "artifacts_hash", "origin", "justification", "collector", "document_ref").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/hasmetadata.go
+++ b/pkg/assembler/backends/ent/schema/hasmetadata.go
@@ -46,6 +46,7 @@ func (HasMetadata) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -61,9 +62,9 @@ func (HasMetadata) Edges() []ent.Edge {
 
 func (HasMetadata) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "document_ref", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "document_ref", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "document_ref", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("key", "value", "justification", "origin", "collector", "timestamp", "document_ref", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/hassourceat.go
+++ b/pkg/assembler/backends/ent/schema/hassourceat.go
@@ -43,6 +43,7 @@ func (HasSourceAt) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -57,7 +58,7 @@ func (HasSourceAt) Edges() []ent.Edge {
 
 func (HasSourceAt) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("source_id", "package_version_id", "justification", "origin", "collector", "known_since").Unique().Annotations(entsql.IndexWhere("package_version_id IS NOT NULL AND package_name_id IS NULL")),
-		index.Fields("source_id", "package_name_id", "justification", "origin", "collector", "known_since").Unique().Annotations(entsql.IndexWhere("package_name_id IS NOT NULL AND package_version_id IS NULL")),
+		index.Fields("source_id", "package_version_id", "justification", "origin", "collector", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("package_version_id IS NOT NULL AND package_name_id IS NULL")),
+		index.Fields("source_id", "package_name_id", "justification", "origin", "collector", "known_since", "document_ref").Unique().Annotations(entsql.IndexWhere("package_name_id IS NOT NULL AND package_version_id IS NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/occurrence.go
+++ b/pkg/assembler/backends/ent/schema/occurrence.go
@@ -46,6 +46,7 @@ func (Occurrence) Fields() []ent.Field {
 		field.String("justification").Comment("Justification for the attested relationship"),
 		field.String("origin").Comment("Document from which this attestation is generated from"),
 		field.String("collector").Comment("GUAC collector for the document"),
+		field.String("document_ref"),
 		field.UUID("source_id", getUUIDv7()).Optional().Nillable(),
 		field.UUID("package_id", getUUIDv7()).Optional().Nillable(),
 	}
@@ -64,9 +65,9 @@ func (Occurrence) Edges() []ent.Edge {
 // Indexes of the Occurrence.
 func (Occurrence) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("justification", "origin", "collector").Edges("artifact", "package").Unique().
+		index.Fields("justification", "origin", "collector", "document_ref").Edges("artifact", "package").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")).StorageKey("occurrence_unique_package"),
-		index.Fields("justification", "origin", "collector").Edges("artifact", "source").Unique().
+		index.Fields("justification", "origin", "collector", "document_ref").Edges("artifact", "source").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")).StorageKey("occurrence_unique_source"),
 
 		// index.Fields("justification", "origin", "collector").Edges("source", "artifact").Unique().

--- a/pkg/assembler/backends/ent/schema/pkgequal.go
+++ b/pkg/assembler/backends/ent/schema/pkgequal.go
@@ -45,6 +45,7 @@ func (PkgEqual) Fields() []ent.Field {
 		field.UUID("equal_pkg_id", getUUIDv7()),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 		field.String("justification"),
 		field.String("packages_hash").Comment("An opaque hash of the package IDs that are equal"),
 	}
@@ -61,6 +62,6 @@ func (PkgEqual) Edges() []ent.Edge {
 // Indexes of the PkgEqual.
 func (PkgEqual) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("pkg_id", "equal_pkg_id", "packages_hash", "origin", "justification", "collector").Unique(),
+		index.Fields("pkg_id", "equal_pkg_id", "packages_hash", "origin", "justification", "collector", "document_ref").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/pointofcontact.go
+++ b/pkg/assembler/backends/ent/schema/pointofcontact.go
@@ -46,6 +46,7 @@ func (PointOfContact) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -61,9 +62,9 @@ func (PointOfContact) Edges() []ent.Edge {
 
 func (PointOfContact) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("since", "email", "info", "justification", "origin", "collector", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("since", "email", "info", "justification", "origin", "collector", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
-		index.Fields("since", "email", "info", "justification", "origin", "collector", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
-		index.Fields("since", "email", "info", "justification", "origin", "collector", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
+		index.Fields("since", "email", "info", "justification", "origin", "collector", "document_ref", "source_id").Unique().Annotations(entsql.IndexWhere("source_id IS NOT NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("since", "email", "info", "justification", "origin", "collector", "document_ref", "package_version_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NOT NULL AND package_name_id IS NULL AND artifact_id IS NULL")),
+		index.Fields("since", "email", "info", "justification", "origin", "collector", "document_ref", "package_name_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NOT NULL AND artifact_id IS NULL")),
+		index.Fields("since", "email", "info", "justification", "origin", "collector", "document_ref", "artifact_id").Unique().Annotations(entsql.IndexWhere("source_id IS NULL AND package_version_id IS NULL AND package_name_id IS NULL AND artifact_id IS NOT NULL")),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/slsaattestation.go
+++ b/pkg/assembler/backends/ent/schema/slsaattestation.go
@@ -54,6 +54,7 @@ func (SLSAAttestation) Fields() []ent.Field {
 		field.Time("finished_on").Comment("Timestamp of build end time"),
 		field.String("origin").Comment("Document from which this attestation is generated from"),
 		field.String("collector").Comment("GUAC collector for the document"),
+		field.String("document_ref"),
 		field.String("built_from_hash").Comment("Hash of the artifacts that was built"),
 	}
 }
@@ -71,6 +72,7 @@ func (SLSAAttestation) Edges() []ent.Edge {
 
 func (SLSAAttestation) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("subject_id", "origin", "collector", "build_type", "slsa_version", "built_by_id", "built_from_hash", "started_on", "finished_on").Unique(),
+		index.Fields("subject_id", "origin", "collector", "document_ref", "build_type",
+			"slsa_version", "built_by_id", "built_from_hash", "started_on", "finished_on").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/vulnequal.go
+++ b/pkg/assembler/backends/ent/schema/vulnequal.go
@@ -40,6 +40,7 @@ func (VulnEqual) Fields() []ent.Field {
 		field.String("justification"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 		field.String("vulnerabilities_hash").Comment("An opaque hash of the vulnerability IDs that are equal"),
 	}
 }
@@ -55,6 +56,6 @@ func (VulnEqual) Edges() []ent.Edge {
 // Indexes of the VulnEqual.
 func (VulnEqual) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("vuln_id", "equal_vuln_id", "vulnerabilities_hash", "justification", "origin", "collector").Unique(),
+		index.Fields("vuln_id", "equal_vuln_id", "vulnerabilities_hash", "justification", "origin", "collector", "document_ref").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/vulnerabilitymetadata.go
+++ b/pkg/assembler/backends/ent/schema/vulnerabilitymetadata.go
@@ -46,6 +46,7 @@ func (VulnerabilityMetadata) Fields() []ent.Field {
 		field.Time("timestamp"),
 		field.String("origin"),
 		field.String("collector"),
+		field.String("document_ref"),
 	}
 }
 
@@ -59,6 +60,6 @@ func (VulnerabilityMetadata) Edges() []ent.Edge {
 // Indexes of the VulnerabilityMetadata.
 func (VulnerabilityMetadata) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("vulnerability_id_id", "score_type", "score_value", "timestamp", "origin", "collector").Unique(),
+		index.Fields("vulnerability_id_id", "score_type", "score_value", "timestamp", "origin", "collector", "document_ref").Unique(),
 	}
 }

--- a/pkg/assembler/backends/ent/slsaattestation.go
+++ b/pkg/assembler/backends/ent/slsaattestation.go
@@ -40,6 +40,8 @@ type SLSAAttestation struct {
 	Origin string `json:"origin,omitempty"`
 	// GUAC collector for the document
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Hash of the artifacts that was built
 	BuiltFromHash string `json:"built_from_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -107,7 +109,7 @@ func (*SLSAAttestation) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case slsaattestation.FieldSlsaPredicate:
 			values[i] = new([]byte)
-		case slsaattestation.FieldBuildType, slsaattestation.FieldSlsaVersion, slsaattestation.FieldOrigin, slsaattestation.FieldCollector, slsaattestation.FieldBuiltFromHash:
+		case slsaattestation.FieldBuildType, slsaattestation.FieldSlsaVersion, slsaattestation.FieldOrigin, slsaattestation.FieldCollector, slsaattestation.FieldDocumentRef, slsaattestation.FieldBuiltFromHash:
 			values[i] = new(sql.NullString)
 		case slsaattestation.FieldStartedOn, slsaattestation.FieldFinishedOn:
 			values[i] = new(sql.NullTime)
@@ -189,6 +191,12 @@ func (sa *SLSAAttestation) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				sa.Collector = value.String
+			}
+		case slsaattestation.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				sa.DocumentRef = value.String
 			}
 		case slsaattestation.FieldBuiltFromHash:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -273,6 +281,9 @@ func (sa *SLSAAttestation) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(sa.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(sa.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("built_from_hash=")
 	builder.WriteString(sa.BuiltFromHash)

--- a/pkg/assembler/backends/ent/slsaattestation/slsaattestation.go
+++ b/pkg/assembler/backends/ent/slsaattestation/slsaattestation.go
@@ -31,6 +31,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldBuiltFromHash holds the string denoting the built_from_hash field in the database.
 	FieldBuiltFromHash = "built_from_hash"
 	// EdgeBuiltFrom holds the string denoting the built_from edge name in mutations.
@@ -74,6 +76,7 @@ var Columns = []string{
 	FieldFinishedOn,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldBuiltFromHash,
 }
 
@@ -144,6 +147,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByBuiltFromHash orders the results by the built_from_hash field.

--- a/pkg/assembler/backends/ent/slsaattestation/where.go
+++ b/pkg/assembler/backends/ent/slsaattestation/where.go
@@ -96,6 +96,11 @@ func Collector(v string) predicate.SLSAAttestation {
 	return predicate.SLSAAttestation(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // BuiltFromHash applies equality check predicate on the "built_from_hash" field. It's identical to BuiltFromHashEQ.
 func BuiltFromHash(v string) predicate.SLSAAttestation {
 	return predicate.SLSAAttestation(sql.FieldEQ(FieldBuiltFromHash, v))
@@ -489,6 +494,71 @@ func CollectorEqualFold(v string) predicate.SLSAAttestation {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.SLSAAttestation {
 	return predicate.SLSAAttestation(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.SLSAAttestation {
+	return predicate.SLSAAttestation(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // BuiltFromHashEQ applies the EQ predicate on the "built_from_hash" field.

--- a/pkg/assembler/backends/ent/slsaattestation_create.go
+++ b/pkg/assembler/backends/ent/slsaattestation_create.go
@@ -81,6 +81,12 @@ func (sac *SLSAAttestationCreate) SetCollector(s string) *SLSAAttestationCreate 
 	return sac
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (sac *SLSAAttestationCreate) SetDocumentRef(s string) *SLSAAttestationCreate {
+	sac.mutation.SetDocumentRef(s)
+	return sac
+}
+
 // SetBuiltFromHash sets the "built_from_hash" field.
 func (sac *SLSAAttestationCreate) SetBuiltFromHash(s string) *SLSAAttestationCreate {
 	sac.mutation.SetBuiltFromHash(s)
@@ -193,6 +199,9 @@ func (sac *SLSAAttestationCreate) check() error {
 	if _, ok := sac.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "SLSAAttestation.collector"`)}
 	}
+	if _, ok := sac.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "SLSAAttestation.document_ref"`)}
+	}
 	if _, ok := sac.mutation.BuiltFromHash(); !ok {
 		return &ValidationError{Name: "built_from_hash", err: errors.New(`ent: missing required field "SLSAAttestation.built_from_hash"`)}
 	}
@@ -265,6 +274,10 @@ func (sac *SLSAAttestationCreate) createSpec() (*SLSAAttestation, *sqlgraph.Crea
 	if value, ok := sac.mutation.Collector(); ok {
 		_spec.SetField(slsaattestation.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := sac.mutation.DocumentRef(); ok {
+		_spec.SetField(slsaattestation.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := sac.mutation.BuiltFromHash(); ok {
 		_spec.SetField(slsaattestation.FieldBuiltFromHash, field.TypeString, value)
@@ -486,6 +499,18 @@ func (u *SLSAAttestationUpsert) UpdateCollector() *SLSAAttestationUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *SLSAAttestationUpsert) SetDocumentRef(v string) *SLSAAttestationUpsert {
+	u.Set(slsaattestation.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *SLSAAttestationUpsert) UpdateDocumentRef() *SLSAAttestationUpsert {
+	u.SetExcluded(slsaattestation.FieldDocumentRef)
+	return u
+}
+
 // SetBuiltFromHash sets the "built_from_hash" field.
 func (u *SLSAAttestationUpsert) SetBuiltFromHash(v string) *SLSAAttestationUpsert {
 	u.Set(slsaattestation.FieldBuiltFromHash, v)
@@ -676,6 +701,20 @@ func (u *SLSAAttestationUpsertOne) SetCollector(v string) *SLSAAttestationUpsert
 func (u *SLSAAttestationUpsertOne) UpdateCollector() *SLSAAttestationUpsertOne {
 	return u.Update(func(s *SLSAAttestationUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *SLSAAttestationUpsertOne) SetDocumentRef(v string) *SLSAAttestationUpsertOne {
+	return u.Update(func(s *SLSAAttestationUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *SLSAAttestationUpsertOne) UpdateDocumentRef() *SLSAAttestationUpsertOne {
+	return u.Update(func(s *SLSAAttestationUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -1038,6 +1077,20 @@ func (u *SLSAAttestationUpsertBulk) SetCollector(v string) *SLSAAttestationUpser
 func (u *SLSAAttestationUpsertBulk) UpdateCollector() *SLSAAttestationUpsertBulk {
 	return u.Update(func(s *SLSAAttestationUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *SLSAAttestationUpsertBulk) SetDocumentRef(v string) *SLSAAttestationUpsertBulk {
+	return u.Update(func(s *SLSAAttestationUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *SLSAAttestationUpsertBulk) UpdateDocumentRef() *SLSAAttestationUpsertBulk {
+	return u.Update(func(s *SLSAAttestationUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/slsaattestation_update.go
+++ b/pkg/assembler/backends/ent/slsaattestation_update.go
@@ -163,6 +163,20 @@ func (sau *SLSAAttestationUpdate) SetNillableCollector(s *string) *SLSAAttestati
 	return sau
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (sau *SLSAAttestationUpdate) SetDocumentRef(s string) *SLSAAttestationUpdate {
+	sau.mutation.SetDocumentRef(s)
+	return sau
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (sau *SLSAAttestationUpdate) SetNillableDocumentRef(s *string) *SLSAAttestationUpdate {
+	if s != nil {
+		sau.SetDocumentRef(*s)
+	}
+	return sau
+}
+
 // SetBuiltFromHash sets the "built_from_hash" field.
 func (sau *SLSAAttestationUpdate) SetBuiltFromHash(s string) *SLSAAttestationUpdate {
 	sau.mutation.SetBuiltFromHash(s)
@@ -318,6 +332,9 @@ func (sau *SLSAAttestationUpdate) sqlSave(ctx context.Context) (n int, err error
 	}
 	if value, ok := sau.mutation.Collector(); ok {
 		_spec.SetField(slsaattestation.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := sau.mutation.DocumentRef(); ok {
+		_spec.SetField(slsaattestation.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := sau.mutation.BuiltFromHash(); ok {
 		_spec.SetField(slsaattestation.FieldBuiltFromHash, field.TypeString, value)
@@ -575,6 +592,20 @@ func (sauo *SLSAAttestationUpdateOne) SetNillableCollector(s *string) *SLSAAttes
 	return sauo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (sauo *SLSAAttestationUpdateOne) SetDocumentRef(s string) *SLSAAttestationUpdateOne {
+	sauo.mutation.SetDocumentRef(s)
+	return sauo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (sauo *SLSAAttestationUpdateOne) SetNillableDocumentRef(s *string) *SLSAAttestationUpdateOne {
+	if s != nil {
+		sauo.SetDocumentRef(*s)
+	}
+	return sauo
+}
+
 // SetBuiltFromHash sets the "built_from_hash" field.
 func (sauo *SLSAAttestationUpdateOne) SetBuiltFromHash(s string) *SLSAAttestationUpdateOne {
 	sauo.mutation.SetBuiltFromHash(s)
@@ -760,6 +791,9 @@ func (sauo *SLSAAttestationUpdateOne) sqlSave(ctx context.Context) (_node *SLSAA
 	}
 	if value, ok := sauo.mutation.Collector(); ok {
 		_spec.SetField(slsaattestation.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := sauo.mutation.DocumentRef(); ok {
+		_spec.SetField(slsaattestation.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := sauo.mutation.BuiltFromHash(); ok {
 		_spec.SetField(slsaattestation.FieldBuiltFromHash, field.TypeString, value)

--- a/pkg/assembler/backends/ent/vulnequal.go
+++ b/pkg/assembler/backends/ent/vulnequal.go
@@ -28,6 +28,8 @@ type VulnEqual struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// An opaque hash of the vulnerability IDs that are equal
 	VulnerabilitiesHash string `json:"vulnerabilities_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -80,7 +82,7 @@ func (*VulnEqual) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case vulnequal.FieldJustification, vulnequal.FieldOrigin, vulnequal.FieldCollector, vulnequal.FieldVulnerabilitiesHash:
+		case vulnequal.FieldJustification, vulnequal.FieldOrigin, vulnequal.FieldCollector, vulnequal.FieldDocumentRef, vulnequal.FieldVulnerabilitiesHash:
 			values[i] = new(sql.NullString)
 		case vulnequal.FieldID, vulnequal.FieldVulnID, vulnequal.FieldEqualVulnID:
 			values[i] = new(uuid.UUID)
@@ -134,6 +136,12 @@ func (ve *VulnEqual) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field collector", values[i])
 			} else if value.Valid {
 				ve.Collector = value.String
+			}
+		case vulnequal.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				ve.DocumentRef = value.String
 			}
 		case vulnequal.FieldVulnerabilitiesHash:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -201,6 +209,9 @@ func (ve *VulnEqual) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(ve.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(ve.DocumentRef)
 	builder.WriteString(", ")
 	builder.WriteString("vulnerabilities_hash=")
 	builder.WriteString(ve.VulnerabilitiesHash)

--- a/pkg/assembler/backends/ent/vulnequal/vulnequal.go
+++ b/pkg/assembler/backends/ent/vulnequal/vulnequal.go
@@ -23,6 +23,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// FieldVulnerabilitiesHash holds the string denoting the vulnerabilities_hash field in the database.
 	FieldVulnerabilitiesHash = "vulnerabilities_hash"
 	// EdgeVulnerabilityA holds the string denoting the vulnerability_a edge name in mutations.
@@ -55,6 +57,7 @@ var Columns = []string{
 	FieldJustification,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 	FieldVulnerabilitiesHash,
 }
 
@@ -104,6 +107,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByVulnerabilitiesHash orders the results by the vulnerabilities_hash field.

--- a/pkg/assembler/backends/ent/vulnequal/where.go
+++ b/pkg/assembler/backends/ent/vulnequal/where.go
@@ -79,6 +79,11 @@ func Collector(v string) predicate.VulnEqual {
 	return predicate.VulnEqual(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // VulnerabilitiesHash applies equality check predicate on the "vulnerabilities_hash" field. It's identical to VulnerabilitiesHashEQ.
 func VulnerabilitiesHash(v string) predicate.VulnEqual {
 	return predicate.VulnEqual(sql.FieldEQ(FieldVulnerabilitiesHash, v))
@@ -317,6 +322,71 @@ func CollectorEqualFold(v string) predicate.VulnEqual {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.VulnEqual {
 	return predicate.VulnEqual(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.VulnEqual {
+	return predicate.VulnEqual(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // VulnerabilitiesHashEQ applies the EQ predicate on the "vulnerabilities_hash" field.

--- a/pkg/assembler/backends/ent/vulnequal_create.go
+++ b/pkg/assembler/backends/ent/vulnequal_create.go
@@ -54,6 +54,12 @@ func (vec *VulnEqualCreate) SetCollector(s string) *VulnEqualCreate {
 	return vec
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (vec *VulnEqualCreate) SetDocumentRef(s string) *VulnEqualCreate {
+	vec.mutation.SetDocumentRef(s)
+	return vec
+}
+
 // SetVulnerabilitiesHash sets the "vulnerabilities_hash" field.
 func (vec *VulnEqualCreate) SetVulnerabilitiesHash(s string) *VulnEqualCreate {
 	vec.mutation.SetVulnerabilitiesHash(s)
@@ -154,6 +160,9 @@ func (vec *VulnEqualCreate) check() error {
 	if _, ok := vec.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "VulnEqual.collector"`)}
 	}
+	if _, ok := vec.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "VulnEqual.document_ref"`)}
+	}
 	if _, ok := vec.mutation.VulnerabilitiesHash(); !ok {
 		return &ValidationError{Name: "vulnerabilities_hash", err: errors.New(`ent: missing required field "VulnEqual.vulnerabilities_hash"`)}
 	}
@@ -210,6 +219,10 @@ func (vec *VulnEqualCreate) createSpec() (*VulnEqual, *sqlgraph.CreateSpec) {
 	if value, ok := vec.mutation.Collector(); ok {
 		_spec.SetField(vulnequal.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := vec.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnequal.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if value, ok := vec.mutation.VulnerabilitiesHash(); ok {
 		_spec.SetField(vulnequal.FieldVulnerabilitiesHash, field.TypeString, value)
@@ -361,6 +374,18 @@ func (u *VulnEqualUpsert) UpdateCollector() *VulnEqualUpsert {
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnEqualUpsert) SetDocumentRef(v string) *VulnEqualUpsert {
+	u.Set(vulnequal.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnEqualUpsert) UpdateDocumentRef() *VulnEqualUpsert {
+	u.SetExcluded(vulnequal.FieldDocumentRef)
+	return u
+}
+
 // SetVulnerabilitiesHash sets the "vulnerabilities_hash" field.
 func (u *VulnEqualUpsert) SetVulnerabilitiesHash(v string) *VulnEqualUpsert {
 	u.Set(vulnequal.FieldVulnerabilitiesHash, v)
@@ -488,6 +513,20 @@ func (u *VulnEqualUpsertOne) SetCollector(v string) *VulnEqualUpsertOne {
 func (u *VulnEqualUpsertOne) UpdateCollector() *VulnEqualUpsertOne {
 	return u.Update(func(s *VulnEqualUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnEqualUpsertOne) SetDocumentRef(v string) *VulnEqualUpsertOne {
+	return u.Update(func(s *VulnEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnEqualUpsertOne) UpdateDocumentRef() *VulnEqualUpsertOne {
+	return u.Update(func(s *VulnEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -787,6 +826,20 @@ func (u *VulnEqualUpsertBulk) SetCollector(v string) *VulnEqualUpsertBulk {
 func (u *VulnEqualUpsertBulk) UpdateCollector() *VulnEqualUpsertBulk {
 	return u.Update(func(s *VulnEqualUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnEqualUpsertBulk) SetDocumentRef(v string) *VulnEqualUpsertBulk {
+	return u.Update(func(s *VulnEqualUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnEqualUpsertBulk) UpdateDocumentRef() *VulnEqualUpsertBulk {
+	return u.Update(func(s *VulnEqualUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/vulnequal_update.go
+++ b/pkg/assembler/backends/ent/vulnequal_update.go
@@ -99,6 +99,20 @@ func (veu *VulnEqualUpdate) SetNillableCollector(s *string) *VulnEqualUpdate {
 	return veu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (veu *VulnEqualUpdate) SetDocumentRef(s string) *VulnEqualUpdate {
+	veu.mutation.SetDocumentRef(s)
+	return veu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (veu *VulnEqualUpdate) SetNillableDocumentRef(s *string) *VulnEqualUpdate {
+	if s != nil {
+		veu.SetDocumentRef(*s)
+	}
+	return veu
+}
+
 // SetVulnerabilitiesHash sets the "vulnerabilities_hash" field.
 func (veu *VulnEqualUpdate) SetVulnerabilitiesHash(s string) *VulnEqualUpdate {
 	veu.mutation.SetVulnerabilitiesHash(s)
@@ -210,6 +224,9 @@ func (veu *VulnEqualUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := veu.mutation.Collector(); ok {
 		_spec.SetField(vulnequal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := veu.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := veu.mutation.VulnerabilitiesHash(); ok {
 		_spec.SetField(vulnequal.FieldVulnerabilitiesHash, field.TypeString, value)
@@ -362,6 +379,20 @@ func (veuo *VulnEqualUpdateOne) SetNillableCollector(s *string) *VulnEqualUpdate
 	return veuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (veuo *VulnEqualUpdateOne) SetDocumentRef(s string) *VulnEqualUpdateOne {
+	veuo.mutation.SetDocumentRef(s)
+	return veuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (veuo *VulnEqualUpdateOne) SetNillableDocumentRef(s *string) *VulnEqualUpdateOne {
+	if s != nil {
+		veuo.SetDocumentRef(*s)
+	}
+	return veuo
+}
+
 // SetVulnerabilitiesHash sets the "vulnerabilities_hash" field.
 func (veuo *VulnEqualUpdateOne) SetVulnerabilitiesHash(s string) *VulnEqualUpdateOne {
 	veuo.mutation.SetVulnerabilitiesHash(s)
@@ -503,6 +534,9 @@ func (veuo *VulnEqualUpdateOne) sqlSave(ctx context.Context) (_node *VulnEqual, 
 	}
 	if value, ok := veuo.mutation.Collector(); ok {
 		_spec.SetField(vulnequal.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := veuo.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnequal.FieldDocumentRef, field.TypeString, value)
 	}
 	if value, ok := veuo.mutation.VulnerabilitiesHash(); ok {
 		_spec.SetField(vulnequal.FieldVulnerabilitiesHash, field.TypeString, value)

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata.go
@@ -31,6 +31,8 @@ type VulnerabilityMetadata struct {
 	Origin string `json:"origin,omitempty"`
 	// Collector holds the value of the "collector" field.
 	Collector string `json:"collector,omitempty"`
+	// DocumentRef holds the value of the "document_ref" field.
+	DocumentRef string `json:"document_ref,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the VulnerabilityMetadataQuery when eager-loading is set.
 	Edges        VulnerabilityMetadataEdges `json:"edges"`
@@ -68,7 +70,7 @@ func (*VulnerabilityMetadata) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case vulnerabilitymetadata.FieldScoreValue:
 			values[i] = new(sql.NullFloat64)
-		case vulnerabilitymetadata.FieldScoreType, vulnerabilitymetadata.FieldOrigin, vulnerabilitymetadata.FieldCollector:
+		case vulnerabilitymetadata.FieldScoreType, vulnerabilitymetadata.FieldOrigin, vulnerabilitymetadata.FieldCollector, vulnerabilitymetadata.FieldDocumentRef:
 			values[i] = new(sql.NullString)
 		case vulnerabilitymetadata.FieldTimestamp:
 			values[i] = new(sql.NullTime)
@@ -131,6 +133,12 @@ func (vm *VulnerabilityMetadata) assignValues(columns []string, values []any) er
 			} else if value.Valid {
 				vm.Collector = value.String
 			}
+		case vulnerabilitymetadata.FieldDocumentRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field document_ref", values[i])
+			} else if value.Valid {
+				vm.DocumentRef = value.String
+			}
 		default:
 			vm.selectValues.Set(columns[i], values[i])
 		}
@@ -189,6 +197,9 @@ func (vm *VulnerabilityMetadata) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("collector=")
 	builder.WriteString(vm.Collector)
+	builder.WriteString(", ")
+	builder.WriteString("document_ref=")
+	builder.WriteString(vm.DocumentRef)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata/vulnerabilitymetadata.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata/vulnerabilitymetadata.go
@@ -29,6 +29,8 @@ const (
 	FieldOrigin = "origin"
 	// FieldCollector holds the string denoting the collector field in the database.
 	FieldCollector = "collector"
+	// FieldDocumentRef holds the string denoting the document_ref field in the database.
+	FieldDocumentRef = "document_ref"
 	// EdgeVulnerabilityID holds the string denoting the vulnerability_id edge name in mutations.
 	EdgeVulnerabilityID = "vulnerability_id"
 	// Table holds the table name of the vulnerabilitymetadata in the database.
@@ -51,6 +53,7 @@ var Columns = []string{
 	FieldTimestamp,
 	FieldOrigin,
 	FieldCollector,
+	FieldDocumentRef,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -133,6 +136,11 @@ func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
 // ByCollector orders the results by the collector field.
 func ByCollector(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCollector, opts...).ToFunc()
+}
+
+// ByDocumentRef orders the results by the document_ref field.
+func ByDocumentRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDocumentRef, opts...).ToFunc()
 }
 
 // ByVulnerabilityIDField orders the results by vulnerability_id field.

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata/where.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata/where.go
@@ -81,6 +81,11 @@ func Collector(v string) predicate.VulnerabilityMetadata {
 	return predicate.VulnerabilityMetadata(sql.FieldEQ(FieldCollector, v))
 }
 
+// DocumentRef applies equality check predicate on the "document_ref" field. It's identical to DocumentRefEQ.
+func DocumentRef(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldEQ(FieldDocumentRef, v))
+}
+
 // VulnerabilityIDIDEQ applies the EQ predicate on the "vulnerability_id_id" field.
 func VulnerabilityIDIDEQ(v uuid.UUID) predicate.VulnerabilityMetadata {
 	return predicate.VulnerabilityMetadata(sql.FieldEQ(FieldVulnerabilityIDID, v))
@@ -329,6 +334,71 @@ func CollectorEqualFold(v string) predicate.VulnerabilityMetadata {
 // CollectorContainsFold applies the ContainsFold predicate on the "collector" field.
 func CollectorContainsFold(v string) predicate.VulnerabilityMetadata {
 	return predicate.VulnerabilityMetadata(sql.FieldContainsFold(FieldCollector, v))
+}
+
+// DocumentRefEQ applies the EQ predicate on the "document_ref" field.
+func DocumentRefEQ(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefNEQ applies the NEQ predicate on the "document_ref" field.
+func DocumentRefNEQ(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldNEQ(FieldDocumentRef, v))
+}
+
+// DocumentRefIn applies the In predicate on the "document_ref" field.
+func DocumentRefIn(vs ...string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefNotIn applies the NotIn predicate on the "document_ref" field.
+func DocumentRefNotIn(vs ...string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldNotIn(FieldDocumentRef, vs...))
+}
+
+// DocumentRefGT applies the GT predicate on the "document_ref" field.
+func DocumentRefGT(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldGT(FieldDocumentRef, v))
+}
+
+// DocumentRefGTE applies the GTE predicate on the "document_ref" field.
+func DocumentRefGTE(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldGTE(FieldDocumentRef, v))
+}
+
+// DocumentRefLT applies the LT predicate on the "document_ref" field.
+func DocumentRefLT(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldLT(FieldDocumentRef, v))
+}
+
+// DocumentRefLTE applies the LTE predicate on the "document_ref" field.
+func DocumentRefLTE(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldLTE(FieldDocumentRef, v))
+}
+
+// DocumentRefContains applies the Contains predicate on the "document_ref" field.
+func DocumentRefContains(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldContains(FieldDocumentRef, v))
+}
+
+// DocumentRefHasPrefix applies the HasPrefix predicate on the "document_ref" field.
+func DocumentRefHasPrefix(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldHasPrefix(FieldDocumentRef, v))
+}
+
+// DocumentRefHasSuffix applies the HasSuffix predicate on the "document_ref" field.
+func DocumentRefHasSuffix(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldHasSuffix(FieldDocumentRef, v))
+}
+
+// DocumentRefEqualFold applies the EqualFold predicate on the "document_ref" field.
+func DocumentRefEqualFold(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldEqualFold(FieldDocumentRef, v))
+}
+
+// DocumentRefContainsFold applies the ContainsFold predicate on the "document_ref" field.
+func DocumentRefContainsFold(v string) predicate.VulnerabilityMetadata {
+	return predicate.VulnerabilityMetadata(sql.FieldContainsFold(FieldDocumentRef, v))
 }
 
 // HasVulnerabilityID applies the HasEdge predicate on the "vulnerability_id" edge.

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata_create.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata_create.go
@@ -61,6 +61,12 @@ func (vmc *VulnerabilityMetadataCreate) SetCollector(s string) *VulnerabilityMet
 	return vmc
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (vmc *VulnerabilityMetadataCreate) SetDocumentRef(s string) *VulnerabilityMetadataCreate {
+	vmc.mutation.SetDocumentRef(s)
+	return vmc
+}
+
 // SetID sets the "id" field.
 func (vmc *VulnerabilityMetadataCreate) SetID(u uuid.UUID) *VulnerabilityMetadataCreate {
 	vmc.mutation.SetID(u)
@@ -146,6 +152,9 @@ func (vmc *VulnerabilityMetadataCreate) check() error {
 	if _, ok := vmc.mutation.Collector(); !ok {
 		return &ValidationError{Name: "collector", err: errors.New(`ent: missing required field "VulnerabilityMetadata.collector"`)}
 	}
+	if _, ok := vmc.mutation.DocumentRef(); !ok {
+		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "VulnerabilityMetadata.document_ref"`)}
+	}
 	if _, ok := vmc.mutation.VulnerabilityIDID(); !ok {
 		return &ValidationError{Name: "vulnerability_id", err: errors.New(`ent: missing required edge "VulnerabilityMetadata.vulnerability_id"`)}
 	}
@@ -204,6 +213,10 @@ func (vmc *VulnerabilityMetadataCreate) createSpec() (*VulnerabilityMetadata, *s
 	if value, ok := vmc.mutation.Collector(); ok {
 		_spec.SetField(vulnerabilitymetadata.FieldCollector, field.TypeString, value)
 		_node.Collector = value
+	}
+	if value, ok := vmc.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnerabilitymetadata.FieldDocumentRef, field.TypeString, value)
+		_node.DocumentRef = value
 	}
 	if nodes := vmc.mutation.VulnerabilityIDIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -352,6 +365,18 @@ func (u *VulnerabilityMetadataUpsert) UpdateCollector() *VulnerabilityMetadataUp
 	return u
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnerabilityMetadataUpsert) SetDocumentRef(v string) *VulnerabilityMetadataUpsert {
+	u.Set(vulnerabilitymetadata.FieldDocumentRef, v)
+	return u
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnerabilityMetadataUpsert) UpdateDocumentRef() *VulnerabilityMetadataUpsert {
+	u.SetExcluded(vulnerabilitymetadata.FieldDocumentRef)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -488,6 +513,20 @@ func (u *VulnerabilityMetadataUpsertOne) SetCollector(v string) *VulnerabilityMe
 func (u *VulnerabilityMetadataUpsertOne) UpdateCollector() *VulnerabilityMetadataUpsertOne {
 	return u.Update(func(s *VulnerabilityMetadataUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnerabilityMetadataUpsertOne) SetDocumentRef(v string) *VulnerabilityMetadataUpsertOne {
+	return u.Update(func(s *VulnerabilityMetadataUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnerabilityMetadataUpsertOne) UpdateDocumentRef() *VulnerabilityMetadataUpsertOne {
+	return u.Update(func(s *VulnerabilityMetadataUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 
@@ -794,6 +833,20 @@ func (u *VulnerabilityMetadataUpsertBulk) SetCollector(v string) *VulnerabilityM
 func (u *VulnerabilityMetadataUpsertBulk) UpdateCollector() *VulnerabilityMetadataUpsertBulk {
 	return u.Update(func(s *VulnerabilityMetadataUpsert) {
 		s.UpdateCollector()
+	})
+}
+
+// SetDocumentRef sets the "document_ref" field.
+func (u *VulnerabilityMetadataUpsertBulk) SetDocumentRef(v string) *VulnerabilityMetadataUpsertBulk {
+	return u.Update(func(s *VulnerabilityMetadataUpsert) {
+		s.SetDocumentRef(v)
+	})
+}
+
+// UpdateDocumentRef sets the "document_ref" field to the value that was provided on create.
+func (u *VulnerabilityMetadataUpsertBulk) UpdateDocumentRef() *VulnerabilityMetadataUpsertBulk {
+	return u.Update(func(s *VulnerabilityMetadataUpsert) {
+		s.UpdateDocumentRef()
 	})
 }
 

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata_update.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata_update.go
@@ -121,6 +121,20 @@ func (vmu *VulnerabilityMetadataUpdate) SetNillableCollector(s *string) *Vulnera
 	return vmu
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (vmu *VulnerabilityMetadataUpdate) SetDocumentRef(s string) *VulnerabilityMetadataUpdate {
+	vmu.mutation.SetDocumentRef(s)
+	return vmu
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (vmu *VulnerabilityMetadataUpdate) SetNillableDocumentRef(s *string) *VulnerabilityMetadataUpdate {
+	if s != nil {
+		vmu.SetDocumentRef(*s)
+	}
+	return vmu
+}
+
 // SetVulnerabilityID sets the "vulnerability_id" edge to the VulnerabilityID entity.
 func (vmu *VulnerabilityMetadataUpdate) SetVulnerabilityID(v *VulnerabilityID) *VulnerabilityMetadataUpdate {
 	return vmu.SetVulnerabilityIDID(v.ID)
@@ -206,6 +220,9 @@ func (vmu *VulnerabilityMetadataUpdate) sqlSave(ctx context.Context) (n int, err
 	}
 	if value, ok := vmu.mutation.Collector(); ok {
 		_spec.SetField(vulnerabilitymetadata.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := vmu.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnerabilitymetadata.FieldDocumentRef, field.TypeString, value)
 	}
 	if vmu.mutation.VulnerabilityIDCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -347,6 +364,20 @@ func (vmuo *VulnerabilityMetadataUpdateOne) SetNillableCollector(s *string) *Vul
 	return vmuo
 }
 
+// SetDocumentRef sets the "document_ref" field.
+func (vmuo *VulnerabilityMetadataUpdateOne) SetDocumentRef(s string) *VulnerabilityMetadataUpdateOne {
+	vmuo.mutation.SetDocumentRef(s)
+	return vmuo
+}
+
+// SetNillableDocumentRef sets the "document_ref" field if the given value is not nil.
+func (vmuo *VulnerabilityMetadataUpdateOne) SetNillableDocumentRef(s *string) *VulnerabilityMetadataUpdateOne {
+	if s != nil {
+		vmuo.SetDocumentRef(*s)
+	}
+	return vmuo
+}
+
 // SetVulnerabilityID sets the "vulnerability_id" edge to the VulnerabilityID entity.
 func (vmuo *VulnerabilityMetadataUpdateOne) SetVulnerabilityID(v *VulnerabilityID) *VulnerabilityMetadataUpdateOne {
 	return vmuo.SetVulnerabilityIDID(v.ID)
@@ -462,6 +493,9 @@ func (vmuo *VulnerabilityMetadataUpdateOne) sqlSave(ctx context.Context) (_node 
 	}
 	if value, ok := vmuo.mutation.Collector(); ok {
 		_spec.SetField(vulnerabilitymetadata.FieldCollector, field.TypeString, value)
+	}
+	if value, ok := vmuo.mutation.DocumentRef(); ok {
+		_spec.SetField(vulnerabilitymetadata.FieldDocumentRef, field.TypeString, value)
 	}
 	if vmuo.mutation.VulnerabilityIDCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/assembler/backends/keyvalue/certifyBad.go
+++ b/pkg/assembler/backends/keyvalue/certifyBad.go
@@ -38,6 +38,7 @@ type badLink struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 	KnownSince    time.Time
 }
 
@@ -114,6 +115,7 @@ func (c *demoClient) ingestCertifyBad(ctx context.Context, subject model.Package
 		Justification: certifyBad.Justification,
 		Origin:        certifyBad.Origin,
 		Collector:     certifyBad.Collector,
+		DocumentRef:   certifyBad.DocumentRef,
 		KnownSince:    certifyBad.KnownSince.UTC(),
 	}
 

--- a/pkg/assembler/backends/keyvalue/certifyBad.go
+++ b/pkg/assembler/backends/keyvalue/certifyBad.go
@@ -52,6 +52,7 @@ func (n *badLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 		timeKey(n.KnownSince),
 	}, ":"))
 }
@@ -277,6 +278,7 @@ func (c *demoClient) addCBIfMatch(ctx context.Context, out []*model.CertifyBad,
 		if noMatch(filter.Justification, link.Justification) ||
 			noMatch(filter.Collector, link.Collector) ||
 			noMatch(filter.Origin, link.Origin) ||
+			noMatch(filter.DocumentRef, link.DocumentRef) ||
 			filter.KnownSince != nil && filter.KnownSince.After(link.KnownSince) {
 			return out, nil
 		}
@@ -369,6 +371,7 @@ func (c *demoClient) buildCertifyBad(ctx context.Context, link *badLink, filter 
 		Justification: link.Justification,
 		Origin:        link.Origin,
 		Collector:     link.Collector,
+		DocumentRef:   link.DocumentRef,
 		KnownSince:    link.KnownSince.UTC(),
 	}
 	return &certifyBad, nil

--- a/pkg/assembler/backends/keyvalue/certifyGood.go
+++ b/pkg/assembler/backends/keyvalue/certifyGood.go
@@ -36,6 +36,7 @@ type goodLink struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 	KnownSince    time.Time
 }
 
@@ -49,6 +50,7 @@ func (n *goodLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 		timeKey(n.KnownSince),
 	}, ":"))
 }
@@ -113,6 +115,7 @@ func (c *demoClient) ingestCertifyGood(ctx context.Context, subject model.Packag
 		Justification: certifyGood.Justification,
 		Origin:        certifyGood.Origin,
 		Collector:     certifyGood.Collector,
+		DocumentRef:   certifyGood.DocumentRef,
 		KnownSince:    certifyGood.KnownSince.UTC(),
 	}
 
@@ -274,6 +277,7 @@ func (c *demoClient) addCGIfMatch(ctx context.Context, out []*model.CertifyGood,
 		if noMatch(filter.Justification, link.Justification) ||
 			noMatch(filter.Collector, link.Collector) ||
 			noMatch(filter.Origin, link.Origin) ||
+			noMatch(filter.DocumentRef, link.DocumentRef) ||
 			filter.KnownSince != nil && filter.KnownSince.After(link.KnownSince) {
 			return out, nil
 		}
@@ -366,6 +370,7 @@ func (c *demoClient) buildCertifyGood(ctx context.Context, link *goodLink, filte
 		Justification: link.Justification,
 		Origin:        link.Origin,
 		Collector:     link.Collector,
+		DocumentRef:   link.DocumentRef,
 		KnownSince:    link.KnownSince.UTC(),
 	}
 	return &certifyGood, nil

--- a/pkg/assembler/backends/keyvalue/certifyLegal.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal.go
@@ -43,6 +43,7 @@ type certifyLegalStruct struct {
 	TimeScanned        time.Time
 	Origin             string
 	Collector          string
+	DocumentRef        string
 }
 
 func (n *certifyLegalStruct) ID() string { return n.ThisID }
@@ -59,6 +60,7 @@ func (n *certifyLegalStruct) Key() string {
 		timeKey(n.TimeScanned),
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -120,6 +122,7 @@ func (c *demoClient) ingestCertifyLegal(ctx context.Context, subject model.Packa
 		Justification:     certifyLegal.Justification,
 		Origin:            certifyLegal.Origin,
 		Collector:         certifyLegal.Collector,
+		DocumentRef:       certifyLegal.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -230,6 +233,7 @@ func (c *demoClient) convLegal(ctx context.Context, in *certifyLegalStruct) (*mo
 		TimeScanned:       in.TimeScanned,
 		Origin:            in.Origin,
 		Collector:         in.Collector,
+		DocumentRef:       in.DocumentRef,
 	}
 	for _, lid := range in.DeclaredLicenses {
 		l, err := byIDkv[*licStruct](ctx, lid, c)
@@ -377,6 +381,7 @@ func (c *demoClient) addLegalIfMatch(ctx context.Context, out []*model.CertifyLe
 		noMatch(filter.Justification, link.Justification) ||
 		noMatch(filter.Origin, link.Origin) ||
 		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) ||
 		(filter.TimeScanned != nil && !link.TimeScanned.Equal(*filter.TimeScanned)) ||
 		!c.matchLicenses(ctx, filter.DeclaredLicenses, link.DeclaredLicenses) ||
 		!c.matchLicenses(ctx, filter.DiscoveredLicenses, link.DiscoveredLicenses) {

--- a/pkg/assembler/backends/keyvalue/certifyScorecard.go
+++ b/pkg/assembler/backends/keyvalue/certifyScorecard.go
@@ -40,6 +40,7 @@ type scorecardLink struct {
 	ScorecardCommit  string
 	Origin           string
 	Collector        string
+	DocumentRef      string
 }
 
 func (n *scorecardLink) ID() string { return n.ThisID }
@@ -53,6 +54,7 @@ func (n *scorecardLink) Key() string {
 		n.ScorecardCommit,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -98,6 +100,7 @@ func (c *demoClient) certifyScorecard(ctx context.Context, source model.IDorSour
 		ScorecardCommit:  scorecard.ScorecardCommit,
 		Origin:           scorecard.Origin,
 		Collector:        scorecard.Collector,
+		DocumentRef:      scorecard.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -232,6 +235,9 @@ func (c *demoClient) addSCIfMatch(ctx context.Context, out []*model.CertifyScore
 	if filter != nil && noMatch(filter.Collector, link.Collector) {
 		return out, nil
 	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
+		return out, nil
+	}
 
 	foundCertifyScorecard, err := c.buildScorecard(ctx, link, filter, false)
 	if err != nil {
@@ -276,6 +282,7 @@ func (c *demoClient) buildScorecard(ctx context.Context, link *scorecardLink, fi
 			ScorecardCommit:  link.ScorecardCommit,
 			Origin:           link.Origin,
 			Collector:        link.Collector,
+			DocumentRef:      link.DocumentRef,
 		},
 	}
 	return &newScorecard, nil

--- a/pkg/assembler/backends/keyvalue/certifyVEXStatement.go
+++ b/pkg/assembler/backends/keyvalue/certifyVEXStatement.go
@@ -41,6 +41,7 @@ type vexLink struct {
 	Justification   model.VexJustification
 	Origin          string
 	Collector       string
+	DocumentRef     string
 }
 
 func (n *vexLink) ID() string { return n.ThisID }
@@ -57,6 +58,7 @@ func (n *vexLink) Key() string {
 		string(n.Justification),
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -119,6 +121,7 @@ func (c *demoClient) ingestVEXStatement(ctx context.Context, subject model.Packa
 		Justification: vexStatement.VexJustification,
 		Origin:        vexStatement.Origin,
 		Collector:     vexStatement.Collector,
+		DocumentRef:   vexStatement.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -303,6 +306,9 @@ func (c *demoClient) addVexIfMatch(ctx context.Context, out []*model.CertifyVEXS
 	if filter != nil && noMatch(filter.Origin, link.Origin) {
 		return out, nil
 	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
+		return out, nil
+	}
 
 	foundCertifyVex, err := c.buildCertifyVEXStatement(ctx, link, filter, false)
 	if err != nil {
@@ -401,5 +407,6 @@ func (c *demoClient) buildCertifyVEXStatement(ctx context.Context, link *vexLink
 		KnownSince:       link.KnownSince,
 		Origin:           link.Origin,
 		Collector:        link.Collector,
+		DocumentRef:      link.DocumentRef,
 	}, nil
 }

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -41,6 +41,7 @@ type certifyVulnerabilityLink struct {
 	ScannerVersion  string
 	Origin          string
 	Collector       string
+	DocumentRef     string
 }
 
 func (n *certifyVulnerabilityLink) ID() string { return n.ThisID }
@@ -55,6 +56,7 @@ func (n *certifyVulnerabilityLink) Key() string {
 		n.ScannerVersion,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -101,6 +103,7 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.I
 		ScannerVersion: certifyVuln.ScannerVersion,
 		Origin:         certifyVuln.Origin,
 		Collector:      certifyVuln.Collector,
+		DocumentRef:    certifyVuln.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -276,6 +279,9 @@ func (c *demoClient) addCVIfMatch(ctx context.Context, out []*model.CertifyVuln,
 	if filter != nil && noMatch(filter.Origin, link.Origin) {
 		return out, nil
 	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
+		return out, nil
+	}
 
 	foundCertifyVuln, err := c.buildCertifyVulnerability(ctx, link, filter, false)
 	if err != nil {
@@ -353,6 +359,7 @@ func (c *demoClient) buildCertifyVulnerability(ctx context.Context, link *certif
 			ScannerVersion: link.ScannerVersion,
 			Origin:         link.Origin,
 			Collector:      link.Collector,
+			DocumentRef:    link.DocumentRef,
 		},
 	}, nil
 }

--- a/pkg/assembler/backends/keyvalue/hasMetadata.go
+++ b/pkg/assembler/backends/keyvalue/hasMetadata.go
@@ -38,6 +38,7 @@ type hasMetadataLink struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *hasMetadataLink) ID() string { return n.ThisID }
@@ -52,6 +53,7 @@ func (n *hasMetadataLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -119,6 +121,7 @@ func (c *demoClient) ingestHasMetadata(ctx context.Context, subject model.Packag
 		Justification: hasMetadata.Justification,
 		Origin:        hasMetadata.Origin,
 		Collector:     hasMetadata.Collector,
+		DocumentRef:   hasMetadata.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -294,6 +297,9 @@ func (c *demoClient) addHMIfMatch(ctx context.Context, out []*model.HasMetadata,
 	if filter != nil && noMatch(filter.Value, link.Value) {
 		return out, nil
 	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
+		return out, nil
+	}
 	// no match if filter time since is after the timestamp
 	if filter != nil && filter.Since != nil && filter.Since.After(link.Timestamp) {
 		return out, nil
@@ -389,6 +395,7 @@ func (c *demoClient) buildHasMetadata(ctx context.Context, link *hasMetadataLink
 		Justification: link.Justification,
 		Origin:        link.Origin,
 		Collector:     link.Collector,
+		DocumentRef:   link.DocumentRef,
 	}
 	return &hasMetadata, nil
 }

--- a/pkg/assembler/backends/keyvalue/hasSBOM.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM.go
@@ -39,6 +39,7 @@ type hasSBOMStruct struct {
 	DownloadLocation     string
 	Origin               string
 	Collector            string
+	DocumentRef          string
 	KnownSince           time.Time
 	IncludedSoftware     []string
 	IncludedDependencies []string
@@ -56,6 +57,7 @@ func (n *hasSBOMStruct) Key() string {
 		n.DownloadLocation,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 		timeKey(n.KnownSince),
 		fmt.Sprint(n.IncludedSoftware),
 		fmt.Sprint(n.IncludedDependencies),
@@ -179,6 +181,7 @@ func (c *demoClient) ingestHasSbom(ctx context.Context, subject model.PackageOrA
 		DownloadLocation:     input.DownloadLocation,
 		Origin:               input.Origin,
 		Collector:            input.Collector,
+		DocumentRef:          input.DocumentRef,
 		KnownSince:           input.KnownSince.UTC(),
 		IncludedSoftware:     includedSoftware,
 		IncludedDependencies: includedDependencies,
@@ -254,6 +257,7 @@ func (c *demoClient) convHasSBOM(ctx context.Context, in *hasSBOMStruct) (*model
 		DownloadLocation: in.DownloadLocation,
 		Origin:           in.Origin,
 		Collector:        in.Collector,
+		DocumentRef:      in.DocumentRef,
 		KnownSince:       in.KnownSince.UTC(),
 	}
 	if in.Pkg != "" {
@@ -408,6 +412,7 @@ func (c *demoClient) addHasSBOMIfMatch(ctx context.Context, out []*model.HasSbom
 			noMatch(filter.DownloadLocation, link.DownloadLocation) ||
 			noMatch(filter.Origin, link.Origin) ||
 			noMatch(filter.Collector, link.Collector) ||
+			noMatch(filter.DocumentRef, link.DocumentRef) ||
 			(filter.KnownSince != nil && filter.KnownSince.After(link.KnownSince)) {
 			return out, nil
 		}

--- a/pkg/assembler/backends/keyvalue/hasSLSA.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA.go
@@ -31,17 +31,18 @@ import (
 
 type (
 	hasSLSAStruct struct {
-		ThisID     string
-		Subject    string
-		BuiltFrom  []string
-		BuiltBy    string
-		BuildType  string
-		Predicates []*model.SLSAPredicate
-		Version    string
-		Start      *time.Time
-		Finish     *time.Time
-		Origin     string
-		Collector  string
+		ThisID      string
+		Subject     string
+		BuiltFrom   []string
+		BuiltBy     string
+		BuildType   string
+		Predicates  []*model.SLSAPredicate
+		Version     string
+		Start       *time.Time
+		Finish      *time.Time
+		Origin      string
+		Collector   string
+		DocumentRef string
 	}
 )
 
@@ -66,6 +67,7 @@ func (n *hasSLSAStruct) Key() string {
 		fn,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -215,11 +217,12 @@ func (c *demoClient) ingestSLSA(ctx context.Context,
 ) {
 	preds := convSLSAP(slsa.SlsaPredicate)
 	in := &hasSLSAStruct{
-		BuildType:  slsa.BuildType,
-		Predicates: preds,
-		Version:    slsa.SlsaVersion,
-		Origin:     slsa.Origin,
-		Collector:  slsa.Collector,
+		BuildType:   slsa.BuildType,
+		Predicates:  preds,
+		Version:     slsa.SlsaVersion,
+		Origin:      slsa.Origin,
+		Collector:   slsa.Collector,
+		DocumentRef: slsa.DocumentRef,
 	}
 	if slsa.StartedOn != nil {
 		t := slsa.StartedOn.UTC()
@@ -339,6 +342,7 @@ func (c *demoClient) convSLSA(ctx context.Context, in *hasSLSAStruct) (*model.Ha
 			FinishedOn:    in.Finish,
 			Origin:        in.Origin,
 			Collector:     in.Collector,
+			DocumentRef:   in.DocumentRef,
 		},
 	}, nil
 }
@@ -355,6 +359,7 @@ func (c *demoClient) addSLSAIfMatch(ctx context.Context, out []*model.HasSlsa,
 		noMatch(filter.SlsaVersion, link.Version) ||
 		noMatch(filter.Origin, link.Origin) ||
 		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) ||
 		(filter.StartedOn != nil && (link.Start == nil || !filter.StartedOn.Equal(*link.Start))) ||
 		(filter.FinishedOn != nil && (link.Finish == nil || !filter.FinishedOn.Equal(*link.Finish))) ||
 		(filter.BuiltBy != nil && filter.BuiltBy.ID != nil && *filter.BuiltBy.ID != bb.ThisID) ||

--- a/pkg/assembler/backends/keyvalue/hasSourceAt.go
+++ b/pkg/assembler/backends/keyvalue/hasSourceAt.go
@@ -36,6 +36,7 @@ type srcMapLink struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *srcMapLink) ID() string { return n.ThisID }
@@ -47,6 +48,7 @@ func (n *srcMapLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -92,6 +94,7 @@ func (c *demoClient) ingestHasSourceAt(ctx context.Context, packageArg model.IDo
 		Justification: hasSourceAt.Justification,
 		Origin:        hasSourceAt.Origin,
 		Collector:     hasSourceAt.Collector,
+		DocumentRef:   hasSourceAt.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -259,6 +262,7 @@ func (c *demoClient) buildHasSourceAt(ctx context.Context, link *srcMapLink, fil
 		Justification: link.Justification,
 		Origin:        link.Origin,
 		Collector:     link.Collector,
+		DocumentRef:   link.DocumentRef,
 	}
 	return &newHSA, nil
 }
@@ -273,6 +277,9 @@ func (c *demoClient) addSrcIfMatch(ctx context.Context, out []*model.HasSourceAt
 		return out, nil
 	}
 	if filter != nil && noMatch(filter.Collector, link.Collector) {
+		return out, nil
+	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
 		return out, nil
 	}
 	if filter != nil && filter.KnownSince != nil && !filter.KnownSince.Equal(link.KnownSince) {

--- a/pkg/assembler/backends/keyvalue/hashEqual.go
+++ b/pkg/assembler/backends/keyvalue/hashEqual.go
@@ -83,6 +83,7 @@ func (c *demoClient) ingestHashEqual(ctx context.Context, artifact model.IDorArt
 		Justification: hashEqual.Justification,
 		Origin:        hashEqual.Origin,
 		Collector:     hashEqual.Collector,
+		DocumentRef:   hashEqual.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)

--- a/pkg/assembler/backends/keyvalue/hashEqual.go
+++ b/pkg/assembler/backends/keyvalue/hashEqual.go
@@ -35,6 +35,7 @@ type hashEqualStruct struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *hashEqualStruct) ID() string { return n.ThisID }
@@ -44,6 +45,7 @@ func (n *hashEqualStruct) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -266,6 +268,7 @@ func (c *demoClient) convHashEqual(ctx context.Context, h *hashEqualStruct) (*mo
 		Artifacts:     artifacts,
 		Origin:        h.Origin,
 		Collector:     h.Collector,
+		DocumentRef:   h.DocumentRef,
 	}, nil
 }
 
@@ -276,6 +279,7 @@ func (c *demoClient) addHEIfMatch(ctx context.Context, out []*model.HashEqual,
 	if noMatch(filter.Justification, link.Justification) ||
 		noMatch(filter.Origin, link.Origin) ||
 		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) ||
 		!c.matchArtifacts(ctx, filter.Artifacts, link.Artifacts) {
 		return out, nil
 	}

--- a/pkg/assembler/backends/keyvalue/isDependency.go
+++ b/pkg/assembler/backends/keyvalue/isDependency.go
@@ -37,6 +37,7 @@ type isDependencyLink struct {
 	Justification  string
 	Origin         string
 	Collector      string
+	DocumentRef    string
 }
 
 func (n *isDependencyLink) ID() string { return n.ThisID }
@@ -49,6 +50,7 @@ func (n *isDependencyLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -93,6 +95,7 @@ func (c *demoClient) ingestDependency(ctx context.Context, packageArg model.IDor
 		Justification:  dependency.Justification,
 		Origin:         dependency.Origin,
 		Collector:      dependency.Collector,
+		DocumentRef:    dependency.DocumentRef,
 	}
 	helper.FixDependencyType(&inLink.DependencyType)
 
@@ -259,6 +262,7 @@ func (c *demoClient) buildIsDependency(ctx context.Context, link *isDependencyLi
 		Justification:     link.Justification,
 		Origin:            link.Origin,
 		Collector:         link.Collector,
+		DocumentRef:       link.DocumentRef,
 	}
 	return &foundIsDependency, nil
 }
@@ -285,6 +289,7 @@ func noMatchIsDep(filter *model.IsDependencySpec, link *isDependencyLink) bool {
 		return noMatch(filter.Justification, link.Justification) ||
 			noMatch(filter.Origin, link.Origin) ||
 			noMatch(filter.Collector, link.Collector) ||
+			noMatch(filter.DocumentRef, link.DocumentRef) ||
 			noMatch(filter.VersionRange, link.VersionRange) ||
 			(filter.DependencyType != nil && *filter.DependencyType != link.DependencyType)
 	} else {

--- a/pkg/assembler/backends/keyvalue/isOccurrence.go
+++ b/pkg/assembler/backends/keyvalue/isOccurrence.go
@@ -37,6 +37,7 @@ type isOccurrenceStruct struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *isOccurrenceStruct) ID() string { return n.ThisID }
@@ -67,6 +68,7 @@ func (n *isOccurrenceStruct) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -109,6 +111,7 @@ func (c *demoClient) ingestOccurrence(ctx context.Context, subject model.Package
 		Justification: occurrence.Justification,
 		Origin:        occurrence.Origin,
 		Collector:     occurrence.Collector,
+		DocumentRef:   occurrence.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -188,6 +191,7 @@ func (c *demoClient) convOccurrence(ctx context.Context, in *isOccurrenceStruct)
 		Justification: in.Justification,
 		Origin:        in.Origin,
 		Collector:     in.Collector,
+		DocumentRef:   in.DocumentRef,
 	}
 	if in.Pkg != "" {
 		p, err := c.buildPackageResponse(ctx, in.Pkg, nil)
@@ -327,7 +331,8 @@ func (c *demoClient) addOccIfMatch(ctx context.Context, out []*model.IsOccurrenc
 
 	if noMatch(filter.Justification, link.Justification) ||
 		noMatch(filter.Origin, link.Origin) ||
-		noMatch(filter.Collector, link.Collector) {
+		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) {
 		return out, nil
 	}
 	if filter.Artifact != nil && !c.artifactMatch(ctx, link.Artifact, filter.Artifact) {
@@ -394,7 +399,8 @@ func (c *demoClient) matchOccurrences(ctx context.Context, filters []*model.IsOc
 		for _, link := range occLinks {
 			if noMatch(filter.Justification, link.Justification) ||
 				noMatch(filter.Origin, link.Origin) ||
-				noMatch(filter.Collector, link.Collector) {
+				noMatch(filter.Collector, link.Collector) ||
+				noMatch(filter.DocumentRef, link.DocumentRef) {
 				continue
 			}
 			if filter.Artifact != nil && !c.artifactMatch(ctx, link.Artifact, filter.Artifact) {

--- a/pkg/assembler/backends/keyvalue/pkgEqual.go
+++ b/pkg/assembler/backends/keyvalue/pkgEqual.go
@@ -33,6 +33,7 @@ type pkgEqualStruct struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *pkgEqualStruct) ID() string { return n.ThisID }
@@ -42,6 +43,7 @@ func (n *pkgEqualStruct) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -76,6 +78,7 @@ func (c *demoClient) convPkgEqual(ctx context.Context, in *pkgEqualStruct) (*mod
 		Justification: in.Justification,
 		Origin:        in.Origin,
 		Collector:     in.Collector,
+		DocumentRef:   in.DocumentRef,
 	}
 	for _, id := range in.Pkgs {
 		p, err := c.buildPackageResponse(ctx, id, nil)
@@ -98,6 +101,7 @@ func (c *demoClient) ingestPkgEqual(ctx context.Context, pkg model.IDorPkgInput,
 		Justification: pkgEqual.Justification,
 		Origin:        pkgEqual.Origin,
 		Collector:     pkgEqual.Collector,
+		DocumentRef:   pkgEqual.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -221,7 +225,8 @@ func (c *demoClient) addCPIfMatch(ctx context.Context, out []*model.PkgEqual,
 ) {
 	if noMatch(filter.Justification, link.Justification) ||
 		noMatch(filter.Origin, link.Origin) ||
-		noMatch(filter.Collector, link.Collector) {
+		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) {
 		return out, nil
 	}
 	for _, ps := range filter.Packages {

--- a/pkg/assembler/backends/keyvalue/pointOfContact.go
+++ b/pkg/assembler/backends/keyvalue/pointOfContact.go
@@ -39,6 +39,7 @@ type pointOfContactLink struct {
 	Justification string
 	Origin        string
 	Collector     string
+	DocumentRef   string
 }
 
 func (n *pointOfContactLink) ID() string { return n.ThisID }
@@ -53,6 +54,7 @@ func (n *pointOfContactLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -120,6 +122,7 @@ func (c *demoClient) ingestPointOfContact(ctx context.Context, subject model.Pac
 		Justification: pointOfContact.Justification,
 		Origin:        pointOfContact.Origin,
 		Collector:     pointOfContact.Collector,
+		DocumentRef:   pointOfContact.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -292,6 +295,9 @@ func (c *demoClient) addPOCIfMatch(ctx context.Context, out []*model.PointOfCont
 	if filter != nil && noMatch(filter.Info, link.Info) {
 		return out, nil
 	}
+	if filter != nil && noMatch(filter.DocumentRef, link.DocumentRef) {
+		return out, nil
+	}
 	// no match if filter time since is after the timestamp
 	if filter != nil && filter.Since != nil && filter.Since.After(link.Since) {
 		return out, nil
@@ -387,6 +393,7 @@ func (c *demoClient) buildPointOfContact(ctx context.Context, link *pointOfConta
 		Justification: link.Justification,
 		Origin:        link.Origin,
 		Collector:     link.Collector,
+		DocumentRef:   link.DocumentRef,
 	}
 	return &pointOfContact, nil
 }

--- a/pkg/assembler/backends/keyvalue/vulnEqual.go
+++ b/pkg/assembler/backends/keyvalue/vulnEqual.go
@@ -34,6 +34,7 @@ type vulnerabilityEqualLink struct {
 	Justification   string
 	Origin          string
 	Collector       string
+	DocumentRef     string
 }
 
 func (n *vulnerabilityEqualLink) ID() string { return n.ThisID }
@@ -43,6 +44,7 @@ func (n *vulnerabilityEqualLink) Key() string {
 		n.Justification,
 		n.Origin,
 		n.Collector,
+		n.DocumentRef,
 	}, ":"))
 }
 
@@ -82,6 +84,7 @@ func (c *demoClient) ingestVulnEqual(ctx context.Context, vulnerability model.ID
 		Justification: vulnEqual.Justification,
 		Origin:        vulnEqual.Origin,
 		Collector:     vulnEqual.Collector,
+		DocumentRef:   vulnEqual.DocumentRef,
 	}
 
 	lock(&c.m, readOnly)
@@ -137,6 +140,7 @@ func (c *demoClient) convVulnEqual(ctx context.Context, in *vulnerabilityEqualLi
 		Justification: in.Justification,
 		Origin:        in.Origin,
 		Collector:     in.Collector,
+		DocumentRef:   in.DocumentRef,
 	}
 	for _, id := range in.Vulnerabilities {
 		v, err := c.buildVulnResponse(ctx, id, nil)
@@ -226,7 +230,8 @@ func (c *demoClient) addVulnIfMatch(ctx context.Context, out []*model.VulnEqual,
 ) {
 	if noMatch(filter.Justification, link.Justification) ||
 		noMatch(filter.Origin, link.Origin) ||
-		noMatch(filter.Collector, link.Collector) {
+		noMatch(filter.Collector, link.Collector) ||
+		noMatch(filter.DocumentRef, link.DocumentRef) {
 		return out, nil
 	}
 	for _, vs := range filter.Vulnerabilities {

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -6632,7 +6632,7 @@ type CertifyBadInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetJustification returns CertifyBadInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -6648,7 +6648,7 @@ func (v *CertifyBadInputSpec) GetOrigin() string { return v.Origin }
 func (v *CertifyBadInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns CertifyBadInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *CertifyBadInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *CertifyBadInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
 // query.
@@ -6816,7 +6816,7 @@ type CertifyGoodInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetJustification returns CertifyGoodInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -6832,7 +6832,7 @@ func (v *CertifyGoodInputSpec) GetOrigin() string { return v.Origin }
 func (v *CertifyGoodInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns CertifyGoodInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *CertifyGoodInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *CertifyGoodInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // CertifyLegalInputSpec represents the input for certifying legal information in
 // mutations.
@@ -6844,7 +6844,7 @@ type CertifyLegalInputSpec struct {
 	TimeScanned       time.Time `json:"timeScanned"`
 	Origin            string    `json:"origin"`
 	Collector         string    `json:"collector"`
-	DocumentRef       *string   `json:"documentRef"`
+	DocumentRef       string    `json:"documentRef"`
 }
 
 // GetDeclaredLicense returns CertifyLegalInputSpec.DeclaredLicense, and is useful for accessing the field via an interface.
@@ -6869,7 +6869,7 @@ func (v *CertifyLegalInputSpec) GetOrigin() string { return v.Origin }
 func (v *CertifyLegalInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns CertifyLegalInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *CertifyLegalInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *CertifyLegalInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // CertifyLegalSpec allows filtering the list of legal certifications to
 // return in a query.
@@ -7830,7 +7830,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetKey returns HasMetadataInputSpec.Key, and is useful for accessing the field via an interface.
@@ -7852,7 +7852,7 @@ func (v *HasMetadataInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasMetadataInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasMetadataInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *HasMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 type HasSBOMIncludesInputSpec struct {
 	Packages     []string `json:"packages"`
@@ -7882,7 +7882,7 @@ type HasSBOMInputSpec struct {
 	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	DocumentRef      *string   `json:"documentRef"`
+	DocumentRef      string    `json:"documentRef"`
 }
 
 // GetUri returns HasSBOMInputSpec.Uri, and is useful for accessing the field via an interface.
@@ -7907,7 +7907,7 @@ func (v *HasSBOMInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasSBOMInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasSBOMInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasSBOMInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *HasSBOMInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
 //
@@ -8139,7 +8139,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetKnownSince returns HasSourceAtInputSpec.KnownSince, and is useful for accessing the field via an interface.
@@ -8155,14 +8155,14 @@ func (v *HasSourceAtInputSpec) GetOrigin() string { return v.Origin }
 func (v *HasSourceAtInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HasSourceAtInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HasSourceAtInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *HasSourceAtInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns HashEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -8175,7 +8175,7 @@ func (v *HashEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *HashEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns HashEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *HashEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *HashEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // IDorArtifactInput allows for specifying either the artifact ID or the ArtifactInputSpec.
 //
@@ -9117,7 +9117,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
-	DocumentRef    *string        `json:"documentRef"`
+	DocumentRef    string         `json:"documentRef"`
 }
 
 // GetVersionRange returns IsDependencyInputSpec.VersionRange, and is useful for accessing the field via an interface.
@@ -9136,7 +9136,7 @@ func (v *IsDependencyInputSpec) GetOrigin() string { return v.Origin }
 func (v *IsDependencyInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns IsDependencyInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *IsDependencyInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *IsDependencyInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // IsDependencySpec allows filtering the list of dependencies to return.
 //
@@ -9185,10 +9185,10 @@ func (v *IsDependencySpec) GetDocumentRef() *string { return v.DocumentRef }
 
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns IsOccurrenceInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -9201,7 +9201,7 @@ func (v *IsOccurrenceInputSpec) GetOrigin() string { return v.Origin }
 func (v *IsOccurrenceInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns IsOccurrenceInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *IsOccurrenceInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *IsOccurrenceInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
 // a query.
@@ -21851,10 +21851,10 @@ func (v *PathResponse) __premarshalJSON() (*__premarshalPathResponse, error) {
 
 // PkgEqualInputSpec represents the input to certify that packages are similar.
 type PkgEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns PkgEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -21867,7 +21867,7 @@ func (v *PkgEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *PkgEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns PkgEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *PkgEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *PkgEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // PkgInputSpec specifies a package for mutations.
 //
@@ -21967,7 +21967,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // GetEmail returns PointOfContactInputSpec.Email, and is useful for accessing the field via an interface.
@@ -21989,7 +21989,7 @@ func (v *PointOfContactInputSpec) GetOrigin() string { return v.Origin }
 func (v *PointOfContactInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns PointOfContactInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *PointOfContactInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *PointOfContactInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
 type SLSAInputSpec struct {
@@ -22000,7 +22000,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time               `json:"finishedOn"`
 	Origin        string                   `json:"origin"`
 	Collector     string                   `json:"collector"`
-	DocumentRef   *string                  `json:"documentRef"`
+	DocumentRef   string                   `json:"documentRef"`
 }
 
 // GetBuildType returns SLSAInputSpec.BuildType, and is useful for accessing the field via an interface.
@@ -22025,7 +22025,7 @@ func (v *SLSAInputSpec) GetOrigin() string { return v.Origin }
 func (v *SLSAInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns SLSAInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *SLSAInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *SLSAInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec.
 type SLSAPredicateInputSpec struct {
@@ -22049,7 +22049,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
-	DocumentRef    *string   `json:"documentRef"`
+	DocumentRef    string    `json:"documentRef"`
 }
 
 // GetTimeScanned returns ScanMetadataInput.TimeScanned, and is useful for accessing the field via an interface.
@@ -22074,7 +22074,7 @@ func (v *ScanMetadataInput) GetOrigin() string { return v.Origin }
 func (v *ScanMetadataInput) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns ScanMetadataInput.DocumentRef, and is useful for accessing the field via an interface.
-func (v *ScanMetadataInput) GetDocumentRef() *string { return v.DocumentRef }
+func (v *ScanMetadataInput) GetDocumentRef() string { return v.DocumentRef }
 
 // ScorecardCheckInputSpec represents the mutation input for a Scorecard check.
 type ScorecardCheckInputSpec struct {
@@ -22109,7 +22109,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                    `json:"scorecardCommit"`
 	Origin           string                    `json:"origin"`
 	Collector        string                    `json:"collector"`
-	DocumentRef      *string                   `json:"documentRef"`
+	DocumentRef      string                    `json:"documentRef"`
 }
 
 // GetChecks returns ScorecardInputSpec.Checks, and is useful for accessing the field via an interface.
@@ -22134,7 +22134,7 @@ func (v *ScorecardInputSpec) GetOrigin() string { return v.Origin }
 func (v *ScorecardInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns ScorecardInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *ScorecardInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *ScorecardInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // ScorecardsResponse is returned by Scorecards on success.
 type ScorecardsResponse struct {
@@ -22394,7 +22394,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
-	DocumentRef      *string          `json:"documentRef"`
+	DocumentRef      string           `json:"documentRef"`
 }
 
 // GetStatus returns VexStatementInputSpec.Status, and is useful for accessing the field via an interface.
@@ -22419,7 +22419,7 @@ func (v *VexStatementInputSpec) GetOrigin() string { return v.Origin }
 func (v *VexStatementInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VexStatementInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VexStatementInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *VexStatementInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // Records the status of a VEX statement subject.
 type VexStatus string
@@ -22433,10 +22433,10 @@ const (
 
 // VulnEqualInputSpec represents the input to link vulnerabilities to each other.
 type VulnEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // GetJustification returns VulnEqualInputSpec.Justification, and is useful for accessing the field via an interface.
@@ -22449,7 +22449,7 @@ func (v *VulnEqualInputSpec) GetOrigin() string { return v.Origin }
 func (v *VulnEqualInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VulnEqualInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VulnEqualInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *VulnEqualInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // VulnerabilitiesResponse is returned by Vulnerabilities on success.
 type VulnerabilitiesResponse struct {
@@ -22581,7 +22581,7 @@ type VulnerabilityMetadataInputSpec struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Origin      string                 `json:"origin"`
 	Collector   string                 `json:"collector"`
-	DocumentRef *string                `json:"documentRef"`
+	DocumentRef string                 `json:"documentRef"`
 }
 
 // GetScoreType returns VulnerabilityMetadataInputSpec.ScoreType, and is useful for accessing the field via an interface.
@@ -22600,7 +22600,7 @@ func (v *VulnerabilityMetadataInputSpec) GetOrigin() string { return v.Origin }
 func (v *VulnerabilityMetadataInputSpec) GetCollector() string { return v.Collector }
 
 // GetDocumentRef returns VulnerabilityMetadataInputSpec.DocumentRef, and is useful for accessing the field via an interface.
-func (v *VulnerabilityMetadataInputSpec) GetDocumentRef() *string { return v.DocumentRef }
+func (v *VulnerabilityMetadataInputSpec) GetDocumentRef() string { return v.DocumentRef }
 
 // Records the type of the score being captured by the score node
 type VulnerabilityScoreType string

--- a/pkg/assembler/graphql/examples/certify_bad.gql
+++ b/pkg/assembler/graphql/examples/certify_bad.gql
@@ -47,6 +47,7 @@ fragment allCertifyBadTree on CertifyBad {
   }
   origin
   collector
+  documentRef
 }
 
 query CertifactBadQ1 {

--- a/pkg/assembler/graphql/examples/certify_good.gql
+++ b/pkg/assembler/graphql/examples/certify_good.gql
@@ -47,6 +47,7 @@ fragment allCertifyGoodTree on CertifyGood {
   }
   origin
   collector
+  documentRef
 }
 
 query CertifactGoodQ1 {

--- a/pkg/assembler/graphql/examples/certify_scorecard.gql
+++ b/pkg/assembler/graphql/examples/certify_scorecard.gql
@@ -29,6 +29,7 @@ fragment allCertifyScorecardTree on CertifyScorecard {
     scorecardCommit
     origin
     collector
+    documentRef
   }
 }
 

--- a/pkg/assembler/graphql/examples/certify_vex.gql
+++ b/pkg/assembler/graphql/examples/certify_vex.gql
@@ -44,6 +44,7 @@ fragment allCertifyVEXStatementTree on CertifyVEXStatement {
   knownSince
   origin
   collector
+  documentRef
 }
 
 query CertifyVEXStatementQ1 {

--- a/pkg/assembler/graphql/examples/certify_vuln.gql
+++ b/pkg/assembler/graphql/examples/certify_vuln.gql
@@ -37,6 +37,7 @@ fragment allCertifyVulnTree on CertifyVuln {
     timeScanned
     origin
     collector
+    documentRef
   }
 }
 

--- a/pkg/assembler/graphql/examples/has_sbom.gql
+++ b/pkg/assembler/graphql/examples/has_sbom.gql
@@ -36,6 +36,7 @@ fragment allHasSBOMTree on HasSBOM {
   origin
   collector
   knownSince
+  documentRef
 }
 
 query HasSBOMQ1 {

--- a/pkg/assembler/graphql/examples/has_slsa.gql
+++ b/pkg/assembler/graphql/examples/has_slsa.gql
@@ -25,6 +25,7 @@ fragment allHasSLSATree on HasSLSA {
     finishedOn
     origin
     collector
+    documentRef
   }
 }
 

--- a/pkg/assembler/graphql/examples/has_source_at.gql
+++ b/pkg/assembler/graphql/examples/has_source_at.gql
@@ -39,6 +39,7 @@ fragment allHasSourceAtTree on HasSourceAt {
   }
   origin
   collector
+  documentRef
 }
 
 query HasSourceAtQ1 {

--- a/pkg/assembler/graphql/examples/hash_equal.gql
+++ b/pkg/assembler/graphql/examples/hash_equal.gql
@@ -8,6 +8,7 @@ fragment allHashEqualTree on HashEqual {
   }
   origin
   collector
+  documentRef
 }
 
 query HashEqualQ1 {

--- a/pkg/assembler/graphql/examples/is_dependency.gql
+++ b/pkg/assembler/graphql/examples/is_dependency.gql
@@ -47,6 +47,7 @@ fragment allIsDependencyTree on IsDependency {
   versionRange
   origin
   collector
+  documentRef
 }
 
 query IsDependencyQ1 {

--- a/pkg/assembler/graphql/examples/is_occurence.gql
+++ b/pkg/assembler/graphql/examples/is_occurence.gql
@@ -46,6 +46,7 @@ fragment allIsOccurrencesTree on IsOccurrence {
   justification
   origin
   collector
+  documentRef
 }
 
 query IsOccurrenceQ1 {

--- a/pkg/assembler/graphql/examples/pkg_equal.gql
+++ b/pkg/assembler/graphql/examples/pkg_equal.gql
@@ -24,6 +24,7 @@ fragment allPkgEqualTree on PkgEqual {
   }
   origin
   collector
+  documentRef
 }
 
 query PkgEqualQ1 {

--- a/pkg/assembler/graphql/examples/vulnEqual.gql
+++ b/pkg/assembler/graphql/examples/vulnEqual.gql
@@ -11,6 +11,7 @@ fragment allVulnEqualTree on VulnEqual {
   justification
   origin
   collector
+  documentRef
 }
 
 query IsVulnerabilityQ1 {

--- a/pkg/assembler/graphql/examples/vuln_metadata.gql
+++ b/pkg/assembler/graphql/examples/vuln_metadata.gql
@@ -13,6 +13,7 @@ fragment allVulnMetadataTree on VulnerabilityMetadata {
   timestamp
   origin
   collector
+  documentRef
 }
 
 query VulnMetadataQ1 {

--- a/pkg/assembler/graphql/generated/certifyBad.generated.go
+++ b/pkg/assembler/graphql/generated/certifyBad.generated.go
@@ -294,11 +294,14 @@ func (ec *executionContext) _CertifyBad_documentRef(ctx context.Context, field g
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyBad_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -362,7 +365,7 @@ func (ec *executionContext) unmarshalInputCertifyBadInputSpec(ctx context.Contex
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -673,6 +676,9 @@ func (ec *executionContext) _CertifyBad(ctx context.Context, sel ast.SelectionSe
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyBad_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyGood.generated.go
+++ b/pkg/assembler/graphql/generated/certifyGood.generated.go
@@ -293,11 +293,14 @@ func (ec *executionContext) _CertifyGood_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyGood_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -361,7 +364,7 @@ func (ec *executionContext) unmarshalInputCertifyGoodInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -492,6 +495,9 @@ func (ec *executionContext) _CertifyGood(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyGood_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyLegal.generated.go
+++ b/pkg/assembler/graphql/generated/certifyLegal.generated.go
@@ -519,11 +519,14 @@ func (ec *executionContext) _CertifyLegal_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyLegal_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -608,7 +611,7 @@ func (ec *executionContext) unmarshalInputCertifyLegalInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -799,6 +802,9 @@ func (ec *executionContext) _CertifyLegal(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyLegal_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyScorecard.generated.go
+++ b/pkg/assembler/graphql/generated/certifyScorecard.generated.go
@@ -490,11 +490,14 @@ func (ec *executionContext) _Scorecard_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Scorecard_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -823,7 +826,7 @@ func (ec *executionContext) unmarshalInputScorecardInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -939,6 +942,9 @@ func (ec *executionContext) _Scorecard(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._Scorecard_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVEXStatement.generated.go
@@ -466,11 +466,14 @@ func (ec *executionContext) _CertifyVEXStatement_documentRef(ctx context.Context
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CertifyVEXStatement_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -754,7 +757,7 @@ func (ec *executionContext) unmarshalInputVexStatementInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -859,6 +862,9 @@ func (ec *executionContext) _CertifyVEXStatement(ctx context.Context, sel ast.Se
 			}
 		case "documentRef":
 			out.Values[i] = ec._CertifyVEXStatement_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/certifyVuln.generated.go
+++ b/pkg/assembler/graphql/generated/certifyVuln.generated.go
@@ -533,11 +533,14 @@ func (ec *executionContext) _ScanMetadata_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ScanMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -719,7 +722,7 @@ func (ec *executionContext) unmarshalInputScanMetadataInput(ctx context.Context,
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -840,6 +843,9 @@ func (ec *executionContext) _ScanMetadata(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._ScanMetadata_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/contact.generated.go
+++ b/pkg/assembler/graphql/generated/contact.generated.go
@@ -375,11 +375,14 @@ func (ec *executionContext) _PointOfContact_documentRef(ctx context.Context, fie
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PointOfContact_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -457,7 +460,7 @@ func (ec *executionContext) unmarshalInputPointOfContactInputSpec(ctx context.Co
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -612,6 +615,9 @@ func (ec *executionContext) _PointOfContact(ctx context.Context, sel ast.Selecti
 			}
 		case "documentRef":
 			out.Values[i] = ec._PointOfContact_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/hasSBOM.generated.go
+++ b/pkg/assembler/graphql/generated/hasSBOM.generated.go
@@ -417,11 +417,14 @@ func (ec *executionContext) _HasSBOM_documentRef(ctx context.Context, field grap
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSBOM_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -713,7 +716,7 @@ func (ec *executionContext) unmarshalInputHasSBOMInputSpec(ctx context.Context, 
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -901,6 +904,9 @@ func (ec *executionContext) _HasSBOM(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasSBOM_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "includedSoftware":
 			out.Values[i] = ec._HasSBOM_includedSoftware(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/assembler/graphql/generated/hasSLSA.generated.go
+++ b/pkg/assembler/graphql/generated/hasSLSA.generated.go
@@ -584,11 +584,14 @@ func (ec *executionContext) _SLSA_documentRef(ctx context.Context, field graphql
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SLSA_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -863,7 +866,7 @@ func (ec *executionContext) unmarshalInputSLSAInputSpec(ctx context.Context, obj
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -1051,6 +1054,9 @@ func (ec *executionContext) _SLSA(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "documentRef":
 			out.Values[i] = ec._SLSA_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/hasSourceAt.generated.go
+++ b/pkg/assembler/graphql/generated/hasSourceAt.generated.go
@@ -351,11 +351,14 @@ func (ec *executionContext) _HasSourceAt_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasSourceAt_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -419,7 +422,7 @@ func (ec *executionContext) unmarshalInputHasSourceAtInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -562,6 +565,9 @@ func (ec *executionContext) _HasSourceAt(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasSourceAt_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/hashEqual.generated.go
+++ b/pkg/assembler/graphql/generated/hashEqual.generated.go
@@ -260,11 +260,14 @@ func (ec *executionContext) _HashEqual_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HashEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -321,7 +324,7 @@ func (ec *executionContext) unmarshalInputHashEqualInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -440,6 +443,9 @@ func (ec *executionContext) _HashEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._HashEqual_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/isDependency.generated.go
+++ b/pkg/assembler/graphql/generated/isDependency.generated.go
@@ -391,11 +391,14 @@ func (ec *executionContext) _IsDependency_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_IsDependency_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -466,7 +469,7 @@ func (ec *executionContext) unmarshalInputIsDependencyInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -621,6 +624,9 @@ func (ec *executionContext) _IsDependency(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._IsDependency_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/isOccurrence.generated.go
+++ b/pkg/assembler/graphql/generated/isOccurrence.generated.go
@@ -301,11 +301,14 @@ func (ec *executionContext) _IsOccurrence_documentRef(ctx context.Context, field
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_IsOccurrence_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -362,7 +365,7 @@ func (ec *executionContext) unmarshalInputIsOccurrenceInputSpec(ctx context.Cont
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -618,6 +621,9 @@ func (ec *executionContext) _IsOccurrence(ctx context.Context, sel ast.Selection
 			}
 		case "documentRef":
 			out.Values[i] = ec._IsOccurrence_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/metadata.generated.go
+++ b/pkg/assembler/graphql/generated/metadata.generated.go
@@ -375,11 +375,14 @@ func (ec *executionContext) _HasMetadata_documentRef(ctx context.Context, field 
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HasMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -457,7 +460,7 @@ func (ec *executionContext) unmarshalInputHasMetadataInputSpec(ctx context.Conte
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -612,6 +615,9 @@ func (ec *executionContext) _HasMetadata(ctx context.Context, sel ast.SelectionS
 			}
 		case "documentRef":
 			out.Values[i] = ec._HasMetadata_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/pkgEqual.generated.go
+++ b/pkg/assembler/graphql/generated/pkgEqual.generated.go
@@ -260,11 +260,14 @@ func (ec *executionContext) _PkgEqual_documentRef(ctx context.Context, field gra
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PkgEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -321,7 +324,7 @@ func (ec *executionContext) unmarshalInputPkgEqualInputSpec(ctx context.Context,
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -440,6 +443,9 @@ func (ec *executionContext) _PkgEqual(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "documentRef":
 			out.Values[i] = ec._PkgEqual_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -3202,7 +3202,7 @@ type CertifyBad {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3238,7 +3238,7 @@ input CertifyBadInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3320,7 +3320,7 @@ type CertifyGood {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3355,7 +3355,7 @@ input CertifyGoodInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -3436,7 +3436,7 @@ type CertifyLegal {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3473,7 +3473,7 @@ input CertifyLegalInputSpec {
   timeScanned: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -3551,7 +3551,7 @@ type Scorecard {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3604,7 +3604,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."
@@ -3724,7 +3724,7 @@ type CertifyVEXStatement {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3758,7 +3758,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -3840,7 +3840,7 @@ type ScanMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3879,7 +3879,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -3959,7 +3959,7 @@ type PointOfContact {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -3997,7 +3997,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4063,7 +4063,7 @@ type HasSBOM {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -4112,7 +4112,7 @@ input HasSBOMInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4193,7 +4193,7 @@ type SLSA {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -4259,7 +4259,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."
@@ -4325,7 +4325,7 @@ type HasSourceAt {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -4346,7 +4346,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4402,7 +4402,7 @@ type HashEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -4426,7 +4426,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4496,7 +4496,7 @@ type IsDependency {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -4527,7 +4527,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4621,7 +4621,7 @@ type IsOccurrence {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -4643,7 +4643,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -4815,7 +4815,7 @@ type HasMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -4853,7 +4853,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -5321,7 +5321,7 @@ type PkgEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -5345,7 +5345,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -5579,7 +5579,7 @@ type VulnEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -5600,7 +5600,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {
@@ -5701,7 +5701,7 @@ type VulnerabilityMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -5734,7 +5734,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/generated/vulnEqual.generated.go
+++ b/pkg/assembler/graphql/generated/vulnEqual.generated.go
@@ -260,11 +260,14 @@ func (ec *executionContext) _VulnEqual_documentRef(ctx context.Context, field gr
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VulnEqual_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -321,7 +324,7 @@ func (ec *executionContext) unmarshalInputVulnEqualInputSpec(ctx context.Context
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -440,6 +443,9 @@ func (ec *executionContext) _VulnEqual(ctx context.Context, sel ast.SelectionSet
 			}
 		case "documentRef":
 			out.Values[i] = ec._VulnEqual_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/generated/vulnMetadata.generated.go
+++ b/pkg/assembler/graphql/generated/vulnMetadata.generated.go
@@ -343,11 +343,14 @@ func (ec *executionContext) _VulnerabilityMetadata_documentRef(ctx context.Conte
 	})
 
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VulnerabilityMetadata_documentRef(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -418,7 +421,7 @@ func (ec *executionContext) unmarshalInputVulnerabilityMetadataInputSpec(ctx con
 			it.Collector = data
 		case "documentRef":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentRef"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -568,6 +571,9 @@ func (ec *executionContext) _VulnerabilityMetadata(ctx context.Context, sel ast.
 			}
 		case "documentRef":
 			out.Values[i] = ec._VulnerabilityMetadata_documentRef(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -114,7 +114,7 @@ type CertifyBad struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyBad) IsNode() {}
@@ -126,7 +126,7 @@ type CertifyBadInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef,omitempty"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -175,7 +175,7 @@ type CertifyGood struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyGood) IsNode() {}
@@ -186,7 +186,7 @@ type CertifyGoodInputSpec struct {
 	KnownSince    time.Time `json:"knownSince"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef,omitempty"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // CertifyBadSpec allows filtering the list of CertifyBad evidence to return in a
@@ -248,7 +248,7 @@ type CertifyLegal struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyLegal) IsNode() {}
@@ -263,7 +263,7 @@ type CertifyLegalInputSpec struct {
 	TimeScanned       time.Time `json:"timeScanned"`
 	Origin            string    `json:"origin"`
 	Collector         string    `json:"collector"`
-	DocumentRef       *string   `json:"documentRef,omitempty"`
+	DocumentRef       string    `json:"documentRef"`
 }
 
 // CertifyLegalSpec allows filtering the list of legal certifications to
@@ -335,7 +335,7 @@ type CertifyVEXStatement struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (CertifyVEXStatement) IsNode() {}
@@ -430,7 +430,7 @@ type HasMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HasMetadata) IsNode() {}
@@ -443,7 +443,7 @@ type HasMetadataInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef,omitempty"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // HasMetadataSpec allows filtering the list of HasMetadata evidence to return in a
@@ -488,7 +488,7 @@ type HasSbom struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 	// Included packages and artifacts
 	IncludedSoftware []PackageOrArtifact `json:"includedSoftware"`
 	// Included dependencies
@@ -515,7 +515,7 @@ type HasSBOMInputSpec struct {
 	KnownSince       time.Time `json:"knownSince"`
 	Origin           string    `json:"origin"`
 	Collector        string    `json:"collector"`
-	DocumentRef      *string   `json:"documentRef,omitempty"`
+	DocumentRef      string    `json:"documentRef"`
 }
 
 // HasSBOMSpec allows filtering the list of HasSBOM to return.
@@ -583,7 +583,7 @@ type HasSourceAt struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HasSourceAt) IsNode() {}
@@ -594,7 +594,7 @@ type HasSourceAtInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef,omitempty"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // HasSourceAtSpec allows filtering the list of HasSourceAt to return.
@@ -621,17 +621,17 @@ type HashEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (HashEqual) IsNode() {}
 
 // HashEqualInputSpec represents the input to certify that packages are similar.
 type HashEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef,omitempty"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // HashEqualSpec allows filtering the list of artifact equality statements to
@@ -732,7 +732,7 @@ type IsDependency struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (IsDependency) IsNode() {}
@@ -745,7 +745,7 @@ type IsDependencyInputSpec struct {
 	Justification  string         `json:"justification"`
 	Origin         string         `json:"origin"`
 	Collector      string         `json:"collector"`
-	DocumentRef    *string        `json:"documentRef,omitempty"`
+	DocumentRef    string         `json:"documentRef"`
 }
 
 // IsDependencySpec allows filtering the list of dependencies to return.
@@ -782,17 +782,17 @@ type IsOccurrence struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (IsOccurrence) IsNode() {}
 
 // IsOccurrenceInputSpec represents the input to record an artifact's origin.
 type IsOccurrenceInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef,omitempty"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // IsOccurrenceSpec allows filtering the list of artifact occurences to return in
@@ -1078,17 +1078,17 @@ type PkgEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (PkgEqual) IsNode() {}
 
 // PkgEqualInputSpec represents the input to certify that packages are similar.
 type PkgEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef,omitempty"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // PkgEqualSpec allows filtering the list of package equality statements to return
@@ -1182,7 +1182,7 @@ type PointOfContact struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (PointOfContact) IsNode() {}
@@ -1195,7 +1195,7 @@ type PointOfContactInputSpec struct {
 	Justification string    `json:"justification"`
 	Origin        string    `json:"origin"`
 	Collector     string    `json:"collector"`
-	DocumentRef   *string   `json:"documentRef,omitempty"`
+	DocumentRef   string    `json:"documentRef"`
 }
 
 // PointOfContactSpec allows filtering the list of PointOfContact evidence to return in a
@@ -1252,7 +1252,7 @@ type Slsa struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 // SLSAInputSpec is the same as SLSA but for mutation input.
@@ -1264,7 +1264,7 @@ type SLSAInputSpec struct {
 	FinishedOn    *time.Time                `json:"finishedOn,omitempty"`
 	Origin        string                    `json:"origin"`
 	Collector     string                    `json:"collector"`
-	DocumentRef   *string                   `json:"documentRef,omitempty"`
+	DocumentRef   string                    `json:"documentRef"`
 }
 
 // SLSAPredicate are the values from the SLSA predicate in key-value pair form.
@@ -1330,7 +1330,7 @@ type ScanMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 // ScanMetadataInput represents the input for certifying vulnerability
@@ -1343,7 +1343,7 @@ type ScanMetadataInput struct {
 	ScannerVersion string    `json:"scannerVersion"`
 	Origin         string    `json:"origin"`
 	Collector      string    `json:"collector"`
-	DocumentRef    *string   `json:"documentRef,omitempty"`
+	DocumentRef    string    `json:"documentRef"`
 }
 
 // Scorecard contains all of the fields present in a Scorecard attestation.
@@ -1367,7 +1367,7 @@ type Scorecard struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 // ScorecardCheck are the individual checks from scorecard and their values as a
@@ -1412,7 +1412,7 @@ type ScorecardInputSpec struct {
 	ScorecardCommit  string                     `json:"scorecardCommit"`
 	Origin           string                     `json:"origin"`
 	Collector        string                     `json:"collector"`
-	DocumentRef      *string                    `json:"documentRef,omitempty"`
+	DocumentRef      string                     `json:"documentRef"`
 }
 
 // Source represents the root of the source trie/tree.
@@ -1511,7 +1511,7 @@ type VexStatementInputSpec struct {
 	KnownSince       time.Time        `json:"knownSince"`
 	Origin           string           `json:"origin"`
 	Collector        string           `json:"collector"`
-	DocumentRef      *string          `json:"documentRef,omitempty"`
+	DocumentRef      string           `json:"documentRef"`
 }
 
 // VulnEqual is an attestation to link two vulnerabilities together as being equal"
@@ -1528,17 +1528,17 @@ type VulnEqual struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (VulnEqual) IsNode() {}
 
 // VulnEqualInputSpec represents the input to link vulnerabilities to each other.
 type VulnEqualInputSpec struct {
-	Justification string  `json:"justification"`
-	Origin        string  `json:"origin"`
-	Collector     string  `json:"collector"`
-	DocumentRef   *string `json:"documentRef,omitempty"`
+	Justification string `json:"justification"`
+	Origin        string `json:"origin"`
+	Collector     string `json:"collector"`
+	DocumentRef   string `json:"documentRef"`
 }
 
 // VulnEqualSpec allows filtering the list of vulnerability links to return
@@ -1646,7 +1646,7 @@ type VulnerabilityMetadata struct {
 	// GUAC collector for the document
 	Collector string `json:"collector"`
 	// Reference location of the document in the persistent blob store (if that is configured)
-	DocumentRef *string `json:"documentRef,omitempty"`
+	DocumentRef string `json:"documentRef"`
 }
 
 func (VulnerabilityMetadata) IsNode() {}
@@ -1658,7 +1658,7 @@ type VulnerabilityMetadataInputSpec struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Origin      string                 `json:"origin"`
 	Collector   string                 `json:"collector"`
-	DocumentRef *string                `json:"documentRef,omitempty"`
+	DocumentRef string                 `json:"documentRef"`
 }
 
 // VulnerabilityMetadataSpec allows filtering the list of VulnerabilityMetadata evidence

--- a/pkg/assembler/graphql/schema/certifyBad.graphql
+++ b/pkg/assembler/graphql/schema/certifyBad.graphql
@@ -82,7 +82,7 @@ type CertifyBad {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -118,7 +118,7 @@ input CertifyBadInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 """

--- a/pkg/assembler/graphql/schema/certifyGood.graphql
+++ b/pkg/assembler/graphql/schema/certifyGood.graphql
@@ -43,7 +43,7 @@ type CertifyGood {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -78,7 +78,7 @@ input CertifyGoodInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -56,7 +56,7 @@ type CertifyLegal {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -93,7 +93,7 @@ input CertifyLegalInputSpec {
   timeScanned: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyScorecard.graphql
+++ b/pkg/assembler/graphql/schema/certifyScorecard.graphql
@@ -61,7 +61,7 @@ type Scorecard {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -114,7 +114,7 @@ input ScorecardInputSpec {
   scorecardCommit: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 "ScorecardCheckInputSpec represents the mutation input for a Scorecard check."

--- a/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
+++ b/pkg/assembler/graphql/schema/certifyVEXStatement.graphql
@@ -94,7 +94,7 @@ type CertifyVEXStatement {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -128,7 +128,7 @@ input VexStatementInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -55,7 +55,7 @@ type ScanMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -94,7 +94,7 @@ input ScanMetadataInput {
   scannerVersion: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/contact.graphql
+++ b/pkg/assembler/graphql/schema/contact.graphql
@@ -55,7 +55,7 @@ type PointOfContact {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -93,7 +93,7 @@ input PointOfContactInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -36,7 +36,7 @@ type HasSBOM {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
   "Included packages and artifacts"
   includedSoftware: [PackageOrArtifact!]!
   "Included dependencies"
@@ -85,7 +85,7 @@ input HasSBOMInputSpec {
   knownSince: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hasSLSA.graphql
+++ b/pkg/assembler/graphql/schema/hasSLSA.graphql
@@ -56,7 +56,7 @@ type SLSA {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -122,7 +122,7 @@ input SLSAInputSpec {
   finishedOn: Time
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 "SLSAPredicateInputSpec allows ingesting SLSAPredicateSpec."

--- a/pkg/assembler/graphql/schema/hasSourceAt.graphql
+++ b/pkg/assembler/graphql/schema/hasSourceAt.graphql
@@ -33,7 +33,7 @@ type HasSourceAt {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 "HasSourceAtSpec allows filtering the list of HasSourceAt to return."
@@ -54,7 +54,7 @@ input HasSourceAtInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/hashEqual.graphql
+++ b/pkg/assembler/graphql/schema/hashEqual.graphql
@@ -29,7 +29,7 @@ type HashEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -53,7 +53,7 @@ input HashEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -45,7 +45,7 @@ type IsDependency {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -76,7 +76,7 @@ input IsDependencyInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/isOccurrence.graphql
+++ b/pkg/assembler/graphql/schema/isOccurrence.graphql
@@ -67,7 +67,7 @@ type IsOccurrence {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -89,7 +89,7 @@ input IsOccurrenceInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/metadata.graphql
+++ b/pkg/assembler/graphql/schema/metadata.graphql
@@ -50,7 +50,7 @@ type HasMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -88,7 +88,7 @@ input HasMetadataInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/pkgEqual.graphql
+++ b/pkg/assembler/graphql/schema/pkgEqual.graphql
@@ -29,7 +29,7 @@ type PkgEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -53,7 +53,7 @@ input PkgEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnEqual.graphql
+++ b/pkg/assembler/graphql/schema/vulnEqual.graphql
@@ -33,7 +33,7 @@ type VulnEqual {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -54,7 +54,7 @@ input VulnEqualInputSpec {
   justification: String!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/assembler/graphql/schema/vulnMetadata.graphql
+++ b/pkg/assembler/graphql/schema/vulnMetadata.graphql
@@ -76,7 +76,7 @@ type VulnerabilityMetadata {
   "GUAC collector for the document"
   collector: String!
   "Reference location of the document in the persistent blob store (if that is configured)"
-  documentRef: String
+  documentRef: String!
 }
 
 """
@@ -109,7 +109,7 @@ input VulnerabilityMetadataInputSpec {
   timestamp: Time!
   origin: String!
   collector: String!
-  documentRef: String
+  documentRef: String!
 }
 
 extend type Query {

--- a/pkg/handler/collector/file/file.go
+++ b/pkg/handler/collector/file/file.go
@@ -90,9 +90,11 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 			return fmt.Errorf("error reading file: %s, err: %w", path, err)
 		}
 
-		source := fmt.Sprintf("file:///%s", path)
+		var docRef string
 		if f.useBlobURL {
-			source = events.GetKey(blob) // this is the blob store path
+			docRef = events.GetKey(blob) // this is the blob store path
+		} else {
+			docRef = ""
 		}
 
 		doc := &processor.Document{
@@ -100,8 +102,9 @@ func (f *fileCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 			Type:   processor.DocumentUnknown,
 			Format: processor.FormatUnknown,
 			SourceInformation: processor.SourceInformation{
-				Collector: string(FileCollector),
-				Source:    source,
+				Collector:   string(FileCollector),
+				Source:      fmt.Sprintf("file:///%s", path),
+				DocumentRef: docRef,
 			},
 		}
 

--- a/pkg/handler/collector/file/file_test.go
+++ b/pkg/handler/collector/file/file_test.go
@@ -81,8 +81,9 @@ func Test_fileCollector_RetrieveArtifacts(t *testing.T) {
 			Type:   processor.DocumentUnknown,
 			Format: processor.FormatUnknown,
 			SourceInformation: processor.SourceInformation{
-				Collector: string(FileCollector),
-				Source:    "sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+				Collector:   string(FileCollector),
+				Source:      "file:///testdata/hello",
+				DocumentRef: "sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
 			}},
 		},
 		wantErr: false,

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -98,4 +98,6 @@ type SourceInformation struct {
 	Collector string
 	// Source describes the source which the collector got this information
 	Source string
+	// DocumentRef describes the location of the document in the blob store
+	DocumentRef string
 }

--- a/pkg/ingestor/parser/common/graph_builder.go
+++ b/pkg/ingestor/parser/common/graph_builder.go
@@ -63,53 +63,93 @@ func addMetadata(predicates *assembler.IngestPredicates, foundIdentities []Trust
 	// and added here.
 	_ = foundIdentities
 
+	for _, v := range predicates.CertifyBad {
+		v.CertifyBad.Collector = srcInfo.Collector
+		v.CertifyBad.Origin = srcInfo.Source
+		v.CertifyBad.DocumentRef = srcInfo.DocumentRef
+	}
+
+	for _, v := range predicates.CertifyGood {
+		v.CertifyGood.Collector = srcInfo.Collector
+		v.CertifyGood.Origin = srcInfo.Source
+		v.CertifyGood.DocumentRef = srcInfo.DocumentRef
+	}
+
+	for _, v := range predicates.CertifyLegal {
+		v.CertifyLegal.Collector = srcInfo.Collector
+		v.CertifyLegal.Origin = srcInfo.Source
+		v.CertifyLegal.DocumentRef = srcInfo.DocumentRef
+	}
+
+	for _, v := range predicates.HashEqual {
+		v.HashEqual.Collector = srcInfo.Collector
+		v.HashEqual.Origin = srcInfo.Source
+		v.HashEqual.DocumentRef = srcInfo.DocumentRef
+	}
+
+	for _, v := range predicates.PkgEqual {
+		v.PkgEqual.Collector = srcInfo.Collector
+		v.PkgEqual.Origin = srcInfo.Source
+		v.PkgEqual.DocumentRef = srcInfo.DocumentRef
+	}
+
 	for _, v := range predicates.CertifyScorecard {
 		v.Scorecard.Collector = srcInfo.Collector
 		v.Scorecard.Origin = srcInfo.Source
+		v.Scorecard.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.IsDependency {
 		v.IsDependency.Collector = srcInfo.Collector
 		v.IsDependency.Origin = srcInfo.Source
+		v.IsDependency.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.IsOccurrence {
 		v.IsOccurrence.Collector = srcInfo.Collector
 		v.IsOccurrence.Origin = srcInfo.Source
+		v.IsOccurrence.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.HasSlsa {
 		v.HasSlsa.Collector = srcInfo.Collector
 		v.HasSlsa.Origin = srcInfo.Source
+		v.HasSlsa.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.HasSBOM {
 		v.HasSBOM.Collector = srcInfo.Collector
 		v.HasSBOM.Origin = srcInfo.Source
+		v.HasSBOM.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.CertifyVuln {
 		v.VulnData.Collector = srcInfo.Collector
 		v.VulnData.Origin = srcInfo.Source
+		v.VulnData.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.VulnEqual {
 		v.VulnEqual.Collector = srcInfo.Collector
 		v.VulnEqual.Origin = srcInfo.Source
+		v.VulnEqual.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.HasSourceAt {
 		v.HasSourceAt.Collector = srcInfo.Collector
 		v.HasSourceAt.Origin = srcInfo.Source
+		v.HasSourceAt.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.VulnMetadata {
 		v.VulnMetadata.Collector = srcInfo.Collector
 		v.VulnMetadata.Origin = srcInfo.Source
+		v.VulnMetadata.DocumentRef = srcInfo.DocumentRef
 	}
 
 	for _, v := range predicates.Vex {
 		v.VexData.Collector = srcInfo.Collector
 		v.VexData.Origin = srcInfo.Source
+		v.VexData.DocumentRef = srcInfo.DocumentRef
 	}
 }


### PR DESCRIPTION
# Description of the PR

Add new `documentRef` field to graphQL schema, updates the parsers and all backends. Unit tests added to test new field. 

closes https://github.com/guacsec/guac/issues/1833

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
