### PR TITLE
Fixes to HTTP Header functionality for CLI commands

### DIFF
--- a/cmd/guaccollect/cmd/gcs.go
+++ b/cmd/guaccollect/cmd/gcs.go
@@ -20,7 +20,6 @@ import (
 type gcsOptions struct {
 	pubSubAddr        string
 	blobAddr          string
-	graphqlEndpoint   string
 	csubClientOptions csub_client.CsubClientOptions
 	bucket            string
 }
@@ -39,7 +38,6 @@ var gcsCmd = &cobra.Command{
 		opts, err := validateGCSFlags(
 			viper.GetString("pubsub-addr"),
 			viper.GetString("blob-addr"),
-			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
 			viper.GetString(gcsCredentialsPathFlag),
 			viper.GetBool("csub-tls"),
@@ -93,7 +91,6 @@ var gcsCmd = &cobra.Command{
 func validateGCSFlags(
 	pubSubAddr,
 	blobAddr,
-	gqlEndpoint,
 	csubAddr,
 	credentialsPath string,
 	csubTls,
@@ -101,9 +98,8 @@ func validateGCSFlags(
 	args []string,
 ) (gcsOptions, error) {
 	opts := gcsOptions{
-		pubSubAddr:      pubSubAddr,
-		blobAddr:        blobAddr,
-		graphqlEndpoint: gqlEndpoint,
+		pubSubAddr: pubSubAddr,
+		blobAddr:   blobAddr,
 	}
 
 	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guaccollect/cmd/s3.go
+++ b/cmd/guaccollect/cmd/s3.go
@@ -28,7 +28,6 @@ type s3Options struct {
 	mp                string                        // message provider name (sqs or kafka, will default to kafka)
 	mpEndpoint        string                        // endpoint for the message provider (only for polling behaviour)
 	poll              bool                          // polling or non-polling behaviour? (defaults to non-polling)
-	graphqlEndpoint   string                        // endpoint for the graphql server
 	csubClientOptions csub_client.CsubClientOptions // options for the collectsub client
 }
 
@@ -64,7 +63,6 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 		s3Opts, err := validateS3Opts(
 			viper.GetString("pubsub-addr"),
 			viper.GetString("blob-addr"),
-			viper.GetString("gql-addr"),
 			viper.GetString("csub-addr"),
 			viper.GetString("s3-url"),
 			viper.GetString("s3-bucket"),
@@ -116,7 +114,6 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 func validateS3Opts(
 	pubSubAddr,
 	blobAddr,
-	graphqlEndpoint,
 	csubAddr,
 	s3url,
 	s3bucket,
@@ -162,7 +159,6 @@ func validateS3Opts(
 		mp:                mp,
 		mpEndpoint:        mpEndpoint,
 		poll:              poll,
-		graphqlEndpoint:   graphqlEndpoint,
 		csubClientOptions: csubClientOptions,
 	}
 

--- a/cmd/guacingest/cmd/root.go
+++ b/cmd/guacingest/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"pubsub-addr", "blob-addr", "csub-addr", "gql-addr"})
+	set, err := cli.BuildFlags([]string{"pubsub-addr", "blob-addr", "csub-addr", "gql-addr", "header-file"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guacone/cmd/bad.go
+++ b/cmd/guacone/cmd/bad.go
@@ -253,7 +253,7 @@ func validateQueryBadFlags(graphqlEndpoint, headerFile string, depth int) (query
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"header-file", "search-depth"})
+	set, err := cli.BuildFlags([]string{"search-depth"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guacone/cmd/bad.go
+++ b/cmd/guacone/cmd/bad.go
@@ -57,12 +57,7 @@ var queryBadCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			logger.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		certifyBadResponse, err := model.CertifyBads(ctx, gqlclient, model.CertifyBadSpec{})

--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -35,6 +36,7 @@ import (
 type certifyOptions struct {
 	// gql endpoint
 	graphqlEndpoint string
+	headerFile      string
 	// // certifyBad/certifyGood
 	good          bool
 	certifyType   string
@@ -53,23 +55,24 @@ var certifyCmd = &cobra.Command{
   <subject> is in the form of "<purl>" for package, "<vcs_tool>+<transport>" for source, or "<algorithm>:<digest>" for artifact.`,
 	TraverseChildren: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := logging.WithLogger(context.Background())
-		logger := logging.FromContext(ctx)
-
 		opts, err := validateCertifyFlags(
 			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
 			viper.GetBool("cert-good"),
 			viper.GetBool("package-name"),
 			args,
 		)
-
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
 			_ = cmd.Help()
 			os.Exit(1)
 		}
 
-		assemblerFunc := ingestor.GetAssembler(ctx, logger, opts.graphqlEndpoint)
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
+
+		assemblerFunc := ingestor.GetAssembler(ctx, logger, opts.graphqlEndpoint, transport)
 
 		preds := &assembler.IngestPredicates{}
 		var pkgInput *model.PkgInputSpec
@@ -156,9 +159,10 @@ var certifyCmd = &cobra.Command{
 	},
 }
 
-func validateCertifyFlags(graphqlEndpoint string, good, pkgName bool, args []string) (certifyOptions, error) {
+func validateCertifyFlags(graphqlEndpoint, headerFile string, good, pkgName bool, args []string) (certifyOptions, error) {
 	var opts certifyOptions
 	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
 	opts.good = good
 	opts.pkgName = pkgName
 	if len(args) != 3 {

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -48,6 +49,7 @@ type fileOptions struct {
 	path string
 	// gql endpoint
 	graphqlEndpoint string
+	headerFile      string
 	// csub client options for identifier strings
 	csubClientOptions client.CsubClientOptions
 }
@@ -56,13 +58,11 @@ var filesCmd = &cobra.Command{
 	Use:   "files [flags] file_path",
 	Short: "take a folder of files and create a GUAC graph, this command talks directly to the graphQL endpoint",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := logging.WithLogger(context.Background())
-		logger := logging.FromContext(ctx)
-
 		opts, err := validateFilesFlags(
 			viper.GetString("verifier-key-path"),
 			viper.GetString("verifier-key-id"),
 			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
 			viper.GetString("csub-addr"),
 			viper.GetBool("csub-tls"),
 			viper.GetBool("csub-tls-skip-verify"),
@@ -72,6 +72,10 @@ var filesCmd = &cobra.Command{
 			_ = cmd.Help()
 			os.Exit(1)
 		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
 
 		// Register Keystore
 		inmemory := inmemory.NewInmemoryProvider()
@@ -122,7 +126,7 @@ var filesCmd = &cobra.Command{
 
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, csubClient); err != nil {
+			if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient); err != nil {
 				gotErr = true
 				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
 				return fmt.Errorf("unable to ingest document: %w", err)
@@ -154,9 +158,10 @@ var filesCmd = &cobra.Command{
 	},
 }
 
-func validateFilesFlags(keyPath string, keyID string, graphqlEndpoint string, csubAddr string, csubTls bool, csubTlsSkipVerify bool, args []string) (fileOptions, error) {
+func validateFilesFlags(keyPath, keyID, graphqlEndpoint, headerFile, csubAddr string, csubTls, csubTlsSkipVerify bool, args []string) (fileOptions, error) {
 	var opts fileOptions
 	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
 
 	if keyPath != "" {
 		if strings.HasSuffix(keyPath, "pem") {

--- a/cmd/guacone/cmd/gcs_test.go
+++ b/cmd/guacone/cmd/gcs_test.go
@@ -62,7 +62,7 @@ func TestValidateGCSFlags(t *testing.T) {
 				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
 			}
 
-			o, err := validateGCSFlags("", "", false, false, tc.credentialsPath, tc.args)
+			o, err := validateGCSFlags("", "", "", tc.credentialsPath, false, false, tc.args)
 			if err != nil {
 				if tc.errorMsg != err.Error() {
 					t.Errorf("expected error message: %s, got: %s", tc.errorMsg, err.Error())

--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -102,12 +102,7 @@ var queryKnownCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			logger.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		t := table.NewWriter()

--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -467,16 +467,5 @@ func validateQueryKnownFlags(graphqlEndpoint, headerFile string, args []string) 
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"header-file"})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
-		os.Exit(1)
-	}
-	queryKnownCmd.Flags().AddFlagSet(set)
-	if err := viper.BindPFlags(queryKnownCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
-		os.Exit(1)
-	}
-
 	queryCmd.AddCommand(queryKnownCmd)
 }

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -84,12 +84,7 @@ var osvCmd = &cobra.Command{
 			defer csubClient.Close()
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			logger.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 		packageQuery := root_package.NewPackageQuery(gqlclient, 0)
 

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -234,16 +234,5 @@ func validateOSVFlags(
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"header-file"})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
-		os.Exit(1)
-	}
-	osvCmd.Flags().AddFlagSet(set)
-	if err := viper.BindPFlags(osvCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
-		os.Exit(1)
-	}
-
 	certifierCmd.AddCommand(osvCmd)
 }

--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -62,12 +62,7 @@ var queryPatchCmd = &cobra.Command{
 			logger.Fatalf("unable to validate flags: %s\n", err)
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			logger.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlClient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		var startID string

--- a/cmd/guacone/cmd/patch.go
+++ b/cmd/guacone/cmd/patch.go
@@ -299,7 +299,6 @@ func validateQueryPatchFlags(
 
 func init() {
 	set, err := cli.BuildFlags([]string{
-		"header-file",
 		"start-purl",
 		"stop-purl",
 		"search-depth",

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
-	set, err := cli.BuildFlags([]string{"gql-addr", "csub-addr", "csub-tls", "csub-tls-skip-verify"})
+	set, err := cli.BuildFlags([]string{"gql-addr", "header-file", "csub-addr", "csub-tls", "csub-tls-skip-verify"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -89,12 +89,7 @@ var scorecardCmd = &cobra.Command{
 			defer csubClient.Close()
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			logger.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		// running and getting the scorecard checks

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -202,16 +202,5 @@ func validateScorecardFlags(
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"header-file"})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
-		os.Exit(1)
-	}
-	scorecardCmd.Flags().AddFlagSet(set)
-	if err := viper.BindPFlags(scorecardCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
-		os.Exit(1)
-	}
-
 	certifierCmd.AddCommand(scorecardCmd)
 }

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -69,12 +68,7 @@ var queryVulnCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		transport, err := cli.NewHTTPHeaderTransport(opts.headerFile, http.DefaultTransport)
-		if err != nil {
-			log.Fatalf("unable to create HTTP transport: %v", err)
-		}
-
-		httpClient := http.Client{Transport: transport}
+		httpClient := http.Client{Transport: cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
 		t := table.NewWriter()

--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -661,7 +661,7 @@ func validateQueryVulnFlags(graphqlEndpoint, headerFile, vulnID string, depth, p
 }
 
 func init() {
-	set, err := cli.BuildFlags([]string{"header-file", "vuln-id", "search-depth", "num-path"})
+	set, err := cli.BuildFlags([]string{"vuln-id", "search-depth", "num-path"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/cmd/guacrest/cmd/server.go
+++ b/cmd/guacrest/cmd/server.go
@@ -40,12 +40,7 @@ func startServer() {
 	ctx := logging.WithLogger(context.Background())
 	logger := logging.FromContext(ctx)
 
-	transport, err := cli.NewHTTPHeaderTransport(flags.headerFile, http.DefaultTransport)
-	if err != nil {
-		logger.Fatalf("unable to create HTTP transport: %+v", err)
-	}
-
-	httpClient := &http.Client{Transport: transport}
+	httpClient := &http.Client{Transport: cli.HTTPHeaderTransport(ctx, flags.headerFile, http.DefaultTransport)}
 	gqlClient := getGraphqlServerClientOrExit(ctx, httpClient)
 	handler := server.NewDefaultServer(gqlClient)
 	handlerWrapper := gen.NewStrictHandler(handler, nil)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -18,8 +18,9 @@ package logging
 import (
 	"context"
 	"fmt"
-	"github.com/guacsec/guac/pkg/version"
 	"strings"
+
+	"github.com/guacsec/guac/pkg/version"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -48,7 +49,7 @@ const (
 type loggerKey struct{}
 
 // Initializes the logger with the input level, defaulting to Info if the input is invalid
-func InitLogger(level LogLevel) {
+func InitLogger(level LogLevel, opts ...zap.Option) {
 	zapLevel, levelErr := zapcore.ParseLevel(string(level))
 	if levelErr != nil {
 		zapLevel = zapcore.InfoLevel
@@ -69,7 +70,7 @@ func InitLogger(level LogLevel) {
 		_ = zapLogger.Sync()
 	}()
 
-	logger = zapLogger.Sugar().With(guacVersion, version.Version)
+	logger = zapLogger.Sugar().With(guacVersion, version.Version).WithOptions(opts...)
 
 	if levelErr != nil {
 		logger.Infof("Invalid log level %s: ", level, levelErr)


### PR DESCRIPTION
# Description of the PR
This is a followup to https://github.com/guacsec/guac/pull/1845 where I made the mistake of not using the HTTP headers with the ingestor. I also made some other minor improvements while I was here. 

- Fix lack of support of the `--header-file` flag in the ingestor code (and the commands that call it)
- Move the flag to top-level commands exclusively to aid its discoverability
- Simplify creating a new transport (make errors fatal - this only ever happens at command startup)
- Also fixed `guacone collect github` using the empty string for a GraphQL endpoint
- Remove unused `graphqlEndpoint` field from `guaccollect s3` and `guaccollect gcs` options structs

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
