### PR TITLE
[FIX] implement fixes based on parsing and querying errors for CDX

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/Khan/genqlient/graphql"
 	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
@@ -433,24 +432,17 @@ func searchDependencyPackagesReverse(ctx context.Context, gqlclient graphql.Clie
 	}
 }
 
-func concurrentVulnAndVexNeighbors(ctx context.Context, gqlclient graphql.Client, pkgID string, isDep model.AllHasSBOMTreeIncludedDependenciesIsDependency, resultChan chan<- struct {
+type pkgVersionNeighborQueryResults struct {
 	pkgVersionNeighborResponse *model.NeighborsResponse
 	isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
-}, wg *sync.WaitGroup) {
-	defer wg.Done()
+}
 
-	logger := logging.FromContext(ctx)
+func getVulnAndVexNeighbors(ctx context.Context, gqlclient graphql.Client, pkgID string, isDep model.AllHasSBOMTreeIncludedDependenciesIsDependency) (*pkgVersionNeighborQueryResults, error) {
 	pkgVersionNeighborResponse, err := model.Neighbors(ctx, gqlclient, pkgID, []model.Edge{model.EdgePackageCertifyVuln, model.EdgePackageCertifyVexStatement})
 	if err != nil {
-		logger.Errorf("error querying neighbor for vulnerability: %w", err)
-		return
+		return nil, fmt.Errorf("failed to get neighbors for pkgID: %s with error %w", pkgID, err)
 	}
-
-	// Send the results to the resultChan
-	resultChan <- struct {
-		pkgVersionNeighborResponse *model.NeighborsResponse
-		isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
-	}{pkgVersionNeighborResponse, isDep}
+	return &pkgVersionNeighborQueryResults{pkgVersionNeighborResponse: pkgVersionNeighborResponse, isDep: isDep}, nil
 }
 
 // searchPkgViaHasSBOM takes in either a purl or URI for the initial value to find the hasSBOM node.
@@ -460,7 +452,7 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 	var path []string
 	var tableRows []table.Row
 	checkedPkgIDs := make(map[string]bool)
-	var wg sync.WaitGroup
+	var collectedPkgVersionResults []*pkgVersionNeighborQueryResults
 
 	queue := make([]string, 0) // the queue of nodes in bfs
 	type dfsNode struct {
@@ -473,11 +465,6 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 
 	nodeMap[searchString] = dfsNode{}
 	queue = append(queue, searchString)
-
-	resultChan := make(chan struct {
-		pkgVersionNeighborResponse *model.NeighborsResponse
-		isDep                      model.AllHasSBOMTreeIncludedDependenciesIsDependency
-	})
 
 	for len(queue) > 0 {
 		now := queue[0]
@@ -560,8 +547,11 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 					if !dfsN.expanded {
 						queue = append(queue, pkgID)
 					}
-					wg.Add(1)
-					go concurrentVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep, resultChan, &wg)
+					pkgVersionNeighbors, err := getVulnAndVexNeighbors(ctx, gqlclient, pkgID, isDep)
+					if err != nil {
+						return nil, nil, fmt.Errorf("getVulnAndVexNeighbors failed with error: %w", err)
+					}
+					collectedPkgVersionResults = append(collectedPkgVersionResults, pkgVersionNeighbors)
 					checkedPkgIDs[pkgID] = true
 				}
 			}
@@ -570,16 +560,10 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 		nodeMap[now] = nowNode
 	}
 
-	// Close the result channel once all goroutines are done
-	go func() {
-		wg.Wait()
-		close(resultChan)
-	}()
-
 	checkedCertifyVulnIDs := make(map[string]bool)
 
 	// Collect results from the channel
-	for result := range resultChan {
+	for _, result := range collectedPkgVersionResults {
 		for _, neighbor := range result.pkgVersionNeighborResponse.Neighbors {
 			if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
 				if !checkedCertifyVulnIDs[certifyVuln.Id] {

--- a/internal/testing/testdata/exampledata/cyclonedx-vex-no-analysis.json
+++ b/internal/testing/testdata/exampledata/cyclonedx-vex-no-analysis.json
@@ -1,0 +1,50 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata" : {
+    "timestamp" : "2022-03-03T00:00:00Z",
+    "component" : {
+      "name" : "ABC",
+      "type" : "application",
+      "bom-ref" : "product-ABC"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "id": "CVE-2021-44228",
+      "source": {
+        "name": "NVD",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H&version=3.1"
+          },
+          "score": 10.0,
+          "severity": "critical",
+          "method": "CVSSv31",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+        }
+      ],
+      "description": "com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the DOMDeserializer class. The highest threat from this vulnerability is data integrity.",
+      "affects": [
+        {
+          "ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#product-ABC",
+          "versions": [
+            {
+              "version": "2.4",
+              "status": "affected"
+            },
+            {
+              "version": "2.6",
+              "status": "affected"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -18,7 +18,6 @@ package testdata
 import (
 	_ "embed"
 	"encoding/base64"
-	"fmt"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -111,6 +110,9 @@ var (
 	//go:embed exampledata/cyclonedx-vex-affected.json
 	CycloneDXVEXAffected []byte
 
+	//go:embed exampledata/cyclonedx-vex-no-analysis.json
+	CycloneDXVEXWithoutAnalysis []byte
+
 	//go:embed exampledata/cyclonedx-vex.xml
 	CyloneDXVEXExampleXML []byte
 
@@ -186,8 +188,8 @@ var (
 			VexData: &generated.VexStatementInputSpec{
 				Status:           generated.VexStatusNotAffected,
 				VexJustification: generated.VexJustificationVulnerableCodeNotInExecutePath,
-				Statement:        "Automated dataflow analysis and manual code review indicates that the vulnerable code is not reachable, either directly or indirectly.",
-				StatusNotes:      fmt.Sprintf("%s:%s", generated.VexStatusNotAffected, generated.VexJustificationVulnerableCodeNotInExecutePath),
+				Statement:        "com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the DOMDeserializer class. The highest threat from this vulnerability is data integrity.",
+				StatusNotes:      "Automated dataflow analysis and manual code review indicates that the vulnerable code is not reachable, either directly or indirectly.",
 				KnownSince:       parseUTCTime("2020-12-03T00:00:00.000Z"),
 			},
 		},
@@ -231,11 +233,28 @@ var (
 	VexDataAffected = &generated.VexStatementInputSpec{
 		Status:           generated.VexStatusAffected,
 		VexJustification: generated.VexJustificationNotProvided,
-		Statement:        "Versions of Product ABC are affected by the vulnerability. Customers are advised to upgrade to the latest release.",
-		StatusNotes:      fmt.Sprintf("%s:%s", generated.VexStatusAffected, generated.VexJustificationNotProvided),
+		Statement:        "",
+		StatusNotes:      "Versions of Product ABC are affected by the vulnerability. Customers are advised to upgrade to the latest release.",
+		KnownSince:       time.Unix(0, 0),
+	}
+	VexDataNoAnalysis = &generated.VexStatementInputSpec{
+		Status:           generated.VexStatusAffected,
+		VexJustification: generated.VexJustificationNotProvided,
+		Statement:        "com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the DOMDeserializer class. The highest threat from this vulnerability is data integrity.",
+		StatusNotes:      "",
 		KnownSince:       time.Unix(0, 0),
 	}
 	CycloneDXAffectedVulnMetadata = []assembler.VulnMetadataIngest{
+		{
+			Vulnerability: VulnSpecAffected,
+			VulnMetadata: &generated.VulnerabilityMetadataInputSpec{
+				ScoreType:  generated.VulnerabilityScoreTypeCvssv31,
+				ScoreValue: 10,
+				Timestamp:  time.Unix(0, 0),
+			},
+		},
+	}
+	CycloneDXNoAnalysisVulnMetadata = []assembler.VulnMetadataIngest{
 		{
 			Vulnerability: VulnSpecAffected,
 			VulnMetadata: &generated.VulnerabilityMetadataInputSpec{
@@ -253,6 +272,16 @@ var (
 			HasSBOM: &model.HasSBOMInputSpec{
 				Algorithm:  "sha256",
 				Digest:     "eb62836ed6339a2d57f66d2e42509718fd480a1befea83f925e918444c369114",
+				KnownSince: parseRfc3339("2022-03-03T00:00:00Z"),
+			},
+		},
+	}
+	HasSBOMVexNoAnalysis = []assembler.HasSBOMIngest{
+		{
+			Pkg: topLevelPkg,
+			HasSBOM: &model.HasSBOMInputSpec{
+				Algorithm:  "sha256",
+				Digest:     "265c99f1f9a09b7fc10c14c97ca1a07fc52ae470f5cbcddd9baf5585fb28221c",
 				KnownSince: parseRfc3339("2022-03-03T00:00:00Z"),
 			},
 		},

--- a/pkg/assembler/helpers/purl.go
+++ b/pkg/assembler/helpers/purl.go
@@ -137,7 +137,7 @@ func purlConvert(p purl.PackageURL) (*model.PkgInputSpec, error) {
 		purl.TypeDebian, purl.TypeGem, purl.TypeGithub,
 		purl.TypeGolang, purl.TypeHackage, purl.TypeHex, purl.TypeMaven,
 		purl.TypeNPM, purl.TypeNuget, purl.TypePyPi, purl.TypeRPM, purl.TypeSwift,
-		purl.TypeGeneric:
+		purl.TypeGeneric, purl.TypeYocto, purl.TypeCpan:
 		// some code
 		r := pkg(p.Type, p.Namespace, p.Name, p.Version, p.Subpath, p.Qualifiers.Map())
 		return r, nil

--- a/pkg/assembler/helpers/purl_test.go
+++ b/pkg/assembler/helpers/purl_test.go
@@ -208,6 +208,14 @@ func TestPurlConvert(t *testing.T) {
 			expected: pkg("oci", "registry.redhat.io/ubi9", "ubi9-container", "sha256:8614ce95268b970880a1eca97dddfce5154fab35418d839c5f75012cccaca0d9", "", map[string]string{
 				"tag": "9.2-489",
 			}),
+		}, {
+			purlUri: "pkg:yocto/dmidecode@2.12-r0?arch=core2-32",
+			expected: pkg("yocto", "", "dmidecode", "2.12-r0", "", map[string]string{
+				"arch": "core2-32",
+			}),
+		}, {
+			purlUri:  "pkg:cpan/Pod-Perldoc@3.20",
+			expected: pkg("cpan", "", "Pod-Perldoc", "3.20", "", map[string]string{}),
 		},
 	}
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -118,6 +118,15 @@ func Test_cyclonedxParser(t *testing.T) {
 		},
 		wantPredicates: affectedVexPredicates(),
 		wantErr:        false,
+	}, {
+		name: "valid CycloneDX VEX document with no analysis",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXVEXWithoutAnalysis,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: noAnalysisVexPredicates(),
+		wantErr:        false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -496,6 +505,41 @@ func affectedVexPredicates() *assembler.IngestPredicates {
 				Pkg:           guacPkgHelper("product-ABC", "2.6"),
 				Vulnerability: testdata.VulnSpecAffected,
 				VexData:       testdata.VexDataAffected,
+			},
+		},
+		CertifyVuln: []assembler.CertifyVulnIngest{
+			{
+				Pkg:           guacPkgHelper("product-ABC", "2.4"),
+				Vulnerability: testdata.VulnSpecAffected,
+				VulnData: &model.ScanMetadataInput{
+					TimeScanned: time.Unix(0, 0),
+				},
+			},
+			{
+				Pkg:           guacPkgHelper("product-ABC", "2.6"),
+				Vulnerability: testdata.VulnSpecAffected,
+				VulnData: &model.ScanMetadataInput{
+					TimeScanned: time.Unix(0, 0),
+				},
+			},
+		},
+	}
+}
+
+func noAnalysisVexPredicates() *assembler.IngestPredicates {
+	return &assembler.IngestPredicates{
+		HasSBOM:      testdata.HasSBOMVexNoAnalysis,
+		VulnMetadata: testdata.CycloneDXNoAnalysisVulnMetadata,
+		Vex: []assembler.VexIngest{
+			{
+				Pkg:           guacPkgHelper("product-ABC", "2.4"),
+				Vulnerability: testdata.VulnSpecAffected,
+				VexData:       testdata.VexDataNoAnalysis,
+			},
+			{
+				Pkg:           guacPkgHelper("product-ABC", "2.6"),
+				Vulnerability: testdata.VulnSpecAffected,
+				VexData:       testdata.VexDataNoAnalysis,
 			},
 		},
 		CertifyVuln: []assembler.CertifyVulnIngest{

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -420,7 +420,7 @@ func fixLicense(ctx context.Context, l *generated.LicenseInputSpec, ol []*spdx.O
 		}
 	}
 	if !found {
-		logger.Error("License identifier %q not found in OtherLicenses", l.Name)
+		logger.Error("License identifier %s not found in OtherLicenses", l.Name)
 		s := "Not found"
 		l.Inline = &s
 	}


### PR DESCRIPTION
# Description of the PR

fix https://github.com/guacsec/guac/issues/1854

Added missing types, fixed issues with CDX VEX ingestion, and fixed SPDX license error output.

Also, fix https://github.com/guacsec/guac/issues/1769

Removing https://github.com/guacsec/guac/blob/main/cmd/guacone/cmd/vulnerability.go#L431-L449 fixes this issue and does not affect the performance.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
