### PR TITLE
Add GUAC Version to Logs

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -18,6 +18,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"github.com/guacsec/guac/pkg/version"
 	"strings"
 
 	"go.uber.org/zap"
@@ -41,6 +42,7 @@ const (
 	Fatal          LogLevel   = "fatal"
 	ChildLoggerKey contextKey = "childLogger"
 	DocumentHash              = "documentHash"
+	guacVersion               = "guac-version"
 )
 
 type loggerKey struct{}
@@ -67,7 +69,7 @@ func InitLogger(level LogLevel) {
 		_ = zapLogger.Sync()
 	}()
 
-	logger = zapLogger.Sugar()
+	logger = zapLogger.Sugar().With(guacVersion, version.Version)
 
 	if levelErr != nil {
 		logger.Infof("Invalid log level %s: ", level, levelErr)


### PR DESCRIPTION
# Description of the PR

- Added GUAC version to logs using a child logger.
- Version info comes from `pkg/version/version.go`, set during build by GoReleaser from the Makefile.

Some example logs:

```
{"level":"info","ts":1713797532.8228843,"caller":"helpers/bulk.go:192","msg":"assembling HasSBOM: 1","guac-version":"v0.5.2-37-gd95860c0-dirty","documentHash":"sha256:91089ed71548f8092f2a6e18451195537708341d60ff101322b550574119dcf4"}
{"level":"info","ts":1713797532.8232749,"caller":"helpers/bulk.go:203","msg":"assembling VEX : 0","guac-version":"v0.5.2-37-gd95860c0-dirty","documentHash":"sha256:91089ed71548f8092f2a6e18451195537708341d60ff101322b550574119dcf4"}
{"level":"info","ts":1713797532.8232844,"caller":"helpers/bulk.go:209","msg":"assembling HashEqual : 0","guac-version":"v0.5.2-37-gd95860c0-dirty","documentHash":"sha256:91089ed71548f8092f2a6e18451195537708341d60ff101322b550574119dcf4"}
{"level":"info","ts":1713797532.823289,"caller":"helpers/bulk.go:215","msg":"assembling PkgEqual : 0","guac-version":"v0.5.2-37-gd95860c0-dirty","documentHash":"sha256:91089ed71548f8092f2a6e18451195537708341d60ff101322b550574119dcf4"}
```

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
