### PR TITLE
[ENT] fix trie output for package, source and vulnerability

### DIFF
--- a/pkg/assembler/backends/ent/backend/helpers.go
+++ b/pkg/assembler/backends/ent/backend/helpers.go
@@ -25,6 +25,11 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+const (
+	// guacIDSplit is used as a separator to concatenate the type and namespace to create an ID
+	guacIDSplit = "guac-split-@@"
+)
+
 type globalID struct {
 	nodeType string
 	id       string

--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -148,12 +148,12 @@ func (b *EntBackend) Neighbors(ctx context.Context, nodeID string, usingOnly []m
 			return []model.Node{}, fmt.Errorf("failed to get pkgName neighbors with id: %s with error: %w", nodeID, err)
 		}
 	case pkgNamespaceString:
-		neighbors, err = b.packageNamespaceNeighbors(ctx, nodeID, processUsingOnly(usingOnly))
+		neighbors, err = b.packageNamespaceNeighbors(ctx, foundGlobalID.id, processUsingOnly(usingOnly))
 		if err != nil {
 			return []model.Node{}, fmt.Errorf("failed to get pkgNamespace neighbors with id: %s with error: %w", nodeID, err)
 		}
 	case pkgTypeString:
-		neighbors, err = b.packageTypeNeighbors(ctx, nodeID, processUsingOnly(usingOnly))
+		neighbors, err = b.packageTypeNeighbors(ctx, foundGlobalID.id, processUsingOnly(usingOnly))
 		if err != nil {
 			return []model.Node{}, fmt.Errorf("failed to get pkgType neighbors with id: %s with error: %w", nodeID, err)
 		}
@@ -163,12 +163,12 @@ func (b *EntBackend) Neighbors(ctx context.Context, nodeID string, usingOnly []m
 			return []model.Node{}, fmt.Errorf("failed to get source name neighbors with id: %s with error: %w", nodeID, err)
 		}
 	case srcNamespaceString:
-		neighbors, err = b.srcNamespaceNeighbors(ctx, nodeID, processUsingOnly(usingOnly))
+		neighbors, err = b.srcNamespaceNeighbors(ctx, foundGlobalID.id, processUsingOnly(usingOnly))
 		if err != nil {
 			return []model.Node{}, fmt.Errorf("failed to get source namespace neighbors with id: %s with error: %w", nodeID, err)
 		}
 	case srcTypeString:
-		neighbors, err = b.srcTypeNeighbors(ctx, nodeID, processUsingOnly(usingOnly))
+		neighbors, err = b.srcTypeNeighbors(ctx, foundGlobalID.id, processUsingOnly(usingOnly))
 		if err != nil {
 			return []model.Node{}, fmt.Errorf("failed to get source type neighbors with id: %s with error: %w", nodeID, err)
 		}
@@ -178,7 +178,7 @@ func (b *EntBackend) Neighbors(ctx context.Context, nodeID string, usingOnly []m
 			return []model.Node{}, fmt.Errorf("failed to get vulnID neighbors with id: %s with error: %w", nodeID, err)
 		}
 	case vulnTypeString:
-		neighbors, err = b.vulnTypeNeighbors(ctx, nodeID, processUsingOnly(usingOnly))
+		neighbors, err = b.vulnTypeNeighbors(ctx, foundGlobalID.id, processUsingOnly(usingOnly))
 		if err != nil {
 			return []model.Node{}, fmt.Errorf("failed to get vuln type neighbors with id: %s with error: %w", nodeID, err)
 		}

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -22,6 +22,7 @@ import (
 	stdsql "database/sql"
 	"fmt"
 	"sort"
+	"strings"
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
@@ -138,6 +139,8 @@ func upsertBulkPackage(ctx context.Context, tx *ent.Tx, pkgInputs []*model.IDorP
 	batches := chunk(pkgInputs, MaxBatchSize)
 	pkgNameIDs := make([]string, 0)
 	pkgVersionIDs := make([]string, 0)
+	pkgTypes := map[string]string{}
+	pkgNamespaces := map[string]string{}
 
 	for _, pkgs := range batches {
 		pkgNameCreates := make([]*ent.PackageNameCreate, len(pkgs))
@@ -153,6 +156,8 @@ func upsertBulkPackage(ctx context.Context, tx *ent.Tx, pkgInputs []*model.IDorP
 			pkgVersionCreates[i] = generatePackageVersionCreate(tx, &pkgVersionID, &pkgNameID, pkgInput)
 
 			pkgNameIDs = append(pkgNameIDs, pkgNameID.String())
+			pkgTypes[pkgNameID.String()] = pkgInput.PackageInput.Type
+			pkgNamespaces[pkgNameID.String()] = strings.Join([]string{pkgInput.PackageInput.Type, stringOrEmpty(pkgInput.PackageInput.Namespace)}, "@@")
 			pkgVersionIDs = append(pkgVersionIDs, pkgVersionID.String())
 		}
 
@@ -182,8 +187,8 @@ func upsertBulkPackage(ctx context.Context, tx *ent.Tx, pkgInputs []*model.IDorP
 	var collectedPkgIDs []model.PackageIDs
 	for i := range pkgVersionIDs {
 		collectedPkgIDs = append(collectedPkgIDs, model.PackageIDs{
-			PackageTypeID:      toGlobalID(pkgTypeString, pkgNameIDs[i]),
-			PackageNamespaceID: toGlobalID(pkgNamespaceString, pkgNameIDs[i]),
+			PackageTypeID:      toGlobalID(pkgTypeString, pkgTypes[pkgNameIDs[i]]),
+			PackageNamespaceID: toGlobalID(pkgNamespaceString, pkgNamespaces[pkgNameIDs[i]]),
 			PackageNameID:      toGlobalID(ent.TypePackageName, pkgNameIDs[i]),
 			PackageVersionID:   toGlobalID(ent.TypePackageVersion, pkgVersionIDs[i])})
 	}
@@ -227,8 +232,8 @@ func upsertPackage(ctx context.Context, tx *ent.Tx, pkg model.IDorPkgInput) (*mo
 	}
 
 	return &model.PackageIDs{
-		PackageTypeID:      toGlobalID(pkgTypeString, pkgNameID.String()),
-		PackageNamespaceID: toGlobalID(pkgNamespaceString, pkgNameID.String()),
+		PackageTypeID:      toGlobalID(pkgTypeString, pkg.PackageInput.Type),
+		PackageNamespaceID: toGlobalID(pkgNamespaceString, strings.Join([]string{pkg.PackageInput.Type, stringOrEmpty(pkg.PackageInput.Namespace)}, "@@")),
 		PackageNameID:      toGlobalID(packagename.Table, pkgNameID.String()),
 		PackageVersionID:   toGlobalID(packageversion.Table, pkgVersionID.String())}, nil
 }
@@ -412,11 +417,11 @@ func (b *EntBackend) packageTypeNeighbors(ctx context.Context, nodeID string, al
 
 		for _, foundPkgName := range pkgNames {
 			out = append(out, &model.Package{
-				ID:   toGlobalID(pkgTypeString, foundPkgName.ID.String()),
+				ID:   toGlobalID(pkgTypeString, foundPkgName.Type),
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        toGlobalID(pkgNamespaceString, foundPkgName.ID.String()),
+						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
 						Namespace: foundPkgName.Namespace,
 						Names:     []*model.PackageName{},
 					},
@@ -430,9 +435,15 @@ func (b *EntBackend) packageTypeNeighbors(ctx context.Context, nodeID string, al
 func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID string, allowedEdges edgeMap) ([]model.Node, error) {
 	var out []model.Node
 
+	// split to find the type and namespace value
+	splitQueryValue := strings.Split(nodeID, "@@")
+	if len(splitQueryValue) != 2 {
+		return out, fmt.Errorf("invalid query for packageNamespaceNeighbors with ID %s", nodeID)
+	}
 	query := b.client.PackageName.Query().
 		Where([]predicate.PackageName{
-			optionalPredicate(&nodeID, packagename.NamespaceEQ),
+			optionalPredicate(&splitQueryValue[0], packagename.TypeEQ),
+			optionalPredicate(&splitQueryValue[1], packagename.NamespaceEQ),
 		}...).
 		Limit(MaxPageSize)
 
@@ -444,11 +455,11 @@ func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID strin
 	for _, foundPkgName := range pkgNames {
 		if allowedEdges[model.EdgePackageNamespacePackageName] {
 			out = append(out, &model.Package{
-				ID:   toGlobalID(pkgTypeString, foundPkgName.ID.String()),
+				ID:   toGlobalID(pkgTypeString, foundPkgName.Type),
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        toGlobalID(pkgNamespaceString, foundPkgName.ID.String()),
+						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, ":")),
 						Namespace: foundPkgName.Namespace,
 						Names: []*model.PackageName{{
 							ID:       toGlobalID(packagename.Table, foundPkgName.ID.String()),
@@ -461,7 +472,7 @@ func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID strin
 		}
 		if allowedEdges[model.EdgePackageNamespacePackageType] {
 			out = append(out, &model.Package{
-				ID:         toGlobalID(pkgTypeString, foundPkgName.ID.String()),
+				ID:         toGlobalID(pkgTypeString, foundPkgName.Type),
 				Type:       foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{},
 			})
@@ -552,11 +563,11 @@ func (b *EntBackend) packageNameNeighbors(ctx context.Context, nodeID string, al
 	for _, foundPkgName := range pkgNames {
 		if allowedEdges[model.EdgePackageNamePackageNamespace] {
 			out = append(out, &model.Package{
-				ID:   toGlobalID(pkgTypeString, foundPkgName.ID.String()),
+				ID:   toGlobalID(pkgTypeString, foundPkgName.Type),
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        toGlobalID(pkgNamespaceString, foundPkgName.ID.String()),
+						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
 						Namespace: foundPkgName.Namespace,
 						Names:     []*model.PackageName{},
 					},
@@ -692,11 +703,11 @@ func (b *EntBackend) packageVersionNeighbors(ctx context.Context, nodeID string,
 			pkgNames = append(pkgNames, backReferencePackageVersion(foundPkgVersion))
 			for _, foundPkgName := range pkgNames {
 				out = append(out, &model.Package{
-					ID:   toGlobalID(pkgTypeString, foundPkgName.ID.String()),
+					ID:   toGlobalID(pkgTypeString, foundPkgName.Type),
 					Type: foundPkgName.Type,
 					Namespaces: []*model.PackageNamespace{
 						{
-							ID:        toGlobalID(pkgNamespaceString, foundPkgName.ID.String()),
+							ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
 							Namespace: foundPkgName.Namespace,
 							Names: []*model.PackageName{{
 								ID:       toGlobalID(packagename.Table, foundPkgName.ID.String()),

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	pkgTypeString      = "pkgType"
-	pkgNamespaceString = "pkgNamespace"
+	pkgTypeString      = "package_types"
+	pkgNamespaceString = "package_namespaces"
 )
 
 func (b *EntBackend) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*model.Package, error) {
@@ -61,7 +61,7 @@ func (b *EntBackend) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*m
 		pkgNames = append(pkgNames, backReferencePackageVersion(collectedPkgVersion))
 	}
 
-	return collect(pkgNames, toModelPackage), nil
+	return toModelPackageTrie(pkgNames), nil
 }
 
 func packageQueryPredicates(pkgSpec *model.PkgSpec) predicate.PackageVersion {
@@ -401,7 +401,7 @@ func (b *EntBackend) packageTypeNeighbors(ctx context.Context, nodeID string, al
 	if allowedEdges[model.EdgePackageTypePackageNamespace] {
 		query := b.client.PackageName.Query().
 			Where([]predicate.PackageName{
-				optionalPredicate(&nodeID, IDEQ),
+				optionalPredicate(&nodeID, packagename.TypeEQ),
 			}...).
 			Limit(MaxPageSize)
 
@@ -432,7 +432,7 @@ func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID strin
 
 	query := b.client.PackageName.Query().
 		Where([]predicate.PackageName{
-			optionalPredicate(&nodeID, IDEQ),
+			optionalPredicate(&nodeID, packagename.NamespaceEQ),
 		}...).
 		Limit(MaxPageSize)
 

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -157,7 +157,7 @@ func upsertBulkPackage(ctx context.Context, tx *ent.Tx, pkgInputs []*model.IDorP
 
 			pkgNameIDs = append(pkgNameIDs, pkgNameID.String())
 			pkgTypes[pkgNameID.String()] = pkgInput.PackageInput.Type
-			pkgNamespaces[pkgNameID.String()] = strings.Join([]string{pkgInput.PackageInput.Type, stringOrEmpty(pkgInput.PackageInput.Namespace)}, "@@")
+			pkgNamespaces[pkgNameID.String()] = strings.Join([]string{pkgInput.PackageInput.Type, stringOrEmpty(pkgInput.PackageInput.Namespace)}, guacIDSplit)
 			pkgVersionIDs = append(pkgVersionIDs, pkgVersionID.String())
 		}
 
@@ -233,7 +233,7 @@ func upsertPackage(ctx context.Context, tx *ent.Tx, pkg model.IDorPkgInput) (*mo
 
 	return &model.PackageIDs{
 		PackageTypeID:      toGlobalID(pkgTypeString, pkg.PackageInput.Type),
-		PackageNamespaceID: toGlobalID(pkgNamespaceString, strings.Join([]string{pkg.PackageInput.Type, stringOrEmpty(pkg.PackageInput.Namespace)}, "@@")),
+		PackageNamespaceID: toGlobalID(pkgNamespaceString, strings.Join([]string{pkg.PackageInput.Type, stringOrEmpty(pkg.PackageInput.Namespace)}, guacIDSplit)),
 		PackageNameID:      toGlobalID(packagename.Table, pkgNameID.String()),
 		PackageVersionID:   toGlobalID(packageversion.Table, pkgVersionID.String())}, nil
 }
@@ -421,7 +421,7 @@ func (b *EntBackend) packageTypeNeighbors(ctx context.Context, nodeID string, al
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
+						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, guacIDSplit)),
 						Namespace: foundPkgName.Namespace,
 						Names:     []*model.PackageName{},
 					},
@@ -436,7 +436,7 @@ func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID strin
 	var out []model.Node
 
 	// split to find the type and namespace value
-	splitQueryValue := strings.Split(nodeID, "@@")
+	splitQueryValue := strings.Split(nodeID, guacIDSplit)
 	if len(splitQueryValue) != 2 {
 		return out, fmt.Errorf("invalid query for packageNamespaceNeighbors with ID %s", nodeID)
 	}
@@ -567,7 +567,7 @@ func (b *EntBackend) packageNameNeighbors(ctx context.Context, nodeID string, al
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
+						ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, guacIDSplit)),
 						Namespace: foundPkgName.Namespace,
 						Names:     []*model.PackageName{},
 					},
@@ -707,7 +707,7 @@ func (b *EntBackend) packageVersionNeighbors(ctx context.Context, nodeID string,
 					Type: foundPkgName.Type,
 					Namespaces: []*model.PackageNamespace{
 						{
-							ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, "@@")),
+							ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, guacIDSplit)),
 							Namespace: foundPkgName.Namespace,
 							Names: []*model.PackageName{{
 								ID:       toGlobalID(packagename.Table, foundPkgName.ID.String()),

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -80,7 +80,7 @@ func (b *EntBackend) FindSoftware(ctx context.Context, searchText string) ([]mod
 		return nil, err
 	}
 	results = append(results, collect(sources, func(v *ent.SourceName) model.PackageSourceOrArtifact {
-		return toModelSourceName(v)
+		return toModelSource(v)
 	})...)
 
 	artifacts, err := b.client.Artifact.Query().Where(

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -384,7 +384,7 @@ func upsertBulkSource(ctx context.Context, tx *ent.Tx, srcInputs []*model.IDorSo
 			srcNameCreates[i] = generateSourceNameCreate(tx, &srcNameID, s)
 			srcNameIDs = append(srcNameIDs, srcNameID.String())
 			srcTypes[srcNameID.String()] = s.SourceInput.Type
-			srcNamespaces[srcNameID.String()] = strings.Join([]string{s.SourceInput.Type, s.SourceInput.Namespace}, "@@")
+			srcNamespaces[srcNameID.String()] = strings.Join([]string{s.SourceInput.Type, s.SourceInput.Namespace}, guacIDSplit)
 		}
 
 		if err := tx.SourceName.CreateBulk(srcNameCreates...).
@@ -449,7 +449,7 @@ func upsertSource(ctx context.Context, tx *ent.Tx, src model.IDorSourceInput) (*
 
 	return &model.SourceIDs{
 		SourceTypeID:      toGlobalID(srcTypeString, src.SourceInput.Type),
-		SourceNamespaceID: toGlobalID(srcNamespaceString, strings.Join([]string{src.SourceInput.Type, src.SourceInput.Namespace}, "@@")),
+		SourceNamespaceID: toGlobalID(srcNamespaceString, strings.Join([]string{src.SourceInput.Type, src.SourceInput.Namespace}, guacIDSplit)),
 		SourceNameID:      toGlobalID(sourcename.Table, srcNameID.String())}, nil
 }
 
@@ -507,7 +507,7 @@ func toModelSourceTrie(collectedSrcNames []*ent.SourceName) []*model.Source {
 
 	for _, srcName := range collectedSrcNames {
 
-		namespaceString := srcName.Namespace + "," + toGlobalID(srcNamespaceString, strings.Join([]string{srcName.Type, srcName.Namespace}, "@@"))
+		namespaceString := srcName.Namespace + "," + toGlobalID(srcNamespaceString, strings.Join([]string{srcName.Type, srcName.Namespace}, guacIDSplit))
 		typeString := srcName.Type + "," + toGlobalID(srcTypeString, srcName.Type)
 
 		sourceName := &model.SourceName{
@@ -573,7 +573,7 @@ func toModelSource(s *ent.SourceName) *model.Source {
 		ID:   toGlobalID(srcTypeString, s.Type),
 		Type: s.Type,
 		Namespaces: []*model.SourceNamespace{{
-			ID:        toGlobalID(srcNamespaceString, strings.Join([]string{s.Type, s.Namespace}, "@@")),
+			ID:        toGlobalID(srcNamespaceString, strings.Join([]string{s.Type, s.Namespace}, guacIDSplit)),
 			Namespace: s.Namespace,
 			Names:     []*model.SourceName{sourceName},
 		}},
@@ -602,7 +602,7 @@ func (b *EntBackend) srcTypeNeighbors(ctx context.Context, nodeID string, allowe
 				Type: foundSrcName.Type,
 				Namespaces: []*model.SourceNamespace{
 					{
-						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, "@@")),
+						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, guacIDSplit)),
 						Namespace: foundSrcName.Namespace,
 						Names:     []*model.SourceName{},
 					},
@@ -617,7 +617,7 @@ func (b *EntBackend) srcNamespaceNeighbors(ctx context.Context, nodeID string, a
 	var out []model.Node
 
 	// split to find the type and namespace value
-	splitQueryValue := strings.Split(nodeID, "@@")
+	splitQueryValue := strings.Split(nodeID, guacIDSplit)
 	if len(splitQueryValue) != 2 {
 		return out, fmt.Errorf("invalid query for srcNamespaceNeighbors with ID %s", nodeID)
 	}
@@ -638,7 +638,7 @@ func (b *EntBackend) srcNamespaceNeighbors(ctx context.Context, nodeID string, a
 				Type: foundSrcName.Type,
 				Namespaces: []*model.SourceNamespace{
 					{
-						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, "@@")),
+						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, guacIDSplit)),
 						Namespace: foundSrcName.Namespace,
 						Names: []*model.SourceName{
 							{
@@ -735,7 +735,7 @@ func (b *EntBackend) srcNameNeighbors(ctx context.Context, nodeID string, allowe
 				Type: foundSrcName.Type,
 				Namespaces: []*model.SourceNamespace{
 					{
-						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, "@@")),
+						ID:        toGlobalID(srcNamespaceString, strings.Join([]string{foundSrcName.Type, foundSrcName.Namespace}, guacIDSplit)),
 						Namespace: foundSrcName.Namespace,
 						Names:     []*model.SourceName{},
 					},

--- a/pkg/assembler/backends/ent/backend/transforms.go
+++ b/pkg/assembler/backends/ent/backend/transforms.go
@@ -53,7 +53,7 @@ func toModelPackageTrie(collectedPkgNames []*ent.PackageName) []*model.Package {
 	for _, pkgName := range collectedPkgNames {
 		nameString := pkgName.Name + "," + toGlobalID(packagename.Table, pkgName.ID.String())
 
-		namespaceString := pkgName.Namespace + "," + toGlobalID(pkgNamespaceString, strings.Join([]string{pkgName.Type, pkgName.Namespace}, "@@"))
+		namespaceString := pkgName.Namespace + "," + toGlobalID(pkgNamespaceString, strings.Join([]string{pkgName.Type, pkgName.Namespace}, guacIDSplit))
 		typeString := pkgName.Type + "," + toGlobalID(pkgTypeString, pkgName.Type)
 
 		if pkgNamespaces, ok := pkgTypes[typeString]; ok {
@@ -123,7 +123,7 @@ func toModelNamespace(n *ent.PackageName) *model.PackageNamespace {
 		return nil
 	}
 	return &model.PackageNamespace{
-		ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{n.Type, n.Namespace}, "@@")),
+		ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{n.Type, n.Namespace}, guacIDSplit)),
 		Namespace: n.Namespace,
 		Names:     collect([]*ent.PackageName{n}, toModelPackageName),
 	}

--- a/pkg/assembler/backends/ent/backend/transforms.go
+++ b/pkg/assembler/backends/ent/backend/transforms.go
@@ -53,7 +53,7 @@ func toModelPackageTrie(collectedPkgNames []*ent.PackageName) []*model.Package {
 	for _, pkgName := range collectedPkgNames {
 		nameString := pkgName.Name + "," + toGlobalID(packagename.Table, pkgName.ID.String())
 
-		namespaceString := pkgName.Namespace + "," + toGlobalID(pkgNamespaceString, pkgName.Namespace)
+		namespaceString := pkgName.Namespace + "," + toGlobalID(pkgNamespaceString, strings.Join([]string{pkgName.Type, pkgName.Namespace}, "@@"))
 		typeString := pkgName.Type + "," + toGlobalID(pkgTypeString, pkgName.Type)
 
 		if pkgNamespaces, ok := pkgTypes[typeString]; ok {
@@ -112,7 +112,7 @@ func toModelPackage(p *ent.PackageName) *model.Package {
 		return nil
 	}
 	return &model.Package{
-		ID:         toGlobalID(pkgTypeString, p.ID.String()),
+		ID:         toGlobalID(pkgTypeString, p.Type),
 		Type:       p.Type,
 		Namespaces: collect([]*ent.PackageName{p}, toModelNamespace),
 	}
@@ -123,7 +123,7 @@ func toModelNamespace(n *ent.PackageName) *model.PackageNamespace {
 		return nil
 	}
 	return &model.PackageNamespace{
-		ID:        toGlobalID(pkgNamespaceString, n.ID.String()),
+		ID:        toGlobalID(pkgNamespaceString, strings.Join([]string{n.Type, n.Namespace}, "@@")),
 		Namespace: n.Namespace,
 		Names:     collect([]*ent.PackageName{n}, toModelPackageName),
 	}

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	vulnTypeString = "vulnType"
+	vulnTypeString = "vulnerability_types"
 	NoVuln         = "novuln"
 )
 
@@ -185,7 +185,7 @@ func toModelVulnerability(collectedVulnID []*ent.VulnerabilityID) []*model.Vulne
 	vulnTypes := map[string][]*model.VulnerabilityID{}
 
 	for _, vulnID := range collectedVulnID {
-		typeString := vulnID.Type
+		typeString := vulnID.Type + "," + toGlobalID(vulnTypeString, vulnID.Type)
 		vulnID := &model.VulnerabilityID{
 			ID:              toGlobalID(vulnerabilityid.Table, vulnID.ID.String()),
 			VulnerabilityID: vulnID.VulnerabilityID,
@@ -200,9 +200,10 @@ func toModelVulnerability(collectedVulnID []*ent.VulnerabilityID) []*model.Vulne
 	}
 	var vulnerabilities []*model.Vulnerability
 	for vulnType, vulnIDs := range vulnTypes {
+		typeValues := strings.Split(vulnType, ",")
 		vuln := &model.Vulnerability{
-			ID:               vulnType,
-			Type:             vulnType,
+			ID:               typeValues[1],
+			Type:             typeValues[0],
 			VulnerabilityIDs: vulnIDs,
 		}
 		vulnerabilities = append(vulnerabilities, vuln)
@@ -221,7 +222,7 @@ func (b *EntBackend) vulnTypeNeighbors(ctx context.Context, nodeID string, allow
 	var out []model.Node
 	if allowedEdges[model.EdgeVulnerabilityTypeVulnerabilityID] {
 		query := b.client.VulnerabilityID.Query().
-			Where(vulnerabilityQueryPredicates(model.VulnerabilitySpec{ID: &nodeID})...).
+			Where(vulnerabilityQueryPredicates(model.VulnerabilitySpec{Type: &nodeID})...).
 			Limit(MaxPageSize)
 
 		vulnIDs, err := query.All(ctx)

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -134,7 +134,7 @@ func upsertBulkVulnerability(ctx context.Context, tx *ent.Tx, vulnInputs []*mode
 			creates[i] = generateVulnerabilityIDCreate(tx, &vulnID, v)
 
 			ids = append(ids, model.VulnerabilityIDs{
-				VulnerabilityTypeID: toGlobalID(vulnTypeString, vulnID.String()),
+				VulnerabilityTypeID: toGlobalID(vulnTypeString, v.VulnerabilityInput.Type),
 				VulnerabilityNodeID: toGlobalID(ent.TypeVulnerabilityID, vulnID.String())})
 		}
 
@@ -176,7 +176,7 @@ func upsertVulnerability(ctx context.Context, tx *ent.Tx, spec model.IDorVulnera
 	}
 
 	return &model.VulnerabilityIDs{
-		VulnerabilityTypeID: toGlobalID(vulnTypeString, vulnID.String()),
+		VulnerabilityTypeID: toGlobalID(vulnTypeString, spec.VulnerabilityInput.Type),
 		VulnerabilityNodeID: toGlobalID(vulnerabilityid.Table, vulnID.String()),
 	}, nil
 }
@@ -232,7 +232,7 @@ func (b *EntBackend) vulnTypeNeighbors(ctx context.Context, nodeID string, allow
 
 		for _, foundVulnID := range vulnIDs {
 			out = append(out, &model.Vulnerability{
-				ID:   toGlobalID(vulnTypeString, foundVulnID.ID.String()),
+				ID:   toGlobalID(vulnTypeString, foundVulnID.Type),
 				Type: foundVulnID.Type,
 				VulnerabilityIDs: []*model.VulnerabilityID{
 					{
@@ -290,7 +290,7 @@ func (b *EntBackend) vulnIdNeighbors(ctx context.Context, nodeID string, allowed
 	for _, foundVulnID := range vulnIDs {
 		if allowedEdges[model.EdgeVulnerabilityIDVulnerabilityType] {
 			out = append(out, &model.Vulnerability{
-				ID:               toGlobalID(vulnTypeString, foundVulnID.ID.String()),
+				ID:               toGlobalID(vulnTypeString, foundVulnID.Type),
 				Type:             foundVulnID.Type,
 				VulnerabilityIDs: []*model.VulnerabilityID{},
 			})


### PR DESCRIPTION
# Description of the PR

fix trie output for package, source and vulnerability. Also update neighbors for `pkgType`, `pkgNamespace`, `srcType`, srcNamespace` and `vulnType`, to search via value instead of ID. 

Packages

![Screenshot 2024-04-23 at 6 44 25 PM](https://github.com/guacsec/guac/assets/88045217/5ad95e5b-6303-4039-97a8-78cf86ed3385)

Sources

![Screenshot 2024-04-23 at 6 44 40 PM](https://github.com/guacsec/guac/assets/88045217/14073133-062a-4747-b52e-2c6d840b227b)

Vulnerabilities 
![Screenshot 2024-04-23 at 5 55 13 PM](https://github.com/guacsec/guac/assets/88045217/b60699d7-ed2e-40a6-a33c-eb0b50fb2abd)


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
