### PR TITLE
Add a client testing library

### DIFF
--- a/internal/testing/graphqlClients/guacdata.go
+++ b/internal/testing/graphqlClients/guacdata.go
@@ -1,0 +1,441 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/assembler/helpers"
+)
+
+const (
+	// nouns
+	defaultHashAlgorithm   = "sha256"
+	defaultSourceType      = "test-type"
+	defaultSourceNamespace = "test-namespace"
+
+	// IsOccurrence
+	defaultIsOccurrenceJustification = "test-justification"
+	defaultIsOccurrenceOrigin        = "test-origin"
+	defaultIsOccurrenceCollector     = "test-collector"
+
+	// HasSbom
+	defaultHasSbomOrigin           = "test-origin"
+	defaultHasSbomCollector        = "test-collector"
+	defaultHasSbomUri              = "test-uri"
+	defaultHasSbomDownloadLocation = "test-download-loc"
+	defaultHasSbomDigest           = "test-digest"
+
+	// IsDependency
+	defaultIsDependencyDependencyType = gql.DependencyTypeUnknown
+	defaultIsDependencyJustification  = "test-justification"
+	defaultIsDependencyOrigin         = "test-origin"
+	defaultIsDependencyCollector      = "test-collector"
+
+	// HashEquals
+	defaultHashEqualJustification = "test-justification"
+	defaultHashEqualOrigin        = "test-origin"
+	defaultHashEqualCollector     = "test-collector"
+
+	// HasSlsa
+	defaultHasSlsaBuildType      = "test-builder=type"
+	defaultHasSlsaVersion        = "test-slsa-version"
+	defaultHasSlsaOrigin         = "test-origin"
+	defaultHasSlsaCollector      = "test-collector"
+	defaultHasSlsaPredicateKey   = "test-predicate-key"
+	defaultHasSlsaPredicateValue = "test-predicate-value"
+)
+
+// Defines the Guac graph, to test clients of the Graphql server.
+//
+// This type, along with the Ingest function, is similar to the backend IngestPredicates
+// type and the corresponding assembler function, but allows for significantly less verbose
+// tests by specifying each noun with a single string and making the various InputSpec
+// structs optional. Additionally, t.Fatalf is called upon any errors. However, this also means
+// that a few inputs aren't supported, such as finer-grained definition of nouns.
+//
+// All verbs are currently attached to packge version nodes, but a configuration for this
+// could be added if needed.
+type GuacData struct {
+	/** the nouns need to be specified here in order to be referenced from a verb **/
+	Packages  []string // packages are specified by purl
+	Artifacts []string // artifacts are specified by digest
+	Sources   []string // sources are specified by the name in the SourceName node
+	Builders  []string // builders are specified by URI
+
+	/** verbs **/
+	HasSboms       []HasSbom
+	IsOccurrences  []IsOccurrence
+	IsDependencies []IsDependency
+	HashEquals     []HashEqual
+	HasSlsas       []HasSlsa
+
+	// Other graphql verbs still need to be added here
+}
+
+type IsDependency struct {
+	DependentPkg  string                     // a previously ingested purl
+	DependencyPkg string                     // a previously ingested purl
+	Spec          *gql.IsDependencyInputSpec // if nil, a default will be used
+}
+
+type IsOccurrence struct {
+	Subject  string                     // a previously ingested purl or source
+	Artifact string                     // a previously ingested digest
+	Spec     *gql.IsOccurrenceInputSpec // if nil, a default will be used
+}
+
+type HasSbom struct {
+	Subject                string   // a previously ingested purl or digest
+	IncludedSoftware       []string // a list of previously ingested purls and digests
+	IncludedIsDependencies []IsDependency
+	IncludedIsOccurrences  []IsOccurrence
+	Spec                   *gql.HasSBOMInputSpec // if nil, a default will be used
+}
+
+type HashEqual struct {
+	ArtifactA string                  // a previously ingested digest
+	ArtifactB string                  // a previously ingested digest
+	Spec      *gql.HashEqualInputSpec // if nil, a default will be used
+}
+
+type HasSlsa struct {
+	Subject   string             // a previously ingested digest
+	BuiltFrom []string           // a list of previously ingested digests
+	BuiltBy   string             // a previously ingested builder
+	Spec      *gql.SLSAInputSpec // if nil, a default will be used
+}
+
+// maintains the ids of nouns, to use when ingesting verbs
+type nounIds struct {
+	PackageIds  map[string]string // map from purls to IDs of PackageName nodes
+	ArtifactIds map[string]string // map from digest to IDs of Artifact nodes
+	SourceIds   map[string]string // map from source names to IDs of SourceName nodes
+	BuilderIds  map[string]string // map from URI to IDs of Builder nodes
+
+}
+
+func Ingest(ctx context.Context, t *testing.T, gqlClient graphql.Client, data GuacData) nounIds {
+	packageIds := map[string]string{}
+	for _, pkg := range data.Packages {
+		packageIds[pkg] = ingestPackage(ctx, t, gqlClient, pkg)
+	}
+
+	artifactIds := map[string]string{}
+	for _, artifact := range data.Artifacts {
+		artifactIds[artifact] = ingestArtifact(ctx, t, gqlClient, artifact)
+	}
+
+	sourceIds := map[string]string{}
+	for _, source := range data.Sources {
+		sourceIds[source] = ingestSource(ctx, t, gqlClient, source)
+	}
+
+	builderIds := map[string]string{}
+	for _, builder := range data.Builders {
+		builderIds[builder] = ingestBuilder(ctx, t, gqlClient, builder)
+	}
+
+	i := nounIds{
+		PackageIds:  packageIds,
+		ArtifactIds: artifactIds,
+		SourceIds:   sourceIds,
+		BuilderIds:  builderIds,
+	}
+
+	for _, sbom := range data.HasSboms {
+		i.ingestHasSbom(ctx, t, gqlClient, sbom)
+	}
+
+	for _, isDependency := range data.IsDependencies {
+		i.ingestIsDependency(ctx, t, gqlClient, isDependency)
+	}
+
+	for _, isOccurrence := range data.IsOccurrences {
+		i.ingestIsOccurrence(ctx, t, gqlClient, isOccurrence)
+	}
+
+	for _, hashEqual := range data.HashEquals {
+		i.ingestHashEqual(ctx, t, gqlClient, hashEqual)
+	}
+
+	for _, hasSlsa := range data.HasSlsas {
+		i.ingestHasSlsa(ctx, t, gqlClient, hasSlsa)
+	}
+
+	return i
+}
+
+func (i nounIds) ingestHasSlsa(ctx context.Context, t *testing.T, gqlClient graphql.Client, hasSlsa HasSlsa) {
+	slsaSpec := hasSlsa.Spec
+	if slsaSpec == nil {
+		slsaSpec = &gql.SLSAInputSpec{
+			BuildType: defaultHasSlsaBuildType,
+			SlsaPredicate: []gql.SLSAPredicateInputSpec{
+				{Key: defaultHasSlsaPredicateKey, Value: defaultHasSlsaPredicateValue},
+			},
+			SlsaVersion: defaultHasSlsaVersion,
+			Origin:      defaultHasSlsaOrigin,
+			Collector:   defaultHasSlsaCollector,
+		}
+	}
+
+	subjectId, ok := i.ArtifactIds[hasSlsa.Subject]
+	if !ok {
+		t.Fatalf("The digest %s has not been ingested", hasSlsa.Subject)
+	}
+	subjectSpec := gql.IDorArtifactInput{ArtifactID: &subjectId}
+
+	builtFromSpecs := []gql.IDorArtifactInput{}
+	for _, buildMaterial := range hasSlsa.BuiltFrom {
+		buildMaterialId, ok := i.ArtifactIds[buildMaterial]
+		if !ok {
+			t.Fatalf("The digest %s has not been ingested", buildMaterial)
+		}
+		builtFromSpec := gql.IDorArtifactInput{ArtifactID: &buildMaterialId}
+		builtFromSpecs = append(builtFromSpecs, builtFromSpec)
+	}
+
+	builderId, ok := i.BuilderIds[hasSlsa.BuiltBy]
+	if !ok {
+		t.Fatalf("The builder %s has not been ingested", hasSlsa.BuiltBy)
+	}
+	builtBySpec := gql.IDorBuilderInput{BuilderID: &builderId}
+
+	_, err := gql.IngestSLSAForArtifact(ctx, gqlClient, subjectSpec, builtFromSpecs, builtBySpec, *slsaSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting HasSlsa when setting up test: %s", err)
+	}
+}
+
+func (i nounIds) ingestHashEqual(ctx context.Context, t *testing.T, gqlClient graphql.Client, hashEqual HashEqual) {
+	spec := hashEqual.Spec
+	if spec == nil {
+		spec = &gql.HashEqualInputSpec{
+			Justification: defaultHashEqualJustification,
+			Origin:        defaultHashEqualOrigin,
+			Collector:     defaultHashEqualCollector,
+		}
+	}
+
+	artifactAId, ok := i.ArtifactIds[hashEqual.ArtifactA]
+	if !ok {
+		t.Fatalf("The digest %s has not been ingested", hashEqual.ArtifactA)
+	}
+	artifactBId, ok := i.ArtifactIds[hashEqual.ArtifactB]
+	if !ok {
+		t.Fatalf("The digest %s has not been ingested", hashEqual.ArtifactB)
+	}
+
+	artifactASpec := gql.IDorArtifactInput{ArtifactID: &artifactAId}
+	artifactBSpec := gql.IDorArtifactInput{ArtifactID: &artifactBId}
+	_, err := gql.IngestHashEqual(ctx, gqlClient, artifactASpec, artifactBSpec, *spec)
+	if err != nil {
+		t.Fatalf("Error ingesting HashEqual when setting up test: %s", err)
+	}
+}
+
+// Returns the id of the IsDependency node
+func (i nounIds) ingestIsDependency(ctx context.Context, t *testing.T, gqlClient graphql.Client, isDependency IsDependency) string {
+	spec := isDependency.Spec
+	if spec == nil {
+		spec = &gql.IsDependencyInputSpec{
+			DependencyType: defaultIsDependencyDependencyType,
+			Justification:  defaultIsDependencyJustification,
+			Origin:         defaultIsDependencyOrigin,
+			Collector:      defaultIsDependencyCollector,
+		}
+	}
+
+	dependentId, ok := i.PackageIds[isDependency.DependentPkg]
+	if !ok {
+		t.Fatalf("The purl %s has not been ingested", isDependency.DependentPkg)
+	}
+	dependencyId := i.PackageIds[isDependency.DependencyPkg]
+	if !ok {
+		t.Fatalf("The purl %s has not been ingested", isDependency.DependencyPkg)
+	}
+
+	// The IsDependency is attached to the package version node
+	flags := gql.MatchFlags{Pkg: gql.PkgMatchTypeSpecificVersion}
+	dependentSpec := gql.IDorPkgInput{PackageVersionID: &dependentId}
+	dependencySpec := gql.IDorPkgInput{PackageVersionID: &dependencyId}
+
+	res, err := gql.IngestIsDependency(ctx, gqlClient, dependentSpec, dependencySpec, flags, *spec)
+	if err != nil {
+		t.Fatalf("Error ingesting IsDependency when setting up test: %s", err)
+	}
+	return res.GetIngestDependency()
+}
+
+// Returns the ID of the IsOccurrence node.
+func (i nounIds) ingestIsOccurrence(ctx context.Context, t *testing.T, gqlClient graphql.Client, isOccurrence IsOccurrence) string {
+	spec := isOccurrence.Spec
+	if spec == nil {
+		spec = &gql.IsOccurrenceInputSpec{
+			Justification: defaultIsOccurrenceJustification,
+			Origin:        defaultIsOccurrenceOrigin,
+			Collector:     defaultIsOccurrenceCollector,
+		}
+	}
+
+	artifactId, ok := i.ArtifactIds[isOccurrence.Artifact]
+	if !ok {
+		t.Fatalf("The digest %s has not been ingested", isOccurrence.Artifact)
+	}
+	artifactSpec := gql.IDorArtifactInput{ArtifactID: &artifactId}
+
+	// the subject can be either a package or a source
+	if v, ok := i.PackageIds[isOccurrence.Subject]; ok {
+		pkgSpec := gql.IDorPkgInput{PackageVersionID: &v}
+		res, err := gql.IngestIsOccurrencePkg(ctx, gqlClient, pkgSpec, artifactSpec, *spec)
+		if err != nil {
+			t.Fatalf("Error ingesting IsOccurrence: %s", err)
+		}
+		return res.GetIngestOccurrence()
+
+	} else if v, ok := i.SourceIds[isOccurrence.Subject]; ok {
+		sourceSpec := gql.IDorSourceInput{SourceNameID: &v}
+		res, err := gql.IngestIsOccurrenceSrc(ctx, gqlClient, sourceSpec, artifactSpec, *spec)
+		if err != nil {
+			t.Fatalf("Error ingesting IsOccurrence: %s", err)
+		}
+		return res.GetIngestOccurrence()
+	}
+
+	t.Fatalf("The purl or source %s has not been ingested", isOccurrence.Subject)
+	return ""
+}
+
+func (i nounIds) ingestHasSbom(ctx context.Context, t *testing.T, gqlClient graphql.Client, hasSbom HasSbom) {
+	isDependencyIds := []string{}
+	for _, dependency := range hasSbom.IncludedIsDependencies {
+		id := i.ingestIsDependency(ctx, t, gqlClient, dependency)
+		isDependencyIds = append(isDependencyIds, id)
+	}
+
+	isOccurrenceIds := []string{}
+	for _, occurrence := range hasSbom.IncludedIsOccurrences {
+		id := i.ingestIsOccurrence(ctx, t, gqlClient, occurrence)
+		isOccurrenceIds = append(isOccurrenceIds, id)
+	}
+
+	includedPackageIds := []string{}
+	includedArtifactIds := []string{}
+	for _, software := range hasSbom.IncludedSoftware {
+		if id, ok := i.PackageIds[software]; ok {
+			includedPackageIds = append(includedPackageIds, id)
+		} else if id, ok := i.ArtifactIds[software]; ok {
+			includedArtifactIds = append(includedArtifactIds, id)
+		} else {
+			t.Fatalf("The purl or digest %s has not been ingested", software)
+		}
+	}
+
+	sbomSpec := hasSbom.Spec
+	if hasSbom.Spec == nil {
+		sbomSpec = &gql.HasSBOMInputSpec{
+			Uri:              defaultHasSbomUri,
+			Algorithm:        defaultHashAlgorithm,
+			Digest:           defaultHasSbomDigest,
+			DownloadLocation: defaultHasSbomDownloadLocation,
+			Origin:           defaultHasSbomOrigin,
+			Collector:        defaultHasSbomCollector,
+			KnownSince:       time.Now(),
+		}
+	}
+	includesSpec := gql.HasSBOMIncludesInputSpec{
+		Packages:     includedPackageIds,
+		Artifacts:    includedArtifactIds,
+		Dependencies: isDependencyIds,
+		Occurrences:  isOccurrenceIds,
+	}
+
+	// the subject can be either a package or an artifact
+	if v, ok := i.PackageIds[hasSbom.Subject]; ok {
+		pkgSpec := gql.IDorPkgInput{PackageVersionID: &v}
+		_, err := gql.IngestHasSBOMPkg(ctx, gqlClient, pkgSpec, *sbomSpec, includesSpec)
+		if err != nil {
+			t.Fatalf("Error ingesting sbom when setting up test: %s", err)
+		}
+	} else if v, ok := i.ArtifactIds[hasSbom.Subject]; ok {
+		artifactSpec := gql.IDorArtifactInput{ArtifactID: &v}
+		_, err := gql.IngestHasSBOMArtifact(ctx, gqlClient, artifactSpec, *sbomSpec, includesSpec)
+		if err != nil {
+			t.Fatalf("Error ingesting sbom when setting up test: %s", err)
+		}
+	} else {
+		t.Fatalf("The purl or digest %s has not been ingested", hasSbom.Subject)
+	}
+}
+
+// Returns the ID of the version node in the package trie
+func ingestPackage(ctx context.Context, t *testing.T, gqlClient graphql.Client, purl string) string {
+	spec, err := helpers.PurlToPkg(purl)
+	if err != nil {
+		t.Fatalf("Could not create a package input spec from a purl: %s", err)
+	}
+	idOrInputSpec := gql.IDorPkgInput{PackageInput: spec}
+	res, err := gql.IngestPackage(ctx, gqlClient, idOrInputSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting package when setting up test: %s", err)
+	}
+	return res.IngestPackage.PackageVersionID
+}
+
+func ingestArtifact(ctx context.Context, t *testing.T, gqlClient graphql.Client, digest string) string {
+	spec := gql.ArtifactInputSpec{
+		Algorithm: defaultHashAlgorithm,
+		Digest:    digest,
+	}
+	idOrInputSpec := gql.IDorArtifactInput{ArtifactInput: &spec}
+	res, err := gql.IngestArtifact(ctx, gqlClient, idOrInputSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting artifact when setting up test: %s", err)
+	}
+	return res.GetIngestArtifact()
+}
+
+// Returns the ID of the SourceName node in the trie.
+func ingestSource(ctx context.Context, t *testing.T, gqlClient graphql.Client, name string) string {
+	spec := gql.SourceInputSpec{
+		Type:      defaultSourceType,
+		Namespace: defaultSourceNamespace,
+	}
+	idorInputSpec := gql.IDorSourceInput{SourceInput: &spec}
+	res, err := gql.IngestSource(ctx, gqlClient, idorInputSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting source when setting up test: %s", err)
+	}
+	return res.GetIngestSource().SourceNameID
+}
+
+func ingestBuilder(ctx context.Context, t *testing.T, gqlClient graphql.Client, uri string) string {
+	spec := gql.BuilderInputSpec{
+		Uri: defaultSourceType,
+	}
+	idorInputSpec := gql.IDorBuilderInput{BuilderInput: &spec}
+	res, err := gql.IngestBuilder(ctx, gqlClient, idorInputSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting builder when setting up test: %s", err)
+	}
+	return res.GetIngestBuilder()
+}

--- a/internal/testing/graphqlClients/testsetup.go
+++ b/internal/testing/graphqlClients/testsetup.go
@@ -1,0 +1,101 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package clients helps set up the graphql backend for testing graphql clients
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	assembler "github.com/guacsec/guac/pkg/assembler/graphql/generated"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+// SetupTest starts the graphql server and returns a client for it. The parameter
+// t is used to register a function to close the server and to fail the test upon
+// any errors.
+func SetupTest(t *testing.T) graphql.Client {
+	gqlHandler := getGraphqlHandler(t)
+	port := startGraphqlServer(t, gqlHandler)
+	serverAddr := fmt.Sprintf("http://localhost:%s", port)
+	client := graphql.NewClient(serverAddr, nil)
+	return client
+}
+
+// startGraphqlServer starts up up the graphql server, registers a function to close it when the test completes,
+// and returns the port it is listening on.
+func startGraphqlServer(t *testing.T, gqlHandler *handler.Server) string {
+	srv := http.Server{Handler: gqlHandler}
+
+	// Create the listener explicitely in order to find the port it listens on
+	listener, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Fatalf("Error initializing listener for graphql server: %v", err)
+		return ""
+	}
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Error getting post from server address: %v", err)
+		return ""
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		t.Logf("Starting graphql server on: %v", listener.Addr())
+		wg.Done()
+		// this thread could still be preempted here, but I don't think we can do better?
+		err := srv.Serve(listener)
+		if err != http.ErrServerClosed {
+			t.Logf("Graphql server finished with error: %v", srv.Serve(listener))
+		}
+	}()
+	wg.Wait()
+
+	closeFunc := func() {
+		err := srv.Close()
+		if err != nil {
+			t.Logf("Error closing graphql server listener")
+		} else {
+			t.Logf("Graphql server shut down")
+		}
+	}
+	t.Cleanup(closeFunc)
+
+	return port
+}
+
+// Gets the handler for the graphql server with the inmem backend resolver.
+func getGraphqlHandler(t *testing.T) *handler.Server {
+	ctx := context.Background()
+	backend, err := backends.Get("keyvalue", ctx, struct{}{})
+	if err != nil {
+		t.Fatalf("Error getting the keyvalue backend")
+	}
+	resolver := resolvers.Resolver{Backend: backend}
+
+	config := assembler.Config{Resolvers: &resolver}
+	config.Directives.Filter = resolvers.Filter
+	return handler.NewDefaultServer(assembler.NewExecutableSchema(config))
+}


### PR DESCRIPTION
In writing a REST API transitive dependencies endpoint, I found I needed an easier way to write tests. This PR is my solution for that, but I also think that more generally testing clients of the Graphql server isn't currently well-supported and this PR can address that.

## How clients are currently tested
One approach that has been taken is to start a new http server for each test and to specify the graph with the [`IngestPredicates`](https://github.com/guacsec/guac/blob/main/pkg/assembler/assembler.go#L32) type. Using `IngestPredicates` to specify the graph is appealing because all of the ingestion code is already implemented in the [assembler function](https://github.com/guacsec/guac/blob/main/pkg/assembler/clients/helpers/bulk.go#L30). However, this leads to very verbose tests because each noun must be specified with its corresponding InputSpec every time it is referenced. Additionally, the verb InputSpecs (e.g. HashEqualInputSpec) are required, but their content is often irrelevant to tests. See the [patch planning tests](https://github.com/guacsec/guac/blob/main/pkg/guacanalytics/patchPlanning_test.go) for where this approach of test setup is used, and that about 900 LOC are used to define 12 graphs.  Verbose tests or tests with duplicate code aren't necessarily bad, but I think this approach does limit readability quite a bit and makes writing tests more difficult. It also requires specifying data that may not be relevant to a test, such as the verb InputSpecs. 

Another approach that has been taken (by https://github.com/guacsec/guac/pull/1705) is to rely on the graphql server that the CI starts during the integration test phase and to create helper functions and types (e.g. [shortcut type](https://github.com/guacsec/guac/blob/cf32140f273dac8b70a4a9fbc506e9d2ccc9191d/pkg/dependencies/dependents_test.go#L39) for IsDependency in that PR) to make it easier and less verbose to specify the graph. However, using the Graphql server that is global to the CI integration tests isn't ideal.

## Description of PR

I think that there should be centralized support to test clients in order to avoid reinventing the wheel and to make testing easier. This PR adds a client testing library that provides a concise way to specify the Guac graph for ingestion (generalizing the approach taken by https://github.com/guacsec/guac/pull/1705), where all nouns can be referenced by a single string and the verb InputSpecs are optional. Additionally, it adds some functions to start up the graphql server for tests. 

Changes to this library should scale linearly with changes / additions to the GQL API. I didn't implement all nouns and verbs, but since this is a testing library I think they can be added as needed. 

See [example use](https://github.com/mdeicas/guac/blob/31267311c89969d49345d803d6d1357e05fb8c4f/pkg/guacrest/server/retrieveDependencies_test.go#L54)

## Alternatives

Another approach to testing clients would be to stub the Graphql client API. To my understanding, this would support smallish unit tests, but does not support end-to-end tests of functionality that makes many, varied calls to the graphql server. 

Yet another approach would be to support defining the Guac graph in a concise way, as this library provides, but then map that representation to the `IngestPredicates` type and use the assembler function, instead writing the ingestion code here. However, that the `HasSbomIncludesSpec` only takes IDs complicates this a bit, and also slightly limits what graphs can be defined.



# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
