### PR TITLE
Add standalone postgres compose

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,3 +189,14 @@ jobs:
           gh release upload ${{ github.ref_name }} guac-demo-compose.yaml
           rm guac-demo-compose.yaml
         shell: bash
+      - name: Modify and publish postgres compose yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          cp container_files/guac-postgres-compose.yaml .
+          sed -i s/\$GUAC_IMAGE/ghcr.io\\/${{ github.repository_owner }}\\/guac:${{ github.ref_name }}/ guac-postgres-compose.yaml
+          gh release upload ${{ github.ref_name }} guac-postgres-compose.yaml
+          rm guac-postgres-compose.yaml
+        shell: bash

--- a/container_files/guac-postgres-compose.yaml
+++ b/container_files/guac-postgres-compose.yaml
@@ -1,0 +1,129 @@
+version: "3.8"
+
+services:
+
+  postgres:
+    image: docker.io/library/postgres:16
+    environment:
+      POSTGRES_USER: guac
+      POSTGRES_PASSWORD: guac
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data:z
+    healthcheck:
+      test: ["CMD", "pg_isready", "--username=guac", "--dbname=guac"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  graphql:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacgql --gql-debug --gql-backend=ent --db-address=postgres://guac:guac@postgres:5432/guac?sslmode=disable"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  nats:
+    image: "docker.io/library/nats:2.9.17-alpine"
+    command: "--jetstream -m 8222"
+    ports:
+      - "4222:4222"
+      # monitoring port
+      - "8222:8222"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "http://localhost:8222/healthz" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  ingestor:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacingest --blob-addr=file:///tmp/blobstore?no_tmp_dir=true --csub-addr=collectsub:2782 --gql-addr=http://graphql:8080/query --pubsub-addr=nats://nats:4222"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      collectsub:
+        condition: service_healthy
+      graphql:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    volumes:
+      - ./blobstore:/tmp/blobstore:z
+
+
+  collectsub:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guaccsub"
+    working_dir: /guac
+    restart: on-failure
+    ports:
+      - "2782:2782"
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "http://localhost:2782" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  depsdev-collector:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guaccollect deps_dev --csub-addr=collectsub:2782 --blob-addr=file:///tmp/blobstore?no_tmp_dir=true  --pubsub-addr=nats://nats:4222"
+    working_dir: /guac
+    restart: on-failure
+    environment:
+      - DEPS_DEV_APIKEY
+    depends_on:
+      collectsub:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    volumes:
+      - ./blobstore:/tmp/blobstore:z
+
+  oci-collector:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guaccollect image --csub-addr=collectsub:2782 --blob-addr=file:///tmp/blobstore?no_tmp_dir=true  --pubsub-addr=nats://nats:4222"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      collectsub:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    volumes:
+      - ./blobstore:/tmp/blobstore:z
+
+  osv-certifier:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacone certifier osv -p --csub-addr=collectsub:2782 --gql-addr=http://graphql:8080/query"
+    working_dir: /guac
+    restart: on-failure
+    depends_on:
+      collectsub:
+        condition: service_healthy
+      graphql:
+        condition: service_healthy
+
+  guac-rest:
+    image: $GUAC_IMAGE
+    command: "/opt/guac/guacrest --rest-api-server-port=8081 --gql-addr=http://graphql:8080/query"
+    working_dir: /guac
+    restart: on-failure
+    ports:
+      - "8081:8081"
+    depends_on:
+      graphql:
+        condition: service_healthy


### PR DESCRIPTION
This compose will be used for new persistent setup instructions. It is a standalone file and doesn't need any additional files to be mounted into the containers. It is a complete single file (not multiple files merged) and doesn't contain anything unnecessary. Future docs will build upon it for adding additional collectors, etc.

Tested with release on my fork:
https://github.com/jeffmendoza/guac/releases/tag/v0.6.0-betajeff
https://github.com/jeffmendoza/guac/releases/download/v0.6.0-betajeff/guac-postgres-compose.yaml

Went through some demos and working well.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
