### PR TITLE
update certifier to use paginated query for package and source

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -5247,6 +5247,7 @@ func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageName) GetVersions() []A
 // the trie.
 type AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion struct {
 	Id         string                                                                                                 `json:"id"`
+	Purl       string                                                                                                 `json:"purl"`
 	Version    string                                                                                                 `json:"version"`
 	Qualifiers []AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier `json:"qualifiers"`
 	Subpath    string                                                                                                 `json:"subpath"`
@@ -5255,6 +5256,11 @@ type AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion 
 // GetId returns AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Id, and is useful for accessing the field via an interface.
 func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion) GetId() string {
 	return v.Id
+}
+
+// GetPurl returns AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Purl, and is useful for accessing the field via an interface.
+func (v *AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion) GetPurl() string {
+	return v.Purl
 }
 
 // GetVersion returns AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion.Version, and is useful for accessing the field via an interface.
@@ -19027,6 +19033,188 @@ type PackageVersionsResponse struct {
 // GetPackages returns PackageVersionsResponse.Packages, and is useful for accessing the field via an interface.
 func (v *PackageVersionsResponse) GetPackages() []PackageVersionsPackagesPackage { return v.Packages }
 
+// PackagesListPackagesListPackageConnection includes the requested fields of the GraphQL type PackageConnection.
+// The GraphQL type's documentation follows.
+//
+// PackageConnection returns the paginated results for Package.
+//
+// totalCount is the total number of results returned.
+//
+// pageInfo provides information to the client if there is
+// a next page of results and the starting and
+// ending cursor for the current set.
+//
+// edges contains the PackageEdge which contains the current cursor
+// and the Package node itself
+type PackagesListPackagesListPackageConnection struct {
+	TotalCount int                                                         `json:"totalCount"`
+	Edges      []PackagesListPackagesListPackageConnectionEdgesPackageEdge `json:"edges"`
+	PageInfo   PackagesListPackagesListPackageConnectionPageInfo           `json:"pageInfo"`
+}
+
+// GetTotalCount returns PackagesListPackagesListPackageConnection.TotalCount, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnection) GetTotalCount() int { return v.TotalCount }
+
+// GetEdges returns PackagesListPackagesListPackageConnection.Edges, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnection) GetEdges() []PackagesListPackagesListPackageConnectionEdgesPackageEdge {
+	return v.Edges
+}
+
+// GetPageInfo returns PackagesListPackagesListPackageConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnection) GetPageInfo() PackagesListPackagesListPackageConnectionPageInfo {
+	return v.PageInfo
+}
+
+// PackagesListPackagesListPackageConnectionEdgesPackageEdge includes the requested fields of the GraphQL type PackageEdge.
+// The GraphQL type's documentation follows.
+//
+// PackageEdge contains the cursor for the resulting node and
+// the Package node itself.
+type PackagesListPackagesListPackageConnectionEdgesPackageEdge struct {
+	Cursor string                                                               `json:"cursor"`
+	Node   PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage `json:"node"`
+}
+
+// GetCursor returns PackagesListPackagesListPackageConnectionEdgesPackageEdge.Cursor, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdge) GetCursor() string {
+	return v.Cursor
+}
+
+// GetNode returns PackagesListPackagesListPackageConnectionEdgesPackageEdge.Node, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdge) GetNode() PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage {
+	return v.Node
+}
+
+// PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage includes the requested fields of the GraphQL type Package.
+// The GraphQL type's documentation follows.
+//
+// Package represents the root of the package trie/tree.
+//
+// We map package information to a trie, closely matching the pURL specification
+// (https://github.com/package-url/purl-spec/blob/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/README.rst),
+// but deviating from it where GUAC heuristics allow for better representation of
+// package information. Each path in the trie fully represents a package; we split
+// the trie based on the pURL components.
+//
+// This node matches a pkg:<type> partial pURL. The type field matches the
+// pURL types but we might also use "guac" for the cases where the pURL
+// representation is not complete or when we have custom rules.
+//
+// Since this node is at the root of the package trie, it is named Package, not
+// PackageType.
+type PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage struct {
+	AllPkgTree `json:"-"`
+}
+
+// GetId returns PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage.Id, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) GetId() string {
+	return v.AllPkgTree.Id
+}
+
+// GetType returns PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage.Type, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) GetType() string {
+	return v.AllPkgTree.Type
+}
+
+// GetNamespaces returns PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage.Namespaces, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) GetNamespaces() []AllPkgTreeNamespacesPackageNamespace {
+	return v.AllPkgTree.Namespaces
+}
+
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllPkgTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalPackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllPkgTreeNamespacesPackageNamespace `json:"namespaces"`
+}
+
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage) __premarshalJSON() (*__premarshalPackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage, error) {
+	var retval __premarshalPackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage
+
+	retval.Id = v.AllPkgTree.Id
+	retval.Type = v.AllPkgTree.Type
+	retval.Namespaces = v.AllPkgTree.Namespaces
+	return &retval, nil
+}
+
+// PackagesListPackagesListPackageConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// PageInfo serves the client information about the paginated query results.
+//
+// hasNextPage is true when there are results to be returned.
+//
+// hasPreviousPage is true when there is a previous page to return to.
+//
+// startCursor is the ID where the query started from.
+//
+// endCursor is where the query ended.
+type PackagesListPackagesListPackageConnectionPageInfo struct {
+	StartCursor *string `json:"startCursor"`
+	EndCursor   *string `json:"endCursor"`
+	HasNextPage bool    `json:"hasNextPage"`
+}
+
+// GetStartCursor returns PackagesListPackagesListPackageConnectionPageInfo.StartCursor, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionPageInfo) GetStartCursor() *string {
+	return v.StartCursor
+}
+
+// GetEndCursor returns PackagesListPackagesListPackageConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
+}
+
+// GetHasNextPage returns PackagesListPackagesListPackageConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *PackagesListPackagesListPackageConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// PackagesListResponse is returned by PackagesList on success.
+type PackagesListResponse struct {
+	// Returns a paginated results via PackageConnection
+	PackagesList *PackagesListPackagesListPackageConnection `json:"packagesList"`
+}
+
+// GetPackagesList returns PackagesListResponse.PackagesList, and is useful for accessing the field via an interface.
+func (v *PackagesListResponse) GetPackagesList() *PackagesListPackagesListPackageConnection {
+	return v.PackagesList
+}
+
 // PackagesPackagesPackage includes the requested fields of the GraphQL type Package.
 // The GraphQL type's documentation follows.
 //
@@ -22520,6 +22708,179 @@ func (v *SourceSpec) GetTag() *string { return v.Tag }
 // GetCommit returns SourceSpec.Commit, and is useful for accessing the field via an interface.
 func (v *SourceSpec) GetCommit() *string { return v.Commit }
 
+// SourcesListResponse is returned by SourcesList on success.
+type SourcesListResponse struct {
+	// Returns a paginated results via SourceConnection
+	SourcesList *SourcesListSourcesListSourceConnection `json:"sourcesList"`
+}
+
+// GetSourcesList returns SourcesListResponse.SourcesList, and is useful for accessing the field via an interface.
+func (v *SourcesListResponse) GetSourcesList() *SourcesListSourcesListSourceConnection {
+	return v.SourcesList
+}
+
+// SourcesListSourcesListSourceConnection includes the requested fields of the GraphQL type SourceConnection.
+// The GraphQL type's documentation follows.
+//
+// SourceConnection returns the paginated results for Source.
+//
+// totalCount is the total number of results returned.
+//
+// pageInfo provides information to the client if there is
+// a next page of results and the starting and
+// ending cursor for the current set.
+//
+// edges contains the SourceEdge which contains the current cursor
+// and the Source node itself
+type SourcesListSourcesListSourceConnection struct {
+	TotalCount int                                                     `json:"totalCount"`
+	Edges      []SourcesListSourcesListSourceConnectionEdgesSourceEdge `json:"edges"`
+	PageInfo   SourcesListSourcesListSourceConnectionPageInfo          `json:"pageInfo"`
+}
+
+// GetTotalCount returns SourcesListSourcesListSourceConnection.TotalCount, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnection) GetTotalCount() int { return v.TotalCount }
+
+// GetEdges returns SourcesListSourcesListSourceConnection.Edges, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnection) GetEdges() []SourcesListSourcesListSourceConnectionEdgesSourceEdge {
+	return v.Edges
+}
+
+// GetPageInfo returns SourcesListSourcesListSourceConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnection) GetPageInfo() SourcesListSourcesListSourceConnectionPageInfo {
+	return v.PageInfo
+}
+
+// SourcesListSourcesListSourceConnectionEdgesSourceEdge includes the requested fields of the GraphQL type SourceEdge.
+// The GraphQL type's documentation follows.
+//
+// SourceEdge contains the cursor for the resulting node and
+// the Source node itself.
+type SourcesListSourcesListSourceConnectionEdgesSourceEdge struct {
+	Cursor string                                                          `json:"cursor"`
+	Node   SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource `json:"node"`
+}
+
+// GetCursor returns SourcesListSourcesListSourceConnectionEdgesSourceEdge.Cursor, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdge) GetCursor() string { return v.Cursor }
+
+// GetNode returns SourcesListSourcesListSourceConnectionEdgesSourceEdge.Node, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdge) GetNode() SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource {
+	return v.Node
+}
+
+// SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource includes the requested fields of the GraphQL type Source.
+// The GraphQL type's documentation follows.
+//
+// Source represents the root of the source trie/tree.
+//
+// We map source information to a trie, as a derivative of the pURL specification:
+// each path in the trie represents a type, namespace, name and an optional
+// qualifier that stands for tag/commit information.
+//
+// This node represents the type part of the trie path. It is used to represent
+// the version control system that is being used.
+//
+// Since this node is at the root of the source trie, it is named Source, not
+// SourceType.
+type SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource struct {
+	AllSourceTree `json:"-"`
+}
+
+// GetId returns SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource.Id, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) GetId() string {
+	return v.AllSourceTree.Id
+}
+
+// GetType returns SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource.Type, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) GetType() string {
+	return v.AllSourceTree.Type
+}
+
+// GetNamespaces returns SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource.Namespaces, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) GetNamespaces() []AllSourceTreeNamespacesSourceNamespace {
+	return v.AllSourceTree.Namespaces
+}
+
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AllSourceTree)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalSourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource struct {
+	Id string `json:"id"`
+
+	Type string `json:"type"`
+
+	Namespaces []AllSourceTreeNamespacesSourceNamespace `json:"namespaces"`
+}
+
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource) __premarshalJSON() (*__premarshalSourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource, error) {
+	var retval __premarshalSourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource
+
+	retval.Id = v.AllSourceTree.Id
+	retval.Type = v.AllSourceTree.Type
+	retval.Namespaces = v.AllSourceTree.Namespaces
+	return &retval, nil
+}
+
+// SourcesListSourcesListSourceConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// PageInfo serves the client information about the paginated query results.
+//
+// hasNextPage is true when there are results to be returned.
+//
+// hasPreviousPage is true when there is a previous page to return to.
+//
+// startCursor is the ID where the query started from.
+//
+// endCursor is where the query ended.
+type SourcesListSourcesListSourceConnectionPageInfo struct {
+	StartCursor *string `json:"startCursor"`
+	EndCursor   *string `json:"endCursor"`
+	HasNextPage bool    `json:"hasNextPage"`
+}
+
+// GetStartCursor returns SourcesListSourcesListSourceConnectionPageInfo.StartCursor, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionPageInfo) GetStartCursor() *string {
+	return v.StartCursor
+}
+
+// GetEndCursor returns SourcesListSourcesListSourceConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionPageInfo) GetEndCursor() *string { return v.EndCursor }
+
+// GetHasNextPage returns SourcesListSourcesListSourceConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *SourcesListSourcesListSourceConnectionPageInfo) GetHasNextPage() bool { return v.HasNextPage }
+
 // SourcesResponse is returned by Sources on success.
 type SourcesResponse struct {
 	// Returns all sources matching a filter.
@@ -24091,6 +24452,22 @@ type __PackagesInput struct {
 // GetFilter returns __PackagesInput.Filter, and is useful for accessing the field via an interface.
 func (v *__PackagesInput) GetFilter() PkgSpec { return v.Filter }
 
+// __PackagesListInput is used internally by genqlient
+type __PackagesListInput struct {
+	Filter PkgSpec `json:"filter"`
+	After  *string `json:"after"`
+	First  *int    `json:"first"`
+}
+
+// GetFilter returns __PackagesListInput.Filter, and is useful for accessing the field via an interface.
+func (v *__PackagesListInput) GetFilter() PkgSpec { return v.Filter }
+
+// GetAfter returns __PackagesListInput.After, and is useful for accessing the field via an interface.
+func (v *__PackagesListInput) GetAfter() *string { return v.After }
+
+// GetFirst returns __PackagesListInput.First, and is useful for accessing the field via an interface.
+func (v *__PackagesListInput) GetFirst() *int { return v.First }
+
 // __PathInput is used internally by genqlient
 type __PathInput struct {
 	Subject       string `json:"subject"`
@@ -24126,6 +24503,22 @@ type __SourcesInput struct {
 
 // GetFilter returns __SourcesInput.Filter, and is useful for accessing the field via an interface.
 func (v *__SourcesInput) GetFilter() SourceSpec { return v.Filter }
+
+// __SourcesListInput is used internally by genqlient
+type __SourcesListInput struct {
+	Filter SourceSpec `json:"filter"`
+	After  *string    `json:"after"`
+	First  *int       `json:"first"`
+}
+
+// GetFilter returns __SourcesListInput.Filter, and is useful for accessing the field via an interface.
+func (v *__SourcesListInput) GetFilter() SourceSpec { return v.Filter }
+
+// GetAfter returns __SourcesListInput.After, and is useful for accessing the field via an interface.
+func (v *__SourcesListInput) GetAfter() *string { return v.After }
+
+// GetFirst returns __SourcesListInput.First, and is useful for accessing the field via an interface.
+func (v *__SourcesListInput) GetFirst() *int { return v.First }
 
 // __VulnerabilitiesInput is used internally by genqlient
 type __VulnerabilitiesInput struct {
@@ -24212,6 +24605,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -24312,6 +24706,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -24402,6 +24797,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -24467,6 +24863,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -24581,6 +24978,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -27296,6 +27694,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -27484,6 +27883,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -27961,6 +28361,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -28436,6 +28837,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -29012,6 +29414,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -29039,6 +29442,78 @@ func Packages(
 	var err_ error
 
 	var data_ PackagesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by PackagesList.
+const PackagesList_Operation = `
+query PackagesList ($filter: PkgSpec!, $after: ID, $first: Int) {
+	packagesList(pkgSpec: $filter, after: $after, first: $first) {
+		totalCount
+		edges {
+			cursor
+			node {
+				... AllPkgTree
+			}
+		}
+		pageInfo {
+			startCursor
+			endCursor
+			hasNextPage
+		}
+	}
+}
+fragment AllPkgTree on Package {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			versions {
+				id
+				purl
+				version
+				qualifiers {
+					key
+					value
+				}
+				subpath
+			}
+		}
+	}
+}
+`
+
+func PackagesList(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	filter PkgSpec,
+	after *string,
+	first *int,
+) (*PackagesListResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "PackagesList",
+		Query:  PackagesList_Operation,
+		Variables: &__PackagesListInput{
+			Filter: filter,
+			After:  after,
+			First:  first,
+		},
+	}
+	var err_ error
+
+	var data_ PackagesListResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(
@@ -29140,6 +29615,7 @@ fragment AllPkgTree on Package {
 			name
 			versions {
 				id
+				purl
 				version
 				qualifiers {
 					key
@@ -29636,6 +30112,70 @@ func Sources(
 	var err_ error
 
 	var data_ SourcesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by SourcesList.
+const SourcesList_Operation = `
+query SourcesList ($filter: SourceSpec!, $after: ID, $first: Int) {
+	sourcesList(sourceSpec: $filter, after: $after, first: $first) {
+		totalCount
+		edges {
+			cursor
+			node {
+				... AllSourceTree
+			}
+		}
+		pageInfo {
+			startCursor
+			endCursor
+			hasNextPage
+		}
+	}
+}
+fragment AllSourceTree on Source {
+	id
+	type
+	namespaces {
+		id
+		namespace
+		names {
+			id
+			name
+			tag
+			commit
+		}
+	}
+}
+`
+
+func SourcesList(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	filter SourceSpec,
+	after *string,
+	first *int,
+) (*SourcesListResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "SourcesList",
+		Query:  SourcesList_Operation,
+		Variables: &__SourcesListInput{
+			Filter: filter,
+			After:  after,
+			First:  first,
+		},
+	}
+	var err_ error
+
+	var data_ SourcesListResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/pkg/assembler/clients/operations/package.graphql
+++ b/pkg/assembler/clients/operations/package.graphql
@@ -39,6 +39,23 @@ mutation IngestPackages($pkgs: [IDorPkgInput!]!) {
 
 # Exposes GraphQL queries to retrieve GUAC packages
 
+query PackagesList($filter: PkgSpec!, $after: ID, $first: Int) {
+  packagesList(pkgSpec: $filter, after: $after, first: $first) {
+    totalCount
+    edges {
+      cursor
+      node {
+        ...AllPkgTree
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+    }
+  }
+}
+
 query Packages($filter: PkgSpec!) {
   packages(pkgSpec: $filter) {
     ...AllPkgTree

--- a/pkg/assembler/clients/operations/source.graphql
+++ b/pkg/assembler/clients/operations/source.graphql
@@ -37,6 +37,24 @@ mutation IngestSources($sources: [IDorSourceInput!]!) {
 
 # Exposes GraphQL queries to retrieve GUAC sources
 
+
+query SourcesList($filter: SourceSpec!, $after: ID, $first: Int) {
+  sourcesList(sourceSpec: $filter, after: $after, first: $first) {
+    totalCount
+    edges {
+      cursor
+      node {
+        ...AllSourceTree
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+    }
+  }
+}
+
 query Sources($filter: SourceSpec!) {
   sources(sourceSpec: $filter) {
     ...AllSourceTree

--- a/pkg/assembler/clients/operations/trees.graphql
+++ b/pkg/assembler/clients/operations/trees.graphql
@@ -30,6 +30,7 @@ fragment AllPkgTree on Package {
       name
       versions {
         id
+        purl
         version
         qualifiers {
           key

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -61,7 +61,7 @@ func TestNewPackageQuery(t *testing.T) {
 
 func Test_packageQuery_GetComponents(t *testing.T) {
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
-	testPypiPackage := generated.PackagesPackagesPackage{}
+	testPypiPackage := generated.PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage{}
 
 	testPypiPackage.Type = "pypi"
 	testPypiPackage.Namespaces = append(testPypiPackage.Namespaces, generated.AllPkgTreeNamespacesPackageNamespace{
@@ -73,13 +73,14 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 				Versions: []generated.AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion{
 					{
 						Version: "1.11.1",
+						Purl:    "pkg:pypi/django@1.11.1",
 					},
 				},
 			},
 		},
 	})
 
-	testOpenSSLPackage := generated.PackagesPackagesPackage{}
+	testOpenSSLPackage := generated.PackagesListPackagesListPackageConnectionEdgesPackageEdgeNodePackage{}
 	testOpenSSLPackage.Type = "conan"
 	testOpenSSLPackage.Namespaces = append(testOpenSSLPackage.Namespaces, generated.AllPkgTreeNamespacesPackageNamespace{
 		Id:        "",
@@ -90,6 +91,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 				Versions: []generated.AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersion{
 					{
 						Version: "3.0.3",
+						Purl:    "pkg:conan/openssl.org/openssl@3.0.3",
 					},
 				},
 			},
@@ -109,7 +111,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 	tests := []struct {
 		name              string
 		daysSinceLastScan int
-		getPackages       func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error)
+		getPackages       func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error)
 		getNeighbors      func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 		wantPackNode      []*PackageNode
 		wantErr           bool
@@ -117,9 +119,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		{
 			name:              "django: daysSinceLastScan=0",
 			daysSinceLastScan: 0,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -136,9 +149,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with certifyVuln",
 			daysSinceLastScan: 0,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -151,9 +175,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with certifyVuln, daysSinceLastScan=30",
 			daysSinceLastScan: 30,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -168,9 +203,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with certifyVuln, timestamp: time now, daysSinceLastScan=30",
 			daysSinceLastScan: 30,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -183,9 +229,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with certifyVuln, daysSinceLastScan=0, IsOccurrence",
 			daysSinceLastScan: 0,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -198,9 +255,20 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "django, daysSinceLastScan=0, IsOccurrence",
 			daysSinceLastScan: 0,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -215,9 +283,24 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:              "multiple packages",
 			daysSinceLastScan: 0,
-			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec) (*generated.PackagesResponse, error) {
-				return &generated.PackagesResponse{
-					Packages: []generated.PackagesPackagesPackage{testPypiPackage, testOpenSSLPackage},
+			getPackages: func(ctx context.Context, client graphql.Client, filter generated.PkgSpec, after *string, first *int) (*generated.PackagesListResponse, error) {
+				return &generated.PackagesListResponse{
+					PackagesList: &generated.PackagesListPackagesListPackageConnection{
+						TotalCount: 1,
+						Edges: []generated.PackagesListPackagesListPackageConnectionEdgesPackageEdge{
+							{
+								Node:   testPypiPackage,
+								Cursor: "",
+							},
+							{
+								Node:   testOpenSSLPackage,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.PackagesListPackagesListPackageConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {

--- a/pkg/certifier/components/source/source_test.go
+++ b/pkg/certifier/components/source/source_test.go
@@ -69,7 +69,7 @@ func TestNewCertifier(t *testing.T) {
 func Test_sourceArtifacts_GetComponents(t *testing.T) {
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")
 
-	testSourceDjangoTag := generated.SourcesSourcesSource{}
+	testSourceDjangoTag := generated.SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource{}
 	testSourceDjangoTag.Type = "git"
 	testSourceDjangoTag.Namespaces = append(testSourceDjangoTag.Namespaces, generated.AllSourceTreeNamespacesSourceNamespace{
 		Id:        "",
@@ -83,7 +83,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		},
 	})
 
-	testSourceDjangoCommit := generated.SourcesSourcesSource{}
+	testSourceDjangoCommit := generated.SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource{}
 	testSourceDjangoCommit.Type = "git"
 	testSourceDjangoCommit.Namespaces = append(testSourceDjangoCommit.Namespaces, generated.AllSourceTreeNamespacesSourceNamespace{
 		Id:        "",
@@ -97,7 +97,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		},
 	})
 
-	testSourceDjangoCommitWithAlgo := generated.SourcesSourcesSource{}
+	testSourceDjangoCommitWithAlgo := generated.SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource{}
 	testSourceDjangoCommitWithAlgo.Type = "git"
 	testSourceDjangoCommitWithAlgo.Namespaces = append(testSourceDjangoCommitWithAlgo.Namespaces, generated.AllSourceTreeNamespacesSourceNamespace{
 		Id:        "",
@@ -111,7 +111,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		},
 	})
 
-	testSourceKubeTestTag := generated.SourcesSourcesSource{}
+	testSourceKubeTestTag := generated.SourcesListSourcesListSourceConnectionEdgesSourceEdgeNodeSource{}
 	testSourceKubeTestTag.Type = "git"
 	testSourceKubeTestTag.Namespaces = append(testSourceKubeTestTag.Namespaces, generated.AllSourceTreeNamespacesSourceNamespace{
 		Id:        "",
@@ -138,7 +138,7 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 	tests := []struct {
 		name              string
 		daysSinceLastScan int
-		getSources        func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error)
+		getSources        func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error)
 		getNeighbors      func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error)
 		wantSourceNode    []*SourceNode
 		wantErr           bool
@@ -146,9 +146,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		{
 			name:              "django: daysSinceLastScan=0, tag specified",
 			daysSinceLastScan: 0,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoTag,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -167,9 +178,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "django: daysSinceLastScan=0, commit specified",
 			daysSinceLastScan: 0,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoCommit},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoCommit,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -188,9 +210,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "django: daysSinceLastScan=0, commit with algorithm specified",
 			daysSinceLastScan: 0,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoCommitWithAlgo},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoCommitWithAlgo,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -209,9 +242,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with scorecard, daysSinceLastScan=0",
 			daysSinceLastScan: 0,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoTag,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -224,9 +268,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with scorecard, timestamp: time past, daysSinceLastScan=30",
 			daysSinceLastScan: 30,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoTag,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -245,9 +300,20 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "django with scorecard, timestamp: time now, daysSinceLastScan=30",
 			daysSinceLastScan: 30,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoTag,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {
@@ -260,9 +326,28 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 		}, {
 			name:              "multiple packages",
 			daysSinceLastScan: 0,
-			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec) (*generated.SourcesResponse, error) {
-				return &generated.SourcesResponse{
-					Sources: []generated.SourcesSourcesSource{testSourceDjangoTag, testSourceDjangoCommit, testSourceKubeTestTag},
+			getSources: func(ctx context.Context, client graphql.Client, filter generated.SourceSpec, after *string, first *int) (*generated.SourcesListResponse, error) {
+				return &generated.SourcesListResponse{
+					SourcesList: &generated.SourcesListSourcesListSourceConnection{
+						TotalCount: 1,
+						Edges: []generated.SourcesListSourcesListSourceConnectionEdgesSourceEdge{
+							{
+								Node:   testSourceDjangoTag,
+								Cursor: "",
+							},
+							{
+								Node:   testSourceDjangoCommit,
+								Cursor: "",
+							},
+							{
+								Node:   testSourceKubeTestTag,
+								Cursor: "",
+							},
+						},
+						PageInfo: generated.SourcesListSourcesListSourceConnectionPageInfo{
+							HasNextPage: false,
+						},
+					},
 				}, nil
 			},
 			getNeighbors: func(ctx context.Context, client graphql.Client, node string, usingOnly []generated.Edge) (*generated.NeighborsResponse, error) {


### PR DESCRIPTION
# Description of the PR

update certifier to use paginated query for package and source to not hit `packages pq: got 563996 parameters but PostgreSQL only supports 65535 parameters\n` error. 

Part of issue #1848

This will be replaced with just `package` and `source` query once the updates to keyvalue are completed for pagination.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
