### PR TITLE
[FIX] Ingestor should not ack message on failure

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -95,7 +95,7 @@ func ingest(cmd *cobra.Command, args []string) {
 
 	emit := func(d *processor.Document) error {
 		if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient); err != nil {
-			logger.Errorf("unable to ingest document %q : %v", d.SourceInformation.Source, err)
+			return fmt.Errorf("unable to ingest document %q : %v", d.SourceInformation.Source, err)
 		}
 		return nil
 	}

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -18,6 +18,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+
 	"go.uber.org/zap"
 
 	"github.com/Khan/genqlient/graphql"
@@ -40,7 +41,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorPkgInputs, err := ingestPackages(ctx, gqlclient, packages)
 			if err != nil {
-				return fmt.Errorf("ingestPackages failed with error: %v", err)
+				return fmt.Errorf("ingestPackages failed with error: %w", err)
 			}
 
 			var pkgVersionIDs []string
@@ -56,7 +57,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorSrcInputs, err := ingestSources(ctx, gqlclient, sources)
 			if err != nil {
-				return fmt.Errorf("ingestSources failed with error: %v", err)
+				return fmt.Errorf("ingestSources failed with error: %w", err)
 			}
 
 			// Ingest Artifacts
@@ -66,7 +67,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorArtInputs, err := ingestArtifacts(ctx, gqlclient, artifacts)
 			if err != nil {
-				return fmt.Errorf("ingestArtifacts failed with error: %v", err)
+				return fmt.Errorf("ingestArtifacts failed with error: %w", err)
 			}
 			var artIDs []string
 			for _, artID := range collectedIDorArtInputs {
@@ -81,7 +82,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorMatInputs, err := ingestArtifacts(ctx, gqlclient, materials)
 			if err != nil {
-				return fmt.Errorf("ingestArtifacts failed with error: %v", err)
+				return fmt.Errorf("ingestArtifacts failed with error: %w", err)
 			}
 
 			// Ingest Builders
@@ -90,7 +91,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorBuilderInputs, err := ingestBuilders(ctx, gqlclient, builders)
 			if err != nil {
-				return fmt.Errorf("ingestBuilders failed with error: %v", err)
+				return fmt.Errorf("ingestBuilders failed with error: %w", err)
 			}
 
 			// Ingest Vulnerabilities
@@ -99,7 +100,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorVulnInputs, err := ingestVulnerabilities(ctx, gqlclient, vulns)
 			if err != nil {
-				return fmt.Errorf("ingestVulnerabilities failed with error: %v", err)
+				return fmt.Errorf("ingestVulnerabilities failed with error: %w", err)
 			}
 
 			// Ingest Licenses
@@ -108,7 +109,7 @@ func GetBulkAssembler(ctx context.Context, logger *zap.SugaredLogger, gqlclient 
 
 			collectedIDorLicenseInputs, err := ingestLicenses(ctx, gqlclient, licenses)
 			if err != nil {
-				return fmt.Errorf("ingestLicenses failed with error: %v", err)
+				return fmt.Errorf("ingestLicenses failed with error: %w", err)
 			}
 
 			logger.Infof("assembling CertifyScorecard: %v", len(p.CertifyScorecard))

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"path/filepath"
 	"strings"
+
+	"go.uber.org/zap"
 
 	uuid "github.com/gofrs/uuid"
 	"github.com/guacsec/guac/pkg/blob"
@@ -119,7 +120,8 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 		doc.ChildLogger = childLogger
 
 		if err := em(&doc); err != nil {
-			childLogger.Error("[processor: %s] failed transportFunc: %v", uuidString, err)
+			childLogger.Errorf("[processor: %s] failed transportFunc: %v", uuidString, err)
+			childLogger.Errorf("[processor: %s] message id: %s not acknowledged in pusbub", uuidString, d.LoggableID)
 			return nil
 		}
 		// ack the message from the queue once the ingestion has occurred via the Emitter (em) function specified above


### PR DESCRIPTION
# Description of the PR

return error from emitter such that if ingestion fails and message is not ack. 

Before it was being logged and that resulted in the error being acked. 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
