### PR TITLE
add missing atlas to post merge CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
         uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc # tag=v3.2.0
         with:
           only-new-issues: true
-          skip-pkg-cache: true
+          skip-cache: true
       - name: Check markdown format
         run: make format
       - name: Check that all linted text is up to date

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -37,6 +37,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Setup the project
         run: go mod download
+      - name: Install atlas
+        uses: ariga/setup-atlas@v0
       - name: Run integration merge test
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of the PR

Fix main test: add missing atlas to post merge CI

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
