### PR TITLE
`publishToQueue` feature flag and add certifiers to guaccollect pipeline

### DIFF
--- a/cmd/guaccollect/cmd/deps_dev.go
+++ b/cmd/guaccollect/cmd/deps_dev.go
@@ -49,6 +49,8 @@ type depsDevOptions struct {
 	enablePrometheus bool
 	// prometheus address
 	prometheusPort int
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 var depsDevCmd = &cobra.Command{
@@ -84,6 +86,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetBool("retrieve-dependencies"),
 			viper.GetBool("enable-prometheus"),
 			viper.GetInt("prometheus-port"),
+			viper.GetBool("publish-to-queue"),
 			args,
 		)
 		if err != nil {
@@ -110,7 +113,7 @@ you have access to read and write to the respective blob store.`,
 			}()
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
 	},
 }
 
@@ -125,6 +128,7 @@ func validateDepsDevFlags(
 	retrieveDependencies,
 	enablePrometheus bool,
 	prometheusPort int,
+	pubToQueue bool,
 	args []string,
 ) (depsDevOptions, error) {
 	var opts depsDevOptions
@@ -134,6 +138,7 @@ func validateDepsDevFlags(
 	opts.retrieveDependencies = retrieveDependencies
 	opts.enablePrometheus = enablePrometheus
 	opts.prometheusPort = prometheusPort
+	opts.publishToQueue = pubToQueue
 	if useCsub {
 		csubOpts, err := csubclient.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 		if err != nil {

--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -111,13 +111,13 @@ func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, pubToQueue bool,
 	return opts, nil
 }
 
-func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub, pubToQueue bool) (func(*processor.Document) error, error) {
+func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub, publishToQueue bool) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return collector.Publish(ctx, d, blobStore, pubsub, pubToQueue)
+		return collector.Publish(ctx, d, blobStore, pubsub, publishToQueue)
 	}, nil
 }
 
-func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string, pubToQueue bool) {
+func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string, publishToQueue bool) {
 	logger := logging.FromContext(ctx)
 
 	// initialize blob store
@@ -127,7 +127,7 @@ func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr
 	}
 
 	var pubsub *emitter.EmitterPubSub
-	if !pubToQueue {
+	if publishToQueue {
 		if strings.HasPrefix(pubsubAddr, "nats://") {
 			// initialize jetstream
 			// TODO: pass in credentials file for NATS secure login
@@ -142,7 +142,7 @@ func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr
 	}
 
 	// Get pipeline of components
-	collectorPubFunc, err := getCollectorPublish(ctx, blobStore, pubsub, pubToQueue)
+	collectorPubFunc, err := getCollectorPublish(ctx, blobStore, pubsub, publishToQueue)
 	if err != nil {
 		logger.Errorf("error: %v", err)
 		os.Exit(1)

--- a/cmd/guaccollect/cmd/files.go
+++ b/cmd/guaccollect/cmd/files.go
@@ -44,6 +44,8 @@ type filesOptions struct {
 	blobAddr string
 	// poll location
 	poll bool
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 var filesCmd = &cobra.Command{
@@ -70,6 +72,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetString("pubsub-addr"),
 			viper.GetString("blob-addr"),
 			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -87,16 +90,17 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register file collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
 	},
 }
 
-func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, args []string) (filesOptions, error) {
+func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, pubToQueue bool, args []string) (filesOptions, error) {
 	var opts filesOptions
 
 	opts.pubsubAddr = pubsubAddr
 	opts.blobAddr = blobAddr
 	opts.poll = poll
+	opts.publishToQueue = pubToQueue
 
 	if len(args) != 1 {
 		return opts, fmt.Errorf("expected positional argument for file_path")
@@ -107,24 +111,14 @@ func validateFilesFlags(pubsubAddr, blobAddr string, poll bool, args []string) (
 	return opts, nil
 }
 
-func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub) (func(*processor.Document) error, error) {
+func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub, pubToQueue bool) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return collector.Publish(ctx, d, blobStore, pubsub)
+		return collector.Publish(ctx, d, blobStore, pubsub, pubToQueue)
 	}, nil
 }
 
-func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string) {
+func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr string, pubToQueue bool) {
 	logger := logging.FromContext(ctx)
-
-	if strings.HasPrefix(pubsubAddr, "nats://") {
-		// initialize jetstream
-		// TODO: pass in credentials file for NATS secure login
-		jetStream := emitter.NewJetStream(pubsubAddr, "", "")
-		if err := jetStream.JetStreamInit(ctx); err != nil {
-			logger.Fatalf("jetStream initialization failed with error: %v", err)
-		}
-		defer jetStream.Close()
-	}
 
 	// initialize blob store
 	blobStore, err := blob.NewBlobStore(ctx, blobAddr)
@@ -132,11 +126,23 @@ func initializeNATsandCollector(ctx context.Context, pubsubAddr string, blobAddr
 		logger.Fatalf("unable to connect to blob store: %v", err)
 	}
 
-	// initialize pubsub
-	pubsub := emitter.NewEmitterPubSub(ctx, pubsubAddr)
+	var pubsub *emitter.EmitterPubSub
+	if !pubToQueue {
+		if strings.HasPrefix(pubsubAddr, "nats://") {
+			// initialize jetstream
+			// TODO: pass in credentials file for NATS secure login
+			jetStream := emitter.NewJetStream(pubsubAddr, "", "")
+			if err := jetStream.JetStreamInit(ctx); err != nil {
+				logger.Fatalf("jetStream initialization failed with error: %v", err)
+			}
+			defer jetStream.Close()
+		}
+		// initialize pubsub
+		pubsub = emitter.NewEmitterPubSub(ctx, pubsubAddr)
+	}
 
 	// Get pipeline of components
-	collectorPubFunc, err := getCollectorPublish(ctx, blobStore, pubsub)
+	collectorPubFunc, err := getCollectorPublish(ctx, blobStore, pubsub, pubToQueue)
 	if err != nil {
 		logger.Errorf("error: %v", err)
 		os.Exit(1)

--- a/cmd/guaccollect/cmd/gcs.go
+++ b/cmd/guaccollect/cmd/gcs.go
@@ -22,6 +22,8 @@ type gcsOptions struct {
 	blobAddr          string
 	csubClientOptions csub_client.CsubClientOptions
 	bucket            string
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 const gcsCredentialsPathFlag = "gcp-credentials-path"
@@ -42,6 +44,7 @@ var gcsCmd = &cobra.Command{
 			viper.GetString(gcsCredentialsPathFlag),
 			viper.GetBool("csub-tls"),
 			viper.GetBool("csub-tls-skip-verify"),
+			viper.GetBool("publish-to-queue"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -84,7 +87,7 @@ var gcsCmd = &cobra.Command{
 			defer csubClient.Close()
 		}
 
-		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr)
+		initializeNATsandCollector(ctx, opts.pubSubAddr, opts.blobAddr, opts.publishToQueue)
 	},
 }
 
@@ -95,11 +98,13 @@ func validateGCSFlags(
 	credentialsPath string,
 	csubTls,
 	csubTlsSkipVerify bool,
+	pubToQueue bool,
 	args []string,
 ) (gcsOptions, error) {
 	opts := gcsOptions{
-		pubSubAddr: pubSubAddr,
-		blobAddr:   blobAddr,
+		pubSubAddr:     pubSubAddr,
+		blobAddr:       blobAddr,
+		publishToQueue: pubToQueue,
 	}
 
 	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guaccollect/cmd/github.go
+++ b/cmd/guaccollect/cmd/github.go
@@ -60,6 +60,8 @@ type githubOptions struct {
 	workflowFileName string
 	// the owner/repo name to use for the collector
 	ownerRepoName string
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 var githubCmd = &cobra.Command{
@@ -99,6 +101,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("use-csub"),
 			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -150,7 +153,7 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register Github collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
 	},
 }
 
@@ -165,6 +168,7 @@ func validateGithubFlags(
 	csubTlsSkipVerify,
 	useCsub,
 	poll bool,
+	pubToQueue bool,
 	args []string,
 ) (githubOptions, error) {
 	var opts githubOptions
@@ -174,6 +178,7 @@ func validateGithubFlags(
 	opts.githubMode = githubMode
 	opts.sbomName = sbomName
 	opts.workflowFileName = workflowFileName
+	opts.publishToQueue = pubToQueue
 
 	if useCsub {
 		csubOpts, err := csubclient.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guaccollect/cmd/oci.go
+++ b/cmd/guaccollect/cmd/oci.go
@@ -42,6 +42,8 @@ type ociOptions struct {
 	blobAddr string
 	// run as poll collector
 	poll bool
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 var ociCmd = &cobra.Command{
@@ -74,6 +76,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("use-csub"),
 			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -91,7 +94,7 @@ you have access to read and write to the respective blob store.`,
 			logger.Fatalf("unable to register oci collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr)
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
 	},
 }
 
@@ -103,12 +106,14 @@ func validateOCIFlags(
 	csubTlsSkipVerify,
 	useCsub,
 	poll bool,
+	pubToQueue bool,
 	args []string,
 ) (ociOptions, error) {
 	var opts ociOptions
 	opts.pubsubAddr = pubsubAddr
 	opts.blobAddr = blobAddr
 	opts.poll = poll
+	opts.publishToQueue = pubToQueue
 
 	if useCsub {
 		csubOpts, err := csubclient.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guaccollect/cmd/osv.go
+++ b/cmd/guaccollect/cmd/osv.go
@@ -1,0 +1,239 @@
+//
+// Copyright 2022 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/certifier/osv"
+	"github.com/guacsec/guac/pkg/cli"
+	"github.com/guacsec/guac/pkg/collectsub/client"
+	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type osvOptions struct {
+	graphqlEndpoint   string
+	headerFile        string
+	poll              bool
+	csubClientOptions client.CsubClientOptions
+	interval          time.Duration
+}
+
+var osvCmd = &cobra.Command{
+	Use:   "osv [flags]",
+	Short: "runs the osv certifier",
+	Run: func(cmd *cobra.Command, args []string) {
+		opts, err := validateOSVFlags(
+			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
+			viper.GetString("interval"),
+			viper.GetString("csub-addr"),
+			viper.GetBool("poll"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
+		)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
+
+		if err := certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV); err != nil {
+			logger.Fatalf("unable to register certifier: %v", err)
+		}
+
+		// initialize collectsub client
+		csubClient, err := csub_client.NewClient(opts.csubClientOptions)
+		if err != nil {
+			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
+			csubClient = nil
+		} else {
+			defer csubClient.Close()
+		}
+
+		httpClient := http.Client{Transport: transport}
+		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
+		packageQuery := root_package.NewPackageQuery(gqlclient, 0)
+
+		totalNum := 0
+		docChan := make(chan *processor.Document)
+		ingestionStop := make(chan bool, 1)
+		tickInterval := 30 * time.Second
+		ticker := time.NewTicker(tickInterval)
+
+		var gotErr int32
+		var wg sync.WaitGroup
+		ingestion := func() {
+			defer wg.Done()
+			var totalDocs []*processor.Document
+			const threshold = 1000
+			stop := false
+			for !stop {
+				select {
+				case <-ticker.C:
+					if len(totalDocs) > 0 {
+						err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
+						if err != nil {
+							stop = true
+							atomic.StoreInt32(&gotErr, 1)
+							logger.Errorf("unable to ingest documents: %v", err)
+						}
+						totalDocs = []*processor.Document{}
+					}
+					ticker.Reset(tickInterval)
+				case d := <-docChan:
+					totalNum += 1
+					totalDocs = append(totalDocs, d)
+					if len(totalDocs) >= threshold {
+						err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
+						if err != nil {
+							stop = true
+							atomic.StoreInt32(&gotErr, 1)
+							logger.Errorf("unable to ingest documents: %v", err)
+						}
+						totalDocs = []*processor.Document{}
+						ticker.Reset(tickInterval)
+					}
+				case <-ingestionStop:
+					stop = true
+				case <-ctx.Done():
+					return
+				}
+			}
+			for len(docChan) > 0 {
+				totalNum += 1
+				totalDocs = append(totalDocs, <-docChan)
+				if len(totalDocs) >= threshold {
+					err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
+					if err != nil {
+						atomic.StoreInt32(&gotErr, 1)
+						logger.Errorf("unable to ingest documents: %v", err)
+					}
+					totalDocs = []*processor.Document{}
+				}
+			}
+			if len(totalDocs) > 0 {
+				err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
+				if err != nil {
+					atomic.StoreInt32(&gotErr, 1)
+					logger.Errorf("unable to ingest documents: %v", err)
+				}
+			}
+		}
+		wg.Add(1)
+		go ingestion()
+
+		// Set emit function to go through the entire pipeline
+		emit := func(d *processor.Document) error {
+			docChan <- d
+			return nil
+		}
+
+		// Collect
+		errHandler := func(err error) bool {
+			if err == nil {
+				logger.Info("certifier ended gracefully")
+				return true
+			}
+			logger.Errorf("certifier ended with error: %v", err)
+			atomic.StoreInt32(&gotErr, 1)
+			// process documents already captures
+			return true
+		}
+
+		ctx, cf := context.WithCancel(ctx)
+		done := make(chan bool, 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := certify.Certify(ctx, packageQuery, emit, errHandler, opts.poll, opts.interval); err != nil {
+				logger.Errorf("Unhandled error in the certifier: %s", err)
+			}
+			done <- true
+		}()
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case s := <-sigs:
+			logger.Infof("Signal received: %s, shutting down gracefully\n", s.String())
+			cf()
+		case <-done:
+			logger.Infof("All certifiers completed")
+		}
+		ingestionStop <- true
+		wg.Wait()
+		cf()
+
+		if atomic.LoadInt32(&gotErr) == 1 {
+			logger.Errorf("completed ingestion with errors")
+		} else {
+			logger.Infof("completed ingesting %v documents", totalNum)
+		}
+	},
+}
+
+func validateOSVFlags(
+	graphqlEndpoint,
+	headerFile,
+	interval,
+	csubAddr string,
+	poll,
+	csubTls,
+	csubTlsSkipVerify bool,
+) (osvOptions, error) {
+	var opts osvOptions
+	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
+	opts.poll = poll
+	i, err := time.ParseDuration(interval)
+	if err != nil {
+		return opts, err
+	}
+	opts.interval = i
+
+	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	if err != nil {
+		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+	}
+	opts.csubClientOptions = csubOpts
+
+	return opts, nil
+}
+
+func init() {
+	rootCmd.AddCommand(osvCmd)
+}

--- a/cmd/guaccollect/cmd/osv.go
+++ b/cmd/guaccollect/cmd/osv.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The GUAC Authors.
+// Copyright 2024 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,46 +21,68 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/blob"
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/cli"
-	"github.com/guacsec/guac/pkg/collectsub/client"
-	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
+	"github.com/guacsec/guac/pkg/emitter"
+	"github.com/guacsec/guac/pkg/handler/collector"
 	"github.com/guacsec/guac/pkg/handler/processor"
-	"github.com/guacsec/guac/pkg/ingestor"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 type osvOptions struct {
-	graphqlEndpoint   string
-	headerFile        string
-	poll              bool
-	csubClientOptions client.CsubClientOptions
-	interval          time.Duration
+	graphqlEndpoint string
+	headerFile      string
+	// address for pubsub connection
+	pubsubAddr string
+	// address for blob store
+	blobAddr string
+	// poll location
+	poll bool
+	// interval between certifier running again
+	interval time.Duration
+	// enable/disable message publish to queue
+	publishToQueue bool
 }
 
 var osvCmd = &cobra.Command{
 	Use:   "osv [flags]",
 	Short: "runs the osv certifier",
+	Long: `
+guaccollect osv runs the osv certifier queries osv.dev for the packages that are collected in guac.
+Ingestion to GUAC happens via an event stream (NATS)
+to allow for decoupling of the collectors from the ingestion into GUAC. 
+
+Each collector collects the "document" and stores it in the blob store for further
+evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via 
+the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for 
+processing and ingestion.
+
+Various blob stores can be used (such as S3, Azure Blob, Google Cloud Bucket) as documented here: https://gocloud.dev/howto/blob/
+For example: "s3://my-bucket?region=us-west-1"
+
+Specific authentication method vary per cloud provider. Please follow the documentation per implementation to ensure
+you have access to read and write to the respective blob store.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, err := validateOSVFlags(
 			viper.GetString("gql-addr"),
 			viper.GetString("header-file"),
+			viper.GetString("pubsub-addr"),
+			viper.GetString("blob-addr"),
 			viper.GetString("interval"),
-			viper.GetString("csub-addr"),
-			viper.GetBool("poll"),
-			viper.GetBool("csub-tls"),
-			viper.GetBool("csub-tls-skip-verify"),
+			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
 		)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -70,168 +92,139 @@ var osvCmd = &cobra.Command{
 
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
-		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
 
 		if err := certify.RegisterCertifier(osv.NewOSVCertificationParser, certifier.CertifierOSV); err != nil {
 			logger.Fatalf("unable to register certifier: %v", err)
 		}
 
-		// initialize collectsub client
-		csubClient, err := csub_client.NewClient(opts.csubClientOptions)
-		if err != nil {
-			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
-			csubClient = nil
-		} else {
-			defer csubClient.Close()
-		}
-
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
 		httpClient := http.Client{Transport: transport}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
-		packageQuery := root_package.NewPackageQuery(gqlclient, 0)
 
-		totalNum := 0
-		docChan := make(chan *processor.Document)
-		ingestionStop := make(chan bool, 1)
-		tickInterval := 30 * time.Second
-		ticker := time.NewTicker(tickInterval)
-
-		var gotErr int32
-		var wg sync.WaitGroup
-		ingestion := func() {
-			defer wg.Done()
-			var totalDocs []*processor.Document
-			const threshold = 1000
-			stop := false
-			for !stop {
-				select {
-				case <-ticker.C:
-					if len(totalDocs) > 0 {
-						err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
-						if err != nil {
-							stop = true
-							atomic.StoreInt32(&gotErr, 1)
-							logger.Errorf("unable to ingest documents: %v", err)
-						}
-						totalDocs = []*processor.Document{}
-					}
-					ticker.Reset(tickInterval)
-				case d := <-docChan:
-					totalNum += 1
-					totalDocs = append(totalDocs, d)
-					if len(totalDocs) >= threshold {
-						err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
-						if err != nil {
-							stop = true
-							atomic.StoreInt32(&gotErr, 1)
-							logger.Errorf("unable to ingest documents: %v", err)
-						}
-						totalDocs = []*processor.Document{}
-						ticker.Reset(tickInterval)
-					}
-				case <-ingestionStop:
-					stop = true
-				case <-ctx.Done():
-					return
-				}
-			}
-			for len(docChan) > 0 {
-				totalNum += 1
-				totalDocs = append(totalDocs, <-docChan)
-				if len(totalDocs) >= threshold {
-					err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
-					if err != nil {
-						atomic.StoreInt32(&gotErr, 1)
-						logger.Errorf("unable to ingest documents: %v", err)
-					}
-					totalDocs = []*processor.Document{}
-				}
-			}
-			if len(totalDocs) > 0 {
-				err = ingestor.MergedIngest(ctx, totalDocs, opts.graphqlEndpoint, transport, csubClient)
-				if err != nil {
-					atomic.StoreInt32(&gotErr, 1)
-					logger.Errorf("unable to ingest documents: %v", err)
-				}
-			}
-		}
-		wg.Add(1)
-		go ingestion()
-
-		// Set emit function to go through the entire pipeline
-		emit := func(d *processor.Document) error {
-			docChan <- d
-			return nil
+		packageQueryFunc, err := getPackageQuery(gqlclient)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
 		}
 
-		// Collect
-		errHandler := func(err error) bool {
-			if err == nil {
-				logger.Info("certifier ended gracefully")
-				return true
-			}
-			logger.Errorf("certifier ended with error: %v", err)
-			atomic.StoreInt32(&gotErr, 1)
-			// process documents already captures
-			return true
-		}
-
-		ctx, cf := context.WithCancel(ctx)
-		done := make(chan bool, 1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := certify.Certify(ctx, packageQuery, emit, errHandler, opts.poll, opts.interval); err != nil {
-				logger.Errorf("Unhandled error in the certifier: %s", err)
-			}
-			done <- true
-		}()
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-		select {
-		case s := <-sigs:
-			logger.Infof("Signal received: %s, shutting down gracefully\n", s.String())
-			cf()
-		case <-done:
-			logger.Infof("All certifiers completed")
-		}
-		ingestionStop <- true
-		wg.Wait()
-		cf()
-
-		if atomic.LoadInt32(&gotErr) == 1 {
-			logger.Errorf("completed ingestion with errors")
-		} else {
-			logger.Infof("completed ingesting %v documents", totalNum)
-		}
+		initializeNATsandCertifier(ctx, opts.blobAddr, opts.pubsubAddr, opts.poll, opts.publishToQueue, opts.interval, packageQueryFunc())
 	},
 }
 
 func validateOSVFlags(
 	graphqlEndpoint,
 	headerFile,
-	interval,
-	csubAddr string,
-	poll,
-	csubTls,
-	csubTlsSkipVerify bool,
-) (osvOptions, error) {
+	pubsubAddr,
+	blobAddr,
+	interval string,
+	poll bool,
+	pubToQueue bool) (osvOptions, error) {
+
 	var opts osvOptions
+
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.headerFile = headerFile
+	opts.pubsubAddr = pubsubAddr
+	opts.blobAddr = blobAddr
 	opts.poll = poll
+	opts.publishToQueue = pubToQueue
+
 	i, err := time.ParseDuration(interval)
 	if err != nil {
-		return opts, err
+		return opts, fmt.Errorf("failed to parser duration with error: %w", err)
 	}
 	opts.interval = i
 
-	csubOpts, err := client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
-	if err != nil {
-		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
-	}
-	opts.csubClientOptions = csubOpts
-
 	return opts, nil
+}
+
+func getCertifierPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub, pubToQueue bool) (func(*processor.Document) error, error) {
+	return func(d *processor.Document) error {
+		return collector.Publish(ctx, d, blobStore, pubsub, pubToQueue)
+	}, nil
+}
+
+func getPackageQuery(client graphql.Client) (func() certifier.QueryComponents, error) {
+	return func() certifier.QueryComponents {
+		packageQuery := root_package.NewPackageQuery(client, 0)
+		return packageQuery
+	}, nil
+}
+
+func initializeNATsandCertifier(ctx context.Context, blobAddr, pubsubAddr string,
+	poll, publishToQueue bool, interval time.Duration, query certifier.QueryComponents) {
+
+	logger := logging.FromContext(ctx)
+
+	blobStore, err := blob.NewBlobStore(ctx, blobAddr)
+	if err != nil {
+		logger.Fatalf("unable to connect to blob store: %v", err)
+	}
+
+	var pubsub *emitter.EmitterPubSub
+	if publishToQueue {
+		if strings.HasPrefix(pubsubAddr, "nats://") {
+			// initialize jetstream
+			// TODO: pass in credentials file for NATS secure login
+			jetStream := emitter.NewJetStream(pubsubAddr, "", "")
+			if err := jetStream.JetStreamInit(ctx); err != nil {
+				logger.Fatalf("jetStream initialization failed with error: %v", err)
+			}
+			defer jetStream.Close()
+		}
+		// initialize pubsub
+		pubsub = emitter.NewEmitterPubSub(ctx, pubsubAddr)
+	}
+
+	certifierPubFunc, err := getCertifierPublish(ctx, blobStore, pubsub, publishToQueue)
+	if err != nil {
+		logger.Errorf("error: %v", err)
+		os.Exit(1)
+	}
+
+	// Set emit function to go through the entire pipeline
+	emit := func(d *processor.Document) error {
+		err = certifierPubFunc(d)
+		// updating the logger to the child logger so that if there is an error we which document has it
+		logger = d.ChildLogger
+		if err != nil {
+			logger.Fatalf("error publishing document from osv certifier: %v", err)
+		}
+		return nil
+	}
+
+	// Collect
+	errHandler := func(err error) bool {
+		if err == nil {
+			logger.Info("osv certifier ended gracefully")
+			return true
+		}
+		logger.Errorf("osv certifier ended with error: %v", err)
+		// Continue to emit any documents still in the docChan
+		return true
+	}
+
+	ctx, cf := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	done := make(chan bool, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := certify.Certify(ctx, query, emit, errHandler, poll, time.Minute*time.Duration(interval)); err != nil {
+			logger.Fatal(err)
+		}
+		done <- true
+	}()
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case s := <-sigs:
+		logger.Infof("Signal received: %s, shutting down gracefully\n", s.String())
+	case <-done:
+		logger.Infof("All Collectors completed")
+	}
+	cf()
+	wg.Wait()
 }
 
 func init() {

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 		"use-csub",
 		"service-poll",
 		"enable-prometheus",
+		"publish-to-queue",
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)

--- a/cmd/guaccollect/cmd/s3.go
+++ b/cmd/guaccollect/cmd/s3.go
@@ -30,6 +30,8 @@ type s3Options struct {
 	mpEndpoint        string                        // endpoint for the message provider (only for polling behaviour)
 	poll              bool                          // polling or non-polling behaviour? (defaults to non-polling)
 	csubClientOptions csub_client.CsubClientOptions // options for the collectsub client
+	publishToQueue    bool                          // enable/disable message publish to queue
+
 }
 
 var s3Cmd = &cobra.Command{
@@ -84,6 +86,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 			viper.GetBool("csub-tls"),
 			viper.GetBool("csub-tls-skip-verify"),
 			viper.GetBool("poll"),
+			viper.GetBool("publish-to-queue"),
 		)
 		if err != nil {
 			fmt.Printf("failed to validate flags: %v\n", err)
@@ -118,7 +121,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 			defer csubClient.Close()
 		}
 
-		initializeNATsandCollector(ctx, s3Opts.pubSubAddr, s3Opts.blobAddr)
+		initializeNATsandCollector(ctx, s3Opts.pubSubAddr, s3Opts.blobAddr, s3Opts.publishToQueue)
 	},
 }
 
@@ -137,6 +140,7 @@ func validateS3Opts(
 	csubTls,
 	csubTlsSkipVerify,
 	poll bool,
+	pubToQueue bool,
 ) (s3Options, error) {
 	var opts s3Options
 
@@ -173,6 +177,7 @@ func validateS3Opts(
 		mpEndpoint:        mpEndpoint,
 		poll:              poll,
 		csubClientOptions: csubClientOptions,
+		publishToQueue:    pubToQueue,
 	}
 
 	return opts, nil

--- a/cmd/guaccollect/cmd/scorecard.go
+++ b/cmd/guaccollect/cmd/scorecard.go
@@ -1,0 +1,160 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/certifier/scorecard"
+	"github.com/guacsec/guac/pkg/cli"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type scorecardOptions struct {
+	graphqlEndpoint string
+	headerFile      string
+	// address for pubsub connection
+	pubsubAddr string
+	// address for blob store
+	blobAddr string
+	// poll location
+	poll bool
+	// interval between certifier running again
+	interval time.Duration
+	// enable/disable message publish to queue
+	publishToQueue bool
+}
+
+var scorecardCmd = &cobra.Command{
+	Use:   "scorecard [flags]",
+	Short: "runs the scorecard certifier",
+	Long: `
+guaccollect scorecard runs the scorecard certifier queries scorecard for sources that are collected in guac.
+Ingestion to GUAC happens via an event stream (NATS)
+to allow for decoupling of the collectors from the ingestion into GUAC. 
+
+Each collector collects the "document" and stores it in the blob store for further
+evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via 
+the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for 
+processing and ingestion.
+
+Various blob stores can be used (such as S3, Azure Blob, Google Cloud Bucket) as documented here: https://gocloud.dev/howto/blob/
+For example: "s3://my-bucket?region=us-west-1"
+
+Specific authentication method vary per cloud provider. Please follow the documentation per implementation to ensure
+you have access to read and write to the respective blob store.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		opts, err := validateScorecardFlags(
+			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
+			viper.GetString("pubsub-addr"),
+			viper.GetString("blob-addr"),
+			viper.GetString("interval"),
+			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
+		)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		// scorecard runner is the scorecard library that runs the scorecard checks
+		scorecardRunner, err := scorecard.NewScorecardRunner(ctx)
+		if err != nil {
+			fmt.Printf("unable to create scorecard runner: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		scorecardCertifier, err := scorecard.NewScorecardCertifier(scorecardRunner)
+		if err != nil {
+			fmt.Printf("unable to create scorecard certifier: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		// this is to satisfy the RegisterCertifier function
+		scCertifier := func() certifier.Certifier { return scorecardCertifier }
+
+		if err := certify.RegisterCertifier(scCertifier, certifier.CertifierScorecard); err != nil {
+			logger.Fatalf("unable to register certifier: %v", err)
+		}
+
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
+		httpClient := http.Client{Transport: transport}
+		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
+
+		sourceQueryFunc, err := getSourceQuery(gqlclient)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		initializeNATsandCertifier(ctx, opts.blobAddr, opts.pubsubAddr, opts.poll, opts.publishToQueue, opts.interval, sourceQueryFunc())
+	},
+}
+
+func validateScorecardFlags(
+	graphqlEndpoint,
+	headerFile,
+	pubsubAddr,
+	blobAddr,
+	interval string,
+	poll bool,
+	pubToQueue bool) (scorecardOptions, error) {
+
+	var opts scorecardOptions
+
+	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
+	opts.pubsubAddr = pubsubAddr
+	opts.blobAddr = blobAddr
+	opts.poll = poll
+	opts.publishToQueue = pubToQueue
+
+	i, err := time.ParseDuration(interval)
+	if err != nil {
+		return opts, fmt.Errorf("failed to parser duration with error: %w", err)
+	}
+	opts.interval = i
+
+	return opts, nil
+}
+
+func getSourceQuery(client graphql.Client) (func() certifier.QueryComponents, error) {
+	return func() certifier.QueryComponents {
+		packageQuery := root_package.NewPackageQuery(client, 0)
+		return packageQuery
+	}, nil
+}
+
+func init() {
+	rootCmd.AddCommand(scorecardCmd)
+}

--- a/guac.yaml
+++ b/guac.yaml
@@ -19,9 +19,13 @@ neptune-realm: neptune
 
 # pubsub setup
 pubsub-addr: nats://localhost:4222
+publish-to-queue: true
 
 # blob store setup. Setup with blob store of choice via https://gocloud.dev/howto/blob/
 blob-addr: file:///tmp/blobstore?no_tmp_dir=true
+
+# certifier interval
+interval: 20m
 
 # CSub setup
 csub-addr: localhost:2782

--- a/internal/testing/cmd/pubsub_test/cmd/files.go
+++ b/internal/testing/cmd/pubsub_test/cmd/files.go
@@ -105,7 +105,7 @@ func validateFlags(user string, pass string, dbAddr string, realm string, pubsub
 
 func getCollectorPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return collector.Publish(ctx, d, blobStore, pubsub)
+		return collector.Publish(ctx, d, blobStore, pubsub, true)
 	}, nil
 }
 

--- a/internal/testing/cmd/pubsub_test/cmd/osv.go
+++ b/internal/testing/cmd/pubsub_test/cmd/osv.go
@@ -86,7 +86,7 @@ func validateOsvFlags(user string, pass string, dbAddr string, realm string, pub
 
 func getCertifierPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub *emitter.EmitterPubSub) (func(*processor.Document) error, error) {
 	return func(d *processor.Document) error {
-		return collector.Publish(ctx, d, blobStore, pubsub)
+		return collector.Publish(ctx, d, blobStore, pubsub, true)
 	}, nil
 }
 

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -35,7 +35,6 @@ func init() {
 
 	// Set of all flags used across GUAC clis and subcommands. Use consistent
 	// names for config file.
-	set.String("pubsub-addr", "nats://127.0.0.1:4222", "gocloud connection string for pubsub configured via https://gocloud.dev/howto/pubsub/ (default is nats://127.0.0.1:4222)")
 	set.String("csub-addr", "localhost:2782", "address to connect to collect-sub service")
 	set.Bool("csub-tls", false, "enable tls connection to the server")
 	set.Bool("csub-tls-skip-verify", false, "skip verifying server certificate (for self-signed certificates for example)")
@@ -59,6 +58,12 @@ func init() {
 
 	// blob store address
 	set.String("blob-addr", "file:///tmp/blobstore?no_tmp_dir=true", "gocloud connection string for blob store configured via https://gocloud.dev/howto/blob/ (default: filesystem)")
+
+	// pubsub address
+	set.String("pubsub-addr", "nats://127.0.0.1:4222", "gocloud connection string for pubsub configured via https://gocloud.dev/howto/pubsub/ (default is nats://127.0.0.1:4222)")
+
+	// enable/disable publish to queue
+	set.Bool("publish-to-queue", true, "enable/disable message publish to queue")
 
 	set.String("neptune-endpoint", "localhost", "address to neptune db")
 	set.Int("neptune-port", 8182, "port used for neptune db connection")

--- a/pkg/handler/collector/collector_test.go
+++ b/pkg/handler/collector/collector_test.go
@@ -168,7 +168,7 @@ func Test_Publish(t *testing.T) {
 
 	logBuffer.Reset()
 
-	err = Publish(ctx, &Ite6SLSADocWithLogger, blobStore, pubsub)
+	err = Publish(ctx, &Ite6SLSADocWithLogger, blobStore, pubsub, true)
 	if err != nil {
 		t.Fatalf("unexpected error on emit: %v", err)
 	}


### PR DESCRIPTION
# Description of the PR

- `publishToQueue` flag (default to true) allows users to pause publishing to the queue. This does not stop the blob store from storing the document. This can be used if you want to instead use a bucket event to drive the pipeline.

- OSV and scorecard certifier have been added to guaccollect so that they can follow the same blob store and pubsub pipeline.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
