### PR TITLE
Support direct connections to ent from the rest api

### DIFF
--- a/cmd/guacrest/cmd/root.go
+++ b/cmd/guacrest/cmd/root.go
@@ -33,14 +33,20 @@ var flags = struct {
 
 	tlsCertFile string
 	tlsKeyFile  string
+
+	dbDirectConnection bool
+	dbDriver           string
+	dbAddress          string
 }{}
 
 var rootCmd = &cobra.Command{
 	Use:   "guacrest",
 	Short: "Guac REST API Server",
-	Long: "The Guac REST API Server provides usable and analysis-focused endpoints. " +
-		"It is backed by the GraphQL API Server, which must be running for this server " +
-		"to work.",
+	Long: "The Guac REST API Server provides usable and analysis-focused endpoints.\n\n " +
+		"The default data backend is the GraphQL API Server, which must be " +
+		"running for this server to work. Some endpoints are optimized with a direct " +
+		"connection to the database that backs the GraphQL API. To enable this, " +
+		"set the db flags.",
 	Version: version.Version,
 	Run: func(command *cobra.Command, args []string) {
 		flags.restAPIServerPort = viper.GetInt("rest-api-server-port")
@@ -48,6 +54,10 @@ var rootCmd = &cobra.Command{
 		flags.headerFile = viper.GetString("header-file")
 		flags.tlsCertFile = viper.GetString("rest-api-tls-cert-file")
 		flags.tlsKeyFile = viper.GetString("rest-api-tls-key-file")
+
+		flags.dbDriver = viper.GetString("db-driver")
+		flags.dbAddress = viper.GetString("db-address")
+		flags.dbDirectConnection = viper.GetBool("db-direct-connection")
 
 		startServer()
 	},
@@ -68,9 +78,14 @@ func init() {
 		"rest-api-server-port",
 		"rest-api-tls-cert-file",
 		"rest-api-tls-key-file",
+
+		// configuration of direct database connection
+		"db-direct-connection",
+		"db-driver",
+		"db-address",
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to setup flags: %v", err)
 		os.Exit(1)
 	}
 

--- a/pkg/assembler/backends/ent/backend/migrations.go
+++ b/pkg/assembler/backends/ent/backend/migrations.go
@@ -22,6 +22,7 @@ import (
 
 	"entgo.io/ent/dialect"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/hook"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/migrate"
 	"github.com/guacsec/guac/pkg/logging"
 
@@ -33,6 +34,19 @@ type BackendOptions struct {
 	Address     string
 	Debug       bool
 	AutoMigrate bool
+}
+
+// GetReadOnlyClient sets up the ent backend and returns a read-only client.
+func GetReadOnlyClient(ctx context.Context, options *BackendOptions) (*ent.Client, error) {
+	client, err := SetupBackend(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	// https://entgo.io/docs/hooks/#mutation
+	client.Use(hook.Reject(
+		ent.OpCreate | ent.OpUpdate | ent.OpUpdateOne | ent.OpDelete | ent.OpDeleteOne,
+	))
+	return client, nil
 }
 
 // SetupBackend sets up the ent backend, preparing the database and returning a client

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -85,6 +85,7 @@ func init() {
 	set.String("rest-api-server-port", "8081", "port to serve the REST API from")
 	set.String("rest-api-tls-cert-file", "", "path to the TLS certificate in PEM format for rest api server")
 	set.String("rest-api-tls-key-file", "", "path to the TLS key in PEM format for rest api server")
+	set.Bool("db-direct-connection", false, "[experimental] connect directly to the database that backs the gql API for optimized endpoint implementations")
 
 	set.String("verifier-key-path", "", "path to pem file to verify dsse")
 	set.String("verifier-key-id", "", "ID of the key to be stored")

--- a/pkg/guacrest/helpers/artifact_test.go
+++ b/pkg/guacrest/helpers/artifact_test.go
@@ -42,10 +42,10 @@ func Test_FindArtifactWithDigest_ArtifactFound(t *testing.T) {
 		Algorithm: "sha256",
 		Digest:    "abc",
 	}}
-  _, err := gql.IngestArtifact(ctx, gqlClient, idOrArtifactSpec)
-  if err != nil {
-    t.Fatalf("Error ingesting test data")
-  } 
+	_, err := gql.IngestArtifact(ctx, gqlClient, idOrArtifactSpec)
+	if err != nil {
+		t.Fatalf("Error ingesting test data")
+	}
 
 	res, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "abc")
 	assert.NoError(t, err)

--- a/pkg/guacrest/server/ent.go
+++ b/pkg/guacrest/server/ent.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent"
+)
+
+// EntConnectedServer implements the REST API interface, using by default the
+// GrapQL API Server as a backend, but also allows overriding the default
+// handlers to ones that directly use the ENT backend.
+// 
+// This is an experimental feature.
+type EntConnectedServer struct {
+	ent *ent.Client
+	*DefaultServer
+}
+
+func NewEntConnectedServer(ent *ent.Client, gqlClient graphql.Client) *EntConnectedServer {
+	return &EntConnectedServer{
+		ent:           ent,
+		DefaultServer: NewDefaultServer(gqlClient),
+	}
+}
+
+// Override DefaultServer with methods here


### PR DESCRIPTION
# Description of the PR

Adds configuration to allow endpoints from the REST API to connect directly to Ent. This will allow bypassing the GraphQl API to use database native functionality.

This option can be enabled with `guacrest --db-direct-connection`. Current endpoint implementations can be overridden to use this optimized implementation by adding methods to `EntConnectedServer`. If `--db-direct-connection` is specified but an endpoint does not have a corresponding `EntConnectedServer` implementation, then the default one will be used.


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
