### PR TITLE
remove GetMatchFlagsFromPkgInput helper as it was not needed for isDependency

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -677,7 +677,7 @@ var (
 		{
 			Pkg:             topLevelPack,
 			DepPkg:          worldFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -687,7 +687,7 @@ var (
 		{
 			Pkg:             topLevelPack,
 			DepPkg:          rootFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -697,7 +697,7 @@ var (
 		{
 			Pkg:             topLevelPack,
 			DepPkg:          triggersFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -707,7 +707,7 @@ var (
 		{
 			Pkg:             topLevelPack,
 			DepPkg:          rsaPubFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -727,7 +727,7 @@ var (
 		{
 			Pkg:             rootFilePack,
 			DepPkg:          rsaPubFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -737,7 +737,7 @@ var (
 		{
 			Pkg:             baselayoutPack,
 			DepPkg:          rootFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",
@@ -747,7 +747,7 @@ var (
 		{
 			Pkg:             keysPack,
 			DepPkg:          rsaPubFilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions},
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
 				VersionRange:   "",

--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -35,7 +35,7 @@ func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputS
 			return &assembler.IsDependencyIngest{
 				Pkg:             foundNode,
 				DepPkg:          rfileNode,
-				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(rfileNode),
+				DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -48,7 +48,7 @@ func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputS
 			return &assembler.IsDependencyIngest{
 				Pkg:             foundNode,
 				DepPkg:          rpackNode,
-				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(rpackNode),
+				DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -70,7 +70,7 @@ func CreateTopLevelIsDeps(topLevel *model.PkgInputSpec, packages map[string][]*m
 				p := assembler.IsDependencyIngest{
 					Pkg:             topLevel,
 					DepPkg:          packNode,
-					DepPkgMatchFlag: GetMatchFlagsFromPkgInput(packNode),
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 					IsDependency: &model.IsDependencyInputSpec{
 						DependencyType: model.DependencyTypeUnknown,
 						Justification:  justification,
@@ -87,7 +87,7 @@ func CreateTopLevelIsDeps(topLevel *model.PkgInputSpec, packages map[string][]*m
 			p := assembler.IsDependencyIngest{
 				Pkg:             topLevel,
 				DepPkg:          fileNode,
-				DepPkgMatchFlag: GetMatchFlagsFromPkgInput(fileNode),
+				DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 				IsDependency: &model.IsDependencyInputSpec{
 					DependencyType: model.DependencyTypeUnknown,
 					Justification:  justification,
@@ -124,12 +124,4 @@ func createTopLevelHasSBOM(blob []byte, uri string, source string, timestamp tim
 			KnownSince:       timestamp,
 		},
 	}
-}
-
-func GetMatchFlagsFromPkgInput(p *model.PkgInputSpec) model.MatchFlags {
-	matchFlags := model.MatchFlags{Pkg: model.PkgMatchTypeAllVersions}
-	if p.Version != nil && *p.Version != "" {
-		matchFlags = model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion}
-	}
-	return matchFlags
 }

--- a/pkg/ingestor/parser/deps_dev/deps_dev.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev.go
@@ -72,7 +72,7 @@ func (d *depsDevParser) GetPredicates(ctx context.Context) *assembler.IngestPred
 		preds.IsDependency = append(preds.IsDependency, assembler.IsDependencyIngest{
 			Pkg:             isDepComp.CurrentPackageInput,
 			DepPkg:          isDepComp.DepPackageInput,
-			DepPkgMatchFlag: common.GetMatchFlagsFromPkgInput(isDepComp.DepPackageInput),
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
 			IsDependency:    isDepComp.IsDependency,
 		})
 	}

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -517,7 +517,7 @@ func Test_spdxParser(t *testing.T) {
 					{
 						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
 						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
-						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						IsDependency: &generated.IsDependencyInputSpec{
 							DependencyType: generated.DependencyTypeUnknown,
 							Justification:  "top-level package GUAC heuristic connecting to each file/package",
@@ -780,7 +780,7 @@ func Test_spdxParser(t *testing.T) {
 					{
 						Pkg:             pUrlToPkgDiscardError("pkg:guac/spdx/testsbom"),
 						DepPkg:          pUrlToPkgDiscardError("pkg:guac/files/sha1:ba1c68d88439599dcca7594d610030a19eda4f63?filename=./include-file"),
-						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeAllVersions},
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						IsDependency: &generated.IsDependencyInputSpec{
 							DependencyType: generated.DependencyTypeUnknown,
 							Justification:  "top-level package GUAC heuristic connecting to each file/package",


### PR DESCRIPTION
# Description of the PR

GetMatchFlagsFromPkgInput was left as a remnant when isDependency could be created at the pkgName level. Changes were madeto the SPDX and CDX parser to create isDependency only at the pkgVersion level. SBOMs in general will always specify a version and not a range. Deps.dev also resolves to a version.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
