### PR TITLE
use underscore instead of colon for blob store key

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -61,7 +61,7 @@ func DecodeEventSubject(ctx context.Context, collectedEvent []byte) (string, err
 
 func GetKey(blob []byte) string {
 	generatedHash := getHash(blob)
-	return fmt.Sprintf("sha256:%s", generatedHash)
+	return fmt.Sprintf("sha256_%s", generatedHash)
 }
 
 // GetDocRef returns the Document Reference of a blob; i.e. the blob store key for this blob.

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -54,3 +54,43 @@ func TestCreateEvent(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{{
+		name: "blob",
+		key:  "testKey",
+		want: "sha256_15291f67d99ea7bc578c3544dadfbb991e66fa69cb36ff70fe30e798e111ff5f",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getKey := GetKey([]byte(tt.key))
+			if getKey != tt.want {
+				t.Errorf("GetKey() = %v, want %v", getKey, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetDocRef(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{{
+		name: "blob",
+		key:  "testKey",
+		want: "sha256_15291f67d99ea7bc578c3544dadfbb991e66fa69cb36ff70fe30e798e111ff5f",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getKey := GetDocRef([]byte(tt.key))
+			if getKey != tt.want {
+				t.Errorf("GetDocRef() = %v, want %v", getKey, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description of the PR

use underscore instead of colon for blob store key (safer and do not need to url encode)

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
