### PR TITLE
[FIX] novuln check for ent query

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -100,7 +100,7 @@ func ingest(cmd *cobra.Command, args []string) {
 			if errors.As(err, &urlErr) {
 				return fmt.Errorf("unable to ingest document due to connection error with graphQL %q : %w", d.SourceInformation.Source, urlErr)
 			}
-			logger.Errorf("unable to ingest document %q : %v", d.SourceInformation.Source, err)
+			d.ChildLogger.Errorf("unable to ingest document %q : %v", d.SourceInformation.Source, err)
 		}
 		return nil
 	}

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -156,11 +156,21 @@ func vulnerabilityQueryPredicates(filter model.VulnerabilitySpec) []predicate.Vu
 	var where = []predicate.VulnerabilityID{
 		optionalPredicate(filter.ID, IDEQ),
 	}
+
+	// setting noVuln to true return all packages that have no vulnerabilities
 	if filter.NoVuln != nil && *filter.NoVuln {
+		filter.Type = ptrfrom.String(NoVuln)
+		filter.VulnerabilityID = ptrfrom.String("")
+	}
+
+	// setting noVuln to false return all packages with vulnerabilities. This adds a
+	// check to make sure type is not equal to `novuln`
+	if filter.NoVuln != nil && !*filter.NoVuln {
 		where = append(where,
-			optionalPredicate(ptrfrom.String(NoVuln), vulnerabilityid.TypeEQ),
+			optionalPredicate(ptrfrom.String(strings.ToLower(NoVuln)), vulnerabilityid.TypeNEQ),
 		)
 	}
+
 	if filter.Type != nil {
 		where = append(where,
 			optionalPredicate(ptrfrom.String(strings.ToLower(*filter.Type)), vulnerabilityid.TypeEQ),
@@ -174,6 +184,7 @@ func vulnerabilityQueryPredicates(filter model.VulnerabilitySpec) []predicate.Vu
 			)
 		}
 	}
+
 	return where
 }
 


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/1889

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [] If GraphQL schema is changed, `make generate` has been run
- [] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
