### PR TITLE
Add nil checks for pkgConn and PackagesList

### DIFF
--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -128,6 +128,9 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, nodeChan chan<- *Pac
 		if err != nil {
 			return fmt.Errorf("failed to query packages with error: %w", err)
 		}
+		if pkgConn == nil || pkgConn.PackagesList == nil {
+			continue
+		}
 		pkgEdges := pkgConn.PackagesList.Edges
 
 		for _, pkgNode := range pkgEdges {


### PR DESCRIPTION
If no packages have been ingested yet the getPackageNodes function can fail with a nil pointer error.