### PR TITLE
fix flag initialization and naming

### DIFF
--- a/cmd/guaccollect/cmd/osv.go
+++ b/cmd/guaccollect/cmd/osv.go
@@ -86,7 +86,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetString("interval"),
 			viper.GetBool("service-poll"),
 			viper.GetBool("publish-to-queue"),
-			viper.GetInt("daysSinceLastScan"),
+			viper.GetInt("last-scan"),
 		)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -232,5 +232,16 @@ func initializeNATsandCertifier(ctx context.Context, blobAddr, pubsubAddr string
 }
 
 func init() {
+	set, err := cli.BuildFlags([]string{"interval",
+		"last-scan", "header-file"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	osvCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(osvCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
 	rootCmd.AddCommand(osvCmd)
 }

--- a/cmd/guaccollect/cmd/root.go
+++ b/cmd/guaccollect/cmd/root.go
@@ -37,8 +37,6 @@ func init() {
 		"service-poll",
 		"enable-prometheus",
 		"publish-to-queue",
-		"interval",
-		"daysSinceLastScan",
 		"gql-addr",
 	})
 	if err != nil {

--- a/cmd/guaccollect/cmd/scorecard.go
+++ b/cmd/guaccollect/cmd/scorecard.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/certify"
-	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	sc "github.com/guacsec/guac/pkg/certifier/components/source"
 	"github.com/guacsec/guac/pkg/certifier/scorecard"
 	"github.com/guacsec/guac/pkg/cli"
 	"github.com/guacsec/guac/pkg/logging"
@@ -46,6 +46,8 @@ type scorecardOptions struct {
 	interval time.Duration
 	// enable/disable message publish to queue
 	publishToQueue bool
+	// setting "daysSinceLastScan" to 0 does not check the timestamp on the scorecard that exist
+	daysSinceLastScan int
 }
 
 var scorecardCmd = &cobra.Command{
@@ -75,6 +77,7 @@ you have access to read and write to the respective blob store.`,
 			viper.GetString("interval"),
 			viper.GetBool("service-poll"),
 			viper.GetBool("publish-to-queue"),
+			viper.GetInt("last-scan"),
 		)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -111,13 +114,13 @@ you have access to read and write to the respective blob store.`,
 		httpClient := http.Client{Transport: transport}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
 
-		sourceQueryFunc, err := getSourceQuery(gqlclient)
+		query, err := sc.NewCertifier(gqlclient, opts.daysSinceLastScan)
 		if err != nil {
-			logger.Errorf("error: %v", err)
+			logger.Errorf("unable to create source query: %v\n", err)
 			os.Exit(1)
 		}
 
-		initializeNATsandCertifier(ctx, opts.blobAddr, opts.pubsubAddr, opts.poll, opts.publishToQueue, opts.interval, sourceQueryFunc())
+		initializeNATsandCertifier(ctx, opts.blobAddr, opts.pubsubAddr, opts.poll, opts.publishToQueue, opts.interval, query)
 	},
 }
 
@@ -128,7 +131,7 @@ func validateScorecardFlags(
 	blobAddr,
 	interval string,
 	poll bool,
-	pubToQueue bool) (scorecardOptions, error) {
+	pubToQueue bool, daysSince int) (scorecardOptions, error) {
 
 	var opts scorecardOptions
 
@@ -144,17 +147,22 @@ func validateScorecardFlags(
 		return opts, fmt.Errorf("failed to parser duration with error: %w", err)
 	}
 	opts.interval = i
+	opts.daysSinceLastScan = daysSince
 
 	return opts, nil
 }
 
-func getSourceQuery(client graphql.Client) (func() certifier.QueryComponents, error) {
-	return func() certifier.QueryComponents {
-		packageQuery := root_package.NewPackageQuery(client, 0)
-		return packageQuery
-	}, nil
-}
-
 func init() {
+	set, err := cli.BuildFlags([]string{"interval",
+		"last-scan", "header-file"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	scorecardCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(scorecardCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
 	rootCmd.AddCommand(scorecardCmd)
 }

--- a/guac.yaml
+++ b/guac.yaml
@@ -27,7 +27,7 @@ blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 # certifier interval
 interval: 20m
 # days since the last vulnerability scan was run. 0 means only run once
-daysSinceLastScan: 0
+last-scan: 0
 
 # CSub setup
 csub-addr: localhost:2782

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -100,7 +100,7 @@ func init() {
 
 	set.StringP("interval", "i", "5m", "if polling set interval, m, h, s, etc.")
 
-	set.IntP("daysSinceLastScan", "l", 0, "days since the last vulnerability scan was run. 0 means only run once")
+	set.IntP("last-scan", "l", 0, "days since the last vulnerability scan was run. Default 0 means only run once")
 
 	set.BoolP("cert-good", "g", false, "enable to certifyGood, otherwise defaults to certifyBad")
 	set.BoolP("package-name", "n", false, "if type is package, enable if attestation is at package-name level (for all versions), defaults to specific version")


### PR DESCRIPTION
# Description of the PR

- change `daysToLastScan` to `last-scan` to follow convention (my bad)
- move flag initialization to be local
- fix scorecard using the source query

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
