### PR TITLE
Expose certifier and deps.dev batch size and add optional latency (defaults to none)

### DIFF
--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -20,7 +20,21 @@ use-csub: true
 
 # certifier polling
 poll: true
-interval: 5m
+# certifier interval
+interval: 20m
+# days since the last vulnerability scan was run. 0 means only run once
+last-scan: 0
+# set the batch size for the package pagination query
+certifier-batch-size: 60000
+# add artificial latency to throttle the certifier
+certifier-latency: ""
 
 # REST API setup
 rest-api-server-port: 8081
+
+# deps.dev
+# add artificial latency to throttle deps.dev
+deps-dev-latency: ""
+
+# query vulnerability during ingestion
+add-vuln-on-ingest: false

--- a/guac.yaml
+++ b/guac.yaml
@@ -28,6 +28,14 @@ blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 interval: 20m
 # days since the last vulnerability scan was run. 0 means only run once
 last-scan: 0
+# set the batch size for the package pagination query
+certifier-batch-size: 60000
+# add artificial latency to throttle the certifier
+certifier-latency: ""
+
+# deps.dev
+# add artificial latency to throttle deps.dev
+deps-dev-latency: ""
 
 # query vulnerability during ingestion
 add-vuln-on-ingest: false

--- a/internal/testing/cmd/pubsub_test/cmd/osv.go
+++ b/internal/testing/cmd/pubsub_test/cmd/osv.go
@@ -92,7 +92,7 @@ func getCertifierPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub 
 
 func getPackageQuery(client graphql.Client) (func() certifier.QueryComponents, error) {
 	return func() certifier.QueryComponents {
-		packageQuery := root_package.NewPackageQuery(client, 0)
+		packageQuery := root_package.NewPackageQuery(client, 0, 60000, nil)
 		return packageQuery
 	}, nil
 }

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -34,6 +34,8 @@ func TestNewPackageQuery(t *testing.T) {
 	type args struct {
 		client            graphql.Client
 		daysSinceLastScan int
+		batchSize         int
+		addedLatency      *time.Duration
 	}
 	tests := []struct {
 		name string
@@ -44,15 +46,19 @@ func TestNewPackageQuery(t *testing.T) {
 		args: args{
 			client:            gqlclient,
 			daysSinceLastScan: 0,
+			batchSize:         60000,
+			addedLatency:      nil,
 		},
 		want: &packageQuery{
 			client:            gqlclient,
 			daysSinceLastScan: 0,
+			batchSize:         60000,
+			addedLatency:      nil,
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewPackageQuery(tt.args.client, tt.args.daysSinceLastScan); !reflect.DeepEqual(got, tt.want) {
+			if got := NewPackageQuery(tt.args.client, tt.args.daysSinceLastScan, tt.args.batchSize, tt.args.addedLatency); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewPackageQuery() = %v, want %v", got, tt.want)
 			}
 		})
@@ -315,12 +321,18 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 			}},
 			wantErr: false,
 		}}
+	addedLatency, err := time.ParseDuration("3ms")
+	if err != nil {
+		t.Errorf("failed to parser duration with error: %v", err)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			p := &packageQuery{
 				client:            nil,
 				daysSinceLastScan: tt.daysSinceLastScan,
+				batchSize:         1,
+				addedLatency:      &addedLatency,
 			}
 			getPackages = tt.getPackages
 			getNeighbors = tt.getNeighbors

--- a/pkg/certifier/components/source/source_test.go
+++ b/pkg/certifier/components/source/source_test.go
@@ -35,6 +35,8 @@ func TestNewCertifier(t *testing.T) {
 	type args struct {
 		client            graphql.Client
 		daysSinceLastScan int
+		batchSize         int
+		addedLatency      *time.Duration
 	}
 	tests := []struct {
 		name    string
@@ -46,15 +48,19 @@ func TestNewCertifier(t *testing.T) {
 		args: args{
 			client:            gqlclient,
 			daysSinceLastScan: 0,
+			batchSize:         60000,
+			addedLatency:      nil,
 		},
 		want: &sourceQuery{
 			client:            gqlclient,
 			daysSinceLastScan: 0,
+			batchSize:         60000,
+			addedLatency:      nil,
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewCertifier(tt.args.client, tt.args.daysSinceLastScan)
+			got, err := NewCertifier(tt.args.client, tt.args.daysSinceLastScan, tt.args.batchSize, tt.args.addedLatency)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewCertifier() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -372,12 +378,18 @@ func Test_sourceArtifacts_GetComponents(t *testing.T) {
 			},
 			wantErr: false,
 		}}
+
+	addedLatency, err := time.ParseDuration("3ms")
+	if err != nil {
+		t.Errorf("failed to parser duration with error: %v", err)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			p := &sourceQuery{
 				client:            nil,
 				daysSinceLastScan: tt.daysSinceLastScan,
+				addedLatency:      &addedLatency,
 			}
 			getSources = tt.getSources
 			getNeighbors = tt.getNeighbors

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -65,6 +65,9 @@ func init() {
 	// enable/disable publish to queue
 	set.Bool("publish-to-queue", true, "enable/disable message publish to queue")
 
+	// the ingestor will query and ingest OSV for vulnerabilities
+	set.Bool("add-vuln-on-ingest", false, "if enabled, the ingestor will query and ingest OSV for vulnerabilities. Warning: This will increase ingestion times")
+
 	set.String("neptune-endpoint", "localhost", "address to neptune db")
 	set.Int("neptune-port", 8182, "port used for neptune db connection")
 	set.String("neptune-region", "us-east-1", "region to connect to neptune db")
@@ -90,10 +93,18 @@ func init() {
 	set.String("verifier-key-path", "", "path to pem file to verify dsse")
 	set.String("verifier-key-id", "", "ID of the key to be stored")
 
+	// certifier
 	set.Bool("service-poll", true, "sets the collector or certifier to polling mode")
 	set.BoolP("poll", "p", false, "sets the collector or certifier to polling mode")
 
-	set.Bool("add-vuln-on-ingest", false, "if enabled, the ingestor will query and ingest OSV for vulnerabilities. Warning: This will increase ingestion times")
+	// set the batch size for the package pagination query
+	set.Int("certifier-batch-size", 60000, "sets the batch size for pagination query for the certifier")
+	// add artificial latency to throttle the certifier
+	set.String("certifier-latency", "", "sets artificial latency on the certifier. Defaults to empty string (not enabled) but can set m, h, s...etc")
+
+	// deps.dev
+	// add artificial latency to throttle deps.dev
+	set.String("deps-dev-latency", "", "sets artificial latency on the deps.dev collector. Defaults to empty string (not enabled) but can set m, h, s...etc")
 
 	set.Bool("retrieve-dependencies", true, "enable the deps.dev collector to retrieve package dependencies")
 

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -92,7 +92,7 @@ func NewDepsCollector(ctx context.Context, collectDataSource datasource.CollectS
 
 	// Connect to the service using TLS.
 	creds := credentials.NewClientTLSFromCert(sysPool, "")
-	conn, err := grpc.Dial("api.deps.dev:443",
+	conn, err := grpc.NewClient("api.deps.dev:443",
 		grpc.WithTransportCredentials(creds),
 		grpc.WithUserAgent(version.UserAgent))
 	if err != nil {

--- a/pkg/handler/collector/deps_dev/deps_dev_test.go
+++ b/pkg/handler/collector/deps_dev/deps_dev_test.go
@@ -48,7 +48,7 @@ func TestNewDepsCollector(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewDepsCollector(ctx, toPurlSource(tt.packages), false, true, 5*time.Second)
+			_, err := NewDepsCollector(ctx, toPurlSource(tt.packages), false, true, 5*time.Second, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewDepsCollector() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -227,7 +227,7 @@ func Test_depsCollector_RetrieveArtifacts(t *testing.T) {
 				ctx = context.Background()
 			}
 
-			c, err := NewDepsCollector(ctx, toPurlSource(tt.packages), tt.poll, !tt.disableGettingDeps, tt.interval)
+			c, err := NewDepsCollector(ctx, toPurlSource(tt.packages), tt.poll, !tt.disableGettingDeps, tt.interval, nil)
 			if err != nil {
 				t.Errorf("NewDepsCollector() error = %v", err)
 				return
@@ -345,8 +345,11 @@ func TestPerformanceDepsCollector(t *testing.T) {
 	} else {
 		ctx = context.Background()
 	}
-
-	c, err := NewDepsCollector(ctx, toPurlSource(tests.packages), tests.poll, true, tests.interval)
+	addedLatency, err := time.ParseDuration("3ms")
+	if err != nil {
+		t.Errorf("failed to parser duration with error: %v", err)
+	}
+	c, err := NewDepsCollector(ctx, toPurlSource(tests.packages), tests.poll, true, tests.interval, &addedLatency)
 	if err != nil {
 		t.Errorf("NewDepsCollector() error = %v", err)
 		return


### PR DESCRIPTION
# Description of the PR

Expose certifier and deps.dev batch size and add optional latency (defaults to none)

```
// set the batch size for the package pagination query
set.Int("certifier-batch-size", 60000, "sets the batch size for pagination query for the certifier")
// add artificial latency to throttle the certifier
set.String("certifier-latency", "", "sets artificial latency on the certifier. Defaults to empty string (not enabled) but can set m, h, s...etc")

// deps.dev
// add artificial latency to throttle deps.dev
set.String("deps-dev-latency", "", "sets artificial latency on the deps.dev collector. Defaults to empty string (not enabled) but can set m, h, s...etc")
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
