### PR TITLE
Move to chainguard static

### DIFF
--- a/dockerfiles/Dockerfile.goreleaser
+++ b/dockerfiles/Dockerfile.goreleaser
@@ -1,11 +1,9 @@
-FROM --platform=$BUILDPLATFORM alpine:latest as certs
-RUN apk --update add ca-certificates
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/static:latest
 
-FROM --platform=$BUILDPLATFORM alpine:latest
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-RUN apk --update --no-cache add wget && rm -rf /var/cache/apk/*
+# Set the working directory
+WORKDIR /opt/guac
 
-WORKDIR /guac
+# Copy the necessary files to the working directory
 COPY guaccollect*  /opt/guac/guaccollect
 COPY guaccsub*  /opt/guac/guaccsub
 COPY guacgql*  /opt/guac/guacgql


### PR DESCRIPTION
- Move to chainguard static to have zero vuln

## With chainguard
```
grype ghcr.io/guacsec/guac:v0.0.0-local-organic-guac-arm64
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                        ghcr.io/guacsec/guac:v0.0.0-local-organic-guac-arm64
 ✔ Parsed image                                                                     sha256:fd5bc85f4446390cfa77f606f63bfa6c6ea2fb58d7b31474322e719f31e76f27
 ✔ Cataloged contents                                                                      4e2577db1e7426f462a0ed67ed8f8148b618556f64e11a954a4eda697d132706
   ├── ✔ Packages                        [890 packages]
   ├── ✔ File digests                    [397 files]
   ├── ✔ File metadata                   [397 locations]
   └── ✔ Executables                     [6 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
 ```
 
 ## With alpine
 ```
  grype ghcr.io/guacsec/guac:v0.7.2-arm64
 ✔ Vulnerability DB                [no update available]
 ✔ Pulled image
 ✔ Loaded image                                                                                                           ghcr.io/guacsec/guac:v0.7.2-arm64
 ✔ Parsed image                                                                     sha256:73d34b8dc03e2227a64256da524798b08ef64177c3e897df811d2a4c512d675d
 ✔ Cataloged contents                                                                      105648747f79dd2db65573ec29df61147b8a3ea27ef0634befacdc33979ac3c7
   ├── ✔ Packages                        [882 packages]
   ├── ✔ File digests                    [83 files]
   ├── ✔ File metadata                   [83 locations]
   └── ✔ Executables                     [28 executables]
 ✔ Scanned for vulnerabilities     [46 vulnerability matches]
   ├── by severity: 6 critical, 0 high, 20 medium, 0 low, 0 negligible (20 unknown)
   └── by status:   16 fixed, 30 not-fixed, 0 ignored
NAME                                              INSTALLED   FIXED-IN    TYPE       VULNERABILITY        SEVERITY
busybox                                           1.36.1-r28  1.36.1-r29  apk        CVE-2023-42365       Medium
busybox                                           1.36.1-r28  1.36.1-r29  apk        CVE-2023-42364       Medium
busybox-binsh                                     1.36.1-r28  1.36.1-r29  apk        CVE-2023-42365       Medium
busybox-binsh                                     1.36.1-r28  1.36.1-r29  apk        CVE-2023-42364       Medium
github.com/Azure/azure-sdk-for-go/sdk/azidentity  v1.5.1      1.6.0       go-module  GHSA-m5vv-6r4h-3vj9  Medium
github.com/vektah/gqlparser/v2                    v2.5.11     2.5.14      go-module  GHSA-2hmf-46v7-v6fx  Medium
libcrypto3                                        3.3.0-r2    3.3.0-r3    apk        CVE-2024-4741        Unknown
libssl3                                           3.3.0-r2    3.3.0-r3    apk        CVE-2024-4741        Unknown
ssl_client                                        1.36.1-r28  1.36.1-r29  apk        CVE-2023-42365       Medium
ssl_client                                        1.36.1-r28  1.36.1-r29  apk        CVE-2023-42364       Medium
stdlib                                            go1.22.1                go-module  CVE-2024-24790       Critical
stdlib                                            go1.22.1                go-module  CVE-2024-24789       Medium
stdlib                                            go1.22.1                go-module  CVE-2024-24788       Unknown
stdlib                                            go1.22.1                go-module  CVE-2024-24787       Unknown
stdlib                                            go1.22.1                go-module  CVE-2023-45288       Unknown
```

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
