### PR TITLE
Fix typo for Google Container Registry URL

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1213,7 +1213,7 @@ var (
 		"predicateType":"https://in-toto.io/attestation/vuln/v0.1",
 		"subject":[
 		   {
-			  "name":"pkg:oci/vul-secondLevel-latest?repository_url=grc.io",
+			  "name":"pkg:oci/vul-secondLevel-latest?repository_url=gcr.io",
 			  "digest":null
 		   }
 		],
@@ -1237,7 +1237,7 @@ var (
 		"predicateType":"https://in-toto.io/attestation/vuln/v0.1",
 		"subject":[
 		   {
-			  "name":"pkg:oci/vul-image-latest?repository_url=grc.io",
+			  "name":"pkg:oci/vul-image-latest?repository_url=gcr.io",
 			  "digest":null
 		   }
 		],
@@ -1303,11 +1303,11 @@ var (
 	 }`
 
 	RootPackage = root_package.PackageNode{
-		Purl: "pkg:oci/vul-image-latest?repository_url=grc.io",
+		Purl: "pkg:oci/vul-image-latest?repository_url=gcr.io",
 	}
 
 	SecondLevelPackage = root_package.PackageNode{
-		Purl: "pkg:oci/vul-secondLevel-latest?repository_url=grc.io",
+		Purl: "pkg:oci/vul-secondLevel-latest?repository_url=gcr.io",
 	}
 
 	Log4JPackage = root_package.PackageNode{


### PR DESCRIPTION
# Description of the PR

This changes updates a misspelled reference to the Google Container Registry gcr.io. The typo grc.io points to a 3rd-party website.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
