### PR TITLE
Parse CycloneDX Legal information

### DIFF
--- a/internal/testing/testdata/exampledata/small-legal-cyclonedx.json
+++ b/internal/testing/testdata/exampledata/small-legal-cyclonedx.json
@@ -1,0 +1,190 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-11-09T11:14:31Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.7.1",
+        "hashes" : [
+          {
+            "alg" : "SHA3-512",
+            "content" : "72ea0ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.acme",
+      "name" : "getting-started",
+      "version" : "1.0.0-SNAPSHOT",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPL-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "LGPL-3.0-or-later"
+          }
+        }
+      ],
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+        }
+      ],
+      "purl" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar"
+    }
+  },
+  "components" : [
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive",
+      "version" : "2.13.4.Final",
+      "description" : "A JAX-RS implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf39044af8c6ba66fc3beb034bc82ae8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-uri-template",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8756663af131035a2090d83f5f1b4054"
+        }
+      ],
+      "licenses" : [
+        {
+          "expression" : "Apache-2.0 AND (MIT OR GPL-2.0-only)"
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "LGPL-3.0-or-later",
+            "text": {
+              "content": "LGPL-3.0-or-later"
+            }
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+      ]
+    }
+  ]
+}

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1036,7 +1036,7 @@ type AllCertifyLegalTree struct {
 	Id string `json:"id"`
 	// The package version or source that is attested
 	Subject AllCertifyLegalTreeSubjectPackageOrSource `json:"-"`
-	// The license expression as delcared
+	// The license expression as declared
 	DeclaredLicense string `json:"declaredLicense"`
 	// A list of license objects found in the declared license expression
 	DeclaredLicenses []AllCertifyLegalTreeDeclaredLicensesLicense `json:"declaredLicenses"`

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5035,7 +5035,7 @@ type CertifyLegal {
   id: ID!
   "The package version or source that is attested"
   subject: PackageOrSource!
-  "The license expression as delcared"
+  "The license expression as declared"
   declaredLicense: String!
   "A list of license objects found in the declared license expression"
   declaredLicenses: [License!]!

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -321,7 +321,7 @@ type CertifyLegal struct {
 	ID string `json:"id"`
 	// The package version or source that is attested
 	Subject PackageOrSource `json:"subject"`
-	// The license expression as delcared
+	// The license expression as declared
 	DeclaredLicense string `json:"declaredLicense"`
 	// A list of license objects found in the declared license expression
 	DeclaredLicenses []*License `json:"declaredLicenses"`

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -37,7 +37,7 @@ type CertifyLegal {
   id: ID!
   "The package version or source that is attested"
   subject: PackageOrSource!
-  "The license expression as delcared"
+  "The license expression as declared"
   declaredLicense: String!
   "A list of license objects found in the declared license expression"
   declaredLicenses: [License!]!

--- a/pkg/ingestor/parser/common/license.go
+++ b/pkg/ingestor/parser/common/license.go
@@ -93,3 +93,7 @@ func HashLicense(inline string) string {
 	s := h.Sum32()
 	return fmt.Sprintf("LicenseRef-%x", s)
 }
+
+func CombineLicense(licenses []string) string {
+	return strings.Join(licenses, " AND ")
+}

--- a/pkg/ingestor/parser/common/license.go
+++ b/pkg/ingestor/parser/common/license.go
@@ -21,7 +21,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 )
 
 var ignore = []string{
@@ -69,17 +69,17 @@ var ignore = []string{
 // "Universal-FOSS-exception-1.0",
 // "WxWindows-exception-3.1",
 
-func ParseLicenses(exp string, lv string) []generated.LicenseInputSpec {
+func ParseLicenses(exp string, lv string) []model.LicenseInputSpec {
 	if exp == "" {
 		return nil
 	}
-	var rv []generated.LicenseInputSpec
+	var rv []model.LicenseInputSpec
 	for _, part := range strings.Split(exp, " ") {
 		p := strings.Trim(part, "()+")
 		if slices.Contains(ignore, p) {
 			continue
 		}
-		rv = append(rv, generated.LicenseInputSpec{
+		rv = append(rv, model.LicenseInputSpec{
 			Name:        p,
 			ListVersion: &lv,
 		})

--- a/pkg/ingestor/parser/common/license_test.go
+++ b/pkg/ingestor/parser/common/license_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCombineLicense(t *testing.T) {
+	tests := []struct {
+		name     string
+		licenses []string
+		want     string
+	}{{
+		name:     "multiple",
+		licenses: []string{"GPL-2.0", "LGPL-3.0-or-later"},
+		want:     "GPL-2.0 AND LGPL-3.0-or-later",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CombineLicense(tt.licenses)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -127,6 +127,15 @@ func Test_cyclonedxParser(t *testing.T) {
 		},
 		wantPredicates: noAnalysisVexPredicates(),
 		wantErr:        false,
+	}, {
+		name: "valid CycloneDX VEX document with license information",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXLegalExample,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
+		wantErr:        false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the PR

Update CDX parser to capture legal information that is contained in the SBOM. Unit tests have been updated to test the new functionality.

Related to the open issue: https://github.com/guacsec/guac/issues/1014, and completes the update to the CycloneDX Parser.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
