### PR TITLE
[ENT] add missing nodes from the node query

### DIFF
--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -491,11 +491,7 @@ func (b *EntBackend) getPkgNameSpace(ctx context.Context, nodeID string) (*model
 				{
 					ID:        pkgNamespaceGlobalID(strings.Join([]string{pn[0].Type, pn[0].Namespace}, ":")),
 					Namespace: pn[0].Namespace,
-					Names: []*model.PackageName{{
-						ID:       pkgNameGlobalID(pn[0].ID.String()),
-						Name:     pn[0].Name,
-						Versions: []*model.PackageVersion{},
-					}},
+					Names:     []*model.PackageName{},
 				},
 			},
 		}

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -489,7 +489,7 @@ func (b *EntBackend) getPkgNameSpace(ctx context.Context, nodeID string) (*model
 			Type: pn[0].Type,
 			Namespaces: []*model.PackageNamespace{
 				{
-					ID:        pkgNamespaceGlobalID(strings.Join([]string{pn[0].Type, pn[0].Namespace}, ":")),
+					ID:        pkgNamespaceGlobalID(strings.Join([]string{pn[0].Type, pn[0].Namespace}, guacIDSplit)),
 					Namespace: pn[0].Namespace,
 					Names:     []*model.PackageName{},
 				},
@@ -580,7 +580,7 @@ func (b *EntBackend) packageNamespaceNeighbors(ctx context.Context, nodeID strin
 				Type: foundPkgName.Type,
 				Namespaces: []*model.PackageNamespace{
 					{
-						ID:        pkgNamespaceGlobalID(strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, ":")),
+						ID:        pkgNamespaceGlobalID(strings.Join([]string{foundPkgName.Type, foundPkgName.Namespace}, guacIDSplit)),
 						Namespace: foundPkgName.Namespace,
 						Names: []*model.PackageName{{
 							ID:       pkgNameGlobalID(foundPkgName.ID.String()),

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -285,6 +285,27 @@ func toModelVulnerabilityID(vulnID *ent.VulnerabilityID) *model.VulnerabilityID 
 	}
 }
 
+func (b *EntBackend) getVulnType(ctx context.Context, nodeID string) (*model.Vulnerability, error) {
+	query := b.client.VulnerabilityID.Query().
+		Where(vulnerabilityQueryPredicates(model.VulnerabilitySpec{Type: &nodeID})...)
+
+	vulnIDs, err := query.All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vuln type for node ID: %s with error: %w", nodeID, err)
+	}
+
+	if len(vulnIDs) > 0 {
+		vulnType := &model.Vulnerability{
+			ID:               vulnTypeGlobalID(vulnIDs[0].Type),
+			Type:             vulnIDs[0].Type,
+			VulnerabilityIDs: []*model.VulnerabilityID{},
+		}
+		return vulnType, nil
+	} else {
+		return nil, fmt.Errorf("failed to get vuln type for node ID: %s", nodeID)
+	}
+}
+
 func (b *EntBackend) vulnTypeNeighbors(ctx context.Context, nodeID string, allowedEdges edgeMap) ([]model.Node, error) {
 	var out []model.Node
 	if allowedEdges[model.EdgeVulnerabilityTypeVulnerabilityID] {


### PR DESCRIPTION
# Description of the PR

The node query did not return nodes for `packageNamespace`, `packageType`, `SourceNamespace`, `SourceType` and `VulnType`. This is now fixed and will properly return for the IDs specified.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
