### PR TITLE
[ENT] #1996 Improve package's qualifiers query

### DIFF
--- a/internal/testing/backend/hasMetadata_test.go
+++ b/internal/testing/backend/hasMetadata_test.go
@@ -761,6 +761,40 @@ func TestHasMetadata(t *testing.T) {
 					DocumentRef: "test",
 				},
 			},
+		}, {
+			Name:  "Two packages with superset qualifiers",
+			InPkg: []*model.PkgInputSpec{testdata.P5, testdata.P7},
+			Calls: []call{
+				{
+					Sub: model.PackageSourceOrArtifactInput{
+						Package: &model.IDorPkgInput{PackageInput: testdata.P5},
+					},
+					Match: &model.MatchFlags{
+						Pkg: model.PkgMatchTypeSpecificVersion,
+					},
+					HM: &model.HasMetadataInputSpec{
+						Key:           "key1",
+						Value:         "value1",
+						Timestamp:     time.Unix(1e9, 0),
+						Justification: "another test justification",
+					},
+				},
+			},
+			Query: &model.HasMetadataSpec{
+				Key:           ptrfrom.String("key1"),
+				Value:         ptrfrom.String("value1"),
+				Since:         ptrfrom.Time(time.Unix(1e9, 0)),
+				Justification: ptrfrom.String("another test justification"),
+			},
+			ExpHM: []*model.HasMetadata{
+				{
+					Subject:       testdata.P5out,
+					Key:           "key1",
+					Value:         "value1",
+					Timestamp:     time.Unix(1e9, 0),
+					Justification: "another test justification",
+				},
+			},
 		},
 	}
 	for _, test := range tests {

--- a/internal/testing/testdata/models.go
+++ b/internal/testing/testdata/models.go
@@ -546,3 +546,17 @@ var P6out = []*model.Package{{
 		}},
 	}},
 }}
+
+var P7 = &model.PkgInputSpec{
+	Type:      P5.Type,
+	Namespace: P5.Namespace,
+	Name:      P5.Name,
+	Version:   P5.Version,
+	Qualifiers: []*model.PackageQualifierInputSpec{{
+		Key:   P5.Qualifiers[0].Key,
+		Value: P5.Qualifiers[0].Value,
+	}, {
+		Key:   "repository_url",
+		Value: "https://alternative.report.url/",
+	}},
+}

--- a/pkg/assembler/backends/ent/packageversion/qualifier_predicates.go
+++ b/pkg/assembler/backends/ent/packageversion/qualifier_predicates.go
@@ -44,6 +44,13 @@ func QualifiersContains(key, value string) func(*sql.Selector) {
 	}
 }
 
+// QualifiersSizeMatch checks the size of the qualifiers array is the expected one
+func QualifiersSizeMatch(size int) func(*sql.Selector) {
+	return func(s *sql.Selector) {
+		s.Where(sqljson.LenEQ(FieldQualifiers, size))
+	}
+}
+
 // QualifiersMatch constructs a JSON field query for the given qualifiers.
 // If the value is nil, it will query for the key only.
 // If the value is not nil, it will query for the key/value pair.
@@ -66,5 +73,6 @@ func QualifiersMatch(spec []*model.PackageQualifierSpec, matchOnlyEmptyQualifier
 				QualifiersContains(q.Key, *q.Value)(s)
 			}
 		}
+		QualifiersSizeMatch(len(spec))(s)
 	}
 }


### PR DESCRIPTION
# Description of the PR

The issue's due to the fact that, when adding an `HasMetadata` node, there's a uniqueness check for the package specs to identify a single package.

In the scenario described in  #1996, both packages
`pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=jar` 
and
`pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar`
have been already ingested.
The `QualifiersMatch` method checks for the provided qualifiers into the DB, i.e. `type=jar`, hence finding both the packages satisfy this condition and hence generating the error because the `HasMetadata` ingestion requires the package to be uniquely identified.

The fix adds a further check that, after having checked all of input package qualifiers are available, it also checks the size of the array of the qualifiers to ensure package with a superset of the input qualifiers, e.g. `repository_url=https://maven.repository.redhat.com/ga/`, aren't considered as a valid matching package.

Fixes #1996 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
