### PR TITLE
Speed up common CertifyVuln ent queries by adding indexes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
 - [ ] If GraphQL schema is changed, `make generate` has been run
 - [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
 - [ ] If OpenAPI spec is changed, `make generate` has been run
+- [ ] If ent schema is changed, `make generate` has been run
 - [ ] If `collectsub` protobuf has been changed, `make proto` has been run
 - [ ] All CI checks are passing (tests and formatting)
 - [ ] All dependent PRs have already been merged

--- a/pkg/assembler/backends/ent/migrate/migrations/20240702195630_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240702195630_ent_diff.sql
@@ -1,0 +1,4 @@
+-- Create index "certifyvuln_package_id" to table: "certify_vulns"
+CREATE INDEX "certifyvuln_package_id" ON "certify_vulns" ("package_id");
+-- Create index "vulnerabilityid_type" to table: "vulnerability_ids"
+CREATE INDEX "vulnerabilityid_type" ON "vulnerability_ids" ("type");

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:Z0P5t/epO2WlS9l+KgcJj/fXXUbYqg9ASBTrDwiUVQ4=
+h1:MoIYlS2hykbmbtvX1IGRCx04rxWGYVC8aJqjVBnEDak=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
+20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -369,6 +369,11 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[1], CertifyVulnsColumns[8], CertifyVulnsColumns[9], CertifyVulnsColumns[10]},
 			},
+			{
+				Name:    "certifyvuln_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyVulnsColumns[10]},
+			},
 		},
 	}
 	// DependenciesColumns holds the columns for the "dependencies" table.
@@ -980,6 +985,11 @@ var (
 				Name:    "vulnerabilityid_vulnerability_id_type",
 				Unique:  true,
 				Columns: []*schema.Column{VulnerabilityIdsColumns[1], VulnerabilityIdsColumns[2]},
+			},
+			{
+				Name:    "vulnerabilityid_type",
+				Unique:  false,
+				Columns: []*schema.Column{VulnerabilityIdsColumns[2]},
 			},
 		},
 	}

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -61,5 +61,6 @@ func (CertifyVuln) Edges() []ent.Edge {
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned", "document_ref").Edges("vulnerability", "package").Unique(),
+		index.Fields("package_id"), // speed up frequently run queries to check when CV nodes affect certain package IDs
 	}
 }

--- a/pkg/assembler/backends/ent/schema/vulnerabilityid.go
+++ b/pkg/assembler/backends/ent/schema/vulnerabilityid.go
@@ -55,5 +55,6 @@ func (VulnerabilityID) Edges() []ent.Edge {
 func (VulnerabilityID) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("vulnerability_id", "type").Unique(),
+		index.Fields("type"), // speed up frequently run queries to check when vuln type is not novuln
 	}
 }


### PR DESCRIPTION
# Description of the PR

In our use of GUAC with the ent backend, we were noticing some high DB load from some `CertifyVuln` queries. This PR should help with that.

I also added a PR checklist item for next time: 

> - [ ] If ent schema is changed, `make generate` has been run

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
