### PR TITLE
Fixed Guacone Query Vuln When Keyvalue is Used

### DIFF
--- a/cmd/guacone/cmd/vulnerability.go
+++ b/cmd/guacone/cmd/vulnerability.go
@@ -561,9 +561,9 @@ func searchPkgViaHasSBOM(ctx context.Context, gqlclient graphql.Client, searchSt
 	for _, result := range collectedPkgVersionResults {
 		for _, neighbor := range result.pkgVersionNeighborResponse.Neighbors {
 			if certifyVuln, ok := neighbor.(*model.NeighborsNeighborsCertifyVuln); ok {
-				if !checkedCertifyVulnIDs[certifyVuln.Vulnerability.Id] {
+				if !checkedCertifyVulnIDs[certifyVuln.Vulnerability.VulnerabilityIDs[0].Id] {
 					if certifyVuln.Vulnerability.Type != noVulnType {
-						checkedCertifyVulnIDs[certifyVuln.Vulnerability.Id] = true
+						checkedCertifyVulnIDs[certifyVuln.Vulnerability.VulnerabilityIDs[0].Id] = true
 						for _, vuln := range certifyVuln.Vulnerability.VulnerabilityIDs {
 							tableRows = append(tableRows, table.Row{certifyVulnStr, certifyVuln.Id, "vulnerability ID: " + vuln.VulnerabilityID})
 							path = append(path, []string{vuln.Id, certifyVuln.Id,


### PR DESCRIPTION
# Description of the PR

* Fixes #1974

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
