### PR TITLE
Fix guacrest docker compose healthchecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ container: check-docker-tool-check check-docker-buildx-tool-check check-goreleas
 	$(LOCAL_IMAGE_NAME)
 	@echo "\nThe guac container image is tagged locally as $(LOCAL_IMAGE_NAME)"
 
-# To run the service, run `make container` and then `make service`
+# To run the service, run `make container` and then `make start-service`
 # making the container is a longer process and thus not a dependency of service.
 .PHONY: start-service
 start-service: check-docker-compose-tool-check

--- a/container_files/guac-demo-compose.yaml
+++ b/container_files/guac-demo-compose.yaml
@@ -69,7 +69,7 @@ services:
         [
           "CMD",
           "wget",
-          "--spider",
+          "-O-",
           "http://localhost:8081/healthz"
         ]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
         [
           "CMD",
           "wget",
-          "--spider",
+          "-O-",
           "http://localhost:8081/healthz"
         ]
       interval: 10s


### PR DESCRIPTION
# Description of the PR

In `main` right now, if you run `make container` followed by `make start-service` from the root dir, or `GUAC_IMAGE=local-organic-guac docker compose -f guac-demo-compose.yaml up --force-recreate` from the `container_files` dir, and then run `docker ps`, `guacrest` will be reported as unhealthy.

This is because the healthcheck uses the `wget`'s `--spider` flag which makes a HEAD request. But the OpenAPI spec for `guacrest` does not allow for that method. So I changed the healthcheck command to use the `wget`'s `-O-` flag instead, which makes a GET request (and doesn't create a file with the response body - which would happen without any `-O` flag - but instead prints it to standard out).

After my commits, I retested the above `docker compose` commands and in both cases `docker ps` shows `guacrest` as healthy.

fixes #2002 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
