### PR TITLE
Fixed incorrect depsdev getProject

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2025,7 +2025,7 @@ var (
 			  "Scorecard":null,
 			  "Source":{
 				 "commit":null,
-				 "name":"js-tokens.git",
+				 "name":"js-tokens",
 				 "namespace":"github.com/lydell",
 				 "tag":null,
 				 "type":"git"
@@ -2061,7 +2061,7 @@ var (
 			  "Scorecard":null,
 			  "Source":{
 				 "commit":null,
-				 "name":"object-assign.git",
+				 "name":"object-assign",
 				 "namespace":"github.com/sindresorhus",
 				 "tag":null,
 				 "type":"git"
@@ -2146,7 +2146,7 @@ var (
 		"Scorecard":null,
 		"Source":{
 		   "commit":null,
-		   "name":"react.git",
+		   "name":"react",
 		   "namespace":"github.com/facebook",
 		   "tag":null,
 		   "type":"git"
@@ -2531,7 +2531,7 @@ var (
 			  "Scorecard":null,
 			  "Source":{
 				 "commit":null,
-				 "name":"camelcase.git",
+				 "name":"camelcase",
 				 "namespace":"github.com/sindresorhus",
 				 "tag":null,
 				 "type":"git"
@@ -2568,7 +2568,7 @@ var (
 		"Scorecard":null,
 		"Source":{
 		   "commit":null,
-		   "name":"yargs-parser.git",
+		   "name":"yargs-parser",
 		   "namespace":"github.com/yargs",
 		   "tag":null,
 		   "type":"git"

--- a/pkg/assembler/helpers/vcs.go
+++ b/pkg/assembler/helpers/vcs.go
@@ -48,7 +48,6 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 		} else {
 			return nil, fmt.Errorf("scheme has unknown source type: %s", u.Host)
 		}
-
 	} else {
 		// Should be <vcs_tool>+<transport>
 		schemeSp := strings.Split(u.Scheme, "+")
@@ -66,6 +65,10 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 	} else {
 		m.Name = strings.TrimPrefix(u.Path, "/")
 	}
+	// Based on the issue https://github.com/guacsec/guac/issues/1413, we need to ensure
+	// that the .git suffix is removed from the repository name. This is because some
+	// repository URLs might include the .git suffix which is not expected by certain endpoints.
+	m.Name = strings.TrimSuffix(m.Name, ".git")
 
 	sp := strings.Split(m.Name, "@")
 	if len(sp) > 2 {

--- a/pkg/assembler/helpers/vcs.go
+++ b/pkg/assembler/helpers/vcs.go
@@ -65,10 +65,6 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 	} else {
 		m.Name = strings.TrimPrefix(u.Path, "/")
 	}
-	// Based on the issue https://github.com/guacsec/guac/issues/1413, we need to ensure
-	// that the .git suffix is removed from the repository name. This is because some
-	// repository URLs might include the .git suffix which is not expected by certain endpoints.
-	m.Name = strings.TrimSuffix(m.Name, ".git")
 
 	sp := strings.Split(m.Name, "@")
 	if len(sp) > 2 {
@@ -84,6 +80,11 @@ func VcsToSrc(vcsUri string) (*model.SourceInputSpec, error) {
 			m.Tag = &tag
 		}
 	}
+
+	// Based on the issue https://github.com/guacsec/guac/issues/1413, we need to ensure
+	// that the .git suffix is removed from the repository name. This is because some
+	// repository URLs might include the .git suffix which is not expected by certain endpoints.
+	m.Name = strings.TrimSuffix(m.Name, ".git")
 
 	return m, nil
 }

--- a/pkg/assembler/helpers/vcs_test.go
+++ b/pkg/assembler/helpers/vcs_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestVcsUriToSrc(t *testing.T) {
-
 	testCases := []struct {
 		uri      string
 		wantErr  bool
@@ -49,7 +48,8 @@ func TestVcsUriToSrc(t *testing.T) {
 			uri:      "git+https://github.com/kubernetes@main",
 			wantErr:  false,
 			expected: src("git", "github.com", "kubernetes", nil, strP("main")),
-		}, {
+		},
+		{
 			uri:      "https://github.com/sfackler/rust-openssl",
 			wantErr:  false,
 			expected: src("git", "github.com/sfackler", "rust-openssl", nil, nil),
@@ -80,10 +80,14 @@ func TestVcsUriToSrc(t *testing.T) {
 			uri:     "github.com/kubernetes@@main",
 			wantErr: true,
 		},
+		{
+			uri:      "git+https://github.com/kubernetes/kubernetes.git",
+			wantErr:  false,
+			expected: src("git", "github.com/kubernetes", "kubernetes", nil, nil),
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("parsing %s", tt.uri), func(t *testing.T) {
-
 			// err == nil should be equivalent to IsVcs
 			if IsVcs(tt.uri) == tt.wantErr {
 				t.Errorf("expected err but IsVcs returned valid vcs uri")

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -614,7 +614,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 				logger.Debugf("The project key was not found in the map: %v", projectReq.ProjectKey)
 				project, err = d.client.GetProject(ctx, projectReq)
 				if err != nil {
-					logger.Debugf("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
+					logger.Infof("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
 					continue
 				}
 			}

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -614,7 +614,7 @@ func (d *depsCollector) collectAdditionalMetadata(ctx context.Context, pkgType s
 				logger.Debugf("The project key was not found in the map: %v", projectReq.ProjectKey)
 				project, err = d.client.GetProject(ctx, projectReq)
 				if err != nil {
-					logger.Infof("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
+					logger.Debugf("unable to get project for: %v, error: %v", projectReq.ProjectKey.Id, err)
 					continue
 				}
 			}

--- a/pkg/handler/collector/deps_dev/deps_dev_test.go
+++ b/pkg/handler/collector/deps_dev/deps_dev_test.go
@@ -503,15 +503,6 @@ func TestDepsCollector_collectAdditionalMetadata(t *testing.T) {
 		wantLog      string
 	}{
 		{
-			testName:     "npm package with .git suffix",
-			pkgType:      "npm",
-			namespace:    ptrfrom.String("@webassemblyjs"),
-			name:         "wasm-parser",
-			version:      ptrfrom.String("1.11.6"),
-			pkgComponent: &PackageComponent{},
-			wantLog:      "",
-		},
-		{
 			testName:     "golang package without .git suffix",
 			pkgType:      "golang",
 			namespace:    ptrfrom.String("github.com/google"),
@@ -550,6 +541,8 @@ func TestDepsCollector_collectAdditionalMetadata(t *testing.T) {
 			}
 
 			_ = c.collectAdditionalMetadata(ctx, tt.pkgType, tt.namespace, tt.name, tt.version, tt.pkgComponent)
+
+			t.Logf(logBuffer.String())
 
 			// Check if the log contains the expected log message
 			if !strings.Contains(logBuffer.String(), tt.wantLog) {

--- a/pkg/handler/collector/deps_dev/deps_dev_test.go
+++ b/pkg/handler/collector/deps_dev/deps_dev_test.go
@@ -26,6 +26,7 @@ import (
 	pb "deps.dev/api/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/dochelper"
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/internal/testing/testdata"
 	"github.com/guacsec/guac/pkg/collectsub/datasource"
 	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
@@ -465,6 +466,13 @@ func TestProjectKey(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "source repo link with .git suffix",
+			links: []*pb.Link{
+				{Label: "SOURCE_REPO", Url: "https://github.com/org/repo.git"},
+			},
+			expected: &pb.ProjectKey{Id: "github.com/org/repo"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -474,6 +482,51 @@ func TestProjectKey(t *testing.T) {
 			key := d.projectKey(version)
 			if key.GetId() != tc.expected.GetId() {
 				t.Errorf("Expected %v, got %v", tc.expected, key)
+			}
+		})
+	}
+}
+
+func TestDepsCollector_collectAdditionalMetadata(t *testing.T) {
+	tests := []struct {
+		testName     string
+		pkgType      string
+		namespace    *string
+		name         string
+		version      *string
+		pkgComponent *PackageComponent
+		wantErr      bool
+	}{
+		{
+			testName:     "npm package with .git suffix",
+			pkgType:      "npm",
+			namespace:    ptrfrom.String("@webassemblyjs"),
+			name:         "wasm-parser",
+			version:      ptrfrom.String("1.11.6"),
+			pkgComponent: &PackageComponent{},
+			wantErr:      false,
+		},
+		{
+			testName:     "golang package without .git suffix",
+			pkgType:      "golang",
+			namespace:    ptrfrom.String("github.com/google"),
+			name:         "wire",
+			version:      ptrfrom.String("v0.5.0"),
+			pkgComponent: &PackageComponent{},
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			c, err := NewDepsCollector(ctx, toPurlSource([]string{}), false, true, 5*time.Second)
+			if err != nil {
+				t.Errorf("NewDepsCollector() error = %v", err)
+				return
+			}
+			if err := c.collectAdditionalMetadata(context.Background(), tt.pkgType, tt.namespace, tt.name, tt.version, tt.pkgComponent); (err != nil) != tt.wantErr {
+				t.Errorf("collectAdditionalMetadata() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/ingestor/parser/deps_dev/deps_dev_test.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev_test.go
@@ -152,7 +152,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					Src: &model.SourceInputSpec{
 						Type:      "git",
 						Namespace: "github.com/facebook",
-						Name:      "react.git",
+						Name:      "react",
 					},
 					HasSourceAt: &model.HasSourceAtInputSpec{
 						KnownSince:    tm.UTC(),
@@ -174,7 +174,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					Src: &model.SourceInputSpec{
 						Type:      "git",
 						Namespace: "github.com/lydell",
-						Name:      "js-tokens.git",
+						Name:      "js-tokens",
 					},
 					HasSourceAt: &model.HasSourceAtInputSpec{
 						KnownSince:    tm.UTC(),
@@ -196,7 +196,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					Src: &model.SourceInputSpec{
 						Type:      "git",
 						Namespace: "github.com/sindresorhus",
-						Name:      "object-assign.git",
+						Name:      "object-assign",
 					},
 					HasSourceAt: &model.HasSourceAtInputSpec{
 						KnownSince:    tm.UTC(),
@@ -449,7 +449,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					Src: &model.SourceInputSpec{
 						Type:      "git",
 						Namespace: "github.com/yargs",
-						Name:      "yargs-parser.git",
+						Name:      "yargs-parser",
 					},
 					HasSourceAt: &model.HasSourceAtInputSpec{
 						KnownSince:    tm.UTC(),
@@ -472,7 +472,7 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					Src: &model.SourceInputSpec{
 						Type:      "git",
 						Namespace: "github.com/sindresorhus",
-						Name:      "camelcase.git",
+						Name:      "camelcase",
 					},
 					HasSourceAt: &model.HasSourceAtInputSpec{
 						KnownSince:    tm.UTC(),

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -1455,7 +1455,8 @@ func Test_spdxParser(t *testing.T) {
 			logging.InitLogger(logging.Debug)
 			if tt.wantWarning != "" {
 				logger, logs = observer.New(zap.DebugLevel)
-				logging.SetLogger(zap.New(logger))
+				l := zap.New(logger).Sugar()
+				logging.SetLogger(t, l)
 			}
 			ctx := logging.WithLogger(context.Background())
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/guacsec/guac/pkg/version"
+	"testing"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -129,6 +130,16 @@ func FromContext(ctx context.Context) *zap.SugaredLogger {
 	return zap.NewNop().Sugar()
 }
 
-func SetLogger(l *zap.Logger) {
-	logger = l.Sugar()
+func replaceLogger(nl *zap.SugaredLogger) {
+	logger = nl
+}
+
+// SetLoggerForTest allows temporarily replacing the global logger for testing purposes.
+// It registers a cleanup function with the testing.T instance to revert the logger.
+func SetLogger(t *testing.T, testLogger *zap.SugaredLogger) {
+	oldLogger := logger
+	replaceLogger(testLogger)
+	t.Cleanup(func() {
+		replaceLogger(oldLogger)
+	})
 }


### PR DESCRIPTION
# Description of the PR

This PR addresses the issue described in #1413. It is based on the changes from PR #1438.

## Reason for New PR:

I do not have permissions to push to the original PRs branch, so I am creating this new pull request to continue the work.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
