### PR TITLE
Fix the e2e

### DIFF
--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -144,15 +144,16 @@ duplicate_schema
 for command in "${ingestion_commands[@]}"; do
   echo @@@@ Running ingestion command: "$command" | tee -a "$LOG_FILE"
   eval "$command"
+
+  echo @@@@ Waiting
+  sleep 60
+
   go run ${GUAC_DIR}"/cmd/guacone" certifier osv -p=false
 
   if [ $? -ne 0 ]; then
     echo "Error: Command '$command' failed" | tee -a "$LOG_FILE"
     exit 1
   fi
-
-  echo @@@@ Waiting
-  sleep 60
 
   echo @@@@ Running queries and validating output
 


### PR DESCRIPTION
# Description of the PR

- The e2e is failing here: https://github.com/guacsec/guac/actions/runs/9859126595/job/27222088392. This PR should fix the issue.
- This issue is being caused because of a race condition.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
