### PR TITLE
add missing indirect dependencies from deps.dev

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1771,6 +1771,31 @@ var (
 				 "origin":"",
 				 "versionRange":"^3.0.0 || ^4.0.0"
 			  }
+		   },
+		   {
+			  "CurrentPackageInput":{
+				 "name":"react",
+				 "namespace":"",
+				 "qualifiers":null,
+				 "subpath":"",
+				 "type":"npm",
+				 "version":"17.0.0"
+			  },
+			  "DepPackageInput":{
+				 "name":"js-tokens",
+				 "namespace":"",
+				 "qualifiers":null,
+				 "subpath":"",
+				 "type":"npm",
+				 "version":"4.0.0"
+			  },
+			  "IsDependency":{
+				 "collector":"",
+				 "dependencyType":"INDIRECT",
+				 "justification":"dependency data collected via deps.dev",
+				 "origin":"",
+				 "versionRange":"^3.0.0 || ^4.0.0"
+			  }
 		   }
 		],
 		"Scorecard":null,

--- a/pkg/ingestor/parser/deps_dev/deps_dev_test.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev_test.go
@@ -107,6 +107,29 @@ func Test_depsDevParser_Parse(t *testing.T) {
 					DepPkg: &model.PkgInputSpec{
 						Type:      "npm",
 						Namespace: ptrfrom.String(""),
+						Name:      "js-tokens",
+						Version:   ptrfrom.String("4.0.0"),
+						Subpath:   ptrfrom.String(""),
+					},
+					IsDependency: &model.IsDependencyInputSpec{
+						DependencyType: model.DependencyTypeIndirect,
+						VersionRange:   "^3.0.0 || ^4.0.0",
+						Justification:  "dependency data collected via deps.dev",
+						Origin:         "",
+						Collector:      "",
+					},
+				}, {
+					Pkg: &model.PkgInputSpec{
+						Type:      "npm",
+						Namespace: ptrfrom.String(""),
+						Name:      "react",
+						Version:   ptrfrom.String("17.0.0"),
+						Subpath:   ptrfrom.String(""),
+					},
+					DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+					DepPkg: &model.PkgInputSpec{
+						Type:      "npm",
+						Namespace: ptrfrom.String(""),
 						Name:      "loose-envify",
 						Version:   ptrfrom.String("1.4.0"),
 						Subpath:   ptrfrom.String(""),


### PR DESCRIPTION
# Description of the PR

As I was removing the version range from deps.dev collector, I noticed that I made a mistake when quantifying the `direct` vs `indirect`. While I captured all the direct, I did not add in the `indirect` dependencies (from the root package). This PR fixes that issues.

deps.dev explanation found here: https://github.com/google/deps.dev/issues/12#issuecomment-1517103380

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
