### PR TITLE
Speed up isDependency query when spec depPkg has pkgID (add ent Pg index)

### DIFF
--- a/pkg/assembler/backends/ent/migrate/migrations/20240712193834_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240712193834_ent_diff.sql
@@ -1,0 +1,2 @@
+-- Create index "dependency_package_id" to table: "dependencies"
+CREATE INDEX "dependency_package_id" ON "dependencies" ("package_id");

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:MoIYlS2hykbmbtvX1IGRCx04rxWGYVC8aJqjVBnEDak=
+h1:LXg/nYCsid8/s+ZoQXWKCibm+F9bkUi1BIhyu2GEPb8=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
+20240712193834_ent_diff.sql h1:gBSeZwJhD3fL9E97DJIGevIwsbe64Lc0YQtxvwpd/Ss=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -431,6 +431,11 @@ var (
 					Where: "dependent_package_name_id IS NULL AND dependent_package_version_id IS NOT NULL",
 				},
 			},
+			{
+				Name:    "dependency_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{DependenciesColumns[7]},
+			},
 		},
 	}
 	// HasMetadataColumns holds the columns for the "has_metadata" table.

--- a/pkg/assembler/backends/ent/schema/dependency.go
+++ b/pkg/assembler/backends/ent/schema/dependency.go
@@ -87,5 +87,6 @@ func (Dependency) Indexes() []ent.Index {
 			Unique().
 			Annotations(entsql.IndexWhere("dependent_package_name_id IS NULL AND dependent_package_version_id IS NOT NULL")).
 			StorageKey("dep_package_version_id"),
+		index.Fields("package_id"), // speed up frequently run queries to check for deps with a certain package ID
 	}
 }


### PR DESCRIPTION
# Description of the PR

I found that doing `isDependency` GQL queries where the filter had a dependent package spec with the package ID specified was slow, and adding this index sped it up a fair bit.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
