### PR TITLE
[ENT] add indexes for common queries on ENT

### DIFF
--- a/internal/testing/testdata/exampledata/ingest_predicates.json
+++ b/internal/testing/testdata/exampledata/ingest_predicates.json
@@ -87,9 +87,6 @@
         ],
         "subpath": ""
       },
-      "depPkgMatchFlag" : {
-        "pkg": "SPECIFIC_VERSION"
-      },
       "isDependency": {
         "dependencyType": "UNKNOWN",
         "justification": "top level package dependency",
@@ -126,9 +123,6 @@
           }
         ],
         "subpath": ""
-      },
-      "depPkgMatchFlag" : {
-        "pkg": "SPECIFIC_VERSION"
       },
       "isDependency": {
         "dependencyType": "UNKNOWN",

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1126,62 +1126,50 @@ var (
 
 	cdxLegalDeps = []assembler.IsDependencyIngest{
 		{
-			Pkg:             cdxTopQuarkusPack,
-			DepPkg:          cdxResteasyPack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxTopQuarkusPack,
+			DepPkg: cdxResteasyPack,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeDirect,
-				VersionRange:   "2.13.4.Final",
 				Justification:  isCDXDepJustifyDependsJustification,
 			},
 		},
 		{
-			Pkg:             cdxTopQuarkusPack,
-			DepPkg:          cdxReactiveCommonPack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxTopQuarkusPack,
+			DepPkg: cdxReactiveCommonPack,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeIndirect,
-				VersionRange:   "2.13.4.Final",
 				Justification:  isCDXDepJustifyDependsJustification,
 			},
 		},
 		{
-			Pkg:             cdxResteasyPack,
-			DepPkg:          cdxReactiveCommonPack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxResteasyPack,
+			DepPkg: cdxReactiveCommonPack,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeDirect,
-				VersionRange:   "2.13.4.Final",
 				Justification:  isCDXDepJustifyDependsJustification,
 			},
 		},
 		{
-			Pkg:             cdxTopQuarkusPack,
-			DepPkg:          cdxSmallRye,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxTopQuarkusPack,
+			DepPkg: cdxSmallRye,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
-				VersionRange:   "2.27.0",
 				Justification:  isDepJustifyTopPkgJustification,
 			},
 		},
 		{
-			Pkg:             cdxTopQuarkusPack,
-			DepPkg:          cdxNetbasePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxTopQuarkusPack,
+			DepPkg: cdxNetbasePack,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
-				VersionRange:   "6.3",
 				Justification:  isDepJustifyTopPkgJustification,
 			},
 		},
 		{
-			Pkg:             cdxTopQuarkusPack,
-			DepPkg:          cdxMicroprofilePack,
-			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			Pkg:    cdxTopQuarkusPack,
+			DepPkg: cdxMicroprofilePack,
 			IsDependency: &model.IsDependencyInputSpec{
 				DependencyType: model.DependencyTypeUnknown,
-				VersionRange:   "1.2",
 				Justification:  isDepJustifyTopPkgJustification,
 			},
 		},

--- a/pkg/assembler/backends/ent/migrate/migrations/20240716182144_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240716182144_ent_diff.sql
@@ -1,0 +1,12 @@
+-- Create index "billofmaterials_artifact_id" to table: "bill_of_materials"
+CREATE INDEX "billofmaterials_artifact_id" ON "bill_of_materials" ("artifact_id") WHERE ((package_id IS NULL) AND (artifact_id IS NOT NULL));
+-- Create index "billofmaterials_package_id" to table: "bill_of_materials"
+CREATE INDEX "billofmaterials_package_id" ON "bill_of_materials" ("package_id") WHERE ((package_id IS NOT NULL) AND (artifact_id IS NULL));
+-- Create index "certifylegal_package_id" to table: "certify_legals"
+CREATE INDEX "certifylegal_package_id" ON "certify_legals" ("package_id") WHERE ((package_id IS NOT NULL) AND (source_id IS NULL));
+-- Create index "dependency_dependent_package_version_id" to table: "dependencies"
+CREATE INDEX "dependency_dependent_package_version_id" ON "dependencies" ("dependent_package_version_id");
+-- Create index "occurrence_artifact_id" to table: "occurrences"
+CREATE INDEX "occurrence_artifact_id" ON "occurrences" ("artifact_id");
+-- Create index "query_occurrence_package_id" to table: "occurrences"
+CREATE INDEX "query_occurrence_package_id" ON "occurrences" ("package_id") WHERE ((package_id IS NOT NULL) AND (source_id IS NULL));

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,6 +1,7 @@
-h1:tylM27WD3aiFco8Hl4NNfSVCY9g42uwOh5O1GMmkWP8=
+h1:2v3i5iU6MalDXCn9jNXp+75vnIcNccKwMbKG2r1uBkc=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
 20240712131658_ent_diff.sql h1:N54EB3Wh2NC2v9RToXo/BfpezLnSeHJBP1ha6VXfxD8=
 20240712193834_ent_diff.sql h1:gHTfEzlqvgYi6NKwT/Mb+wooWsVjAkp98zfg1OvdoZw=
+20240716182144_ent_diff.sql h1:Pm0/+7zkBUGOY/AiF3bCJzW8giL5+uSg/j/0SUDsuNg=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -82,6 +82,22 @@ var (
 					Where: "package_id IS NULL AND artifact_id IS NOT NULL",
 				},
 			},
+			{
+				Name:    "billofmaterials_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{BillOfMaterialsColumns[13]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "package_id IS NOT NULL AND artifact_id IS NULL",
+				},
+			},
+			{
+				Name:    "billofmaterials_artifact_id",
+				Unique:  false,
+				Columns: []*schema.Column{BillOfMaterialsColumns[14]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "package_id IS NULL AND artifact_id IS NOT NULL",
+				},
+			},
 		},
 	}
 	// BuildersColumns holds the columns for the "builders" table.
@@ -230,6 +246,14 @@ var (
 				Name:    "certifylegal_package_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
 				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "package_id IS NOT NULL AND source_id IS NULL",
+				},
+			},
+			{
+				Name:    "certifylegal_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyLegalsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},
@@ -416,6 +440,11 @@ var (
 				Name:    "dependency_package_id",
 				Unique:  false,
 				Columns: []*schema.Column{DependenciesColumns[6]},
+			},
+			{
+				Name:    "dependency_dependent_package_version_id",
+				Unique:  false,
+				Columns: []*schema.Column{DependenciesColumns[7]},
 			},
 		},
 	}
@@ -666,6 +695,19 @@ var (
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
+			},
+			{
+				Name:    "query_occurrence_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{OccurrencesColumns[6]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "package_id IS NOT NULL AND source_id IS NULL",
+				},
+			},
+			{
+				Name:    "occurrence_artifact_id",
+				Unique:  false,
+				Columns: []*schema.Column{OccurrencesColumns[5]},
 			},
 		},
 	}

--- a/pkg/assembler/backends/ent/schema/billofmaterials.go
+++ b/pkg/assembler/backends/ent/schema/billofmaterials.go
@@ -74,5 +74,7 @@ func (BillOfMaterials) Indexes() []ent.Index {
 		index.Fields("algorithm", "digest", "uri", "download_location", "known_since", "included_packages_hash",
 			"included_artifacts_hash", "included_dependencies_hash", "included_occurrences_hash", "origin", "collector", "document_ref").Edges("artifact").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND artifact_id IS NOT NULL")).StorageKey("sbom_artifact_id"),
+		index.Fields("package_id").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND artifact_id IS NULL")),  // query when subject is package ID
+		index.Fields("artifact_id").Annotations(entsql.IndexWhere("package_id IS NULL AND artifact_id IS NOT NULL")), // query when subject is artifact ID
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certifylegal.go
+++ b/pkg/assembler/backends/ent/schema/certifylegal.go
@@ -71,5 +71,6 @@ func (CertifyLegal) Indexes() []ent.Index {
 			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),
+		index.Fields("package_id").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")), // query when subject is package ID
 	}
 }

--- a/pkg/assembler/backends/ent/schema/dependency.go
+++ b/pkg/assembler/backends/ent/schema/dependency.go
@@ -73,6 +73,7 @@ func (Dependency) Edges() []ent.Edge {
 func (Dependency) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("dependency_type", "justification", "origin", "collector", "document_ref", "package_id", "dependent_package_version_id").Unique(),
-		index.Fields("package_id"), // speed up frequently run queries to check for deps with a certain package ID
+		index.Fields("package_id"),                   // speed up frequently run queries to check for deps with a certain package ID
+		index.Fields("dependent_package_version_id"), // query via the dependent package ID
 	}
 }

--- a/pkg/assembler/backends/ent/schema/occurrence.go
+++ b/pkg/assembler/backends/ent/schema/occurrence.go
@@ -69,5 +69,7 @@ func (Occurrence) Indexes() []ent.Index {
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")).StorageKey("occurrence_package_id"),
 		index.Fields("justification", "origin", "collector", "document_ref").Edges("artifact", "source").Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")).StorageKey("occurrence_source_id"),
+		index.Fields("package_id").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")).StorageKey("query_occurrence_package_id"), //querying subject - package ID
+		index.Fields("artifact_id"), //querying object - artifact ID
 	}
 }


### PR DESCRIPTION
# Description of the PR

add indexes for common queries on ENT. Specifically:


`isDependency`: DepPkg: id
`isDependency`: Pkg: id
`isOccurrence`: Artifact: id
`isOccurrence`: Subject: Package: id
`CertifyVuln`: Package: id & Vuln: NoVuln:false
`HasSBOM`: Subject: Package: id
`HasSBOM`: Subject: Artifact: id
`CertifyLegal`: Subject: Package: id

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
