### PR TITLE
update dependency schema to make dependent_package_version_id required

### DIFF
--- a/pkg/assembler/backends/ent/dependency/where.go
+++ b/pkg/assembler/backends/ent/dependency/where.go
@@ -124,16 +124,6 @@ func DependentPackageVersionIDNotIn(vs ...uuid.UUID) predicate.Dependency {
 	return predicate.Dependency(sql.FieldNotIn(FieldDependentPackageVersionID, vs...))
 }
 
-// DependentPackageVersionIDIsNil applies the IsNil predicate on the "dependent_package_version_id" field.
-func DependentPackageVersionIDIsNil() predicate.Dependency {
-	return predicate.Dependency(sql.FieldIsNull(FieldDependentPackageVersionID))
-}
-
-// DependentPackageVersionIDNotNil applies the NotNil predicate on the "dependent_package_version_id" field.
-func DependentPackageVersionIDNotNil() predicate.Dependency {
-	return predicate.Dependency(sql.FieldNotNull(FieldDependentPackageVersionID))
-}
-
 // DependencyTypeEQ applies the EQ predicate on the "dependency_type" field.
 func DependencyTypeEQ(v DependencyType) predicate.Dependency {
 	return predicate.Dependency(sql.FieldEQ(FieldDependencyType, v))

--- a/pkg/assembler/backends/ent/dependency_create.go
+++ b/pkg/assembler/backends/ent/dependency_create.go
@@ -37,14 +37,6 @@ func (dc *DependencyCreate) SetDependentPackageVersionID(u uuid.UUID) *Dependenc
 	return dc
 }
 
-// SetNillableDependentPackageVersionID sets the "dependent_package_version_id" field if the given value is not nil.
-func (dc *DependencyCreate) SetNillableDependentPackageVersionID(u *uuid.UUID) *DependencyCreate {
-	if u != nil {
-		dc.SetDependentPackageVersionID(*u)
-	}
-	return dc
-}
-
 // SetDependencyType sets the "dependency_type" field.
 func (dc *DependencyCreate) SetDependencyType(dt dependency.DependencyType) *DependencyCreate {
 	dc.mutation.SetDependencyType(dt)
@@ -160,6 +152,9 @@ func (dc *DependencyCreate) check() error {
 	if _, ok := dc.mutation.PackageID(); !ok {
 		return &ValidationError{Name: "package_id", err: errors.New(`ent: missing required field "Dependency.package_id"`)}
 	}
+	if _, ok := dc.mutation.DependentPackageVersionID(); !ok {
+		return &ValidationError{Name: "dependent_package_version_id", err: errors.New(`ent: missing required field "Dependency.dependent_package_version_id"`)}
+	}
 	if _, ok := dc.mutation.DependencyType(); !ok {
 		return &ValidationError{Name: "dependency_type", err: errors.New(`ent: missing required field "Dependency.dependency_type"`)}
 	}
@@ -182,6 +177,9 @@ func (dc *DependencyCreate) check() error {
 	}
 	if len(dc.mutation.PackageIDs()) == 0 {
 		return &ValidationError{Name: "package", err: errors.New(`ent: missing required edge "Dependency.package"`)}
+	}
+	if len(dc.mutation.DependentPackageVersionIDs()) == 0 {
+		return &ValidationError{Name: "dependent_package_version", err: errors.New(`ent: missing required edge "Dependency.dependent_package_version"`)}
 	}
 	return nil
 }
@@ -365,12 +363,6 @@ func (u *DependencyUpsert) UpdateDependentPackageVersionID() *DependencyUpsert {
 	return u
 }
 
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (u *DependencyUpsert) ClearDependentPackageVersionID() *DependencyUpsert {
-	u.SetNull(dependency.FieldDependentPackageVersionID)
-	return u
-}
-
 // SetDependencyType sets the "dependency_type" field.
 func (u *DependencyUpsert) SetDependencyType(v dependency.DependencyType) *DependencyUpsert {
 	u.Set(dependency.FieldDependencyType, v)
@@ -504,13 +496,6 @@ func (u *DependencyUpsertOne) SetDependentPackageVersionID(v uuid.UUID) *Depende
 func (u *DependencyUpsertOne) UpdateDependentPackageVersionID() *DependencyUpsertOne {
 	return u.Update(func(s *DependencyUpsert) {
 		s.UpdateDependentPackageVersionID()
-	})
-}
-
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (u *DependencyUpsertOne) ClearDependentPackageVersionID() *DependencyUpsertOne {
-	return u.Update(func(s *DependencyUpsert) {
-		s.ClearDependentPackageVersionID()
 	})
 }
 
@@ -824,13 +809,6 @@ func (u *DependencyUpsertBulk) SetDependentPackageVersionID(v uuid.UUID) *Depend
 func (u *DependencyUpsertBulk) UpdateDependentPackageVersionID() *DependencyUpsertBulk {
 	return u.Update(func(s *DependencyUpsert) {
 		s.UpdateDependentPackageVersionID()
-	})
-}
-
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (u *DependencyUpsertBulk) ClearDependentPackageVersionID() *DependencyUpsertBulk {
-	return u.Update(func(s *DependencyUpsert) {
-		s.ClearDependentPackageVersionID()
 	})
 }
 

--- a/pkg/assembler/backends/ent/dependency_update.go
+++ b/pkg/assembler/backends/ent/dependency_update.go
@@ -58,12 +58,6 @@ func (du *DependencyUpdate) SetNillableDependentPackageVersionID(u *uuid.UUID) *
 	return du
 }
 
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (du *DependencyUpdate) ClearDependentPackageVersionID() *DependencyUpdate {
-	du.mutation.ClearDependentPackageVersionID()
-	return du
-}
-
 // SetDependencyType sets the "dependency_type" field.
 func (du *DependencyUpdate) SetDependencyType(dt dependency.DependencyType) *DependencyUpdate {
 	du.mutation.SetDependencyType(dt)
@@ -233,6 +227,9 @@ func (du *DependencyUpdate) check() error {
 	}
 	if du.mutation.PackageCleared() && len(du.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Dependency.package"`)
+	}
+	if du.mutation.DependentPackageVersionCleared() && len(du.mutation.DependentPackageVersionIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Dependency.dependent_package_version"`)
 	}
 	return nil
 }
@@ -412,12 +409,6 @@ func (duo *DependencyUpdateOne) SetNillableDependentPackageVersionID(u *uuid.UUI
 	if u != nil {
 		duo.SetDependentPackageVersionID(*u)
 	}
-	return duo
-}
-
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (duo *DependencyUpdateOne) ClearDependentPackageVersionID() *DependencyUpdateOne {
-	duo.mutation.ClearDependentPackageVersionID()
 	return duo
 }
 
@@ -603,6 +594,9 @@ func (duo *DependencyUpdateOne) check() error {
 	}
 	if duo.mutation.PackageCleared() && len(duo.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Dependency.package"`)
+	}
+	if duo.mutation.DependentPackageVersionCleared() && len(duo.mutation.DependentPackageVersionIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Dependency.dependent_package_version"`)
 	}
 	return nil
 }

--- a/pkg/assembler/backends/ent/gql_edge.go
+++ b/pkg/assembler/backends/ent/gql_edge.go
@@ -349,7 +349,7 @@ func (d *Dependency) DependentPackageVersion(ctx context.Context) (*PackageVersi
 	if IsNotLoaded(err) {
 		result, err = d.QueryDependentPackageVersion().Only(ctx)
 	}
-	return result, MaskNotFound(err)
+	return result, err
 }
 
 func (d *Dependency) IncludedInSboms(ctx context.Context) (result []*BillOfMaterials, err error) {

--- a/pkg/assembler/backends/ent/migrate/migrations/20240802204508_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240802204508_ent_diff.sql
@@ -1,0 +1,2 @@
+-- Modify "dependencies" table
+ALTER TABLE "dependencies" ALTER COLUMN "dependent_package_version_id" SET NOT NULL;

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,7 +1,8 @@
-h1:2v3i5iU6MalDXCn9jNXp+75vnIcNccKwMbKG2r1uBkc=
+h1:mYbfXOAYvSgAht05+9wroDncH1ZJDdll9KZ1sDjie30=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
 20240712131658_ent_diff.sql h1:N54EB3Wh2NC2v9RToXo/BfpezLnSeHJBP1ha6VXfxD8=
 20240712193834_ent_diff.sql h1:gHTfEzlqvgYi6NKwT/Mb+wooWsVjAkp98zfg1OvdoZw=
 20240716182144_ent_diff.sql h1:Pm0/+7zkBUGOY/AiF3bCJzW8giL5+uSg/j/0SUDsuNg=
+20240802204508_ent_diff.sql h1:+qucLy0vqkEDoJsfG4Phh+babyGB5Ud/Dn0+WNB6BLY=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -409,7 +409,7 @@ var (
 		{Name: "collector", Type: field.TypeString},
 		{Name: "document_ref", Type: field.TypeString},
 		{Name: "package_id", Type: field.TypeUUID},
-		{Name: "dependent_package_version_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "dependent_package_version_id", Type: field.TypeUUID},
 	}
 	// DependenciesTable holds the schema information for the "dependencies" table.
 	DependenciesTable = &schema.Table{

--- a/pkg/assembler/backends/ent/mutation.go
+++ b/pkg/assembler/backends/ent/mutation.go
@@ -8749,22 +8749,9 @@ func (m *DependencyMutation) OldDependentPackageVersionID(ctx context.Context) (
 	return oldValue.DependentPackageVersionID, nil
 }
 
-// ClearDependentPackageVersionID clears the value of the "dependent_package_version_id" field.
-func (m *DependencyMutation) ClearDependentPackageVersionID() {
-	m.dependent_package_version = nil
-	m.clearedFields[dependency.FieldDependentPackageVersionID] = struct{}{}
-}
-
-// DependentPackageVersionIDCleared returns if the "dependent_package_version_id" field was cleared in this mutation.
-func (m *DependencyMutation) DependentPackageVersionIDCleared() bool {
-	_, ok := m.clearedFields[dependency.FieldDependentPackageVersionID]
-	return ok
-}
-
 // ResetDependentPackageVersionID resets all changes to the "dependent_package_version_id" field.
 func (m *DependencyMutation) ResetDependentPackageVersionID() {
 	m.dependent_package_version = nil
-	delete(m.clearedFields, dependency.FieldDependentPackageVersionID)
 }
 
 // SetDependencyType sets the "dependency_type" field.
@@ -8982,7 +8969,7 @@ func (m *DependencyMutation) ClearDependentPackageVersion() {
 
 // DependentPackageVersionCleared reports if the "dependent_package_version" edge to the PackageVersion entity was cleared.
 func (m *DependencyMutation) DependentPackageVersionCleared() bool {
-	return m.DependentPackageVersionIDCleared() || m.cleareddependent_package_version
+	return m.cleareddependent_package_version
 }
 
 // DependentPackageVersionIDs returns the "dependent_package_version" edge IDs in the mutation.
@@ -9243,11 +9230,7 @@ func (m *DependencyMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *DependencyMutation) ClearedFields() []string {
-	var fields []string
-	if m.FieldCleared(dependency.FieldDependentPackageVersionID) {
-		fields = append(fields, dependency.FieldDependentPackageVersionID)
-	}
-	return fields
+	return nil
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -9260,11 +9243,6 @@ func (m *DependencyMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *DependencyMutation) ClearField(name string) error {
-	switch name {
-	case dependency.FieldDependentPackageVersionID:
-		m.ClearDependentPackageVersionID()
-		return nil
-	}
 	return fmt.Errorf("unknown Dependency nullable field %s", name)
 }
 

--- a/pkg/assembler/backends/ent/schema/dependency.go
+++ b/pkg/assembler/backends/ent/schema/dependency.go
@@ -46,7 +46,7 @@ func (Dependency) Fields() []ent.Field {
 			Unique().
 			Immutable(),
 		field.UUID("package_id", getUUIDv7()),
-		field.UUID("dependent_package_version_id", getUUIDv7()).Optional(),
+		field.UUID("dependent_package_version_id", getUUIDv7()),
 		field.Enum("dependency_type").Values(model.DependencyTypeDirect.String(), model.DependencyTypeIndirect.String(), model.DependencyTypeUnknown.String()),
 		field.String("justification"),
 		field.String("origin"),
@@ -63,6 +63,7 @@ func (Dependency) Edges() []ent.Edge {
 			Field("package_id").
 			Unique().Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("dependent_package_version", PackageVersion.Type).
+			Required().
 			Field("dependent_package_version_id").
 			Unique().Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.From("included_in_sboms", BillOfMaterials.Type).Ref("included_dependencies").Annotations(entsql.OnDelete(entsql.Cascade)),


### PR DESCRIPTION
# Description of the PR

update dependency schema to make dependent_package_version_id required. 

I have created a script located here: https://github.com/pxp928/guac-update-db

That can be run so that the migration can occur without an issue.

This is a breaking change to exisiting ENT databases.



# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
