### PR TITLE
update ent and regen code to fix atlas diff issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 require (
 	deps.dev/api/v3 v3.0.0-20240701054435-542fb1833d6b
 	entgo.io/contrib v0.5.0
-	entgo.io/ent v0.13.1
+	entgo.io/ent v0.14.0
 	github.com/99designs/gqlgen v0.17.48
 	github.com/CycloneDX/cyclonedx-go v0.9.0
 	github.com/Khan/genqlient v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ deps.dev/util/semver v0.0.0-20240701054435-542fb1833d6b h1:5Jdj8VFE7qdAKVaDDXb68
 deps.dev/util/semver v0.0.0-20240701054435-542fb1833d6b/go.mod h1:jkcH+k02gWHBiZ7G4OnUOkSZ6WDq54Pt5DrOA8FN8Uo=
 entgo.io/contrib v0.5.0 h1:M4IqodImfUm327RDwNAITLNz3PsxVeC3rD4DPeVA8Gs=
 entgo.io/contrib v0.5.0/go.mod h1:q8dXQCmzqpSlVdT2bWDydjgznGcy3y4zmsYmVFC9V/U=
-entgo.io/ent v0.13.1 h1:uD8QwN1h6SNphdCCzmkMN3feSUzNnVvV/WIkHKMbzOE=
-entgo.io/ent v0.13.1/go.mod h1:qCEmo+biw3ccBn9OyL4ZK5dfpwg++l1Gxwac5B1206A=
+entgo.io/ent v0.14.0 h1:EO3Z9aZ5bXJatJeGqu/EVdnNr6K4mRq3rWe5owt0MC4=
+entgo.io/ent v0.14.0/go.mod h1:qCEmo+biw3ccBn9OyL4ZK5dfpwg++l1Gxwac5B1206A=
 github.com/99designs/gqlgen v0.17.48 h1:Wgk7n9PIdnmpsC1aJJV4eiZCGkAkoamKOtXAp/crpzQ=
 github.com/99designs/gqlgen v0.17.48/go.mod h1:hYeQ+ygPbcapbaHtHMbZ1DHMVNT+1tGU+fI+Hy4kqIo=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3 h1:uDF62mbd9bypXWi19V1bN5NZEO84JqgmI5G73ibAmrk=

--- a/pkg/assembler/backends/ent/artifact_query.go
+++ b/pkg/assembler/backends/ent/artifact_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -336,7 +337,7 @@ func (aq *ArtifactQuery) QueryIncludedInSboms() *BillOfMaterialsQuery {
 // First returns the first Artifact entity from the query.
 // Returns a *NotFoundError when no Artifact was found.
 func (aq *ArtifactQuery) First(ctx context.Context) (*Artifact, error) {
-	nodes, err := aq.Limit(1).All(setContextOp(ctx, aq.ctx, "First"))
+	nodes, err := aq.Limit(1).All(setContextOp(ctx, aq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +360,7 @@ func (aq *ArtifactQuery) FirstX(ctx context.Context) *Artifact {
 // Returns a *NotFoundError when no Artifact ID was found.
 func (aq *ArtifactQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = aq.Limit(1).IDs(setContextOp(ctx, aq.ctx, "FirstID")); err != nil {
+	if ids, err = aq.Limit(1).IDs(setContextOp(ctx, aq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -382,7 +383,7 @@ func (aq *ArtifactQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one Artifact entity is found.
 // Returns a *NotFoundError when no Artifact entities are found.
 func (aq *ArtifactQuery) Only(ctx context.Context) (*Artifact, error) {
-	nodes, err := aq.Limit(2).All(setContextOp(ctx, aq.ctx, "Only"))
+	nodes, err := aq.Limit(2).All(setContextOp(ctx, aq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +411,7 @@ func (aq *ArtifactQuery) OnlyX(ctx context.Context) *Artifact {
 // Returns a *NotFoundError when no entities are found.
 func (aq *ArtifactQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = aq.Limit(2).IDs(setContextOp(ctx, aq.ctx, "OnlyID")); err != nil {
+	if ids, err = aq.Limit(2).IDs(setContextOp(ctx, aq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -435,7 +436,7 @@ func (aq *ArtifactQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Artifacts.
 func (aq *ArtifactQuery) All(ctx context.Context) ([]*Artifact, error) {
-	ctx = setContextOp(ctx, aq.ctx, "All")
+	ctx = setContextOp(ctx, aq.ctx, ent.OpQueryAll)
 	if err := aq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -457,7 +458,7 @@ func (aq *ArtifactQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) {
 	if aq.ctx.Unique == nil && aq.path != nil {
 		aq.Unique(true)
 	}
-	ctx = setContextOp(ctx, aq.ctx, "IDs")
+	ctx = setContextOp(ctx, aq.ctx, ent.OpQueryIDs)
 	if err = aq.Select(artifact.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -475,7 +476,7 @@ func (aq *ArtifactQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (aq *ArtifactQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, aq.ctx, "Count")
+	ctx = setContextOp(ctx, aq.ctx, ent.OpQueryCount)
 	if err := aq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -493,7 +494,7 @@ func (aq *ArtifactQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (aq *ArtifactQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, aq.ctx, "Exist")
+	ctx = setContextOp(ctx, aq.ctx, ent.OpQueryExist)
 	switch _, err := aq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -1600,7 +1601,7 @@ func (agb *ArtifactGroupBy) Aggregate(fns ...AggregateFunc) *ArtifactGroupBy {
 
 // Scan applies the selector query and scans the result into the given value.
 func (agb *ArtifactGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, agb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, agb.build.ctx, ent.OpQueryGroupBy)
 	if err := agb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -1648,7 +1649,7 @@ func (as *ArtifactSelect) Aggregate(fns ...AggregateFunc) *ArtifactSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (as *ArtifactSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, as.ctx, "Select")
+	ctx = setContextOp(ctx, as.ctx, ent.OpQuerySelect)
 	if err := as.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/billofmaterials_query.go
+++ b/pkg/assembler/backends/ent/billofmaterials_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -210,7 +211,7 @@ func (bomq *BillOfMaterialsQuery) QueryIncludedOccurrences() *OccurrenceQuery {
 // First returns the first BillOfMaterials entity from the query.
 // Returns a *NotFoundError when no BillOfMaterials was found.
 func (bomq *BillOfMaterialsQuery) First(ctx context.Context) (*BillOfMaterials, error) {
-	nodes, err := bomq.Limit(1).All(setContextOp(ctx, bomq.ctx, "First"))
+	nodes, err := bomq.Limit(1).All(setContextOp(ctx, bomq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (bomq *BillOfMaterialsQuery) FirstX(ctx context.Context) *BillOfMaterials {
 // Returns a *NotFoundError when no BillOfMaterials ID was found.
 func (bomq *BillOfMaterialsQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = bomq.Limit(1).IDs(setContextOp(ctx, bomq.ctx, "FirstID")); err != nil {
+	if ids, err = bomq.Limit(1).IDs(setContextOp(ctx, bomq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -256,7 +257,7 @@ func (bomq *BillOfMaterialsQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one BillOfMaterials entity is found.
 // Returns a *NotFoundError when no BillOfMaterials entities are found.
 func (bomq *BillOfMaterialsQuery) Only(ctx context.Context) (*BillOfMaterials, error) {
-	nodes, err := bomq.Limit(2).All(setContextOp(ctx, bomq.ctx, "Only"))
+	nodes, err := bomq.Limit(2).All(setContextOp(ctx, bomq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +285,7 @@ func (bomq *BillOfMaterialsQuery) OnlyX(ctx context.Context) *BillOfMaterials {
 // Returns a *NotFoundError when no entities are found.
 func (bomq *BillOfMaterialsQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = bomq.Limit(2).IDs(setContextOp(ctx, bomq.ctx, "OnlyID")); err != nil {
+	if ids, err = bomq.Limit(2).IDs(setContextOp(ctx, bomq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -309,7 +310,7 @@ func (bomq *BillOfMaterialsQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of BillOfMaterialsSlice.
 func (bomq *BillOfMaterialsQuery) All(ctx context.Context) ([]*BillOfMaterials, error) {
-	ctx = setContextOp(ctx, bomq.ctx, "All")
+	ctx = setContextOp(ctx, bomq.ctx, ent.OpQueryAll)
 	if err := bomq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -331,7 +332,7 @@ func (bomq *BillOfMaterialsQuery) IDs(ctx context.Context) (ids []uuid.UUID, err
 	if bomq.ctx.Unique == nil && bomq.path != nil {
 		bomq.Unique(true)
 	}
-	ctx = setContextOp(ctx, bomq.ctx, "IDs")
+	ctx = setContextOp(ctx, bomq.ctx, ent.OpQueryIDs)
 	if err = bomq.Select(billofmaterials.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (bomq *BillOfMaterialsQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (bomq *BillOfMaterialsQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, bomq.ctx, "Count")
+	ctx = setContextOp(ctx, bomq.ctx, ent.OpQueryCount)
 	if err := bomq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -367,7 +368,7 @@ func (bomq *BillOfMaterialsQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (bomq *BillOfMaterialsQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, bomq.ctx, "Exist")
+	ctx = setContextOp(ctx, bomq.ctx, ent.OpQueryExist)
 	switch _, err := bomq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -1138,7 +1139,7 @@ func (bomgb *BillOfMaterialsGroupBy) Aggregate(fns ...AggregateFunc) *BillOfMate
 
 // Scan applies the selector query and scans the result into the given value.
 func (bomgb *BillOfMaterialsGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, bomgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, bomgb.build.ctx, ent.OpQueryGroupBy)
 	if err := bomgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -1186,7 +1187,7 @@ func (boms *BillOfMaterialsSelect) Aggregate(fns ...AggregateFunc) *BillOfMateri
 
 // Scan applies the selector query and scans the result into the given value.
 func (boms *BillOfMaterialsSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, boms.ctx, "Select")
+	ctx = setContextOp(ctx, boms.ctx, ent.OpQuerySelect)
 	if err := boms.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/builder_query.go
+++ b/pkg/assembler/backends/ent/builder_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -89,7 +90,7 @@ func (bq *BuilderQuery) QuerySlsaAttestations() *SLSAAttestationQuery {
 // First returns the first Builder entity from the query.
 // Returns a *NotFoundError when no Builder was found.
 func (bq *BuilderQuery) First(ctx context.Context) (*Builder, error) {
-	nodes, err := bq.Limit(1).All(setContextOp(ctx, bq.ctx, "First"))
+	nodes, err := bq.Limit(1).All(setContextOp(ctx, bq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func (bq *BuilderQuery) FirstX(ctx context.Context) *Builder {
 // Returns a *NotFoundError when no Builder ID was found.
 func (bq *BuilderQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = bq.Limit(1).IDs(setContextOp(ctx, bq.ctx, "FirstID")); err != nil {
+	if ids, err = bq.Limit(1).IDs(setContextOp(ctx, bq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -135,7 +136,7 @@ func (bq *BuilderQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one Builder entity is found.
 // Returns a *NotFoundError when no Builder entities are found.
 func (bq *BuilderQuery) Only(ctx context.Context) (*Builder, error) {
-	nodes, err := bq.Limit(2).All(setContextOp(ctx, bq.ctx, "Only"))
+	nodes, err := bq.Limit(2).All(setContextOp(ctx, bq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (bq *BuilderQuery) OnlyX(ctx context.Context) *Builder {
 // Returns a *NotFoundError when no entities are found.
 func (bq *BuilderQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = bq.Limit(2).IDs(setContextOp(ctx, bq.ctx, "OnlyID")); err != nil {
+	if ids, err = bq.Limit(2).IDs(setContextOp(ctx, bq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -188,7 +189,7 @@ func (bq *BuilderQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Builders.
 func (bq *BuilderQuery) All(ctx context.Context) ([]*Builder, error) {
-	ctx = setContextOp(ctx, bq.ctx, "All")
+	ctx = setContextOp(ctx, bq.ctx, ent.OpQueryAll)
 	if err := bq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -210,7 +211,7 @@ func (bq *BuilderQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) {
 	if bq.ctx.Unique == nil && bq.path != nil {
 		bq.Unique(true)
 	}
-	ctx = setContextOp(ctx, bq.ctx, "IDs")
+	ctx = setContextOp(ctx, bq.ctx, ent.OpQueryIDs)
 	if err = bq.Select(builder.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -228,7 +229,7 @@ func (bq *BuilderQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (bq *BuilderQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, bq.ctx, "Count")
+	ctx = setContextOp(ctx, bq.ctx, ent.OpQueryCount)
 	if err := bq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -246,7 +247,7 @@ func (bq *BuilderQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (bq *BuilderQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, bq.ctx, "Exist")
+	ctx = setContextOp(ctx, bq.ctx, ent.OpQueryExist)
 	switch _, err := bq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -564,7 +565,7 @@ func (bgb *BuilderGroupBy) Aggregate(fns ...AggregateFunc) *BuilderGroupBy {
 
 // Scan applies the selector query and scans the result into the given value.
 func (bgb *BuilderGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, bgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, bgb.build.ctx, ent.OpQueryGroupBy)
 	if err := bgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -612,7 +613,7 @@ func (bs *BuilderSelect) Aggregate(fns ...AggregateFunc) *BuilderSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (bs *BuilderSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, bs.ctx, "Select")
+	ctx = setContextOp(ctx, bs.ctx, ent.OpQuerySelect)
 	if err := bs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certification_query.go
+++ b/pkg/assembler/backends/ent/certification_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -159,7 +160,7 @@ func (cq *CertificationQuery) QueryArtifact() *ArtifactQuery {
 // First returns the first Certification entity from the query.
 // Returns a *NotFoundError when no Certification was found.
 func (cq *CertificationQuery) First(ctx context.Context) (*Certification, error) {
-	nodes, err := cq.Limit(1).All(setContextOp(ctx, cq.ctx, "First"))
+	nodes, err := cq.Limit(1).All(setContextOp(ctx, cq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (cq *CertificationQuery) FirstX(ctx context.Context) *Certification {
 // Returns a *NotFoundError when no Certification ID was found.
 func (cq *CertificationQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cq.Limit(1).IDs(setContextOp(ctx, cq.ctx, "FirstID")); err != nil {
+	if ids, err = cq.Limit(1).IDs(setContextOp(ctx, cq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -205,7 +206,7 @@ func (cq *CertificationQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one Certification entity is found.
 // Returns a *NotFoundError when no Certification entities are found.
 func (cq *CertificationQuery) Only(ctx context.Context) (*Certification, error) {
-	nodes, err := cq.Limit(2).All(setContextOp(ctx, cq.ctx, "Only"))
+	nodes, err := cq.Limit(2).All(setContextOp(ctx, cq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (cq *CertificationQuery) OnlyX(ctx context.Context) *Certification {
 // Returns a *NotFoundError when no entities are found.
 func (cq *CertificationQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cq.Limit(2).IDs(setContextOp(ctx, cq.ctx, "OnlyID")); err != nil {
+	if ids, err = cq.Limit(2).IDs(setContextOp(ctx, cq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -258,7 +259,7 @@ func (cq *CertificationQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Certifications.
 func (cq *CertificationQuery) All(ctx context.Context) ([]*Certification, error) {
-	ctx = setContextOp(ctx, cq.ctx, "All")
+	ctx = setContextOp(ctx, cq.ctx, ent.OpQueryAll)
 	if err := cq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (cq *CertificationQuery) IDs(ctx context.Context) (ids []uuid.UUID, err err
 	if cq.ctx.Unique == nil && cq.path != nil {
 		cq.Unique(true)
 	}
-	ctx = setContextOp(ctx, cq.ctx, "IDs")
+	ctx = setContextOp(ctx, cq.ctx, ent.OpQueryIDs)
 	if err = cq.Select(certification.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (cq *CertificationQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (cq *CertificationQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, cq.ctx, "Count")
+	ctx = setContextOp(ctx, cq.ctx, ent.OpQueryCount)
 	if err := cq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -316,7 +317,7 @@ func (cq *CertificationQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (cq *CertificationQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, cq.ctx, "Exist")
+	ctx = setContextOp(ctx, cq.ctx, ent.OpQueryExist)
 	switch _, err := cq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -779,7 +780,7 @@ func (cgb *CertificationGroupBy) Aggregate(fns ...AggregateFunc) *CertificationG
 
 // Scan applies the selector query and scans the result into the given value.
 func (cgb *CertificationGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, cgb.build.ctx, ent.OpQueryGroupBy)
 	if err := cgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -827,7 +828,7 @@ func (cs *CertificationSelect) Aggregate(fns ...AggregateFunc) *CertificationSel
 
 // Scan applies the selector query and scans the result into the given value.
 func (cs *CertificationSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cs.ctx, "Select")
+	ctx = setContextOp(ctx, cs.ctx, ent.OpQuerySelect)
 	if err := cs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certifylegal_query.go
+++ b/pkg/assembler/backends/ent/certifylegal_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -161,7 +162,7 @@ func (clq *CertifyLegalQuery) QueryDiscoveredLicenses() *LicenseQuery {
 // First returns the first CertifyLegal entity from the query.
 // Returns a *NotFoundError when no CertifyLegal was found.
 func (clq *CertifyLegalQuery) First(ctx context.Context) (*CertifyLegal, error) {
-	nodes, err := clq.Limit(1).All(setContextOp(ctx, clq.ctx, "First"))
+	nodes, err := clq.Limit(1).All(setContextOp(ctx, clq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (clq *CertifyLegalQuery) FirstX(ctx context.Context) *CertifyLegal {
 // Returns a *NotFoundError when no CertifyLegal ID was found.
 func (clq *CertifyLegalQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = clq.Limit(1).IDs(setContextOp(ctx, clq.ctx, "FirstID")); err != nil {
+	if ids, err = clq.Limit(1).IDs(setContextOp(ctx, clq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -207,7 +208,7 @@ func (clq *CertifyLegalQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one CertifyLegal entity is found.
 // Returns a *NotFoundError when no CertifyLegal entities are found.
 func (clq *CertifyLegalQuery) Only(ctx context.Context) (*CertifyLegal, error) {
-	nodes, err := clq.Limit(2).All(setContextOp(ctx, clq.ctx, "Only"))
+	nodes, err := clq.Limit(2).All(setContextOp(ctx, clq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (clq *CertifyLegalQuery) OnlyX(ctx context.Context) *CertifyLegal {
 // Returns a *NotFoundError when no entities are found.
 func (clq *CertifyLegalQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = clq.Limit(2).IDs(setContextOp(ctx, clq.ctx, "OnlyID")); err != nil {
+	if ids, err = clq.Limit(2).IDs(setContextOp(ctx, clq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -260,7 +261,7 @@ func (clq *CertifyLegalQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of CertifyLegals.
 func (clq *CertifyLegalQuery) All(ctx context.Context) ([]*CertifyLegal, error) {
-	ctx = setContextOp(ctx, clq.ctx, "All")
+	ctx = setContextOp(ctx, clq.ctx, ent.OpQueryAll)
 	if err := clq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ func (clq *CertifyLegalQuery) IDs(ctx context.Context) (ids []uuid.UUID, err err
 	if clq.ctx.Unique == nil && clq.path != nil {
 		clq.Unique(true)
 	}
-	ctx = setContextOp(ctx, clq.ctx, "IDs")
+	ctx = setContextOp(ctx, clq.ctx, ent.OpQueryIDs)
 	if err = clq.Select(certifylegal.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (clq *CertifyLegalQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (clq *CertifyLegalQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, clq.ctx, "Count")
+	ctx = setContextOp(ctx, clq.ctx, ent.OpQueryCount)
 	if err := clq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -318,7 +319,7 @@ func (clq *CertifyLegalQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (clq *CertifyLegalQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, clq.ctx, "Exist")
+	ctx = setContextOp(ctx, clq.ctx, ent.OpQueryExist)
 	switch _, err := clq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -877,7 +878,7 @@ func (clgb *CertifyLegalGroupBy) Aggregate(fns ...AggregateFunc) *CertifyLegalGr
 
 // Scan applies the selector query and scans the result into the given value.
 func (clgb *CertifyLegalGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, clgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, clgb.build.ctx, ent.OpQueryGroupBy)
 	if err := clgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -925,7 +926,7 @@ func (cls *CertifyLegalSelect) Aggregate(fns ...AggregateFunc) *CertifyLegalSele
 
 // Scan applies the selector query and scans the result into the given value.
 func (cls *CertifyLegalSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cls.ctx, "Select")
+	ctx = setContextOp(ctx, cls.ctx, ent.OpQuerySelect)
 	if err := cls.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certifyscorecard_create.go
+++ b/pkg/assembler/backends/ent/certifyscorecard_create.go
@@ -202,7 +202,7 @@ func (csc *CertifyScorecardCreate) check() error {
 	if _, ok := csc.mutation.ChecksHash(); !ok {
 		return &ValidationError{Name: "checks_hash", err: errors.New(`ent: missing required field "CertifyScorecard.checks_hash"`)}
 	}
-	if _, ok := csc.mutation.SourceID(); !ok {
+	if len(csc.mutation.SourceIDs()) == 0 {
 		return &ValidationError{Name: "source", err: errors.New(`ent: missing required edge "CertifyScorecard.source"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/certifyscorecard_query.go
+++ b/pkg/assembler/backends/ent/certifyscorecard_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -87,7 +88,7 @@ func (csq *CertifyScorecardQuery) QuerySource() *SourceNameQuery {
 // First returns the first CertifyScorecard entity from the query.
 // Returns a *NotFoundError when no CertifyScorecard was found.
 func (csq *CertifyScorecardQuery) First(ctx context.Context) (*CertifyScorecard, error) {
-	nodes, err := csq.Limit(1).All(setContextOp(ctx, csq.ctx, "First"))
+	nodes, err := csq.Limit(1).All(setContextOp(ctx, csq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (csq *CertifyScorecardQuery) FirstX(ctx context.Context) *CertifyScorecard 
 // Returns a *NotFoundError when no CertifyScorecard ID was found.
 func (csq *CertifyScorecardQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = csq.Limit(1).IDs(setContextOp(ctx, csq.ctx, "FirstID")); err != nil {
+	if ids, err = csq.Limit(1).IDs(setContextOp(ctx, csq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -133,7 +134,7 @@ func (csq *CertifyScorecardQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one CertifyScorecard entity is found.
 // Returns a *NotFoundError when no CertifyScorecard entities are found.
 func (csq *CertifyScorecardQuery) Only(ctx context.Context) (*CertifyScorecard, error) {
-	nodes, err := csq.Limit(2).All(setContextOp(ctx, csq.ctx, "Only"))
+	nodes, err := csq.Limit(2).All(setContextOp(ctx, csq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (csq *CertifyScorecardQuery) OnlyX(ctx context.Context) *CertifyScorecard {
 // Returns a *NotFoundError when no entities are found.
 func (csq *CertifyScorecardQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = csq.Limit(2).IDs(setContextOp(ctx, csq.ctx, "OnlyID")); err != nil {
+	if ids, err = csq.Limit(2).IDs(setContextOp(ctx, csq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -186,7 +187,7 @@ func (csq *CertifyScorecardQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of CertifyScorecards.
 func (csq *CertifyScorecardQuery) All(ctx context.Context) ([]*CertifyScorecard, error) {
-	ctx = setContextOp(ctx, csq.ctx, "All")
+	ctx = setContextOp(ctx, csq.ctx, ent.OpQueryAll)
 	if err := csq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -208,7 +209,7 @@ func (csq *CertifyScorecardQuery) IDs(ctx context.Context) (ids []uuid.UUID, err
 	if csq.ctx.Unique == nil && csq.path != nil {
 		csq.Unique(true)
 	}
-	ctx = setContextOp(ctx, csq.ctx, "IDs")
+	ctx = setContextOp(ctx, csq.ctx, ent.OpQueryIDs)
 	if err = csq.Select(certifyscorecard.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (csq *CertifyScorecardQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (csq *CertifyScorecardQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, csq.ctx, "Count")
+	ctx = setContextOp(ctx, csq.ctx, ent.OpQueryCount)
 	if err := csq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -244,7 +245,7 @@ func (csq *CertifyScorecardQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (csq *CertifyScorecardQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, csq.ctx, "Exist")
+	ctx = setContextOp(ctx, csq.ctx, ent.OpQueryExist)
 	switch _, err := csq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -542,7 +543,7 @@ func (csgb *CertifyScorecardGroupBy) Aggregate(fns ...AggregateFunc) *CertifySco
 
 // Scan applies the selector query and scans the result into the given value.
 func (csgb *CertifyScorecardGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, csgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, csgb.build.ctx, ent.OpQueryGroupBy)
 	if err := csgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -590,7 +591,7 @@ func (css *CertifyScorecardSelect) Aggregate(fns ...AggregateFunc) *CertifyScore
 
 // Scan applies the selector query and scans the result into the given value.
 func (css *CertifyScorecardSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, css.ctx, "Select")
+	ctx = setContextOp(ctx, css.ctx, ent.OpQuerySelect)
 	if err := css.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certifyscorecard_update.go
+++ b/pkg/assembler/backends/ent/certifyscorecard_update.go
@@ -222,7 +222,7 @@ func (csu *CertifyScorecardUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (csu *CertifyScorecardUpdate) check() error {
-	if _, ok := csu.mutation.SourceID(); csu.mutation.SourceCleared() && !ok {
+	if csu.mutation.SourceCleared() && len(csu.mutation.SourceIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyScorecard.source"`)
 	}
 	return nil
@@ -527,7 +527,7 @@ func (csuo *CertifyScorecardUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (csuo *CertifyScorecardUpdateOne) check() error {
-	if _, ok := csuo.mutation.SourceID(); csuo.mutation.SourceCleared() && !ok {
+	if csuo.mutation.SourceCleared() && len(csuo.mutation.SourceIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyScorecard.source"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/certifyvex_create.go
+++ b/pkg/assembler/backends/ent/certifyvex_create.go
@@ -208,7 +208,7 @@ func (cvc *CertifyVexCreate) check() error {
 	if _, ok := cvc.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyVex.document_ref"`)}
 	}
-	if _, ok := cvc.mutation.VulnerabilityID(); !ok {
+	if len(cvc.mutation.VulnerabilityIDs()) == 0 {
 		return &ValidationError{Name: "vulnerability", err: errors.New(`ent: missing required edge "CertifyVex.vulnerability"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/certifyvex_query.go
+++ b/pkg/assembler/backends/ent/certifyvex_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -135,7 +136,7 @@ func (cvq *CertifyVexQuery) QueryVulnerability() *VulnerabilityIDQuery {
 // First returns the first CertifyVex entity from the query.
 // Returns a *NotFoundError when no CertifyVex was found.
 func (cvq *CertifyVexQuery) First(ctx context.Context) (*CertifyVex, error) {
-	nodes, err := cvq.Limit(1).All(setContextOp(ctx, cvq.ctx, "First"))
+	nodes, err := cvq.Limit(1).All(setContextOp(ctx, cvq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func (cvq *CertifyVexQuery) FirstX(ctx context.Context) *CertifyVex {
 // Returns a *NotFoundError when no CertifyVex ID was found.
 func (cvq *CertifyVexQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cvq.Limit(1).IDs(setContextOp(ctx, cvq.ctx, "FirstID")); err != nil {
+	if ids, err = cvq.Limit(1).IDs(setContextOp(ctx, cvq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -181,7 +182,7 @@ func (cvq *CertifyVexQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one CertifyVex entity is found.
 // Returns a *NotFoundError when no CertifyVex entities are found.
 func (cvq *CertifyVexQuery) Only(ctx context.Context) (*CertifyVex, error) {
-	nodes, err := cvq.Limit(2).All(setContextOp(ctx, cvq.ctx, "Only"))
+	nodes, err := cvq.Limit(2).All(setContextOp(ctx, cvq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (cvq *CertifyVexQuery) OnlyX(ctx context.Context) *CertifyVex {
 // Returns a *NotFoundError when no entities are found.
 func (cvq *CertifyVexQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cvq.Limit(2).IDs(setContextOp(ctx, cvq.ctx, "OnlyID")); err != nil {
+	if ids, err = cvq.Limit(2).IDs(setContextOp(ctx, cvq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -234,7 +235,7 @@ func (cvq *CertifyVexQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of CertifyVexes.
 func (cvq *CertifyVexQuery) All(ctx context.Context) ([]*CertifyVex, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "All")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryAll)
 	if err := cvq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -256,7 +257,7 @@ func (cvq *CertifyVexQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error
 	if cvq.ctx.Unique == nil && cvq.path != nil {
 		cvq.Unique(true)
 	}
-	ctx = setContextOp(ctx, cvq.ctx, "IDs")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryIDs)
 	if err = cvq.Select(certifyvex.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (cvq *CertifyVexQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (cvq *CertifyVexQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "Count")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryCount)
 	if err := cvq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -292,7 +293,7 @@ func (cvq *CertifyVexQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (cvq *CertifyVexQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "Exist")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryExist)
 	switch _, err := cvq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -698,7 +699,7 @@ func (cvgb *CertifyVexGroupBy) Aggregate(fns ...AggregateFunc) *CertifyVexGroupB
 
 // Scan applies the selector query and scans the result into the given value.
 func (cvgb *CertifyVexGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cvgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, cvgb.build.ctx, ent.OpQueryGroupBy)
 	if err := cvgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -746,7 +747,7 @@ func (cvs *CertifyVexSelect) Aggregate(fns ...AggregateFunc) *CertifyVexSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (cvs *CertifyVexSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cvs.ctx, "Select")
+	ctx = setContextOp(ctx, cvs.ctx, ent.OpQuerySelect)
 	if err := cvs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certifyvex_update.go
+++ b/pkg/assembler/backends/ent/certifyvex_update.go
@@ -265,7 +265,7 @@ func (cvu *CertifyVexUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (cvu *CertifyVexUpdate) check() error {
-	if _, ok := cvu.mutation.VulnerabilityID(); cvu.mutation.VulnerabilityCleared() && !ok {
+	if cvu.mutation.VulnerabilityCleared() && len(cvu.mutation.VulnerabilityIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVex.vulnerability"`)
 	}
 	return nil
@@ -660,7 +660,7 @@ func (cvuo *CertifyVexUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (cvuo *CertifyVexUpdateOne) check() error {
-	if _, ok := cvuo.mutation.VulnerabilityID(); cvuo.mutation.VulnerabilityCleared() && !ok {
+	if cvuo.mutation.VulnerabilityCleared() && len(cvuo.mutation.VulnerabilityIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVex.vulnerability"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/certifyvuln_create.go
+++ b/pkg/assembler/backends/ent/certifyvuln_create.go
@@ -183,10 +183,10 @@ func (cvc *CertifyVulnCreate) check() error {
 	if _, ok := cvc.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "CertifyVuln.document_ref"`)}
 	}
-	if _, ok := cvc.mutation.VulnerabilityID(); !ok {
+	if len(cvc.mutation.VulnerabilityIDs()) == 0 {
 		return &ValidationError{Name: "vulnerability", err: errors.New(`ent: missing required edge "CertifyVuln.vulnerability"`)}
 	}
-	if _, ok := cvc.mutation.PackageID(); !ok {
+	if len(cvc.mutation.PackageIDs()) == 0 {
 		return &ValidationError{Name: "package", err: errors.New(`ent: missing required edge "CertifyVuln.package"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/certifyvuln_query.go
+++ b/pkg/assembler/backends/ent/certifyvuln_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -111,7 +112,7 @@ func (cvq *CertifyVulnQuery) QueryPackage() *PackageVersionQuery {
 // First returns the first CertifyVuln entity from the query.
 // Returns a *NotFoundError when no CertifyVuln was found.
 func (cvq *CertifyVulnQuery) First(ctx context.Context) (*CertifyVuln, error) {
-	nodes, err := cvq.Limit(1).All(setContextOp(ctx, cvq.ctx, "First"))
+	nodes, err := cvq.Limit(1).All(setContextOp(ctx, cvq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (cvq *CertifyVulnQuery) FirstX(ctx context.Context) *CertifyVuln {
 // Returns a *NotFoundError when no CertifyVuln ID was found.
 func (cvq *CertifyVulnQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cvq.Limit(1).IDs(setContextOp(ctx, cvq.ctx, "FirstID")); err != nil {
+	if ids, err = cvq.Limit(1).IDs(setContextOp(ctx, cvq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -157,7 +158,7 @@ func (cvq *CertifyVulnQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one CertifyVuln entity is found.
 // Returns a *NotFoundError when no CertifyVuln entities are found.
 func (cvq *CertifyVulnQuery) Only(ctx context.Context) (*CertifyVuln, error) {
-	nodes, err := cvq.Limit(2).All(setContextOp(ctx, cvq.ctx, "Only"))
+	nodes, err := cvq.Limit(2).All(setContextOp(ctx, cvq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +186,7 @@ func (cvq *CertifyVulnQuery) OnlyX(ctx context.Context) *CertifyVuln {
 // Returns a *NotFoundError when no entities are found.
 func (cvq *CertifyVulnQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = cvq.Limit(2).IDs(setContextOp(ctx, cvq.ctx, "OnlyID")); err != nil {
+	if ids, err = cvq.Limit(2).IDs(setContextOp(ctx, cvq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -210,7 +211,7 @@ func (cvq *CertifyVulnQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of CertifyVulns.
 func (cvq *CertifyVulnQuery) All(ctx context.Context) ([]*CertifyVuln, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "All")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryAll)
 	if err := cvq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (cvq *CertifyVulnQuery) IDs(ctx context.Context) (ids []uuid.UUID, err erro
 	if cvq.ctx.Unique == nil && cvq.path != nil {
 		cvq.Unique(true)
 	}
-	ctx = setContextOp(ctx, cvq.ctx, "IDs")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryIDs)
 	if err = cvq.Select(certifyvuln.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (cvq *CertifyVulnQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (cvq *CertifyVulnQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "Count")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryCount)
 	if err := cvq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -268,7 +269,7 @@ func (cvq *CertifyVulnQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (cvq *CertifyVulnQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, cvq.ctx, "Exist")
+	ctx = setContextOp(ctx, cvq.ctx, ent.OpQueryExist)
 	switch _, err := cvq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -617,7 +618,7 @@ func (cvgb *CertifyVulnGroupBy) Aggregate(fns ...AggregateFunc) *CertifyVulnGrou
 
 // Scan applies the selector query and scans the result into the given value.
 func (cvgb *CertifyVulnGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cvgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, cvgb.build.ctx, ent.OpQueryGroupBy)
 	if err := cvgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -665,7 +666,7 @@ func (cvs *CertifyVulnSelect) Aggregate(fns ...AggregateFunc) *CertifyVulnSelect
 
 // Scan applies the selector query and scans the result into the given value.
 func (cvs *CertifyVulnSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, cvs.ctx, "Select")
+	ctx = setContextOp(ctx, cvs.ctx, ent.OpQuerySelect)
 	if err := cvs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/certifyvuln_update.go
+++ b/pkg/assembler/backends/ent/certifyvuln_update.go
@@ -227,10 +227,10 @@ func (cvu *CertifyVulnUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (cvu *CertifyVulnUpdate) check() error {
-	if _, ok := cvu.mutation.VulnerabilityID(); cvu.mutation.VulnerabilityCleared() && !ok {
+	if cvu.mutation.VulnerabilityCleared() && len(cvu.mutation.VulnerabilityIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVuln.vulnerability"`)
 	}
-	if _, ok := cvu.mutation.PackageID(); cvu.mutation.PackageCleared() && !ok {
+	if cvu.mutation.PackageCleared() && len(cvu.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVuln.package"`)
 	}
 	return nil
@@ -559,10 +559,10 @@ func (cvuo *CertifyVulnUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (cvuo *CertifyVulnUpdateOne) check() error {
-	if _, ok := cvuo.mutation.VulnerabilityID(); cvuo.mutation.VulnerabilityCleared() && !ok {
+	if cvuo.mutation.VulnerabilityCleared() && len(cvuo.mutation.VulnerabilityIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVuln.vulnerability"`)
 	}
-	if _, ok := cvuo.mutation.PackageID(); cvuo.mutation.PackageCleared() && !ok {
+	if cvuo.mutation.PackageCleared() && len(cvuo.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "CertifyVuln.package"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/dependency_create.go
+++ b/pkg/assembler/backends/ent/dependency_create.go
@@ -180,7 +180,7 @@ func (dc *DependencyCreate) check() error {
 	if _, ok := dc.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "Dependency.document_ref"`)}
 	}
-	if _, ok := dc.mutation.PackageID(); !ok {
+	if len(dc.mutation.PackageIDs()) == 0 {
 		return &ValidationError{Name: "package", err: errors.New(`ent: missing required edge "Dependency.package"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/dependency_query.go
+++ b/pkg/assembler/backends/ent/dependency_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -136,7 +137,7 @@ func (dq *DependencyQuery) QueryIncludedInSboms() *BillOfMaterialsQuery {
 // First returns the first Dependency entity from the query.
 // Returns a *NotFoundError when no Dependency was found.
 func (dq *DependencyQuery) First(ctx context.Context) (*Dependency, error) {
-	nodes, err := dq.Limit(1).All(setContextOp(ctx, dq.ctx, "First"))
+	nodes, err := dq.Limit(1).All(setContextOp(ctx, dq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (dq *DependencyQuery) FirstX(ctx context.Context) *Dependency {
 // Returns a *NotFoundError when no Dependency ID was found.
 func (dq *DependencyQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = dq.Limit(1).IDs(setContextOp(ctx, dq.ctx, "FirstID")); err != nil {
+	if ids, err = dq.Limit(1).IDs(setContextOp(ctx, dq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -182,7 +183,7 @@ func (dq *DependencyQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one Dependency entity is found.
 // Returns a *NotFoundError when no Dependency entities are found.
 func (dq *DependencyQuery) Only(ctx context.Context) (*Dependency, error) {
-	nodes, err := dq.Limit(2).All(setContextOp(ctx, dq.ctx, "Only"))
+	nodes, err := dq.Limit(2).All(setContextOp(ctx, dq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +211,7 @@ func (dq *DependencyQuery) OnlyX(ctx context.Context) *Dependency {
 // Returns a *NotFoundError when no entities are found.
 func (dq *DependencyQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = dq.Limit(2).IDs(setContextOp(ctx, dq.ctx, "OnlyID")); err != nil {
+	if ids, err = dq.Limit(2).IDs(setContextOp(ctx, dq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -235,7 +236,7 @@ func (dq *DependencyQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Dependencies.
 func (dq *DependencyQuery) All(ctx context.Context) ([]*Dependency, error) {
-	ctx = setContextOp(ctx, dq.ctx, "All")
+	ctx = setContextOp(ctx, dq.ctx, ent.OpQueryAll)
 	if err := dq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (dq *DependencyQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error)
 	if dq.ctx.Unique == nil && dq.path != nil {
 		dq.Unique(true)
 	}
-	ctx = setContextOp(ctx, dq.ctx, "IDs")
+	ctx = setContextOp(ctx, dq.ctx, ent.OpQueryIDs)
 	if err = dq.Select(dependency.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func (dq *DependencyQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (dq *DependencyQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, dq.ctx, "Count")
+	ctx = setContextOp(ctx, dq.ctx, ent.OpQueryCount)
 	if err := dq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -293,7 +294,7 @@ func (dq *DependencyQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (dq *DependencyQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, dq.ctx, "Exist")
+	ctx = setContextOp(ctx, dq.ctx, ent.OpQueryExist)
 	switch _, err := dq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -744,7 +745,7 @@ func (dgb *DependencyGroupBy) Aggregate(fns ...AggregateFunc) *DependencyGroupBy
 
 // Scan applies the selector query and scans the result into the given value.
 func (dgb *DependencyGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, dgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, dgb.build.ctx, ent.OpQueryGroupBy)
 	if err := dgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -792,7 +793,7 @@ func (ds *DependencySelect) Aggregate(fns ...AggregateFunc) *DependencySelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (ds *DependencySelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, ds.ctx, "Select")
+	ctx = setContextOp(ctx, ds.ctx, ent.OpQuerySelect)
 	if err := ds.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/dependency_update.go
+++ b/pkg/assembler/backends/ent/dependency_update.go
@@ -231,7 +231,7 @@ func (du *DependencyUpdate) check() error {
 			return &ValidationError{Name: "dependency_type", err: fmt.Errorf(`ent: validator failed for field "Dependency.dependency_type": %w`, err)}
 		}
 	}
-	if _, ok := du.mutation.PackageID(); du.mutation.PackageCleared() && !ok {
+	if du.mutation.PackageCleared() && len(du.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Dependency.package"`)
 	}
 	return nil
@@ -601,7 +601,7 @@ func (duo *DependencyUpdateOne) check() error {
 			return &ValidationError{Name: "dependency_type", err: fmt.Errorf(`ent: validator failed for field "Dependency.dependency_type": %w`, err)}
 		}
 	}
-	if _, ok := duo.mutation.PackageID(); duo.mutation.PackageCleared() && !ok {
+	if duo.mutation.PackageCleared() && len(duo.mutation.PackageIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Dependency.package"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/ent.go
+++ b/pkg/assembler/backends/ent/ent.go
@@ -91,7 +91,7 @@ var (
 	columnCheck sql.ColumnCheck
 )
 
-// columnChecker checks if the column exists in the given table.
+// checkColumn checks if the column exists in the given table.
 func checkColumn(table, column string) error {
 	initCheck.Do(func() {
 		columnCheck = sql.NewColumnCheck(map[string]func(string) bool{

--- a/pkg/assembler/backends/ent/hashequal_create.go
+++ b/pkg/assembler/backends/ent/hashequal_create.go
@@ -166,10 +166,10 @@ func (hec *HashEqualCreate) check() error {
 	if _, ok := hec.mutation.ArtifactsHash(); !ok {
 		return &ValidationError{Name: "artifacts_hash", err: errors.New(`ent: missing required field "HashEqual.artifacts_hash"`)}
 	}
-	if _, ok := hec.mutation.ArtifactAID(); !ok {
+	if len(hec.mutation.ArtifactAIDs()) == 0 {
 		return &ValidationError{Name: "artifact_a", err: errors.New(`ent: missing required edge "HashEqual.artifact_a"`)}
 	}
-	if _, ok := hec.mutation.ArtifactBID(); !ok {
+	if len(hec.mutation.ArtifactBIDs()) == 0 {
 		return &ValidationError{Name: "artifact_b", err: errors.New(`ent: missing required edge "HashEqual.artifact_b"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/hashequal_query.go
+++ b/pkg/assembler/backends/ent/hashequal_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -110,7 +111,7 @@ func (heq *HashEqualQuery) QueryArtifactB() *ArtifactQuery {
 // First returns the first HashEqual entity from the query.
 // Returns a *NotFoundError when no HashEqual was found.
 func (heq *HashEqualQuery) First(ctx context.Context) (*HashEqual, error) {
-	nodes, err := heq.Limit(1).All(setContextOp(ctx, heq.ctx, "First"))
+	nodes, err := heq.Limit(1).All(setContextOp(ctx, heq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (heq *HashEqualQuery) FirstX(ctx context.Context) *HashEqual {
 // Returns a *NotFoundError when no HashEqual ID was found.
 func (heq *HashEqualQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = heq.Limit(1).IDs(setContextOp(ctx, heq.ctx, "FirstID")); err != nil {
+	if ids, err = heq.Limit(1).IDs(setContextOp(ctx, heq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -156,7 +157,7 @@ func (heq *HashEqualQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one HashEqual entity is found.
 // Returns a *NotFoundError when no HashEqual entities are found.
 func (heq *HashEqualQuery) Only(ctx context.Context) (*HashEqual, error) {
-	nodes, err := heq.Limit(2).All(setContextOp(ctx, heq.ctx, "Only"))
+	nodes, err := heq.Limit(2).All(setContextOp(ctx, heq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (heq *HashEqualQuery) OnlyX(ctx context.Context) *HashEqual {
 // Returns a *NotFoundError when no entities are found.
 func (heq *HashEqualQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = heq.Limit(2).IDs(setContextOp(ctx, heq.ctx, "OnlyID")); err != nil {
+	if ids, err = heq.Limit(2).IDs(setContextOp(ctx, heq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -209,7 +210,7 @@ func (heq *HashEqualQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of HashEquals.
 func (heq *HashEqualQuery) All(ctx context.Context) ([]*HashEqual, error) {
-	ctx = setContextOp(ctx, heq.ctx, "All")
+	ctx = setContextOp(ctx, heq.ctx, ent.OpQueryAll)
 	if err := heq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (heq *HashEqualQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error)
 	if heq.ctx.Unique == nil && heq.path != nil {
 		heq.Unique(true)
 	}
-	ctx = setContextOp(ctx, heq.ctx, "IDs")
+	ctx = setContextOp(ctx, heq.ctx, ent.OpQueryIDs)
 	if err = heq.Select(hashequal.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -249,7 +250,7 @@ func (heq *HashEqualQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (heq *HashEqualQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, heq.ctx, "Count")
+	ctx = setContextOp(ctx, heq.ctx, ent.OpQueryCount)
 	if err := heq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -267,7 +268,7 @@ func (heq *HashEqualQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (heq *HashEqualQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, heq.ctx, "Exist")
+	ctx = setContextOp(ctx, heq.ctx, ent.OpQueryExist)
 	switch _, err := heq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -616,7 +617,7 @@ func (hegb *HashEqualGroupBy) Aggregate(fns ...AggregateFunc) *HashEqualGroupBy 
 
 // Scan applies the selector query and scans the result into the given value.
 func (hegb *HashEqualGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hegb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, hegb.build.ctx, ent.OpQueryGroupBy)
 	if err := hegb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -664,7 +665,7 @@ func (hes *HashEqualSelect) Aggregate(fns ...AggregateFunc) *HashEqualSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (hes *HashEqualSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hes.ctx, "Select")
+	ctx = setContextOp(ctx, hes.ctx, ent.OpQuerySelect)
 	if err := hes.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/hashequal_update.go
+++ b/pkg/assembler/backends/ent/hashequal_update.go
@@ -195,10 +195,10 @@ func (heu *HashEqualUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (heu *HashEqualUpdate) check() error {
-	if _, ok := heu.mutation.ArtifactAID(); heu.mutation.ArtifactACleared() && !ok {
+	if heu.mutation.ArtifactACleared() && len(heu.mutation.ArtifactAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HashEqual.artifact_a"`)
 	}
-	if _, ok := heu.mutation.ArtifactBID(); heu.mutation.ArtifactBCleared() && !ok {
+	if heu.mutation.ArtifactBCleared() && len(heu.mutation.ArtifactBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HashEqual.artifact_b"`)
 	}
 	return nil
@@ -488,10 +488,10 @@ func (heuo *HashEqualUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (heuo *HashEqualUpdateOne) check() error {
-	if _, ok := heuo.mutation.ArtifactAID(); heuo.mutation.ArtifactACleared() && !ok {
+	if heuo.mutation.ArtifactACleared() && len(heuo.mutation.ArtifactAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HashEqual.artifact_a"`)
 	}
-	if _, ok := heuo.mutation.ArtifactBID(); heuo.mutation.ArtifactBCleared() && !ok {
+	if heuo.mutation.ArtifactBCleared() && len(heuo.mutation.ArtifactBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HashEqual.artifact_b"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/hasmetadata_query.go
+++ b/pkg/assembler/backends/ent/hasmetadata_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -159,7 +160,7 @@ func (hmq *HasMetadataQuery) QueryArtifact() *ArtifactQuery {
 // First returns the first HasMetadata entity from the query.
 // Returns a *NotFoundError when no HasMetadata was found.
 func (hmq *HasMetadataQuery) First(ctx context.Context) (*HasMetadata, error) {
-	nodes, err := hmq.Limit(1).All(setContextOp(ctx, hmq.ctx, "First"))
+	nodes, err := hmq.Limit(1).All(setContextOp(ctx, hmq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (hmq *HasMetadataQuery) FirstX(ctx context.Context) *HasMetadata {
 // Returns a *NotFoundError when no HasMetadata ID was found.
 func (hmq *HasMetadataQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = hmq.Limit(1).IDs(setContextOp(ctx, hmq.ctx, "FirstID")); err != nil {
+	if ids, err = hmq.Limit(1).IDs(setContextOp(ctx, hmq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -205,7 +206,7 @@ func (hmq *HasMetadataQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one HasMetadata entity is found.
 // Returns a *NotFoundError when no HasMetadata entities are found.
 func (hmq *HasMetadataQuery) Only(ctx context.Context) (*HasMetadata, error) {
-	nodes, err := hmq.Limit(2).All(setContextOp(ctx, hmq.ctx, "Only"))
+	nodes, err := hmq.Limit(2).All(setContextOp(ctx, hmq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (hmq *HasMetadataQuery) OnlyX(ctx context.Context) *HasMetadata {
 // Returns a *NotFoundError when no entities are found.
 func (hmq *HasMetadataQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = hmq.Limit(2).IDs(setContextOp(ctx, hmq.ctx, "OnlyID")); err != nil {
+	if ids, err = hmq.Limit(2).IDs(setContextOp(ctx, hmq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -258,7 +259,7 @@ func (hmq *HasMetadataQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of HasMetadataSlice.
 func (hmq *HasMetadataQuery) All(ctx context.Context) ([]*HasMetadata, error) {
-	ctx = setContextOp(ctx, hmq.ctx, "All")
+	ctx = setContextOp(ctx, hmq.ctx, ent.OpQueryAll)
 	if err := hmq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (hmq *HasMetadataQuery) IDs(ctx context.Context) (ids []uuid.UUID, err erro
 	if hmq.ctx.Unique == nil && hmq.path != nil {
 		hmq.Unique(true)
 	}
-	ctx = setContextOp(ctx, hmq.ctx, "IDs")
+	ctx = setContextOp(ctx, hmq.ctx, ent.OpQueryIDs)
 	if err = hmq.Select(hasmetadata.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (hmq *HasMetadataQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (hmq *HasMetadataQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, hmq.ctx, "Count")
+	ctx = setContextOp(ctx, hmq.ctx, ent.OpQueryCount)
 	if err := hmq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -316,7 +317,7 @@ func (hmq *HasMetadataQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (hmq *HasMetadataQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, hmq.ctx, "Exist")
+	ctx = setContextOp(ctx, hmq.ctx, ent.OpQueryExist)
 	switch _, err := hmq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -779,7 +780,7 @@ func (hmgb *HasMetadataGroupBy) Aggregate(fns ...AggregateFunc) *HasMetadataGrou
 
 // Scan applies the selector query and scans the result into the given value.
 func (hmgb *HasMetadataGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hmgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, hmgb.build.ctx, ent.OpQueryGroupBy)
 	if err := hmgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -827,7 +828,7 @@ func (hms *HasMetadataSelect) Aggregate(fns ...AggregateFunc) *HasMetadataSelect
 
 // Scan applies the selector query and scans the result into the given value.
 func (hms *HasMetadataSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hms.ctx, "Select")
+	ctx = setContextOp(ctx, hms.ctx, ent.OpQuerySelect)
 	if err := hms.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/hassourceat_create.go
+++ b/pkg/assembler/backends/ent/hassourceat_create.go
@@ -195,7 +195,7 @@ func (hsac *HasSourceAtCreate) check() error {
 	if _, ok := hsac.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "HasSourceAt.document_ref"`)}
 	}
-	if _, ok := hsac.mutation.SourceID(); !ok {
+	if len(hsac.mutation.SourceIDs()) == 0 {
 		return &ValidationError{Name: "source", err: errors.New(`ent: missing required edge "HasSourceAt.source"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/hassourceat_query.go
+++ b/pkg/assembler/backends/ent/hassourceat_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -135,7 +136,7 @@ func (hsaq *HasSourceAtQuery) QuerySource() *SourceNameQuery {
 // First returns the first HasSourceAt entity from the query.
 // Returns a *NotFoundError when no HasSourceAt was found.
 func (hsaq *HasSourceAtQuery) First(ctx context.Context) (*HasSourceAt, error) {
-	nodes, err := hsaq.Limit(1).All(setContextOp(ctx, hsaq.ctx, "First"))
+	nodes, err := hsaq.Limit(1).All(setContextOp(ctx, hsaq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func (hsaq *HasSourceAtQuery) FirstX(ctx context.Context) *HasSourceAt {
 // Returns a *NotFoundError when no HasSourceAt ID was found.
 func (hsaq *HasSourceAtQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = hsaq.Limit(1).IDs(setContextOp(ctx, hsaq.ctx, "FirstID")); err != nil {
+	if ids, err = hsaq.Limit(1).IDs(setContextOp(ctx, hsaq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -181,7 +182,7 @@ func (hsaq *HasSourceAtQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one HasSourceAt entity is found.
 // Returns a *NotFoundError when no HasSourceAt entities are found.
 func (hsaq *HasSourceAtQuery) Only(ctx context.Context) (*HasSourceAt, error) {
-	nodes, err := hsaq.Limit(2).All(setContextOp(ctx, hsaq.ctx, "Only"))
+	nodes, err := hsaq.Limit(2).All(setContextOp(ctx, hsaq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (hsaq *HasSourceAtQuery) OnlyX(ctx context.Context) *HasSourceAt {
 // Returns a *NotFoundError when no entities are found.
 func (hsaq *HasSourceAtQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = hsaq.Limit(2).IDs(setContextOp(ctx, hsaq.ctx, "OnlyID")); err != nil {
+	if ids, err = hsaq.Limit(2).IDs(setContextOp(ctx, hsaq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -234,7 +235,7 @@ func (hsaq *HasSourceAtQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of HasSourceAts.
 func (hsaq *HasSourceAtQuery) All(ctx context.Context) ([]*HasSourceAt, error) {
-	ctx = setContextOp(ctx, hsaq.ctx, "All")
+	ctx = setContextOp(ctx, hsaq.ctx, ent.OpQueryAll)
 	if err := hsaq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -256,7 +257,7 @@ func (hsaq *HasSourceAtQuery) IDs(ctx context.Context) (ids []uuid.UUID, err err
 	if hsaq.ctx.Unique == nil && hsaq.path != nil {
 		hsaq.Unique(true)
 	}
-	ctx = setContextOp(ctx, hsaq.ctx, "IDs")
+	ctx = setContextOp(ctx, hsaq.ctx, ent.OpQueryIDs)
 	if err = hsaq.Select(hassourceat.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (hsaq *HasSourceAtQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (hsaq *HasSourceAtQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, hsaq.ctx, "Count")
+	ctx = setContextOp(ctx, hsaq.ctx, ent.OpQueryCount)
 	if err := hsaq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -292,7 +293,7 @@ func (hsaq *HasSourceAtQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (hsaq *HasSourceAtQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, hsaq.ctx, "Exist")
+	ctx = setContextOp(ctx, hsaq.ctx, ent.OpQueryExist)
 	switch _, err := hsaq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -698,7 +699,7 @@ func (hsagb *HasSourceAtGroupBy) Aggregate(fns ...AggregateFunc) *HasSourceAtGro
 
 // Scan applies the selector query and scans the result into the given value.
 func (hsagb *HasSourceAtGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hsagb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, hsagb.build.ctx, ent.OpQueryGroupBy)
 	if err := hsagb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -746,7 +747,7 @@ func (hsas *HasSourceAtSelect) Aggregate(fns ...AggregateFunc) *HasSourceAtSelec
 
 // Scan applies the selector query and scans the result into the given value.
 func (hsas *HasSourceAtSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, hsas.ctx, "Select")
+	ctx = setContextOp(ctx, hsas.ctx, ent.OpQuerySelect)
 	if err := hsas.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/hassourceat_update.go
+++ b/pkg/assembler/backends/ent/hassourceat_update.go
@@ -237,7 +237,7 @@ func (hsau *HasSourceAtUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (hsau *HasSourceAtUpdate) check() error {
-	if _, ok := hsau.mutation.SourceID(); hsau.mutation.SourceCleared() && !ok {
+	if hsau.mutation.SourceCleared() && len(hsau.mutation.SourceIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HasSourceAt.source"`)
 	}
 	return nil
@@ -595,7 +595,7 @@ func (hsauo *HasSourceAtUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (hsauo *HasSourceAtUpdateOne) check() error {
-	if _, ok := hsauo.mutation.SourceID(); hsauo.mutation.SourceCleared() && !ok {
+	if hsauo.mutation.SourceCleared() && len(hsauo.mutation.SourceIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "HasSourceAt.source"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/license_query.go
+++ b/pkg/assembler/backends/ent/license_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -113,7 +114,7 @@ func (lq *LicenseQuery) QueryDiscoveredInCertifyLegals() *CertifyLegalQuery {
 // First returns the first License entity from the query.
 // Returns a *NotFoundError when no License was found.
 func (lq *LicenseQuery) First(ctx context.Context) (*License, error) {
-	nodes, err := lq.Limit(1).All(setContextOp(ctx, lq.ctx, "First"))
+	nodes, err := lq.Limit(1).All(setContextOp(ctx, lq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func (lq *LicenseQuery) FirstX(ctx context.Context) *License {
 // Returns a *NotFoundError when no License ID was found.
 func (lq *LicenseQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = lq.Limit(1).IDs(setContextOp(ctx, lq.ctx, "FirstID")); err != nil {
+	if ids, err = lq.Limit(1).IDs(setContextOp(ctx, lq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -159,7 +160,7 @@ func (lq *LicenseQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one License entity is found.
 // Returns a *NotFoundError when no License entities are found.
 func (lq *LicenseQuery) Only(ctx context.Context) (*License, error) {
-	nodes, err := lq.Limit(2).All(setContextOp(ctx, lq.ctx, "Only"))
+	nodes, err := lq.Limit(2).All(setContextOp(ctx, lq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +188,7 @@ func (lq *LicenseQuery) OnlyX(ctx context.Context) *License {
 // Returns a *NotFoundError when no entities are found.
 func (lq *LicenseQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = lq.Limit(2).IDs(setContextOp(ctx, lq.ctx, "OnlyID")); err != nil {
+	if ids, err = lq.Limit(2).IDs(setContextOp(ctx, lq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -212,7 +213,7 @@ func (lq *LicenseQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Licenses.
 func (lq *LicenseQuery) All(ctx context.Context) ([]*License, error) {
-	ctx = setContextOp(ctx, lq.ctx, "All")
+	ctx = setContextOp(ctx, lq.ctx, ent.OpQueryAll)
 	if err := lq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -234,7 +235,7 @@ func (lq *LicenseQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) {
 	if lq.ctx.Unique == nil && lq.path != nil {
 		lq.Unique(true)
 	}
-	ctx = setContextOp(ctx, lq.ctx, "IDs")
+	ctx = setContextOp(ctx, lq.ctx, ent.OpQueryIDs)
 	if err = lq.Select(license.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -252,7 +253,7 @@ func (lq *LicenseQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (lq *LicenseQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, lq.ctx, "Count")
+	ctx = setContextOp(ctx, lq.ctx, ent.OpQueryCount)
 	if err := lq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -270,7 +271,7 @@ func (lq *LicenseQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (lq *LicenseQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, lq.ctx, "Exist")
+	ctx = setContextOp(ctx, lq.ctx, ent.OpQueryExist)
 	switch _, err := lq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -725,7 +726,7 @@ func (lgb *LicenseGroupBy) Aggregate(fns ...AggregateFunc) *LicenseGroupBy {
 
 // Scan applies the selector query and scans the result into the given value.
 func (lgb *LicenseGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, lgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, lgb.build.ctx, ent.OpQueryGroupBy)
 	if err := lgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -773,7 +774,7 @@ func (ls *LicenseSelect) Aggregate(fns ...AggregateFunc) *LicenseSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (ls *LicenseSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, ls.ctx, "Select")
+	ctx = setContextOp(ctx, ls.ctx, ent.OpQuerySelect)
 	if err := ls.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/occurrence_create.go
+++ b/pkg/assembler/backends/ent/occurrence_create.go
@@ -187,7 +187,7 @@ func (oc *OccurrenceCreate) check() error {
 	if _, ok := oc.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "Occurrence.document_ref"`)}
 	}
-	if _, ok := oc.mutation.ArtifactID(); !ok {
+	if len(oc.mutation.ArtifactIDs()) == 0 {
 		return &ValidationError{Name: "artifact", err: errors.New(`ent: missing required edge "Occurrence.artifact"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/occurrence_query.go
+++ b/pkg/assembler/backends/ent/occurrence_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -161,7 +162,7 @@ func (oq *OccurrenceQuery) QueryIncludedInSboms() *BillOfMaterialsQuery {
 // First returns the first Occurrence entity from the query.
 // Returns a *NotFoundError when no Occurrence was found.
 func (oq *OccurrenceQuery) First(ctx context.Context) (*Occurrence, error) {
-	nodes, err := oq.Limit(1).All(setContextOp(ctx, oq.ctx, "First"))
+	nodes, err := oq.Limit(1).All(setContextOp(ctx, oq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (oq *OccurrenceQuery) FirstX(ctx context.Context) *Occurrence {
 // Returns a *NotFoundError when no Occurrence ID was found.
 func (oq *OccurrenceQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = oq.Limit(1).IDs(setContextOp(ctx, oq.ctx, "FirstID")); err != nil {
+	if ids, err = oq.Limit(1).IDs(setContextOp(ctx, oq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -207,7 +208,7 @@ func (oq *OccurrenceQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one Occurrence entity is found.
 // Returns a *NotFoundError when no Occurrence entities are found.
 func (oq *OccurrenceQuery) Only(ctx context.Context) (*Occurrence, error) {
-	nodes, err := oq.Limit(2).All(setContextOp(ctx, oq.ctx, "Only"))
+	nodes, err := oq.Limit(2).All(setContextOp(ctx, oq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (oq *OccurrenceQuery) OnlyX(ctx context.Context) *Occurrence {
 // Returns a *NotFoundError when no entities are found.
 func (oq *OccurrenceQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = oq.Limit(2).IDs(setContextOp(ctx, oq.ctx, "OnlyID")); err != nil {
+	if ids, err = oq.Limit(2).IDs(setContextOp(ctx, oq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -260,7 +261,7 @@ func (oq *OccurrenceQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of Occurrences.
 func (oq *OccurrenceQuery) All(ctx context.Context) ([]*Occurrence, error) {
-	ctx = setContextOp(ctx, oq.ctx, "All")
+	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryAll)
 	if err := oq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ func (oq *OccurrenceQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error)
 	if oq.ctx.Unique == nil && oq.path != nil {
 		oq.Unique(true)
 	}
-	ctx = setContextOp(ctx, oq.ctx, "IDs")
+	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryIDs)
 	if err = oq.Select(occurrence.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (oq *OccurrenceQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (oq *OccurrenceQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, oq.ctx, "Count")
+	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryCount)
 	if err := oq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -318,7 +319,7 @@ func (oq *OccurrenceQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (oq *OccurrenceQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, oq.ctx, "Exist")
+	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryExist)
 	switch _, err := oq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -826,7 +827,7 @@ func (ogb *OccurrenceGroupBy) Aggregate(fns ...AggregateFunc) *OccurrenceGroupBy
 
 // Scan applies the selector query and scans the result into the given value.
 func (ogb *OccurrenceGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, ogb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, ogb.build.ctx, ent.OpQueryGroupBy)
 	if err := ogb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -874,7 +875,7 @@ func (os *OccurrenceSelect) Aggregate(fns ...AggregateFunc) *OccurrenceSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (os *OccurrenceSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, os.ctx, "Select")
+	ctx = setContextOp(ctx, os.ctx, ent.OpQuerySelect)
 	if err := os.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/occurrence_update.go
+++ b/pkg/assembler/backends/ent/occurrence_update.go
@@ -245,7 +245,7 @@ func (ou *OccurrenceUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (ou *OccurrenceUpdate) check() error {
-	if _, ok := ou.mutation.ArtifactID(); ou.mutation.ArtifactCleared() && !ok {
+	if ou.mutation.ArtifactCleared() && len(ou.mutation.ArtifactIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Occurrence.artifact"`)
 	}
 	return nil
@@ -653,7 +653,7 @@ func (ouo *OccurrenceUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (ouo *OccurrenceUpdateOne) check() error {
-	if _, ok := ouo.mutation.ArtifactID(); ouo.mutation.ArtifactCleared() && !ok {
+	if ouo.mutation.ArtifactCleared() && len(ouo.mutation.ArtifactIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "Occurrence.artifact"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/packagename_query.go
+++ b/pkg/assembler/backends/ent/packagename_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -189,7 +190,7 @@ func (pnq *PackageNameQuery) QueryPoc() *PointOfContactQuery {
 // First returns the first PackageName entity from the query.
 // Returns a *NotFoundError when no PackageName was found.
 func (pnq *PackageNameQuery) First(ctx context.Context) (*PackageName, error) {
-	nodes, err := pnq.Limit(1).All(setContextOp(ctx, pnq.ctx, "First"))
+	nodes, err := pnq.Limit(1).All(setContextOp(ctx, pnq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (pnq *PackageNameQuery) FirstX(ctx context.Context) *PackageName {
 // Returns a *NotFoundError when no PackageName ID was found.
 func (pnq *PackageNameQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pnq.Limit(1).IDs(setContextOp(ctx, pnq.ctx, "FirstID")); err != nil {
+	if ids, err = pnq.Limit(1).IDs(setContextOp(ctx, pnq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -235,7 +236,7 @@ func (pnq *PackageNameQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one PackageName entity is found.
 // Returns a *NotFoundError when no PackageName entities are found.
 func (pnq *PackageNameQuery) Only(ctx context.Context) (*PackageName, error) {
-	nodes, err := pnq.Limit(2).All(setContextOp(ctx, pnq.ctx, "Only"))
+	nodes, err := pnq.Limit(2).All(setContextOp(ctx, pnq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func (pnq *PackageNameQuery) OnlyX(ctx context.Context) *PackageName {
 // Returns a *NotFoundError when no entities are found.
 func (pnq *PackageNameQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pnq.Limit(2).IDs(setContextOp(ctx, pnq.ctx, "OnlyID")); err != nil {
+	if ids, err = pnq.Limit(2).IDs(setContextOp(ctx, pnq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -288,7 +289,7 @@ func (pnq *PackageNameQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of PackageNames.
 func (pnq *PackageNameQuery) All(ctx context.Context) ([]*PackageName, error) {
-	ctx = setContextOp(ctx, pnq.ctx, "All")
+	ctx = setContextOp(ctx, pnq.ctx, ent.OpQueryAll)
 	if err := pnq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -310,7 +311,7 @@ func (pnq *PackageNameQuery) IDs(ctx context.Context) (ids []uuid.UUID, err erro
 	if pnq.ctx.Unique == nil && pnq.path != nil {
 		pnq.Unique(true)
 	}
-	ctx = setContextOp(ctx, pnq.ctx, "IDs")
+	ctx = setContextOp(ctx, pnq.ctx, ent.OpQueryIDs)
 	if err = pnq.Select(packagename.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (pnq *PackageNameQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (pnq *PackageNameQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, pnq.ctx, "Count")
+	ctx = setContextOp(ctx, pnq.ctx, ent.OpQueryCount)
 	if err := pnq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -346,7 +347,7 @@ func (pnq *PackageNameQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (pnq *PackageNameQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, pnq.ctx, "Exist")
+	ctx = setContextOp(ctx, pnq.ctx, ent.OpQueryExist)
 	switch _, err := pnq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -960,7 +961,7 @@ func (pngb *PackageNameGroupBy) Aggregate(fns ...AggregateFunc) *PackageNameGrou
 
 // Scan applies the selector query and scans the result into the given value.
 func (pngb *PackageNameGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pngb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, pngb.build.ctx, ent.OpQueryGroupBy)
 	if err := pngb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -1008,7 +1009,7 @@ func (pns *PackageNameSelect) Aggregate(fns ...AggregateFunc) *PackageNameSelect
 
 // Scan applies the selector query and scans the result into the given value.
 func (pns *PackageNameSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pns.ctx, "Select")
+	ctx = setContextOp(ctx, pns.ctx, ent.OpQuerySelect)
 	if err := pns.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/packageversion_create.go
+++ b/pkg/assembler/backends/ent/packageversion_create.go
@@ -374,7 +374,7 @@ func (pvc *PackageVersionCreate) check() error {
 	if _, ok := pvc.mutation.Hash(); !ok {
 		return &ValidationError{Name: "hash", err: errors.New(`ent: missing required field "PackageVersion.hash"`)}
 	}
-	if _, ok := pvc.mutation.NameID(); !ok {
+	if len(pvc.mutation.NameIDs()) == 0 {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required edge "PackageVersion.name"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/packageversion_query.go
+++ b/pkg/assembler/backends/ent/packageversion_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -435,7 +436,7 @@ func (pvq *PackageVersionQuery) QueryCertifyLegal() *CertifyLegalQuery {
 // First returns the first PackageVersion entity from the query.
 // Returns a *NotFoundError when no PackageVersion was found.
 func (pvq *PackageVersionQuery) First(ctx context.Context) (*PackageVersion, error) {
-	nodes, err := pvq.Limit(1).All(setContextOp(ctx, pvq.ctx, "First"))
+	nodes, err := pvq.Limit(1).All(setContextOp(ctx, pvq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +459,7 @@ func (pvq *PackageVersionQuery) FirstX(ctx context.Context) *PackageVersion {
 // Returns a *NotFoundError when no PackageVersion ID was found.
 func (pvq *PackageVersionQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pvq.Limit(1).IDs(setContextOp(ctx, pvq.ctx, "FirstID")); err != nil {
+	if ids, err = pvq.Limit(1).IDs(setContextOp(ctx, pvq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -481,7 +482,7 @@ func (pvq *PackageVersionQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one PackageVersion entity is found.
 // Returns a *NotFoundError when no PackageVersion entities are found.
 func (pvq *PackageVersionQuery) Only(ctx context.Context) (*PackageVersion, error) {
-	nodes, err := pvq.Limit(2).All(setContextOp(ctx, pvq.ctx, "Only"))
+	nodes, err := pvq.Limit(2).All(setContextOp(ctx, pvq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +510,7 @@ func (pvq *PackageVersionQuery) OnlyX(ctx context.Context) *PackageVersion {
 // Returns a *NotFoundError when no entities are found.
 func (pvq *PackageVersionQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pvq.Limit(2).IDs(setContextOp(ctx, pvq.ctx, "OnlyID")); err != nil {
+	if ids, err = pvq.Limit(2).IDs(setContextOp(ctx, pvq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -534,7 +535,7 @@ func (pvq *PackageVersionQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of PackageVersions.
 func (pvq *PackageVersionQuery) All(ctx context.Context) ([]*PackageVersion, error) {
-	ctx = setContextOp(ctx, pvq.ctx, "All")
+	ctx = setContextOp(ctx, pvq.ctx, ent.OpQueryAll)
 	if err := pvq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -556,7 +557,7 @@ func (pvq *PackageVersionQuery) IDs(ctx context.Context) (ids []uuid.UUID, err e
 	if pvq.ctx.Unique == nil && pvq.path != nil {
 		pvq.Unique(true)
 	}
-	ctx = setContextOp(ctx, pvq.ctx, "IDs")
+	ctx = setContextOp(ctx, pvq.ctx, ent.OpQueryIDs)
 	if err = pvq.Select(packageversion.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -574,7 +575,7 @@ func (pvq *PackageVersionQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (pvq *PackageVersionQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, pvq.ctx, "Count")
+	ctx = setContextOp(ctx, pvq.ctx, ent.OpQueryCount)
 	if err := pvq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -592,7 +593,7 @@ func (pvq *PackageVersionQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (pvq *PackageVersionQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, pvq.ctx, "Exist")
+	ctx = setContextOp(ctx, pvq.ctx, ent.OpQueryExist)
 	switch _, err := pvq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -1943,7 +1944,7 @@ func (pvgb *PackageVersionGroupBy) Aggregate(fns ...AggregateFunc) *PackageVersi
 
 // Scan applies the selector query and scans the result into the given value.
 func (pvgb *PackageVersionGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pvgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, pvgb.build.ctx, ent.OpQueryGroupBy)
 	if err := pvgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -1991,7 +1992,7 @@ func (pvs *PackageVersionSelect) Aggregate(fns ...AggregateFunc) *PackageVersion
 
 // Scan applies the selector query and scans the result into the given value.
 func (pvs *PackageVersionSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pvs.ctx, "Select")
+	ctx = setContextOp(ctx, pvs.ctx, ent.OpQuerySelect)
 	if err := pvs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/packageversion_update.go
+++ b/pkg/assembler/backends/ent/packageversion_update.go
@@ -665,7 +665,7 @@ func (pvu *PackageVersionUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (pvu *PackageVersionUpdate) check() error {
-	if _, ok := pvu.mutation.NameID(); pvu.mutation.NameCleared() && !ok {
+	if pvu.mutation.NameCleared() && len(pvu.mutation.NameIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PackageVersion.name"`)
 	}
 	return nil
@@ -2018,7 +2018,7 @@ func (pvuo *PackageVersionUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (pvuo *PackageVersionUpdateOne) check() error {
-	if _, ok := pvuo.mutation.NameID(); pvuo.mutation.NameCleared() && !ok {
+	if pvuo.mutation.NameCleared() && len(pvuo.mutation.NameIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PackageVersion.name"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/pkgequal_create.go
+++ b/pkg/assembler/backends/ent/pkgequal_create.go
@@ -166,10 +166,10 @@ func (pec *PkgEqualCreate) check() error {
 	if _, ok := pec.mutation.PackagesHash(); !ok {
 		return &ValidationError{Name: "packages_hash", err: errors.New(`ent: missing required field "PkgEqual.packages_hash"`)}
 	}
-	if _, ok := pec.mutation.PackageAID(); !ok {
+	if len(pec.mutation.PackageAIDs()) == 0 {
 		return &ValidationError{Name: "package_a", err: errors.New(`ent: missing required edge "PkgEqual.package_a"`)}
 	}
-	if _, ok := pec.mutation.PackageBID(); !ok {
+	if len(pec.mutation.PackageBIDs()) == 0 {
 		return &ValidationError{Name: "package_b", err: errors.New(`ent: missing required edge "PkgEqual.package_b"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/pkgequal_query.go
+++ b/pkg/assembler/backends/ent/pkgequal_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -110,7 +111,7 @@ func (peq *PkgEqualQuery) QueryPackageB() *PackageVersionQuery {
 // First returns the first PkgEqual entity from the query.
 // Returns a *NotFoundError when no PkgEqual was found.
 func (peq *PkgEqualQuery) First(ctx context.Context) (*PkgEqual, error) {
-	nodes, err := peq.Limit(1).All(setContextOp(ctx, peq.ctx, "First"))
+	nodes, err := peq.Limit(1).All(setContextOp(ctx, peq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (peq *PkgEqualQuery) FirstX(ctx context.Context) *PkgEqual {
 // Returns a *NotFoundError when no PkgEqual ID was found.
 func (peq *PkgEqualQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = peq.Limit(1).IDs(setContextOp(ctx, peq.ctx, "FirstID")); err != nil {
+	if ids, err = peq.Limit(1).IDs(setContextOp(ctx, peq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -156,7 +157,7 @@ func (peq *PkgEqualQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one PkgEqual entity is found.
 // Returns a *NotFoundError when no PkgEqual entities are found.
 func (peq *PkgEqualQuery) Only(ctx context.Context) (*PkgEqual, error) {
-	nodes, err := peq.Limit(2).All(setContextOp(ctx, peq.ctx, "Only"))
+	nodes, err := peq.Limit(2).All(setContextOp(ctx, peq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (peq *PkgEqualQuery) OnlyX(ctx context.Context) *PkgEqual {
 // Returns a *NotFoundError when no entities are found.
 func (peq *PkgEqualQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = peq.Limit(2).IDs(setContextOp(ctx, peq.ctx, "OnlyID")); err != nil {
+	if ids, err = peq.Limit(2).IDs(setContextOp(ctx, peq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -209,7 +210,7 @@ func (peq *PkgEqualQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of PkgEquals.
 func (peq *PkgEqualQuery) All(ctx context.Context) ([]*PkgEqual, error) {
-	ctx = setContextOp(ctx, peq.ctx, "All")
+	ctx = setContextOp(ctx, peq.ctx, ent.OpQueryAll)
 	if err := peq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (peq *PkgEqualQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) 
 	if peq.ctx.Unique == nil && peq.path != nil {
 		peq.Unique(true)
 	}
-	ctx = setContextOp(ctx, peq.ctx, "IDs")
+	ctx = setContextOp(ctx, peq.ctx, ent.OpQueryIDs)
 	if err = peq.Select(pkgequal.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -249,7 +250,7 @@ func (peq *PkgEqualQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (peq *PkgEqualQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, peq.ctx, "Count")
+	ctx = setContextOp(ctx, peq.ctx, ent.OpQueryCount)
 	if err := peq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -267,7 +268,7 @@ func (peq *PkgEqualQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (peq *PkgEqualQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, peq.ctx, "Exist")
+	ctx = setContextOp(ctx, peq.ctx, ent.OpQueryExist)
 	switch _, err := peq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -616,7 +617,7 @@ func (pegb *PkgEqualGroupBy) Aggregate(fns ...AggregateFunc) *PkgEqualGroupBy {
 
 // Scan applies the selector query and scans the result into the given value.
 func (pegb *PkgEqualGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pegb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, pegb.build.ctx, ent.OpQueryGroupBy)
 	if err := pegb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -664,7 +665,7 @@ func (pes *PkgEqualSelect) Aggregate(fns ...AggregateFunc) *PkgEqualSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (pes *PkgEqualSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pes.ctx, "Select")
+	ctx = setContextOp(ctx, pes.ctx, ent.OpQuerySelect)
 	if err := pes.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/pkgequal_update.go
+++ b/pkg/assembler/backends/ent/pkgequal_update.go
@@ -195,10 +195,10 @@ func (peu *PkgEqualUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (peu *PkgEqualUpdate) check() error {
-	if _, ok := peu.mutation.PackageAID(); peu.mutation.PackageACleared() && !ok {
+	if peu.mutation.PackageACleared() && len(peu.mutation.PackageAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PkgEqual.package_a"`)
 	}
-	if _, ok := peu.mutation.PackageBID(); peu.mutation.PackageBCleared() && !ok {
+	if peu.mutation.PackageBCleared() && len(peu.mutation.PackageBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PkgEqual.package_b"`)
 	}
 	return nil
@@ -488,10 +488,10 @@ func (peuo *PkgEqualUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (peuo *PkgEqualUpdateOne) check() error {
-	if _, ok := peuo.mutation.PackageAID(); peuo.mutation.PackageACleared() && !ok {
+	if peuo.mutation.PackageACleared() && len(peuo.mutation.PackageAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PkgEqual.package_a"`)
 	}
-	if _, ok := peuo.mutation.PackageBID(); peuo.mutation.PackageBCleared() && !ok {
+	if peuo.mutation.PackageBCleared() && len(peuo.mutation.PackageBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "PkgEqual.package_b"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/pointofcontact_query.go
+++ b/pkg/assembler/backends/ent/pointofcontact_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -159,7 +160,7 @@ func (pocq *PointOfContactQuery) QueryArtifact() *ArtifactQuery {
 // First returns the first PointOfContact entity from the query.
 // Returns a *NotFoundError when no PointOfContact was found.
 func (pocq *PointOfContactQuery) First(ctx context.Context) (*PointOfContact, error) {
-	nodes, err := pocq.Limit(1).All(setContextOp(ctx, pocq.ctx, "First"))
+	nodes, err := pocq.Limit(1).All(setContextOp(ctx, pocq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (pocq *PointOfContactQuery) FirstX(ctx context.Context) *PointOfContact {
 // Returns a *NotFoundError when no PointOfContact ID was found.
 func (pocq *PointOfContactQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pocq.Limit(1).IDs(setContextOp(ctx, pocq.ctx, "FirstID")); err != nil {
+	if ids, err = pocq.Limit(1).IDs(setContextOp(ctx, pocq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -205,7 +206,7 @@ func (pocq *PointOfContactQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one PointOfContact entity is found.
 // Returns a *NotFoundError when no PointOfContact entities are found.
 func (pocq *PointOfContactQuery) Only(ctx context.Context) (*PointOfContact, error) {
-	nodes, err := pocq.Limit(2).All(setContextOp(ctx, pocq.ctx, "Only"))
+	nodes, err := pocq.Limit(2).All(setContextOp(ctx, pocq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (pocq *PointOfContactQuery) OnlyX(ctx context.Context) *PointOfContact {
 // Returns a *NotFoundError when no entities are found.
 func (pocq *PointOfContactQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = pocq.Limit(2).IDs(setContextOp(ctx, pocq.ctx, "OnlyID")); err != nil {
+	if ids, err = pocq.Limit(2).IDs(setContextOp(ctx, pocq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -258,7 +259,7 @@ func (pocq *PointOfContactQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of PointOfContacts.
 func (pocq *PointOfContactQuery) All(ctx context.Context) ([]*PointOfContact, error) {
-	ctx = setContextOp(ctx, pocq.ctx, "All")
+	ctx = setContextOp(ctx, pocq.ctx, ent.OpQueryAll)
 	if err := pocq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (pocq *PointOfContactQuery) IDs(ctx context.Context) (ids []uuid.UUID, err 
 	if pocq.ctx.Unique == nil && pocq.path != nil {
 		pocq.Unique(true)
 	}
-	ctx = setContextOp(ctx, pocq.ctx, "IDs")
+	ctx = setContextOp(ctx, pocq.ctx, ent.OpQueryIDs)
 	if err = pocq.Select(pointofcontact.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (pocq *PointOfContactQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (pocq *PointOfContactQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, pocq.ctx, "Count")
+	ctx = setContextOp(ctx, pocq.ctx, ent.OpQueryCount)
 	if err := pocq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -316,7 +317,7 @@ func (pocq *PointOfContactQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (pocq *PointOfContactQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, pocq.ctx, "Exist")
+	ctx = setContextOp(ctx, pocq.ctx, ent.OpQueryExist)
 	switch _, err := pocq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -779,7 +780,7 @@ func (pocgb *PointOfContactGroupBy) Aggregate(fns ...AggregateFunc) *PointOfCont
 
 // Scan applies the selector query and scans the result into the given value.
 func (pocgb *PointOfContactGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pocgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, pocgb.build.ctx, ent.OpQueryGroupBy)
 	if err := pocgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -827,7 +828,7 @@ func (pocs *PointOfContactSelect) Aggregate(fns ...AggregateFunc) *PointOfContac
 
 // Scan applies the selector query and scans the result into the given value.
 func (pocs *PointOfContactSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, pocs.ctx, "Select")
+	ctx = setContextOp(ctx, pocs.ctx, ent.OpQuerySelect)
 	if err := pocs.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/runtime/runtime.go
+++ b/pkg/assembler/backends/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/guacsec/guac/pkg/assembler/backends/ent/runtime.go
 
 const (
-	Version = "v0.13.1"                                         // Version of ent codegen.
-	Sum     = "h1:uD8QwN1h6SNphdCCzmkMN3feSUzNnVvV/WIkHKMbzOE=" // Sum of ent codegen.
+	Version = "v0.14.0"                                         // Version of ent codegen.
+	Sum     = "h1:EO3Z9aZ5bXJatJeGqu/EVdnNr6K4mRq3rWe5owt0MC4=" // Sum of ent codegen.
 )

--- a/pkg/assembler/backends/ent/slsaattestation_create.go
+++ b/pkg/assembler/backends/ent/slsaattestation_create.go
@@ -205,10 +205,10 @@ func (sac *SLSAAttestationCreate) check() error {
 	if _, ok := sac.mutation.BuiltFromHash(); !ok {
 		return &ValidationError{Name: "built_from_hash", err: errors.New(`ent: missing required field "SLSAAttestation.built_from_hash"`)}
 	}
-	if _, ok := sac.mutation.BuiltByID(); !ok {
+	if len(sac.mutation.BuiltByIDs()) == 0 {
 		return &ValidationError{Name: "built_by", err: errors.New(`ent: missing required edge "SLSAAttestation.built_by"`)}
 	}
-	if _, ok := sac.mutation.SubjectID(); !ok {
+	if len(sac.mutation.SubjectIDs()) == 0 {
 		return &ValidationError{Name: "subject", err: errors.New(`ent: missing required edge "SLSAAttestation.subject"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/slsaattestation_query.go
+++ b/pkg/assembler/backends/ent/slsaattestation_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -136,7 +137,7 @@ func (saq *SLSAAttestationQuery) QuerySubject() *ArtifactQuery {
 // First returns the first SLSAAttestation entity from the query.
 // Returns a *NotFoundError when no SLSAAttestation was found.
 func (saq *SLSAAttestationQuery) First(ctx context.Context) (*SLSAAttestation, error) {
-	nodes, err := saq.Limit(1).All(setContextOp(ctx, saq.ctx, "First"))
+	nodes, err := saq.Limit(1).All(setContextOp(ctx, saq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (saq *SLSAAttestationQuery) FirstX(ctx context.Context) *SLSAAttestation {
 // Returns a *NotFoundError when no SLSAAttestation ID was found.
 func (saq *SLSAAttestationQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = saq.Limit(1).IDs(setContextOp(ctx, saq.ctx, "FirstID")); err != nil {
+	if ids, err = saq.Limit(1).IDs(setContextOp(ctx, saq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -182,7 +183,7 @@ func (saq *SLSAAttestationQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one SLSAAttestation entity is found.
 // Returns a *NotFoundError when no SLSAAttestation entities are found.
 func (saq *SLSAAttestationQuery) Only(ctx context.Context) (*SLSAAttestation, error) {
-	nodes, err := saq.Limit(2).All(setContextOp(ctx, saq.ctx, "Only"))
+	nodes, err := saq.Limit(2).All(setContextOp(ctx, saq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +211,7 @@ func (saq *SLSAAttestationQuery) OnlyX(ctx context.Context) *SLSAAttestation {
 // Returns a *NotFoundError when no entities are found.
 func (saq *SLSAAttestationQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = saq.Limit(2).IDs(setContextOp(ctx, saq.ctx, "OnlyID")); err != nil {
+	if ids, err = saq.Limit(2).IDs(setContextOp(ctx, saq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -235,7 +236,7 @@ func (saq *SLSAAttestationQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of SLSAAttestations.
 func (saq *SLSAAttestationQuery) All(ctx context.Context) ([]*SLSAAttestation, error) {
-	ctx = setContextOp(ctx, saq.ctx, "All")
+	ctx = setContextOp(ctx, saq.ctx, ent.OpQueryAll)
 	if err := saq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (saq *SLSAAttestationQuery) IDs(ctx context.Context) (ids []uuid.UUID, err 
 	if saq.ctx.Unique == nil && saq.path != nil {
 		saq.Unique(true)
 	}
-	ctx = setContextOp(ctx, saq.ctx, "IDs")
+	ctx = setContextOp(ctx, saq.ctx, ent.OpQueryIDs)
 	if err = saq.Select(slsaattestation.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func (saq *SLSAAttestationQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (saq *SLSAAttestationQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, saq.ctx, "Count")
+	ctx = setContextOp(ctx, saq.ctx, ent.OpQueryCount)
 	if err := saq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -293,7 +294,7 @@ func (saq *SLSAAttestationQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (saq *SLSAAttestationQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, saq.ctx, "Exist")
+	ctx = setContextOp(ctx, saq.ctx, ent.OpQueryExist)
 	switch _, err := saq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -744,7 +745,7 @@ func (sagb *SLSAAttestationGroupBy) Aggregate(fns ...AggregateFunc) *SLSAAttesta
 
 // Scan applies the selector query and scans the result into the given value.
 func (sagb *SLSAAttestationGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, sagb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, sagb.build.ctx, ent.OpQueryGroupBy)
 	if err := sagb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -792,7 +793,7 @@ func (sas *SLSAAttestationSelect) Aggregate(fns ...AggregateFunc) *SLSAAttestati
 
 // Scan applies the selector query and scans the result into the given value.
 func (sas *SLSAAttestationSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, sas.ctx, "Select")
+	ctx = setContextOp(ctx, sas.ctx, ent.OpQuerySelect)
 	if err := sas.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/slsaattestation_update.go
+++ b/pkg/assembler/backends/ent/slsaattestation_update.go
@@ -283,10 +283,10 @@ func (sau *SLSAAttestationUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (sau *SLSAAttestationUpdate) check() error {
-	if _, ok := sau.mutation.BuiltByID(); sau.mutation.BuiltByCleared() && !ok {
+	if sau.mutation.BuiltByCleared() && len(sau.mutation.BuiltByIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SLSAAttestation.built_by"`)
 	}
-	if _, ok := sau.mutation.SubjectID(); sau.mutation.SubjectCleared() && !ok {
+	if sau.mutation.SubjectCleared() && len(sau.mutation.SubjectIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SLSAAttestation.subject"`)
 	}
 	return nil
@@ -725,10 +725,10 @@ func (sauo *SLSAAttestationUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (sauo *SLSAAttestationUpdateOne) check() error {
-	if _, ok := sauo.mutation.BuiltByID(); sauo.mutation.BuiltByCleared() && !ok {
+	if sauo.mutation.BuiltByCleared() && len(sauo.mutation.BuiltByIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SLSAAttestation.built_by"`)
 	}
-	if _, ok := sauo.mutation.SubjectID(); sauo.mutation.SubjectCleared() && !ok {
+	if sauo.mutation.SubjectCleared() && len(sauo.mutation.SubjectIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SLSAAttestation.subject"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/sourcename_query.go
+++ b/pkg/assembler/backends/ent/sourcename_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -239,7 +240,7 @@ func (snq *SourceNameQuery) QueryCertifyLegal() *CertifyLegalQuery {
 // First returns the first SourceName entity from the query.
 // Returns a *NotFoundError when no SourceName was found.
 func (snq *SourceNameQuery) First(ctx context.Context) (*SourceName, error) {
-	nodes, err := snq.Limit(1).All(setContextOp(ctx, snq.ctx, "First"))
+	nodes, err := snq.Limit(1).All(setContextOp(ctx, snq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +263,7 @@ func (snq *SourceNameQuery) FirstX(ctx context.Context) *SourceName {
 // Returns a *NotFoundError when no SourceName ID was found.
 func (snq *SourceNameQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = snq.Limit(1).IDs(setContextOp(ctx, snq.ctx, "FirstID")); err != nil {
+	if ids, err = snq.Limit(1).IDs(setContextOp(ctx, snq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -285,7 +286,7 @@ func (snq *SourceNameQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one SourceName entity is found.
 // Returns a *NotFoundError when no SourceName entities are found.
 func (snq *SourceNameQuery) Only(ctx context.Context) (*SourceName, error) {
-	nodes, err := snq.Limit(2).All(setContextOp(ctx, snq.ctx, "Only"))
+	nodes, err := snq.Limit(2).All(setContextOp(ctx, snq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +314,7 @@ func (snq *SourceNameQuery) OnlyX(ctx context.Context) *SourceName {
 // Returns a *NotFoundError when no entities are found.
 func (snq *SourceNameQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = snq.Limit(2).IDs(setContextOp(ctx, snq.ctx, "OnlyID")); err != nil {
+	if ids, err = snq.Limit(2).IDs(setContextOp(ctx, snq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -338,7 +339,7 @@ func (snq *SourceNameQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of SourceNames.
 func (snq *SourceNameQuery) All(ctx context.Context) ([]*SourceName, error) {
-	ctx = setContextOp(ctx, snq.ctx, "All")
+	ctx = setContextOp(ctx, snq.ctx, ent.OpQueryAll)
 	if err := snq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -360,7 +361,7 @@ func (snq *SourceNameQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error
 	if snq.ctx.Unique == nil && snq.path != nil {
 		snq.Unique(true)
 	}
-	ctx = setContextOp(ctx, snq.ctx, "IDs")
+	ctx = setContextOp(ctx, snq.ctx, ent.OpQueryIDs)
 	if err = snq.Select(sourcename.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -378,7 +379,7 @@ func (snq *SourceNameQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (snq *SourceNameQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, snq.ctx, "Count")
+	ctx = setContextOp(ctx, snq.ctx, ent.OpQueryCount)
 	if err := snq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -396,7 +397,7 @@ func (snq *SourceNameQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (snq *SourceNameQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, snq.ctx, "Exist")
+	ctx = setContextOp(ctx, snq.ctx, ent.OpQueryExist)
 	switch _, err := snq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -1155,7 +1156,7 @@ func (sngb *SourceNameGroupBy) Aggregate(fns ...AggregateFunc) *SourceNameGroupB
 
 // Scan applies the selector query and scans the result into the given value.
 func (sngb *SourceNameGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, sngb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, sngb.build.ctx, ent.OpQueryGroupBy)
 	if err := sngb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -1203,7 +1204,7 @@ func (sns *SourceNameSelect) Aggregate(fns ...AggregateFunc) *SourceNameSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (sns *SourceNameSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, sns.ctx, "Select")
+	ctx = setContextOp(ctx, sns.ctx, ent.OpQuerySelect)
 	if err := sns.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/vulnequal_create.go
+++ b/pkg/assembler/backends/ent/vulnequal_create.go
@@ -166,10 +166,10 @@ func (vec *VulnEqualCreate) check() error {
 	if _, ok := vec.mutation.VulnerabilitiesHash(); !ok {
 		return &ValidationError{Name: "vulnerabilities_hash", err: errors.New(`ent: missing required field "VulnEqual.vulnerabilities_hash"`)}
 	}
-	if _, ok := vec.mutation.VulnerabilityAID(); !ok {
+	if len(vec.mutation.VulnerabilityAIDs()) == 0 {
 		return &ValidationError{Name: "vulnerability_a", err: errors.New(`ent: missing required edge "VulnEqual.vulnerability_a"`)}
 	}
-	if _, ok := vec.mutation.VulnerabilityBID(); !ok {
+	if len(vec.mutation.VulnerabilityBIDs()) == 0 {
 		return &ValidationError{Name: "vulnerability_b", err: errors.New(`ent: missing required edge "VulnEqual.vulnerability_b"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/vulnequal_query.go
+++ b/pkg/assembler/backends/ent/vulnequal_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -110,7 +111,7 @@ func (veq *VulnEqualQuery) QueryVulnerabilityB() *VulnerabilityIDQuery {
 // First returns the first VulnEqual entity from the query.
 // Returns a *NotFoundError when no VulnEqual was found.
 func (veq *VulnEqualQuery) First(ctx context.Context) (*VulnEqual, error) {
-	nodes, err := veq.Limit(1).All(setContextOp(ctx, veq.ctx, "First"))
+	nodes, err := veq.Limit(1).All(setContextOp(ctx, veq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (veq *VulnEqualQuery) FirstX(ctx context.Context) *VulnEqual {
 // Returns a *NotFoundError when no VulnEqual ID was found.
 func (veq *VulnEqualQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = veq.Limit(1).IDs(setContextOp(ctx, veq.ctx, "FirstID")); err != nil {
+	if ids, err = veq.Limit(1).IDs(setContextOp(ctx, veq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -156,7 +157,7 @@ func (veq *VulnEqualQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one VulnEqual entity is found.
 // Returns a *NotFoundError when no VulnEqual entities are found.
 func (veq *VulnEqualQuery) Only(ctx context.Context) (*VulnEqual, error) {
-	nodes, err := veq.Limit(2).All(setContextOp(ctx, veq.ctx, "Only"))
+	nodes, err := veq.Limit(2).All(setContextOp(ctx, veq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (veq *VulnEqualQuery) OnlyX(ctx context.Context) *VulnEqual {
 // Returns a *NotFoundError when no entities are found.
 func (veq *VulnEqualQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = veq.Limit(2).IDs(setContextOp(ctx, veq.ctx, "OnlyID")); err != nil {
+	if ids, err = veq.Limit(2).IDs(setContextOp(ctx, veq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -209,7 +210,7 @@ func (veq *VulnEqualQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of VulnEquals.
 func (veq *VulnEqualQuery) All(ctx context.Context) ([]*VulnEqual, error) {
-	ctx = setContextOp(ctx, veq.ctx, "All")
+	ctx = setContextOp(ctx, veq.ctx, ent.OpQueryAll)
 	if err := veq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (veq *VulnEqualQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error)
 	if veq.ctx.Unique == nil && veq.path != nil {
 		veq.Unique(true)
 	}
-	ctx = setContextOp(ctx, veq.ctx, "IDs")
+	ctx = setContextOp(ctx, veq.ctx, ent.OpQueryIDs)
 	if err = veq.Select(vulnequal.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -249,7 +250,7 @@ func (veq *VulnEqualQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (veq *VulnEqualQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, veq.ctx, "Count")
+	ctx = setContextOp(ctx, veq.ctx, ent.OpQueryCount)
 	if err := veq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -267,7 +268,7 @@ func (veq *VulnEqualQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (veq *VulnEqualQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, veq.ctx, "Exist")
+	ctx = setContextOp(ctx, veq.ctx, ent.OpQueryExist)
 	switch _, err := veq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -616,7 +617,7 @@ func (vegb *VulnEqualGroupBy) Aggregate(fns ...AggregateFunc) *VulnEqualGroupBy 
 
 // Scan applies the selector query and scans the result into the given value.
 func (vegb *VulnEqualGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, vegb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, vegb.build.ctx, ent.OpQueryGroupBy)
 	if err := vegb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -664,7 +665,7 @@ func (ves *VulnEqualSelect) Aggregate(fns ...AggregateFunc) *VulnEqualSelect {
 
 // Scan applies the selector query and scans the result into the given value.
 func (ves *VulnEqualSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, ves.ctx, "Select")
+	ctx = setContextOp(ctx, ves.ctx, ent.OpQuerySelect)
 	if err := ves.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/vulnequal_update.go
+++ b/pkg/assembler/backends/ent/vulnequal_update.go
@@ -195,10 +195,10 @@ func (veu *VulnEqualUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (veu *VulnEqualUpdate) check() error {
-	if _, ok := veu.mutation.VulnerabilityAID(); veu.mutation.VulnerabilityACleared() && !ok {
+	if veu.mutation.VulnerabilityACleared() && len(veu.mutation.VulnerabilityAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnEqual.vulnerability_a"`)
 	}
-	if _, ok := veu.mutation.VulnerabilityBID(); veu.mutation.VulnerabilityBCleared() && !ok {
+	if veu.mutation.VulnerabilityBCleared() && len(veu.mutation.VulnerabilityBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnEqual.vulnerability_b"`)
 	}
 	return nil
@@ -488,10 +488,10 @@ func (veuo *VulnEqualUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (veuo *VulnEqualUpdateOne) check() error {
-	if _, ok := veuo.mutation.VulnerabilityAID(); veuo.mutation.VulnerabilityACleared() && !ok {
+	if veuo.mutation.VulnerabilityACleared() && len(veuo.mutation.VulnerabilityAIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnEqual.vulnerability_a"`)
 	}
-	if _, ok := veuo.mutation.VulnerabilityBID(); veuo.mutation.VulnerabilityBCleared() && !ok {
+	if veuo.mutation.VulnerabilityBCleared() && len(veuo.mutation.VulnerabilityBIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnEqual.vulnerability_b"`)
 	}
 	return nil

--- a/pkg/assembler/backends/ent/vulnerabilityid_query.go
+++ b/pkg/assembler/backends/ent/vulnerabilityid_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -188,7 +189,7 @@ func (viq *VulnerabilityIDQuery) QueryVex() *CertifyVexQuery {
 // First returns the first VulnerabilityID entity from the query.
 // Returns a *NotFoundError when no VulnerabilityID was found.
 func (viq *VulnerabilityIDQuery) First(ctx context.Context) (*VulnerabilityID, error) {
-	nodes, err := viq.Limit(1).All(setContextOp(ctx, viq.ctx, "First"))
+	nodes, err := viq.Limit(1).All(setContextOp(ctx, viq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,7 @@ func (viq *VulnerabilityIDQuery) FirstX(ctx context.Context) *VulnerabilityID {
 // Returns a *NotFoundError when no VulnerabilityID ID was found.
 func (viq *VulnerabilityIDQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = viq.Limit(1).IDs(setContextOp(ctx, viq.ctx, "FirstID")); err != nil {
+	if ids, err = viq.Limit(1).IDs(setContextOp(ctx, viq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -234,7 +235,7 @@ func (viq *VulnerabilityIDQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one VulnerabilityID entity is found.
 // Returns a *NotFoundError when no VulnerabilityID entities are found.
 func (viq *VulnerabilityIDQuery) Only(ctx context.Context) (*VulnerabilityID, error) {
-	nodes, err := viq.Limit(2).All(setContextOp(ctx, viq.ctx, "Only"))
+	nodes, err := viq.Limit(2).All(setContextOp(ctx, viq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +263,7 @@ func (viq *VulnerabilityIDQuery) OnlyX(ctx context.Context) *VulnerabilityID {
 // Returns a *NotFoundError when no entities are found.
 func (viq *VulnerabilityIDQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = viq.Limit(2).IDs(setContextOp(ctx, viq.ctx, "OnlyID")); err != nil {
+	if ids, err = viq.Limit(2).IDs(setContextOp(ctx, viq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -287,7 +288,7 @@ func (viq *VulnerabilityIDQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of VulnerabilityIDs.
 func (viq *VulnerabilityIDQuery) All(ctx context.Context) ([]*VulnerabilityID, error) {
-	ctx = setContextOp(ctx, viq.ctx, "All")
+	ctx = setContextOp(ctx, viq.ctx, ent.OpQueryAll)
 	if err := viq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ func (viq *VulnerabilityIDQuery) IDs(ctx context.Context) (ids []uuid.UUID, err 
 	if viq.ctx.Unique == nil && viq.path != nil {
 		viq.Unique(true)
 	}
-	ctx = setContextOp(ctx, viq.ctx, "IDs")
+	ctx = setContextOp(ctx, viq.ctx, ent.OpQueryIDs)
 	if err = viq.Select(vulnerabilityid.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (viq *VulnerabilityIDQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (viq *VulnerabilityIDQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, viq.ctx, "Count")
+	ctx = setContextOp(ctx, viq.ctx, ent.OpQueryCount)
 	if err := viq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -345,7 +346,7 @@ func (viq *VulnerabilityIDQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (viq *VulnerabilityIDQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, viq.ctx, "Exist")
+	ctx = setContextOp(ctx, viq.ctx, ent.OpQueryExist)
 	switch _, err := viq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -947,7 +948,7 @@ func (vigb *VulnerabilityIDGroupBy) Aggregate(fns ...AggregateFunc) *Vulnerabili
 
 // Scan applies the selector query and scans the result into the given value.
 func (vigb *VulnerabilityIDGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, vigb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, vigb.build.ctx, ent.OpQueryGroupBy)
 	if err := vigb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -995,7 +996,7 @@ func (vis *VulnerabilityIDSelect) Aggregate(fns ...AggregateFunc) *Vulnerability
 
 // Scan applies the selector query and scans the result into the given value.
 func (vis *VulnerabilityIDSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, vis.ctx, "Select")
+	ctx = setContextOp(ctx, vis.ctx, ent.OpQuerySelect)
 	if err := vis.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata_create.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata_create.go
@@ -155,7 +155,7 @@ func (vmc *VulnerabilityMetadataCreate) check() error {
 	if _, ok := vmc.mutation.DocumentRef(); !ok {
 		return &ValidationError{Name: "document_ref", err: errors.New(`ent: missing required field "VulnerabilityMetadata.document_ref"`)}
 	}
-	if _, ok := vmc.mutation.VulnerabilityIDID(); !ok {
+	if len(vmc.mutation.VulnerabilityIDIDs()) == 0 {
 		return &ValidationError{Name: "vulnerability_id", err: errors.New(`ent: missing required edge "VulnerabilityMetadata.vulnerability_id"`)}
 	}
 	return nil

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata_query.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata_query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
@@ -87,7 +88,7 @@ func (vmq *VulnerabilityMetadataQuery) QueryVulnerabilityID() *VulnerabilityIDQu
 // First returns the first VulnerabilityMetadata entity from the query.
 // Returns a *NotFoundError when no VulnerabilityMetadata was found.
 func (vmq *VulnerabilityMetadataQuery) First(ctx context.Context) (*VulnerabilityMetadata, error) {
-	nodes, err := vmq.Limit(1).All(setContextOp(ctx, vmq.ctx, "First"))
+	nodes, err := vmq.Limit(1).All(setContextOp(ctx, vmq.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (vmq *VulnerabilityMetadataQuery) FirstX(ctx context.Context) *Vulnerabilit
 // Returns a *NotFoundError when no VulnerabilityMetadata ID was found.
 func (vmq *VulnerabilityMetadataQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = vmq.Limit(1).IDs(setContextOp(ctx, vmq.ctx, "FirstID")); err != nil {
+	if ids, err = vmq.Limit(1).IDs(setContextOp(ctx, vmq.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -133,7 +134,7 @@ func (vmq *VulnerabilityMetadataQuery) FirstIDX(ctx context.Context) uuid.UUID {
 // Returns a *NotSingularError when more than one VulnerabilityMetadata entity is found.
 // Returns a *NotFoundError when no VulnerabilityMetadata entities are found.
 func (vmq *VulnerabilityMetadataQuery) Only(ctx context.Context) (*VulnerabilityMetadata, error) {
-	nodes, err := vmq.Limit(2).All(setContextOp(ctx, vmq.ctx, "Only"))
+	nodes, err := vmq.Limit(2).All(setContextOp(ctx, vmq.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (vmq *VulnerabilityMetadataQuery) OnlyX(ctx context.Context) *Vulnerability
 // Returns a *NotFoundError when no entities are found.
 func (vmq *VulnerabilityMetadataQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID
-	if ids, err = vmq.Limit(2).IDs(setContextOp(ctx, vmq.ctx, "OnlyID")); err != nil {
+	if ids, err = vmq.Limit(2).IDs(setContextOp(ctx, vmq.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -186,7 +187,7 @@ func (vmq *VulnerabilityMetadataQuery) OnlyIDX(ctx context.Context) uuid.UUID {
 
 // All executes the query and returns a list of VulnerabilityMetadataSlice.
 func (vmq *VulnerabilityMetadataQuery) All(ctx context.Context) ([]*VulnerabilityMetadata, error) {
-	ctx = setContextOp(ctx, vmq.ctx, "All")
+	ctx = setContextOp(ctx, vmq.ctx, ent.OpQueryAll)
 	if err := vmq.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
@@ -208,7 +209,7 @@ func (vmq *VulnerabilityMetadataQuery) IDs(ctx context.Context) (ids []uuid.UUID
 	if vmq.ctx.Unique == nil && vmq.path != nil {
 		vmq.Unique(true)
 	}
-	ctx = setContextOp(ctx, vmq.ctx, "IDs")
+	ctx = setContextOp(ctx, vmq.ctx, ent.OpQueryIDs)
 	if err = vmq.Select(vulnerabilitymetadata.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (vmq *VulnerabilityMetadataQuery) IDsX(ctx context.Context) []uuid.UUID {
 
 // Count returns the count of the given query.
 func (vmq *VulnerabilityMetadataQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, vmq.ctx, "Count")
+	ctx = setContextOp(ctx, vmq.ctx, ent.OpQueryCount)
 	if err := vmq.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
@@ -244,7 +245,7 @@ func (vmq *VulnerabilityMetadataQuery) CountX(ctx context.Context) int {
 
 // Exist returns true if the query has elements in the graph.
 func (vmq *VulnerabilityMetadataQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, vmq.ctx, "Exist")
+	ctx = setContextOp(ctx, vmq.ctx, ent.OpQueryExist)
 	switch _, err := vmq.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
@@ -542,7 +543,7 @@ func (vmgb *VulnerabilityMetadataGroupBy) Aggregate(fns ...AggregateFunc) *Vulne
 
 // Scan applies the selector query and scans the result into the given value.
 func (vmgb *VulnerabilityMetadataGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, vmgb.build.ctx, "GroupBy")
+	ctx = setContextOp(ctx, vmgb.build.ctx, ent.OpQueryGroupBy)
 	if err := vmgb.build.prepareQuery(ctx); err != nil {
 		return err
 	}
@@ -590,7 +591,7 @@ func (vms *VulnerabilityMetadataSelect) Aggregate(fns ...AggregateFunc) *Vulnera
 
 // Scan applies the selector query and scans the result into the given value.
 func (vms *VulnerabilityMetadataSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, vms.ctx, "Select")
+	ctx = setContextOp(ctx, vms.ctx, ent.OpQuerySelect)
 	if err := vms.prepareQuery(ctx); err != nil {
 		return err
 	}

--- a/pkg/assembler/backends/ent/vulnerabilitymetadata_update.go
+++ b/pkg/assembler/backends/ent/vulnerabilitymetadata_update.go
@@ -185,7 +185,7 @@ func (vmu *VulnerabilityMetadataUpdate) check() error {
 			return &ValidationError{Name: "score_type", err: fmt.Errorf(`ent: validator failed for field "VulnerabilityMetadata.score_type": %w`, err)}
 		}
 	}
-	if _, ok := vmu.mutation.VulnerabilityIDID(); vmu.mutation.VulnerabilityIDCleared() && !ok {
+	if vmu.mutation.VulnerabilityIDCleared() && len(vmu.mutation.VulnerabilityIDIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnerabilityMetadata.vulnerability_id"`)
 	}
 	return nil
@@ -441,7 +441,7 @@ func (vmuo *VulnerabilityMetadataUpdateOne) check() error {
 			return &ValidationError{Name: "score_type", err: fmt.Errorf(`ent: validator failed for field "VulnerabilityMetadata.score_type": %w`, err)}
 		}
 	}
-	if _, ok := vmuo.mutation.VulnerabilityIDID(); vmuo.mutation.VulnerabilityIDCleared() && !ok {
+	if vmuo.mutation.VulnerabilityIDCleared() && len(vmuo.mutation.VulnerabilityIDIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "VulnerabilityMetadata.vulnerability_id"`)
 	}
 	return nil


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/2057

update ent to the latest and regen code.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
