### PR TITLE
ensure cdx parser does not error on v1.5 or below license parsing

### DIFF
--- a/internal/testing/testdata/exampledata/cdx-v1.4.json
+++ b/internal/testing/testdata/exampledata/cdx-v1.4.json
@@ -1,0 +1,94 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2022-09-18T19:48:00Z",
+        "component": {
+            "type": "application",
+            "author": "Thomas Jensen and the boxes contributors",
+            "name": "boxes",
+            "version": "2.2.0",
+            "description": "Command Line ASCII Boxes Unlimited!",
+            "licenses": [
+                {
+                    "expression": "GPL-3.0-only"
+                }
+            ],
+            "copyright": "Copyright (c) 1999-2021 Thomas Jensen and the boxes contributors",
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://boxes.thomasjensen.com/"
+                },
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/ascii-boxes/boxes/"
+                },
+                {
+                    "type": "issue-tracker",
+                    "url": "https://github.com/ascii-boxes/boxes/issues"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "primaryLanguage",
+                    "value": "C"
+                }
+            ]
+        }
+    },
+    "components": [
+        {
+            "type": "library",
+            "author": "Ben Pfaff, Bruno Haible, and Daiki Ueno",
+            "name": "libunistring",
+            "version": "0.9.10-4",
+            "description": "Functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard",
+            "licenses": [
+                {
+                    "expression": "GPL-3.0-or-later"
+                },
+                {
+                    "expression": "GPL-2.0-only"
+                }
+            ],
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.gnu.org/software/libunistring/"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "primaryLanguage",
+                    "value": "C"
+                }
+            ]
+        },
+        {
+            "type": "library",
+            "author": "Philip Hazel",
+            "name": "PCRE2",
+            "version": "10.40",
+            "description": "PCRE2 - Perl-compatible regular expressions (revised API)",
+            "licenses": [
+                {
+                    "expression": "BSD-3-Clause"
+                }
+            ],
+            "externalReferences": [
+                {
+                    "type": "website",
+                    "url": "https://www.pcre.org/"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "primaryLanguage",
+                    "value": "C"
+                }
+            ]
+        }
+    ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -89,6 +89,9 @@ var (
 	//go:embed exampledata/big-mongo-cyclonedx.json
 	CycloneDXBigExample []byte
 
+	//go:embed exampledata/cdx-v1.4.json
+	CycloneDXVersion1_4 []byte
+
 	//go:embed exampledata/npm-cyclonedx-dependencies-missing-depends-on.json
 	CycloneDXDependenciesMissingDependsOn []byte
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -17,6 +17,7 @@ package cyclonedx
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ func Test_cyclonedxParser(t *testing.T) {
 		doc            *processor.Document
 		wantPredicates *assembler.IngestPredicates
 		wantErr        bool
+		reportedErr    error
 	}{{
 		name: "valid small CycloneDX document",
 		doc: &processor.Document{
@@ -136,6 +138,16 @@ func Test_cyclonedxParser(t *testing.T) {
 		},
 		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
 		wantErr:        false,
+	}, {
+		name: "CycloneDX v1.4 with valid but unparsable license information",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXVersion1_4,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
+		wantErr:        true,
+		reportedErr:    unsupportedLicenseVersionError,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -146,6 +158,12 @@ func Test_cyclonedxParser(t *testing.T) {
 				return
 			}
 			if err != nil {
+				if tt.reportedErr != nil {
+					if !errors.Is(err, tt.reportedErr) {
+						t.Errorf("failed to get error specified = %v, wantErr %v", err, tt.reportedErr)
+						return
+					}
+				}
 				return
 			}
 


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/2048

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
