### PR TITLE
Return hasSBOM and hasSLSA IDs from the assembler

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -99,7 +99,7 @@ func ingest(cmd *cobra.Command, args []string) {
 	defer csubClient.Close()
 
 	emit := func(d *processor.Document) error {
-		if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
+		if _, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
 			var urlErr *url.Error
 			if errors.As(err, &urlErr) {
 				return fmt.Errorf("unable to ingest document due to connection error with graphQL %q : %w", d.SourceInformation.Source, urlErr)

--- a/cmd/guacone/cmd/annotate_metadata.go
+++ b/cmd/guacone/cmd/annotate_metadata.go
@@ -125,7 +125,7 @@ var annotateMetadata = &cobra.Command{
 		preds.HasMetadata = append(preds.HasMetadata, metadata)
 		assemblerInputs := []assembler.IngestPredicates{*preds}
 
-		err = assemblerFunc(assemblerInputs)
+		_, err = assemblerFunc(assemblerInputs)
 		if err != nil {
 			logger.Fatalf("unable to assemble graphs: %v", err)
 		}

--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -152,7 +152,7 @@ var certifyCmd = &cobra.Command{
 
 		assemblerInputs := []assembler.IngestPredicates{*preds}
 
-		err = assemblerFunc(assemblerInputs)
+		_, err = assemblerFunc(assemblerInputs)
 		if err != nil {
 			logger.Fatalf("unable to assemble graphs: %v", err)
 		}

--- a/cmd/guacone/cmd/deps_dev.go
+++ b/cmd/guacone/cmd/deps_dev.go
@@ -87,7 +87,7 @@ var depsDevCmd = &cobra.Command{
 		emit := func(d *processor.Document) error {
 			totalNum += 1
 
-			if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csc, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
+			if _, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csc, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)
 			}

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -129,7 +129,7 @@ var filesCmd = &cobra.Command{
 
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			if err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
+			if _, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion); err != nil {
 				gotErr = true
 				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
 				return fmt.Errorf("unable to ingest document: %w", err)

--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -112,7 +112,7 @@ var gcsCmd = &cobra.Command{
 
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
+			_, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
 
 			if err != nil {
 				gotErr = true

--- a/cmd/guacone/cmd/github.go
+++ b/cmd/guacone/cmd/github.go
@@ -155,7 +155,7 @@ var githubCmd = &cobra.Command{
 		var errFound bool
 
 		emit := func(d *processor.Document) error {
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
+			_, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
 
 			if err != nil {
 				errFound = true

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -90,7 +90,7 @@ var ociCmd = &cobra.Command{
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
+			_, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
 
 			if err != nil {
 				gotErr = true

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -137,7 +137,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 		errFound := false
 
 		emit := func(d *processor.Document) error {
-			err := ingestor.Ingest(ctx, d, s3Opts.graphqlEndpoint, transport, csubClient, s3Opts.queryVulnOnIngestion, s3Opts.queryLicenseOnIngestion)
+			_, err := ingestor.Ingest(ctx, d, s3Opts.graphqlEndpoint, transport, csubClient, s3Opts.queryVulnOnIngestion, s3Opts.queryLicenseOnIngestion)
 
 			if err != nil {
 				errFound = true

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -133,7 +133,7 @@ var scorecardCmd = &cobra.Command{
 		// Set emit function to go through the entire pipeline
 		emit := func(d *processor.Document) error {
 			totalNum += 1
-			err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
+			_, err := ingestor.Ingest(ctx, d, opts.graphqlEndpoint, transport, csubClient, opts.queryVulnOnIngestion, opts.queryLicenseOnIngestion)
 
 			if err != nil {
 				return fmt.Errorf("unable to ingest document: %v", err)

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -8,7 +8,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS	 IS" BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -44,7 +44,7 @@ func Ingest(
 	csubClient csub_client.Client,
 	scanForVulns bool,
 	scanForLicense bool,
-) error {
+) (*helpers.AssemblerIngestedIDs, error) {
 	logger := d.ChildLogger
 	// Get pipeline of components
 	processorFunc := GetProcessor(ctx)
@@ -56,26 +56,26 @@ func Ingest(
 
 	docTree, err := processorFunc(d)
 	if err != nil {
-		return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
+		return nil, fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
 	}
 
 	predicates, idstrings, err := ingestorFunc(docTree)
 	if err != nil {
-		return fmt.Errorf("unable to ingest doc tree: %v", err)
+		return nil, fmt.Errorf("unable to ingest doc tree: %v", err)
 	}
 
 	if err := collectSubEmitFunc(idstrings); err != nil {
 		logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
 	}
 
-	if err := assemblerFunc(predicates); err != nil {
-		return fmt.Errorf("error assembling graphs for %q : %w", d.SourceInformation.Source, err)
+	if ingestedIDs, err := assemblerFunc(predicates); err != nil {
+		return nil, fmt.Errorf("error assembling graphs for %q : %w", d.SourceInformation.Source, err)
 	}
 
 	t := time.Now()
 	elapsed := t.Sub(start)
 	logger.Infof("[%v] completed doc %+v", elapsed, d.SourceInformation)
-	return nil
+	return ingestedIDs, nil
 }
 
 func MergedIngest(
@@ -174,11 +174,11 @@ func GetAssembler(
 	childLogger *zap.SugaredLogger,
 	graphqlEndpoint string,
 	transport http.RoundTripper,
-) func([]assembler.IngestPredicates) error {
+) func([]assembler.IngestPredicates) (*helpers.AssemblerIngestedIDs, error) {
 	httpClient := http.Client{Transport: transport}
 	gqlclient := graphql.NewClient(graphqlEndpoint, &httpClient)
-	f := helpers.GetBulkAssembler(ctx, childLogger, gqlclient)
-	return f
+
+	return helpers.GetBulkAssembler(ctx, childLogger, gqlclient)
 }
 
 func GetCollectSubEmit(ctx context.Context, csubClient csub_client.Client) func([]*parser_common.IdentifierStrings) error {

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -68,7 +68,8 @@ func Ingest(
 		logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
 	}
 
-	if ingestedIDs, err := assemblerFunc(predicates); err != nil {
+	ingestedIDs, err := assemblerFunc(predicates)
+	if err != nil {
 		return nil, fmt.Errorf("error assembling graphs for %q : %w", d.SourceInformation.Source, err)
 	}
 
@@ -130,7 +131,7 @@ func MergedIngest(
 			totalPredicates += 1
 			// enough predicates have been collected, worth sending them to GraphQL server
 			if totalPredicates == 5000 {
-				err = assemblerFunc(predicates)
+				_, err = assemblerFunc(predicates)
 				if err != nil {
 					return fmt.Errorf("unable to assemble graphs: %v", err)
 				}
@@ -147,7 +148,7 @@ func MergedIngest(
 		logger.Infof("unable to create entries in collectsub server, but continuing: %v", err)
 	}
 
-	err = assemblerFunc(predicates)
+	_, err = assemblerFunc(predicates)
 	if err != nil {
 		return fmt.Errorf("unable to assemble graphs: %v", err)
 	}


### PR DESCRIPTION
# Description of the PR

The ingestor will not return hasSBOM and hasSLSA IDs on ingestion that can be used for other queries or as a starting point for GUAC analysis.

IDs output:

```
&{[bill_of_materials:a69bfc10-0ea2-5c5f-a1a3-828adaf21134] []}
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
