### PR TITLE
[fix] cdx parser empty purl identifier and deduplication

### DIFF
--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -117,3 +117,23 @@ func createTopLevelHasSBOM(blob []byte, uri string, source string, timestamp tim
 		},
 	}
 }
+
+func RemoveDuplicateIdentifiers(identifierStrings *IdentifierStrings) {
+	identifierStrings.PurlStrings = removeDuplicate(identifierStrings.PurlStrings)
+	identifierStrings.GithubReleaseStrings = removeDuplicate(identifierStrings.GithubReleaseStrings)
+	identifierStrings.OciStrings = removeDuplicate(identifierStrings.OciStrings)
+	identifierStrings.VcsStrings = removeDuplicate(identifierStrings.VcsStrings)
+	identifierStrings.UnclassifiedStrings = removeDuplicate(identifierStrings.UnclassifiedStrings)
+}
+
+func removeDuplicate[T comparable](sliceList []T) []T {
+	allKeys := make(map[T]bool)
+	list := []T{}
+	for _, item := range sliceList {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -119,11 +119,21 @@ func createTopLevelHasSBOM(blob []byte, uri string, source string, timestamp tim
 }
 
 func RemoveDuplicateIdentifiers(identifierStrings *IdentifierStrings) {
-	identifierStrings.PurlStrings = removeDuplicate(identifierStrings.PurlStrings)
-	identifierStrings.GithubReleaseStrings = removeDuplicate(identifierStrings.GithubReleaseStrings)
-	identifierStrings.OciStrings = removeDuplicate(identifierStrings.OciStrings)
-	identifierStrings.VcsStrings = removeDuplicate(identifierStrings.VcsStrings)
-	identifierStrings.UnclassifiedStrings = removeDuplicate(identifierStrings.UnclassifiedStrings)
+	if len(identifierStrings.PurlStrings) > 0 {
+		identifierStrings.PurlStrings = removeDuplicate(identifierStrings.PurlStrings)
+	}
+	if len(identifierStrings.GithubReleaseStrings) > 0 {
+		identifierStrings.GithubReleaseStrings = removeDuplicate(identifierStrings.GithubReleaseStrings)
+	}
+	if len(identifierStrings.OciStrings) > 0 {
+		identifierStrings.OciStrings = removeDuplicate(identifierStrings.OciStrings)
+	}
+	if len(identifierStrings.VcsStrings) > 0 {
+		identifierStrings.VcsStrings = removeDuplicate(identifierStrings.VcsStrings)
+	}
+	if len(identifierStrings.UnclassifiedStrings) > 0 {
+		identifierStrings.UnclassifiedStrings = removeDuplicate(identifierStrings.UnclassifiedStrings)
+	}
 }
 
 func removeDuplicate[T comparable](sliceList []T) []T {

--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -99,6 +99,8 @@ func (c *csafParser) GetIdentities(ctx context.Context) []common.TrustInformatio
 }
 
 func (c *csafParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(c.identifierStrings)
 	return c.identifierStrings, nil
 }
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -234,7 +234,7 @@ func (c *cyclonedxParser) getPackages() error {
 				return err
 			}
 			c.packagePackages[comp.BOMRef] = append(c.packagePackages[comp.BOMRef], pkg)
-			c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, comp.PackageURL)
+			c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, purl)
 
 			// if checksums exists create an artifact for each of them
 			if comp.Hashes != nil {
@@ -352,6 +352,8 @@ func ParseCycloneDXBOM(doc *processor.Document) (*cdx.BOM, error) {
 }
 
 func (c *cyclonedxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(c.identifierStrings)
 	return c.identifierStrings, nil
 }
 

--- a/pkg/ingestor/parser/deps_dev/deps_dev.go
+++ b/pkg/ingestor/parser/deps_dev/deps_dev.go
@@ -135,5 +135,7 @@ func (d *depsDevParser) GetIdentifiers(ctx context.Context) (*common.IdentifierS
 		pkg := depComp.CurrentPackage
 		idstrings.PurlStrings = append(idstrings.PurlStrings, helpers.PkgInputSpecToPurl(pkg))
 	}
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(idstrings)
 	return idstrings, nil
 }

--- a/pkg/ingestor/parser/open_vex/parser_open_vex.go
+++ b/pkg/ingestor/parser/open_vex/parser_open_vex.go
@@ -111,6 +111,8 @@ func (c *openVEXParser) GetIdentities(ctx context.Context) []common.TrustInforma
 }
 
 func (c *openVEXParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(c.identifierStrings)
 	return c.identifierStrings, nil
 }
 

--- a/pkg/ingestor/parser/scorecard/parser_scorecard.go
+++ b/pkg/ingestor/parser/scorecard/parser_scorecard.go
@@ -89,9 +89,13 @@ func (p *scorecardParser) GetIdentities(ctx context.Context) []common.TrustInfor
 }
 
 func (p *scorecardParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
-	return &common.IdentifierStrings{
+	identifierStrings := &common.IdentifierStrings{
 		VcsStrings: p.vcsStrings,
-	}, nil
+	}
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(identifierStrings)
+
+	return identifierStrings, nil
 }
 
 func (p *scorecardParser) getPredicates(s *sc.JSONScorecardResultV2) error {

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -438,5 +438,7 @@ func (s *slsaParser) GetIdentities(ctx context.Context) []common.TrustInformatio
 }
 
 func (s *slsaParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(s.identifierStrings)
 	return s.identifierStrings, nil
 }

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -476,6 +476,8 @@ func (s *spdxParser) GetIdentities(ctx context.Context) []common.TrustInformatio
 }
 
 func (s *spdxParser) GetIdentifiers(ctx context.Context) (*common.IdentifierStrings, error) {
+	// filter our duplicate identifiers
+	common.RemoveDuplicateIdentifiers(s.identifierStrings)
 	return s.identifierStrings, nil
 }
 


### PR DESCRIPTION
# Description of the PR

fixes #2078 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
