### PR TITLE
remove daysSinceLastScan as it is redundant with certifier interval

### DIFF
--- a/cmd/guacone/cmd/license.go
+++ b/cmd/guacone/cmd/license.go
@@ -96,7 +96,7 @@ var cdCmd = &cobra.Command{
 
 		httpClient := http.Client{Transport: transport}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
-		packageQuery := root_package.NewPackageQuery(gqlclient, 0, opts.batchSize, opts.addedLatency)
+		packageQuery := root_package.NewPackageQuery(gqlclient, opts.batchSize, opts.addedLatency)
 
 		totalNum := 0
 		docChan := make(chan *processor.Document)

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -96,7 +96,7 @@ var osvCmd = &cobra.Command{
 
 		httpClient := http.Client{Transport: transport}
 		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
-		packageQuery := root_package.NewPackageQuery(gqlclient, 0, opts.batchSize, opts.addedLatency)
+		packageQuery := root_package.NewPackageQuery(gqlclient, opts.batchSize, opts.addedLatency)
 
 		totalNum := 0
 		docChan := make(chan *processor.Document)

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -112,8 +112,7 @@ var scorecardCmd = &cobra.Command{
 		}
 
 		// scorecard certifier is the certifier that gets the scorecard data graphQL
-		// setting "daysSinceLastScan" to 0 does not check the timestamp on the scorecard that exist
-		query, err := sc.NewCertifier(gqlclient, 0, opts.batchSize, opts.addedLatency)
+		query, err := sc.NewCertifier(gqlclient, opts.batchSize, opts.addedLatency)
 
 		if err != nil {
 			fmt.Printf("unable to create scorecard certifier: %v\n", err)

--- a/container_files/guac/guac.yaml
+++ b/container_files/guac/guac.yaml
@@ -22,8 +22,7 @@ use-csub: true
 poll: true
 # certifier interval
 interval: 20m
-# days since the last vulnerability scan was run. 0 means only run once
-last-scan: 0
+
 # set the batch size for the package pagination query
 certifier-batch-size: 60000
 # add artificial latency to throttle the certifier

--- a/guac.yaml
+++ b/guac.yaml
@@ -26,8 +26,7 @@ blob-addr: file:///tmp/blobstore?no_tmp_dir=true
 
 # certifier interval
 interval: 20m
-# days since the last vulnerability scan was run. 0 means only run once
-last-scan: 0
+
 # set the batch size for the package pagination query
 certifier-batch-size: 60000
 # add artificial latency to throttle the certifier

--- a/internal/testing/cmd/pubsub_test/cmd/osv.go
+++ b/internal/testing/cmd/pubsub_test/cmd/osv.go
@@ -92,7 +92,7 @@ func getCertifierPublish(ctx context.Context, blobStore *blob.BlobStore, pubsub 
 
 func getPackageQuery(client graphql.Client) (func() certifier.QueryComponents, error) {
 	return func() certifier.QueryComponents {
-		packageQuery := root_package.NewPackageQuery(client, 0, 60000, nil)
+		packageQuery := root_package.NewPackageQuery(client, 60000, nil)
 		return packageQuery
 	}, nil
 }

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -148,8 +148,6 @@ for command in "${ingestion_commands[@]}"; do
   echo @@@@ Waiting
   sleep 60
 
-  go run ${GUAC_DIR}"/cmd/guacone" certifier osv -p=false
-
   if [ $? -ne 0 ]; then
     echo "Error: Command '$command' failed" | tee -a "$LOG_FILE"
     exit 1

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -117,8 +117,6 @@ func init() {
 
 	set.StringP("interval", "i", "5m", "if polling set interval, m, h, s, etc.")
 
-	set.IntP("last-scan", "l", 0, "days since the last vulnerability scan was run. Default 0 means only run once")
-
 	set.BoolP("cert-good", "g", false, "enable to certifyGood, otherwise defaults to certifyBad")
 	set.BoolP("package-name", "n", false, "if type is package, enable if attestation is at package-name level (for all versions), defaults to specific version")
 


### PR DESCRIPTION
# Description of the PR

fixes #2077 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
