### PR TITLE
atlas migration update to build/publish only on tag release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
 
   build-atlas:
     runs-on: ubuntu-latest
-
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Check out the code
         uses: actions/checkout@v3

--- a/pkg/assembler/backends/ent/migrate/atlas.sh
+++ b/pkg/assembler/backends/ent/migrate/atlas.sh
@@ -6,4 +6,4 @@ if [ -z "$PGUSER" ] || [ -z "$PGPASSWORD" ] || [ -z "$PGHOST" ] || [ -z "$PGPORT
   exit 1
 fi
 
-atlas migrate apply --dir file:///app/migrations --url "postgres://$PGUSER:$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE?sslmode=disable"
+atlas migrate apply --dir file:///app/migrations --url "postgres://$PGUSER:$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE?search_path=public"


### PR DESCRIPTION
# Description of the PR

[atlas] add missing search_path and change workflow to publish only on tag release

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
