### PR TITLE
change atlas migration to take into account ent auto migration index names

### DIFF
--- a/pkg/assembler/backends/ent/migrate/migrations/20240826162616_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240826162616_ent_diff.sql
@@ -1,3 +1,7 @@
+-- Change ENT auto-migration index name from "certifylegal_package_id_declar_37fd118fe84f0a1eb9042a047d066a77" to "certifylegal_package_id_declared_license_discovered_license_att" from table: "certify_legals"
+ALTER INDEX IF EXISTS "certifylegal_package_id_declar_37fd118fe84f0a1eb9042a047d066a77" RENAME TO "certifylegal_package_id_declared_license_discovered_license_att";
+-- Change ENT auto-migration index name from "certifylegal_source_id_declare_7172c32e012f5a3f84156bd57473bcd2" to "certifylegal_source_id_declared_license_discovered_license_attr" from table: "certify_legals"
+ALTER INDEX IF EXISTS "certifylegal_source_id_declare_7172c32e012f5a3f84156bd57473bcd2" RENAME TO "certifylegal_source_id_declared_license_discovered_license_attr";
 -- Drop index "certifylegal_package_id_declared_license_discovered_license_att" from table: "certify_legals"
 DROP INDEX "certifylegal_package_id_declared_license_discovered_license_att";
 -- Drop index "certifylegal_source_id_declared_license_discovered_license_attr" from table: "certify_legals"

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:p91DT6mdrk56hQIikoWT8avsWdGxD7Uh9ujfIycAQo0=
+h1:M51Y4ohvnw/wDyk8aQyQCS7gTRQweSLLOOUq/S6KLzI=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -6,4 +6,4 @@ h1:p91DT6mdrk56hQIikoWT8avsWdGxD7Uh9ujfIycAQo0=
 20240712193834_ent_diff.sql h1:gHTfEzlqvgYi6NKwT/Mb+wooWsVjAkp98zfg1OvdoZw=
 20240716182144_ent_diff.sql h1:Pm0/+7zkBUGOY/AiF3bCJzW8giL5+uSg/j/0SUDsuNg=
 20240802204508_ent_diff.sql h1:+qucLy0vqkEDoJsfG4Phh+babyGB5Ud/Dn0+WNB6BLY=
-20240826162616_ent_diff.sql h1:o0yD+RA3Xi8dF0GrpTPquBYqsoKPvva9msDwTHhHCZc=
+20240826162616_ent_diff.sql h1:VyzOoAHvz3Ct8o/nva5qmyFzPOVmrJnXlrwpUCwoCHw=


### PR DESCRIPTION
# Description of the PR

```
-- Change ENT auto-migration index name from "certifylegal_package_id_declar_37fd118fe84f0a1eb9042a047d066a77" to "certifylegal_package_id_declared_license_discovered_license_att" from table: "certify_legals"
-- Change ENT auto-migration index name from "certifylegal_source_id_declare_7172c32e012f5a3f84156bd57473bcd2" to "certifylegal_source_id_declared_license_discovered_license_attr" from table: "certify_legals"
```

This will allow for altas migration to complete successfully when ENT auto migration was used to create the initial DB.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
