### PR TITLE
retry on network error for certifiers

### DIFF
--- a/cmd/guaccollect/cmd/osv.go
+++ b/cmd/guaccollect/cmd/osv.go
@@ -224,8 +224,8 @@ func initializeNATsandCertifier(ctx context.Context, blobAddr, pubsubAddr string
 			return true
 		}
 		logger.Errorf("certifier ended with error: %v", err)
-		// Continue to emit any documents still in the docChan
-		return true
+		// exit the loop but drain the channel first
+		return false
 	}
 
 	ctx, cf := context.WithCancel(ctx)


### PR DESCRIPTION
# Description of the PR

fixes: https://github.com/guacsec/guac/issues/1099

If network error, certifier will re-try 10 times before exiting (draining the channel first if needed).

```
go run ./cmd/guaccollect cd
{"level":"info","ts":1725974740.635828,"caller":"logging/logger.go:79","msg":"Logging at info level","guac-version":"v0.0.1-custom"}
{"level":"info","ts":1725974740.635917,"caller":"cli/init.go:65","msg":"Using config file: /Users/parth/Documents/pxp928/artifact-ff/guac.yaml","guac-version":"v0.0.1-custom"}
{"level":"error","ts":1725974740.641422,"caller":"certify/certify.go:74","msg":"GetComponents failed with error: failed to query packages with error: Post \"http://localhost:8080/query\": dial tcp [::1]:8080: connect: connection refused","guac-version":"v0.0.1-custom","stacktrace":"github.com/guacsec/guac/pkg/certifier/certify.Certify.func1.1\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:74\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify.func1.2.retryWithBackoff.1\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:199\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify.func1.2\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:82"}
Retrying operation in 1.000000 seconds
{"level":"error","ts":1725974741.64575,"caller":"certify/certify.go:74","msg":"GetComponents failed with error: failed to query packages with error: Post \"http://localhost:8080/query\": dial tcp [::1]:8080: connect: connection refused","guac-version":"v0.0.1-custom","stacktrace":"github.com/guacsec/guac/pkg/certifier/certify.Certify.func1.1\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:74\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify.func1.2.retryWithBackoff.1\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:199\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify.func1.2\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:82"}
Retrying operation in 2.000000 seconds
{"level":"error","ts":1725974743.64704,"caller":"cmd/osv.go:226","msg":"certifier ended with error: GetComponents failed with error: failed to query packages with error: Post \"http://localhost:8080/query\": dial tcp [::1]:8080: connect: connection refused","guac-version":"v0.0.1-custom","stacktrace":"github.com/guacsec/guac/cmd/guaccollect/cmd.initializeNATsandCertifier.func2\n\t/Users/parth/Documents/pxp928/artifact-ff/cmd/guaccollect/cmd/osv.go:226\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify.func1\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:93\ngithub.com/guacsec/guac/pkg/certifier/certify.Certify\n\t/Users/parth/Documents/pxp928/artifact-ff/pkg/certifier/certify/certify.go:109\ngithub.com/guacsec/guac/cmd/guaccollect/cmd.initializeNATsandCertifier.func3\n\t/Users/parth/Documents/pxp928/artifact-ff/cmd/guaccollect/cmd/osv.go:237"}
{"level":"fatal","ts":1725974743.647269,"caller":"cmd/osv.go:238","msg":"certifier failed with an error: GetComponents failed with error: failed to query packages with error: Post \"http://localhost:8080/query\": dial tcp [::1]:8080: connect: connection refused","guac-version":"v0.0.1-custom","stacktrace":"github.com/guacsec/guac/cmd/guaccollect/cmd.initializeNATsandCertifier.func3\n\t/Users/parth/Documents/pxp928/artifact-ff/cmd/guaccollect/cmd/osv.go:238"}
exit status 1
```

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
