### PR TITLE
CDX parser captures version as an artifact for images

### DIFF
--- a/internal/testing/testdata/exampledata/distroless-cyclonedx-invalid-version.json
+++ b/internal/testing/testdata/exampledata/distroless-cyclonedx-invalid-version.json
@@ -1,0 +1,180 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:6a44e622-2983-4566-bf90-f87b6103ebaf",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2022-10-08T10:01:23-04:00",
+    "tools": [
+      {
+        "vendor": "anchore",
+        "name": "syft",
+        "version": "0.58.0"
+      }
+    ],
+    "component": {
+      "bom-ref": "5885a240f2842b78",
+      "type": "container",
+      "name": "gcr.io/distroless/static",
+      "version": "nonroot"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:deb/debian/base-files@11.1+deb11u5?arch=amd64\u0026distro=debian-11\u0026package-id=f998ebd648b2753b",
+      "type": "library",
+      "publisher": "Santiago Vila \u003csanvila@debian.org\u003e",
+      "name": "base-files",
+      "version": "11.1+deb11u5",
+      "cpe": "cpe:2.3:a:base-files:base-files:11.1\\+deb11u5:*:*:*:*:*:*:*",
+      "purl": "pkg:deb/debian/base-files@11.1+deb11u5?arch=amd64\u0026distro=debian-11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "dpkgdb-cataloger"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "DpkgMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "deb"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:base-files:base_files:11.1\\+deb11u5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:base_files:base-files:11.1\\+deb11u5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:base_files:base_files:11.1\\+deb11u5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:base:base-files:11.1\\+deb11u5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:base:base_files:11.1\\+deb11u5:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/share/doc/base-files/copyright"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/var/lib/dpkg/status.d/base"
+        },
+        {
+          "name": "syft:metadata:installedSize",
+          "value": "340"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:deb/debian/netbase@6.3?arch=all\u0026distro=debian-11\u0026package-id=913906225fd3778b",
+      "type": "library",
+      "publisher": "Marco d'Itri \u003cmd@linux.it\u003e",
+      "name": "netbase",
+      "version": "6.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "cpe": "cpe:2.3:a:netbase:netbase:6.3:*:*:*:*:*:*:*",
+      "purl": "pkg:deb/debian/netbase@6.3?arch=all\u0026distro=debian-11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "dpkgdb-cataloger"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "DpkgMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "deb"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/share/doc/netbase/copyright"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/var/lib/dpkg/status.d/netbase"
+        },
+        {
+          "name": "syft:metadata:installedSize",
+          "value": "41"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:deb/debian/tzdata@2021a-1+deb11u6?arch=all\u0026distro=debian-11\u0026package-id=c1a811f89bc7edaf",
+      "type": "library",
+      "publisher": "GNU Libc Maintainers \u003cdebian-glibc@lists.debian.org\u003e",
+      "name": "tzdata",
+      "version": "2021a-1+deb11u6",
+      "cpe": "cpe:2.3:a:tzdata:tzdata:2021a-1\\+deb11u6:*:*:*:*:*:*:*",
+      "purl": "pkg:deb/debian/tzdata@2021a-1+deb11u6?arch=all\u0026distro=debian-11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "dpkgdb-cataloger"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "DpkgMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "deb"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/share/doc/tzdata/copyright"
+        },
+        {
+          "name": "syft:location:1:layerID",
+          "value": "sha256:528453af6f60f474766a9e288640095ccbf52e0f09ff068b1d11331c34f8bae1"
+        },
+        {
+          "name": "syft:location:1:path",
+          "value": "/var/lib/dpkg/status.d/tzdata"
+        },
+        {
+          "name": "syft:metadata:installedSize",
+          "value": "3404"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1107,13 +1107,16 @@ var (
 
 	CdxHasSBOM = []assembler.HasSBOMIngest{
 		{
-			Pkg: cdxTopLevelPack,
 			HasSBOM: &model.HasSBOMInputSpec{
 				Uri:              "urn:uuid:6a44e622-2983-4566-bf90-f87b6103ebaf",
 				Algorithm:        "sha256",
 				Digest:           "01942b5eefd3c15b50318c66d8d16627be573197c877e8a286a8cb12de7939cb",
 				DownloadLocation: "TestSource",
 				KnownSince:       cdxTime,
+			},
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha256",
+				Digest:    "6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
 			},
 		},
 	}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -77,6 +77,9 @@ var (
 	//go:embed exampledata/distroless-cyclonedx.json
 	CycloneDXDistrolessExample []byte
 
+	//go:embed exampledata/distroless-cyclonedx-invalid-version.json
+	CycloneDXDistrolessInvalidVersionExample []byte
+
 	//go:embed exampledata/busybox-cyclonedx.json
 	CycloneDXBusyboxExample []byte
 
@@ -1068,6 +1071,8 @@ var (
 	// CycloneDX Testdata
 	cdxTopLevelPack, _ = asmhelpers.PurlToPkg("pkg:guac/cdx/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=nonroot")
 
+	cdxTopLevelInvalidVersionPack, _ = asmhelpers.PurlToPkg("pkg:guac/cdx/gcr.io/distroless/static@nonroot")
+
 	cdxTzdataPack, _ = asmhelpers.PurlToPkg("pkg:deb/debian/tzdata@2021a-1+deb11u6?arch=all&distro=debian-11")
 
 	cdxNetbasePack, _ = asmhelpers.PurlToPkg("pkg:deb/debian/netbase@6.3?arch=all&distro=debian-11")
@@ -1124,6 +1129,51 @@ var (
 	CdxIngestionPredicates = assembler.IngestPredicates{
 		IsDependency: CdxDeps,
 		HasSBOM:      CdxHasSBOM,
+	}
+
+	CdxHasSBOMInvalidVersion = []assembler.HasSBOMIngest{
+		{
+			Pkg: cdxTopLevelInvalidVersionPack,
+			HasSBOM: &model.HasSBOMInputSpec{
+				Uri:              "urn:uuid:6a44e622-2983-4566-bf90-f87b6103ebaf",
+				Algorithm:        "sha256",
+				Digest:           "cb3ea440e0529e8b07e0e1b694e96ec10149fd00d8b634a0027e5e15f11e3c9b",
+				DownloadLocation: "TestSource",
+				KnownSince:       cdxTime,
+			},
+		},
+	}
+
+	CdxInvalidVersionDeps = []assembler.IsDependencyIngest{
+		{
+			Pkg:    cdxTopLevelInvalidVersionPack,
+			DepPkg: cdxBasefilesPack,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    cdxTopLevelInvalidVersionPack,
+			DepPkg: cdxNetbasePack,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    cdxTopLevelInvalidVersionPack,
+			DepPkg: cdxTzdataPack,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+	}
+
+	CdxIngestionInvalidVersionPredicates = assembler.IngestPredicates{
+		IsDependency: CdxInvalidVersionDeps,
+		HasSBOM:      CdxHasSBOMInvalidVersion,
 	}
 
 	cdxTopQuarkusPack, _ = asmhelpers.PurlToPkg("pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar")

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -360,7 +360,7 @@ func (c *cyclonedxParser) GetIdentifiers(ctx context.Context) (*common.Identifie
 func getArtifactInput(subject string) (*model.ArtifactInputSpec, error) {
 	split := strings.Split(subject, ":")
 	if len(split) != 2 {
-		return nil, fmt.Errorf("failed to parse artifact. Needs to be in algorithm:digest form")
+		return nil, fmt.Errorf("failed to parse subject: %s. Needs to be in algorithm:digest form", subject)
 	}
 	artifactInput := &model.ArtifactInputSpec{
 		Algorithm: strings.ToLower(split[0]),
@@ -384,11 +384,11 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 			if topLevelPkgs[0].Version != nil && *topLevelPkgs[0].Version != "" {
 				artInput, err := getArtifactInput(*topLevelPkgs[0].Version)
 				if err != nil {
-					logger.Errorf("CDX artifact was not parsable: %v", err)
+					logger.Infof("CDX artifact was not parsable: %v", err)
+				} else {
+					topLevelArts = append(topLevelArts, artInput)
+					logger.Infof("getArtInput %v", artInput)
 				}
-				topLevelArts = append(topLevelArts, artInput)
-
-				logger.Infof("getArtInput %v", artInput)
 			}
 		} else {
 			topLevelArts = c.packageArtifacts[c.cdxBom.Metadata.Component.BOMRef]

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -69,7 +69,7 @@ type vulnData struct {
 	vex          []assembler.VexIngest
 }
 
-var unsupportedLicenseVersionError error = errors.New("GUAC CycloneDX license ingestion currently only support CycloneDX v1.5")
+var errUnsupportedLicenseVersion error = errors.New("GUAC CycloneDX license ingestion currently only support CycloneDX v1.5")
 
 func NewCycloneDXParser() common.DocumentParser {
 	return &cyclonedxParser{
@@ -294,7 +294,7 @@ func (c *cyclonedxParser) getLicenseInformation(comp cdx.Component) error {
 				// having multiple expressions is not valid per v1.5 so we currently do not support any
 				// version below it.
 				if compLicense.Expression != "" {
-					return unsupportedLicenseVersionError
+					return errUnsupportedLicenseVersion
 				}
 				// skip if the license is not set or the SPDX expression is not set
 				if compLicense.License == nil {
@@ -505,7 +505,6 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 							if dependencyType == model.DependencyTypeUnknown {
 								justificationStr = "top-level package GUAC heuristic connecting to each file/package"
 							}
-							fmt.Println(topLevelPkgs, topLevelArts)
 							p, err := common.GetIsDep(topLevelPkgs[0], depPkg, []*model.PkgInputSpec{}, justificationStr, dependencyType)
 							if err != nil {
 								logger.Errorf("error generating CycloneDX edge %v", err)

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -147,7 +147,7 @@ func Test_cyclonedxParser(t *testing.T) {
 		},
 		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
 		wantErr:        true,
-		reportedErr:    unsupportedLicenseVersionError,
+		reportedErr:    errUnsupportedLicenseVersion,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -54,6 +54,19 @@ func Test_cyclonedxParser(t *testing.T) {
 		wantPredicates: &testdata.CdxIngestionPredicates,
 		wantErr:        false,
 	}, {
+		name: "valid small CycloneDX document - invalid container version",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXDistrolessInvalidVersionExample,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+			SourceInformation: processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		},
+		wantPredicates: &testdata.CdxIngestionInvalidVersionPredicates,
+		wantErr:        false,
+	}, {
 		name: "valid small CycloneDX document with package dependencies and a hash",
 		doc: &processor.Document{
 			Blob:   testdata.CycloneDXExampleSmallDeps,


### PR DESCRIPTION
# Description of the PR

* Checking if the version contains the image hash and using that as the artifact.
* Fixes https://github.com/guacsec/guac/issues/2098

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
