### PR TITLE
Update CD certifier to ignore LicenseRef licenses

### DIFF
--- a/pkg/ingestor/parser/clearlydefined/clearlydefined.go
+++ b/pkg/ingestor/parser/clearlydefined/clearlydefined.go
@@ -113,11 +113,11 @@ func (c *parser) parseClearlyDefined(_ context.Context, s *attestation.ClearlyDe
 		var discoveredLicenseStr string = ""
 		if len(s.Predicate.Definition.Licensed.Facets.Core.Discovered.Expressions) > 0 {
 			discoveredLicenseStr = common.CombineLicense(s.Predicate.Definition.Licensed.Facets.Core.Discovered.Expressions)
-			discoveredLicenses = append(discoveredLicenses, common.ParseLicenses(discoveredLicenseStr, nil, nil)...)
+			discoveredLicenses = append(discoveredLicenses, common.ParseLicenses(discoveredLicenseStr, nil, nil, true)...)
 		}
 
 		declared := assembler.CertifyLegalIngest{
-			Declared:   common.ParseLicenses(s.Predicate.Definition.Licensed.Declared, nil, nil),
+			Declared:   common.ParseLicenses(s.Predicate.Definition.Licensed.Declared, nil, nil, true),
 			Discovered: discoveredLicenses,
 			CertifyLegal: &generated.CertifyLegalInputSpec{
 				DeclaredLicense:   s.Predicate.Definition.Licensed.Declared,
@@ -140,7 +140,7 @@ func (c *parser) parseClearlyDefined(_ context.Context, s *attestation.ClearlyDe
 
 			discovered := assembler.CertifyLegalIngest{
 				Declared:   []generated.LicenseInputSpec{},
-				Discovered: common.ParseLicenses(discoveredLicense, nil, nil),
+				Discovered: common.ParseLicenses(discoveredLicense, nil, nil, true),
 				CertifyLegal: &generated.CertifyLegalInputSpec{
 					DiscoveredLicense: discoveredLicense,
 					DeclaredLicense:   "",

--- a/pkg/ingestor/parser/common/license.go
+++ b/pkg/ingestor/parser/common/license.go
@@ -69,7 +69,7 @@ var ignore = []string{
 // "Universal-FOSS-exception-1.0",
 // "WxWindows-exception-3.1",
 
-func ParseLicenses(exp string, lv *string, inLineMap map[string]string) []model.LicenseInputSpec {
+func ParseLicenses(exp string, lv *string, inLineMap map[string]string, ignoreLR bool) []model.LicenseInputSpec {
 	if exp == "" {
 		return nil
 	}
@@ -78,6 +78,9 @@ func ParseLicenses(exp string, lv *string, inLineMap map[string]string) []model.
 	for _, part := range strings.Split(exp, " ") {
 		p := strings.Trim(part, "()+")
 		if slices.Contains(ignore, p) {
+			continue
+		}
+		if ignoreLR && strings.HasPrefix(p, "LicenseRef") {
 			continue
 		}
 		var license model.LicenseInputSpec

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -409,8 +409,8 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 	// license information
 	for id, cls := range c.packageLegals {
 		for _, cl := range cls {
-			dec := common.ParseLicenses(cl.DeclaredLicense, nil, c.licenseInLine)
-			dis := common.ParseLicenses(cl.DiscoveredLicense, nil, c.licenseInLine)
+			dec := common.ParseLicenses(cl.DeclaredLicense, nil, c.licenseInLine, false)
+			dis := common.ParseLicenses(cl.DiscoveredLicense, nil, c.licenseInLine, false)
 			for _, pkg := range c.packagePackages[id] {
 				cli := assembler.CertifyLegalIngest{
 					Pkg:          pkg,

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -373,8 +373,8 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 	}
 	for id, cls := range s.packageLegals {
 		for _, cl := range cls {
-			dec := common.ParseLicenses(cl.DeclaredLicense, &lv, nil)
-			dis := common.ParseLicenses(cl.DiscoveredLicense, &lv, nil)
+			dec := common.ParseLicenses(cl.DeclaredLicense, &lv, nil, false)
+			dis := common.ParseLicenses(cl.DiscoveredLicense, &lv, nil, false)
 			for i := range dec {
 				o, n := fixLicense(ctx, &dec[i], s.spdxDoc.OtherLicenses)
 				if o != "" {


### PR DESCRIPTION
# Description of the PR

Firs step of #2133

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
