### PR TITLE
Fix guacEmpty being added into the ENT DB causing errors

### DIFF
--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	srcTypeString      = "source_types"
-	srcNamespaceString = "source_namespaces"
+	srcTypeString             = "source_types"
+	srcNamespaceString        = "source_namespaces"
+	guacEmpty          string = "guac-empty-@@"
 )
 
 func hasSourceAtGlobalID(id string) string {
@@ -539,13 +540,38 @@ func upsertBulkSource(ctx context.Context, tx *ent.Tx, srcInputs []*model.IDorSo
 }
 
 func generateSourceNameCreate(tx *ent.Tx, srcNameID *uuid.UUID, srcInput *model.IDorSourceInput) *ent.SourceNameCreate {
+	var namespace string
+	var tag *string
+	var commit *string
+	if srcInput.SourceInput.Namespace == guacEmpty {
+		namespace = ""
+	} else {
+		namespace = srcInput.SourceInput.Namespace
+	}
+
+	if srcInput.SourceInput.Tag != nil {
+		if *srcInput.SourceInput.Tag == guacEmpty {
+			tag = ptrfrom.String("")
+		} else {
+			tag = srcInput.SourceInput.Tag
+		}
+	}
+
+	if srcInput.SourceInput.Commit != nil {
+		if *srcInput.SourceInput.Commit == guacEmpty {
+			commit = ptrfrom.String("")
+		} else {
+			commit = srcInput.SourceInput.Commit
+		}
+	}
+
 	return tx.SourceName.Create().
 		SetID(*srcNameID).
 		SetType(srcInput.SourceInput.Type).
-		SetNamespace(srcInput.SourceInput.Namespace).
+		SetNamespace(namespace).
 		SetName(srcInput.SourceInput.Name).
-		SetTag(stringOrEmpty(srcInput.SourceInput.Tag)).
-		SetCommit(stringOrEmpty(srcInput.SourceInput.Commit))
+		SetTag(stringOrEmpty(tag)).
+		SetCommit(stringOrEmpty(commit))
 }
 
 func upsertSource(ctx context.Context, tx *ent.Tx, src model.IDorSourceInput) (*model.SourceIDs, error) {

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -540,6 +540,8 @@ func upsertBulkSource(ctx context.Context, tx *ent.Tx, srcInputs []*model.IDorSo
 }
 
 func generateSourceNameCreate(tx *ent.Tx, srcNameID *uuid.UUID, srcInput *model.IDorSourceInput) *ent.SourceNameCreate {
+
+	// ensure that guacEmpty does not get added into the DB
 	var namespace string
 	var tag *string
 	var commit *string

--- a/pkg/assembler/backends/ent/migrate/migrations/20240918165345.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240918165345.sql
@@ -1,0 +1,15 @@
+-- Update the 'namespace' field if it contains 'guac-empty-@@'
+UPDATE source_names
+SET namespace = REPLACE(namespace, 'guac-empty-@@', '')
+WHERE namespace LIKE '%guac-empty-@@%';
+
+-- Update the 'tag' field if it contains 'guac-empty-@@'
+UPDATE source_names
+SET tag = REPLACE(tag, 'guac-empty-@@', '')
+WHERE tag LIKE '%guac-empty-@@%';
+
+-- Update the 'commit' field if it contains 'guac-empty-@@'
+UPDATE source_names
+SET commit = REPLACE(commit, 'guac-empty-@@', '')
+WHERE commit LIKE '%guac-empty-@@%';
+

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:M51Y4ohvnw/wDyk8aQyQCS7gTRQweSLLOOUq/S6KLzI=
+h1:4m5T/TgdBGibMa72PIaSuAkf+RI5hL1fQLxBH53lRas=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -7,3 +7,4 @@ h1:M51Y4ohvnw/wDyk8aQyQCS7gTRQweSLLOOUq/S6KLzI=
 20240716182144_ent_diff.sql h1:Pm0/+7zkBUGOY/AiF3bCJzW8giL5+uSg/j/0SUDsuNg=
 20240802204508_ent_diff.sql h1:+qucLy0vqkEDoJsfG4Phh+babyGB5Ud/Dn0+WNB6BLY=
 20240826162616_ent_diff.sql h1:VyzOoAHvz3Ct8o/nva5qmyFzPOVmrJnXlrwpUCwoCHw=
+20240918165345.sql h1:wpfJhr9rJSWWzbTA85rnLppDjGscJVaFpE1uZJXpScY=

--- a/pkg/assembler/helpers/source.go
+++ b/pkg/assembler/helpers/source.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -83,18 +84,31 @@ func GuacSrcIdToSourceInput(srcID string) (*generated.SourceInputSpec, error) {
 	}
 
 	srcInput := &generated.SourceInputSpec{
-		Type:      srcIDSplit[0],
-		Namespace: srcIDSplit[1],
-		Name:      srcIDSplit[2],
+		Type: srcIDSplit[0],
+		Name: srcIDSplit[2],
+	}
+
+	if srcIDSplit[1] == guacEmpty {
+		srcInput.Namespace = ""
+	} else {
+		srcInput.Namespace = srcIDSplit[1]
 	}
 
 	if srcIDSplit[3] != "" {
-		srcInput.Tag = &srcIDSplit[3]
+		if srcIDSplit[3] == guacEmpty {
+			srcInput.Tag = ptrfrom.String("")
+		} else {
+			srcInput.Tag = &srcIDSplit[3]
+		}
 	}
 
 	trimmedCommit := strings.TrimRight(srcIDSplit[4], "?")
 	if trimmedCommit != "" {
-		srcInput.Commit = &trimmedCommit
+		if trimmedCommit == guacEmpty {
+			srcInput.Commit = ptrfrom.String("")
+		} else {
+			srcInput.Commit = &trimmedCommit
+		}
 	}
 
 	return srcInput, nil

--- a/pkg/assembler/helpers/source_test.go
+++ b/pkg/assembler/helpers/source_test.go
@@ -191,6 +191,15 @@ func TestGuacSrcIdToSourceInput(t *testing.T) {
 				Tag:       ptrfrom.String("2.8.1"),
 			},
 		},
+		{
+			srcID: "pypi::guac-empty-@@::click::8.1.7::?",
+			want: &generated.SourceInputSpec{
+				Type:      "pypi",
+				Namespace: "",
+				Name:      "click",
+				Tag:       ptrfrom.String("8.1.7"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.srcID, func(t *testing.T) {

--- a/pkg/assembler/helpers/source_test.go
+++ b/pkg/assembler/helpers/source_test.go
@@ -200,6 +200,25 @@ func TestGuacSrcIdToSourceInput(t *testing.T) {
 				Tag:       ptrfrom.String("8.1.7"),
 			},
 		},
+		{
+			srcID: "pypi::guac-empty-@@::click::guac-empty-@@::?",
+			want: &generated.SourceInputSpec{
+				Type:      "pypi",
+				Namespace: "",
+				Name:      "click",
+				Tag:       ptrfrom.String(""),
+			},
+		},
+		{
+			srcID: "pypi::guac-empty-@@::click::8.1.7::guac-empty-@@?",
+			want: &generated.SourceInputSpec{
+				Type:      "pypi",
+				Namespace: "",
+				Name:      "click",
+				Tag:       ptrfrom.String("8.1.7"),
+				Commit:    ptrfrom.String(""),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.srcID, func(t *testing.T) {


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/2135

This PR also creates an Atlas migration that will fix this issue for any running instance of GUAC (ENT backend) if needed.

I did some testing locally and the migration works as intended.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
