### PR TITLE
[ENT] drop discovered_license from required index on certifyLegal

### DIFF
--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -142,7 +142,6 @@ func (b *EntBackend) IngestCertifyLegals(ctx context.Context, subjects model.Pac
 func certifyLegalConflictColumns() []string {
 	return []string{
 		certifylegal.FieldDeclaredLicense,
-		certifylegal.FieldDiscoveredLicense,
 		certifylegal.FieldJustification,
 		certifylegal.FieldTimeScanned,
 		certifylegal.FieldOrigin,

--- a/pkg/assembler/backends/ent/migrate/migrations/20240919142722_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20240919142722_ent_diff.sql
@@ -1,0 +1,8 @@
+-- Drop index "certifylegal_package_id_declared_license_discovered_license_jus" from table: "certify_legals"
+DROP INDEX "certifylegal_package_id_declared_license_discovered_license_jus";
+-- Drop index "certifylegal_source_id_declared_license_discovered_license_just" from table: "certify_legals"
+DROP INDEX "certifylegal_source_id_declared_license_discovered_license_just";
+-- Create index "certifylegal_package_id_declared_license_justification_time_sca" to table: "certify_legals"
+CREATE UNIQUE INDEX "certifylegal_package_id_declared_license_justification_time_sca" ON "certify_legals" ("package_id", "declared_license", "justification", "time_scanned", "origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash") WHERE ((package_id IS NOT NULL) AND (source_id IS NULL));
+-- Create index "certifylegal_source_id_declared_license_justification_time_scan" to table: "certify_legals"
+CREATE UNIQUE INDEX "certifylegal_source_id_declared_license_justification_time_scan" ON "certify_legals" ("source_id", "declared_license", "justification", "time_scanned", "origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash") WHERE ((package_id IS NULL) AND (source_id IS NOT NULL));

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4m5T/TgdBGibMa72PIaSuAkf+RI5hL1fQLxBH53lRas=
+h1:3eRFoV2cM7hzSkmdDQ8HwhoF99Mp0L9r4o4UFWTzXe4=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -8,3 +8,4 @@ h1:4m5T/TgdBGibMa72PIaSuAkf+RI5hL1fQLxBH53lRas=
 20240802204508_ent_diff.sql h1:+qucLy0vqkEDoJsfG4Phh+babyGB5Ud/Dn0+WNB6BLY=
 20240826162616_ent_diff.sql h1:VyzOoAHvz3Ct8o/nva5qmyFzPOVmrJnXlrwpUCwoCHw=
 20240918165345.sql h1:wpfJhr9rJSWWzbTA85rnLppDjGscJVaFpE1uZJXpScY=
+20240919142722_ent_diff.sql h1:hcb42aHj5QUwbd7HXsUFnnAzHIckdXfGRDNYa24rns8=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -235,17 +235,17 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifylegal_source_id_declared_license_discovered_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_source_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
 			},
 			{
-				Name:    "certifylegal_package_id_declared_license_discovered_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_package_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},

--- a/pkg/assembler/backends/ent/schema/certifylegal.go
+++ b/pkg/assembler/backends/ent/schema/certifylegal.go
@@ -63,11 +63,11 @@ func (CertifyLegal) Edges() []ent.Edge {
 
 func (CertifyLegal) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("source_id", "declared_license", "discovered_license", "justification", "time_scanned",
+		index.Fields("source_id", "declared_license", "justification", "time_scanned",
 			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")),
-		index.Fields("package_id", "declared_license", "discovered_license", "justification", "time_scanned",
+		index.Fields("package_id", "declared_license", "justification", "time_scanned",
 			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),


### PR DESCRIPTION
# Description of the PR

drop discovered_license from required index as it is covered by the discovered_license_hash
Migration also created!


fixes https://github.com/guacsec/guac/issues/2138


# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
