### PR TITLE
fix error handling on certifier

### DIFF
--- a/cmd/guaccollect/cmd/osv.go
+++ b/cmd/guaccollect/cmd/osv.go
@@ -222,9 +222,9 @@ func initializeNATsandCertifier(ctx context.Context, blobAddr, pubsubAddr string
 		if err == nil {
 			return true
 		}
-		logger.Errorf("certifier ended with error: %v", err)
-		// exit the loop but drain the channel first
-		return false
+		logger.Errorf("certifier encountered an error: %v, continuing...", err)
+		// log the error but continue forward with the rest of the package processing
+		return true
 	}
 
 	ctx, cf := context.WithCancel(ctx)

--- a/pkg/certifier/certify/certify.go
+++ b/pkg/certifier/certify/certify.go
@@ -90,7 +90,7 @@ func Certify(ctx context.Context, query certifier.QueryComponents, emitter certi
 					return fmt.Errorf("generate certifier documents error: %w", err)
 				}
 			case err := <-errChan:
-				if !handleErr(err) {
+				if err != nil {
 					// drain channel before exiting
 					drainComponentChannel(compChan, ctx, emitter, handleErr)
 					return err
@@ -119,14 +119,14 @@ func Certify(ctx context.Context, query certifier.QueryComponents, emitter certi
 			select {
 			case <-ticker.C:
 				// add logging to determine when the certifier run is started
-				logger.Infof("Starting polling certifier run: %v", time.Now().UTC())
+				logger.Infof("Starting certifier run: %v", time.Now().UTC())
 				err := runCertifier()
 				if err != nil {
 					return fmt.Errorf("certifier failed with an error: %w", err)
 				}
 				// reset the interval timer and log completion of the current certifier run
 				ticker.Reset(interval)
-				logger.Infof("Certifier polling run completed: %v", time.Now().UTC())
+				logger.Infof("Certifier run completed: %v", time.Now().UTC())
 			// if the context has been canceled return the err.
 			case <-ctx.Done():
 				return ctx.Err() // nolint:wrapcheck

--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -39,7 +39,7 @@ func PurlsVulnScan(ctx context.Context, purls []string) ([]assembler.VulnEqualIn
 
 	if osvProcessorDocs, err := osv_certifier.EvaluateOSVResponse(ctx, &http.Client{
 		Transport: version.UATransport,
-	}, purls); err != nil {
+	}, purls, nil); err != nil {
 		return nil, nil, fmt.Errorf("failed get response from OSV with error: %w", err)
 	} else {
 		for _, doc := range osvProcessorDocs {
@@ -109,7 +109,7 @@ func runQueryOnBatchedPurls(ctx context.Context, cdParser common.DocumentParser,
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 	if cdProcessorDocs, err := cd_certifier.EvaluateClearlyDefinedDefinition(ctx, &http.Client{
 		Transport: version.UATransport,
-	}, batchPurls); err != nil {
+	}, batchPurls, nil); err != nil {
 		return nil, nil, fmt.Errorf("failed get definition from clearly defined with error: %w", err)
 	} else {
 		for _, doc := range cdProcessorDocs {


### PR DESCRIPTION
# Description of the PR

fix error handling on certifier to fail on network error when graphQL server is not up but keep running when a service issue is encountered.

fixes https://github.com/guacsec/guac/issues/2150

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
