### PR TITLE
improve on ingestion license check

### DIFF
--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -64,40 +64,12 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 	var certLegalIngest []assembler.CertifyLegalIngest
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 
-	if len(purls) > 249 {
-		i := 0
-		var batchPurls []string
-		for _, purl := range purls {
-			if i < 248 {
-				batchPurls = append(batchPurls, purl)
-				i++
-			} else {
-				batchPurls = append(batchPurls, purl)
-				batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, batchPurls)
-				if err != nil {
-					return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
-				}
-				certLegalIngest = append(certLegalIngest, batchedCL...)
-				hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
-				batchPurls = make([]string, 0)
-			}
-		}
-		if len(batchPurls) > 0 {
-			batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, batchPurls)
-			if err != nil {
-				return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
-			}
-			certLegalIngest = append(certLegalIngest, batchedCL...)
-			hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
-		}
-	} else {
-		batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, purls)
-		if err != nil {
-			return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
-		}
-		certLegalIngest = append(certLegalIngest, batchedCL...)
-		hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
+	batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, purls)
+	if err != nil {
+		return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
 	}
+	certLegalIngest = append(certLegalIngest, batchedCL...)
+	hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
 
 	return certLegalIngest, hasSourceAtIngest, nil
 }
@@ -109,7 +81,7 @@ func runQueryOnBatchedPurls(ctx context.Context, cdParser common.DocumentParser,
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 	if cdProcessorDocs, err := cd_certifier.EvaluateClearlyDefinedDefinition(ctx, &http.Client{
 		Transport: version.UATransport,
-	}, batchPurls, nil); err != nil {
+	}, batchPurls, nil, false); err != nil {
 		return nil, nil, fmt.Errorf("failed get definition from clearly defined with error: %w", err)
 	} else {
 		for _, doc := range cdProcessorDocs {

--- a/pkg/ingestor/parser/common/scanner/scanner_test.go
+++ b/pkg/ingestor/parser/common/scanner/scanner_test.go
@@ -373,27 +373,6 @@ func TestPurlsLicenseScan(t *testing.T) {
 					Collector:         "clearlydefined",
 				},
 			},
-			{
-				Src: &generated.SourceInputSpec{
-					Type:      "sourcearchive",
-					Namespace: "org.apache.logging.log4j",
-					Name:      "log4j-core",
-					Tag:       ptrfrom.String("2.8.1"),
-				},
-				Declared: []generated.LicenseInputSpec{},
-				Discovered: []generated.LicenseInputSpec{
-					{Name: "Apache-2.0", ListVersion: &lvUnknown},
-					{Name: "NOASSERTION", ListVersion: &lvUnknown},
-				},
-				CertifyLegal: &generated.CertifyLegalInputSpec{
-					DiscoveredLicense: "Apache-2.0 AND NOASSERTION",
-					Attribution:       "Copyright 2005-2006 Tim Fennell,Copyright 1999-2012 Apache Software Foundation,Copyright 1999-2005 The Apache Software Foundation",
-					Justification:     "Retrieved from ClearlyDefined",
-					TimeScanned:       tm,
-					Origin:            "clearlydefined",
-					Collector:         "clearlydefined",
-				},
-			},
 		},
 		wantHSAs: []assembler.HasSourceAtIngest{
 			{


### PR DESCRIPTION
# Description of the PR

- remove unneeded batching (as the rate limit was not being hit)
- do not query for source license on ingestion (only enabled when the certifier runs)

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
