### PR TITLE
CycloneDX SBOM: support nested components

### DIFF
--- a/internal/testing/testdata/exampledata/cyclonedx-components-flat.json
+++ b/internal/testing/testdata/exampledata/cyclonedx-components-flat.json
@@ -1,0 +1,91 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:c096003c-c9fa-4d9e-9390-fefa51745fe1",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-09-24T08:20:03Z",
+    "component": {
+      "type": "container",
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416"
+    }
+  },
+  "components": [
+    {
+      "type": "container",
+      "bom-ref": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416",
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "version": "sha256:41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "publisher": "Red Hat, Inc.",
+      "name": "abattis-cantarell-fonts",
+      "version": "0.0.25-6.el8",
+      "purl": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+      "name": "compiler",
+      "version": "23.1.4.0-1-redhat-00001",
+      "purl": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+      "externalReferences": [
+        {
+          "type": "build-meta",
+          "url": "",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "e96edb6e7bab65204479c293378a7485ae2d1c8f"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416",
+      "dependsOn": [
+        "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+        "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+      "dependsOn": []
+    }
+  ]
+}

--- a/internal/testing/testdata/exampledata/cyclonedx-components-nested.json
+++ b/internal/testing/testdata/exampledata/cyclonedx-components-nested.json
@@ -1,0 +1,93 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:c096003c-c9fa-4d9e-9390-fefa51745fe1",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-09-24T08:20:03Z",
+    "component": {
+      "type": "container",
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416"
+    }
+  },
+  "components": [
+    {
+      "type": "container",
+      "bom-ref": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416",
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "version": "sha256:41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416",
+      "components": [
+        {
+          "type": "library",
+          "bom-ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+          "publisher": "Red Hat, Inc.",
+          "name": "abattis-cantarell-fonts",
+          "version": "0.0.25-6.el8",
+          "purl": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+          "properties": [
+            {
+              "name": "sbomer:package:type",
+              "value": "rpm"
+            },
+            {
+              "name": "sbomer:location:0:path",
+              "value": "/var/lib/rpm/Packages"
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "bom-ref": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+          "name": "compiler",
+          "version": "23.1.4.0-1-redhat-00001",
+          "purl": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+          "externalReferences": [
+            {
+              "type": "build-meta",
+              "url": "",
+              "hashes": [
+                {
+                  "alg": "SHA-1",
+                  "content": "e96edb6e7bab65204479c293378a7485ae2d1c8f"
+                }
+              ]
+            }
+          ],
+          "properties": [
+            {
+              "name": "sbomer:package:language",
+              "value": "java"
+            },
+            {
+              "name": "sbomer:package:type",
+              "value": "java-archive"
+            },
+            {
+              "name": "sbomer:location:0:path",
+              "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416",
+      "dependsOn": [
+        "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+        "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar",
+      "dependsOn": []
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -18,6 +18,7 @@ package testdata
 import (
 	_ "embed"
 	"encoding/base64"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -3464,8 +3465,14 @@ func certifyScorecardLess(e1, e2 assembler.CertifyScorecardIngest) bool {
 	return gLess(e1, e2)
 }
 
-func isDependencyLess(e1, e2 assembler.IsDependencyIngest) bool {
-	return gLess(e1, e2)
+func isDependencyLess(a, b assembler.IsDependencyIngest) bool {
+	if strings.Compare(a.Pkg.Name, b.Pkg.Name) != 0 {
+		return a.Pkg.Name < b.Pkg.Name
+	}
+	if d := strings.Compare(a.DepPkg.Name, b.DepPkg.Name); d != 0 {
+		return a.DepPkg.Name < b.DepPkg.Name
+	}
+	return false
 }
 
 func isOccurenceLess(e1, e2 assembler.IsOccurrenceIngest) bool {

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -194,6 +194,12 @@ var (
 	//go:embed exampledata/small-legal-cyclonedx.json
 	CycloneDXLegalExample []byte
 
+	//go:embed exampledata/cyclonedx-components-nested.json
+	CycloneDXComponentsNested []byte
+
+	//go:embed exampledata/cyclonedx-components-flat.json
+	CycloneDXComponentsFlat []byte
+
 	// json format
 	json = jsoniter.ConfigCompatibleWithStandardLibrary
 	// CycloneDX VEX testdata unaffected
@@ -1624,6 +1630,123 @@ var (
 		HasSBOM:      quarkusParentPackageHasSBOM,
 		CertifyLegal: quarkusParentPackageLegal,
 	}
+
+	NestedComponentsPredicates = assembler.IngestPredicates{
+		IsDependency: ociComponentsIsDependencyIngests,
+		IsOccurrence: []assembler.IsOccurrenceIngest{
+			{
+				Pkg:          ociMandrel,
+				Artifact:     ociMandrelArtifact,
+				IsOccurrence: isOccurrenceJustifyTopPkg,
+			},
+		},
+		HasSBOM: nestedComponentsHasSBOM,
+	}
+
+	FlatComponentsPredicates = assembler.IngestPredicates{
+		IsDependency: ociComponentsIsDependencyIngests,
+		IsOccurrence: []assembler.IsOccurrenceIngest{
+			{
+				Pkg:          ociMandrel,
+				Artifact:     ociMandrelArtifact,
+				IsOccurrence: isOccurrenceJustifyTopPkg,
+			},
+		},
+		HasSBOM: flatComponentsHasSBOM,
+	}
+
+	ociComponentsIsDependencyIngests = []assembler.IsDependencyIngest{
+		{
+			Pkg:    ociMandrel,
+			DepPkg: mavenCompiler,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeDirect,
+				Justification:  isCDXDepJustifyDependsJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: mavenCompiler,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: mavenCompiler,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: ociMandrel,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: abattisCantarellFonts,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeDirect,
+				Justification:  isCDXDepJustifyDependsJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: abattisCantarellFonts,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:    ociMandrel,
+			DepPkg: abattisCantarellFonts,
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+	}
+
+	ociMandrel, _            = asmhelpers.PurlToPkg("pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04?arch=amd64&os=linux&tag=23.1-13.1724180416")
+	mavenCompiler, _         = asmhelpers.PurlToPkg("pkg:maven/compiler/compiler@23.1.4.0-1-redhat-00001?type=jar")
+	abattisCantarellFonts, _ = asmhelpers.PurlToPkg("pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch")
+	ociMandrelArtifact       = &model.ArtifactInputSpec{
+		Algorithm: "sha256",
+		Digest:    "41d92dafa5ccbf7f76fa81c5a0e7de83c51166f27bea9b98df018f644016bf04",
+	}
+
+	nestedComponentsHasSBOM = []assembler.HasSBOMIngest{
+		{
+			Artifact: ociMandrelArtifact,
+			HasSBOM: &model.HasSBOMInputSpec{
+				Uri:        "urn:uuid:c096003c-c9fa-4d9e-9390-fefa51745fe1",
+				Algorithm:  "sha256",
+				Digest:     "6a9598f69e87d0c45f3dd4c5d69d8812b734b28f07506a9f7b6ada7e9696c5e5",
+				KnownSince: nestedComponentsTime,
+			},
+		},
+	}
+
+	flatComponentsHasSBOM = []assembler.HasSBOMIngest{
+		{
+			Artifact: ociMandrelArtifact,
+			HasSBOM: &model.HasSBOMInputSpec{
+				Uri:        "urn:uuid:c096003c-c9fa-4d9e-9390-fefa51745fe1",
+				Algorithm:  "sha256",
+				Digest:     "1dedfbd09dbf68a29279395444e76f300285cf1731ad25f39252c4d689403531",
+				KnownSince: nestedComponentsTime,
+			},
+		},
+	}
+
+	nestedComponentsTime, _ = time.Parse(time.RFC3339, "2024-09-24T08:20:03Z")
 
 	// ceritifer testdata
 

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -255,8 +255,7 @@ func traverseComponents(c cyclonedxParser, components *[]cdx.Component) error {
 				return fmt.Errorf("failed to get license information for component package with error: %w", err)
 			}
 
-			err = traverseComponents(c, comp.Components)
-			if err != nil {
+			if err := traverseComponents(c, comp.Components); err != nil {
 				return err
 			}
 		}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -210,8 +210,12 @@ func parseContainerType(name string, version string, topLevel bool) string {
 }
 
 func (c *cyclonedxParser) getPackages() error {
-	if c.cdxBom.Components != nil {
-		for _, comp := range *c.cdxBom.Components {
+	return traverseComponents(*c, c.cdxBom.Components)
+}
+
+func traverseComponents(c cyclonedxParser, components *[]cdx.Component) error {
+	if components != nil {
+		for _, comp := range *components {
 			// skipping over the "operating-system" type as it does not contain
 			// the required purl for package node. Currently there is no use-case
 			// to capture OS for GUAC.
@@ -249,6 +253,11 @@ func (c *cyclonedxParser) getPackages() error {
 			// get other component packages
 			if err := c.getLicenseInformation(comp); err != nil {
 				return fmt.Errorf("failed to get license information for component package with error: %w", err)
+			}
+
+			err = traverseComponents(c, comp.Components)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -369,7 +369,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 	tests := []struct {
 		name     string
 		cdxBom   *cdx.BOM
-		wantPurl string
+		wantPurl []string
 	}{{
 		name: "purl provided",
 		cdxBom: &cdx.BOM{
@@ -380,7 +380,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				PackageURL: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
 			}},
 		},
-		wantPurl: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+		wantPurl: []string{"pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot"},
 	}, {
 		name: "gcr.io/distroless/static:nonroot - purl not provided",
 		cdxBom: &cdx.BOM{
@@ -390,7 +390,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=nonroot",
+		wantPurl: []string{"pkg:guac/pkg/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=nonroot"},
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified",
 
@@ -401,7 +401,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag=",
+		wantPurl: []string{"pkg:guac/pkg/gcr.io/distroless/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?tag="},
 	}, {
 		name: "gcr.io/distroless/static - purl not provided, tag not specified, version not specified",
 
@@ -411,7 +411,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Type: cdx.ComponentTypeContainer,
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/gcr.io/distroless/static@?tag=",
+		wantPurl: []string{"pkg:guac/pkg/gcr.io/distroless/static@?tag="},
 	}, {
 		name: "library/debian:latest - purl not provided, assume docker.io",
 
@@ -422,7 +422,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest",
+		wantPurl: []string{"pkg:guac/pkg/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest"},
 	}, {
 		name: "library/debian - purl not provided, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -432,7 +432,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=",
+		wantPurl: []string{"pkg:guac/pkg/library/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag="},
 	}, {
 		name: "library - purl not provided, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -442,7 +442,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/library@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=",
+		wantPurl: []string{"pkg:guac/pkg/library@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag="},
 	}, {
 		name: "name split length too long, tag not specified",
 		cdxBom: &cdx.BOM{
@@ -452,7 +452,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/ghcr.io/guacsec/guac/guacsec@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+		wantPurl: []string{"pkg:guac/pkg/ghcr.io/guacsec/guac/guacsec@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"},
 	}, {
 		name: "name contains local registry, tag specified",
 		cdxBom: &cdx.BOM{
@@ -462,7 +462,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/foo.registry.com:4443/myapp/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest",
+		wantPurl: []string{"pkg:guac/pkg/foo.registry.com:4443/myapp/debian@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?tag=latest"},
 	}, {
 		name: "ComponentTypeLibrary",
 
@@ -473,7 +473,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/pkg/ghcr.io/guacsec/guac/guacsec@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+		wantPurl: []string{"pkg:guac/pkg/ghcr.io/guacsec/guac/guacsec@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"},
 	}, {
 		name: "file type - purl nor provided, version provided",
 		cdxBom: &cdx.BOM{
@@ -483,7 +483,7 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
 			}},
 		},
-		wantPurl: "pkg:guac/files/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?filename=/home/work/test/build/webserver",
+		wantPurl: []string{"pkg:guac/files/sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870?filename=/home/work/test/build/webserver"},
 	}, {
 		name: "file type - purl nor provided, version not provided",
 		cdxBom: &cdx.BOM{
@@ -492,7 +492,31 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 				Type: cdx.ComponentTypeFile,
 			}},
 		},
-		wantPurl: "pkg:guac/files/home/work/test/build/webserver",
+		wantPurl: []string{"pkg:guac/files/home/work/test/build/webserver"},
+	}, {
+		name: "nested components",
+		cdxBom: &cdx.BOM{
+			Components: &[]cdx.Component{{
+				Name: "/home/work/test/build/webserver",
+				Type: cdx.ComponentTypeFile,
+				Components: &[]cdx.Component{{
+					Name:       "gcr.io/distroless/static:nonroot",
+					Type:       cdx.ComponentTypeContainer,
+					Version:    "sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388",
+					PackageURL: "pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+					Components: &[]cdx.Component{{
+						Name:    "ghcr.io/guacsec/guac/guacsec",
+						Type:    cdx.ComponentTypeLibrary,
+						Version: "sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+					}},
+				}},
+			}},
+		},
+		wantPurl: []string{
+			"pkg:guac/files/home/work/test/build/webserver",
+			"pkg:oci/static@sha256:6ad5b696af3ca05a048bd29bf0f623040462638cb0b29c8d702cbb2805687388?repository_url=gcr.io/distroless/static&tag=nonroot",
+			"pkg:guac/pkg/ghcr.io/guacsec/guac/guacsec@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870",
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -510,12 +534,17 @@ func Test_cyclonedxParser_getComponentPackages(t *testing.T) {
 			if err := c.getPackages(); err != nil {
 				t.Errorf("Failed to getTopLevelPackage %s", err)
 			}
-			wantPackage, err := asmhelpers.PurlToPkg(tt.wantPurl)
-			if err != nil {
-				t.Errorf("Failed to parse purl %v %v", tt.wantPurl, err)
+			wantPackage := make([]*model.PkgInputSpec, len(tt.wantPurl))
+			for i, item := range tt.wantPurl {
+				pkg, err := asmhelpers.PurlToPkg(item)
+				if err != nil {
+					t.Errorf("Failed to parse purl %v %v", tt.wantPurl, err)
+				}
+				wantPackage[i] = pkg
 			}
+
 			for _, comp := range *tt.cdxBom.Components {
-				if d := cmp.Diff(*wantPackage, *c.packagePackages[comp.BOMRef][0]); len(d) != 0 {
+				if d := cmp.Diff(wantPackage, c.packagePackages[comp.BOMRef]); len(d) != 0 {
 					t.Errorf("addRootPackage failed to produce expected package for %v", tt.name)
 					t.Errorf("spdx.GetPredicate mismatch values (+got, -expected): %s", d)
 				}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -161,6 +161,24 @@ func Test_cyclonedxParser(t *testing.T) {
 		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
 		wantErr:        true,
 		reportedErr:    errUnsupportedLicenseVersion,
+	}, {
+		name: "CycloneDX nested components",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXComponentsNested,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: &testdata.NestedComponentsPredicates,
+		wantErr:        false,
+	}, {
+		name: "CycloneDX flat components",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXComponentsFlat,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: &testdata.FlatComponentsPredicates,
+		wantErr:        false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description of the PR

Implemented recursive traversal for nested components in CycloneDX SBOM.

Fixes #2155 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
