### PR TITLE
LicenseInputSpec: do not add 'ListVersion' with 'Inline'

### DIFF
--- a/pkg/ingestor/parser/common/license.go
+++ b/pkg/ingestor/parser/common/license.go
@@ -83,9 +83,8 @@ func ParseLicenses(exp string, lv *string, inLineMap map[string]string) []model.
 		var license *model.LicenseInputSpec
 		if inline, ok := inLineMap[p]; ok {
 			license = &model.LicenseInputSpec{
-				Name:        p,
-				Inline:      &inline,
-				ListVersion: lv,
+				Name:   p,
+				Inline: &inline,
 			}
 		} else {
 			if !strings.HasPrefix(p, "LicenseRef") {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -1016,9 +1016,8 @@ func Test_spdxParser(t *testing.T) {
 						},
 						Declared: []generated.LicenseInputSpec{
 							{
-								Name:        "LicenseRef-2ba8ded3",
-								Inline:      ptrfrom.String("Redistribution and use of the this code or any derivative works are permitted provided that the following conditions are met..."),
-								ListVersion: ptrfrom.String("1.2.3"),
+								Name:   "LicenseRef-2ba8ded3",
+								Inline: ptrfrom.String("Redistribution and use of the this code or any derivative works are permitted provided that the following conditions are met..."),
 							},
 						},
 						CertifyLegal: &generated.CertifyLegalInputSpec{


### PR DESCRIPTION
# Description of the PR

The changes prevents a `LicenseInputSpec` instance to be created with `Inline` and `ListVersion` when the former has a value.

Fixes #2165 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
