### PR TITLE
add comment on certifier when last-scan is set or not set

### DIFF
--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/logging"
 )
 
 const guacType string = "guac"
@@ -64,6 +65,15 @@ func NewPackageQuery(client graphql.Client, queryType generated.QueryType, batch
 func (p *packageQuery) GetComponents(ctx context.Context, compChan chan<- interface{}) error {
 	if compChan == nil {
 		return fmt.Errorf("compChan cannot be nil")
+	}
+
+	// logger
+	logger := logging.FromContext(ctx)
+	if p.lastScan != nil {
+		lastScanTime := time.Now().Add(time.Duration(-*p.lastScan) * time.Hour).UTC()
+		logger.Infof("last-scan set to: %d hours, last scan time set to: %v", *p.lastScan, lastScanTime)
+	} else {
+		logger.Infof("last-scan not set, running on full package list")
 	}
 
 	tickInterval := 5 * time.Second


### PR DESCRIPTION
# Description of the PR

add comment on certifier when last-scan is set or not set

```
{"level":"info","ts":1728063401.121687,"caller":"certify/certify.go:109","msg":"Starting certifier run: 2024-10-04 17:36:41.121594 +0000 UTC","guac-version":"v0.0.1-custom"}
{"level":"info","ts":1728063401.1218429,"caller":"root_package/root_package.go:74","msg":"last-scan set to: 4, last scan time set to: 2024-10-04 13:36:41.121823 +0000 UTC","guac-version":"v0.0.1-custom"}
{"level":"info","ts":1728063401.241639,"caller":"certify/certify.go:114","msg":"Certifier run completed: 2024-10-04 17:36:41.241626 +0000 UTC","guac-version":"v0.0.1-custom"}
```

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
