### PR TITLE
Fix CD discovered license link in gql generated docs

### DIFF
--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1024,7 +1024,7 @@ func (v *AllCertifyGoodSubjectSource) __premarshalJSON() (*__premarshalAllCertif
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -8195,7 +8195,7 @@ func (v *CertifyGoodSpec) GetDocumentRef() *string { return v.DocumentRef }
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -8439,7 +8439,7 @@ func (v *CertifyLegalListCertifyLegalListCertifyLegalConnectionEdgesCertifyLegal
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -13805,7 +13805,7 @@ func (v *NeighborsNeighborsCertifyGood) __premarshalJSON() (*__premarshalNeighbo
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -17260,7 +17260,7 @@ func (v *NodeNodeCertifyGood) __premarshalJSON() (*__premarshalNodeNodeCertifyGo
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -19767,7 +19767,7 @@ func (v *NodesNodesCertifyGood) __premarshalJSON() (*__premarshalNodesNodesCerti
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice
@@ -23798,7 +23798,7 @@ func (v *PathPathCertifyGood) __premarshalJSON() (*__premarshalPathPathCertifyGo
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5040,7 +5040,7 @@ The certification information is either copied from an attestation found in an
 SBOM or created by a collector/scanner.
 
 Discovered license is also known as Concluded. More information:
-https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 
 Attribution is also known as Copyright Text. It is what could be displayed to
 comply with notice

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -309,7 +309,7 @@ type CertifyGoodSpec struct {
 // SBOM or created by a collector/scanner.
 //
 // Discovered license is also known as Concluded. More information:
-// https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+// https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 //
 // Attribution is also known as Copyright Text. It is what could be displayed to
 // comply with notice

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -24,7 +24,7 @@ The certification information is either copied from an attestation found in an
 SBOM or created by a collector/scanner.
 
 Discovered license is also known as Concluded. More information:
-https://docs.clearlydefined.io/curation-guidelines#the-difference-between-declared-and-discovered-licenses
+https://docs.clearlydefined.io/docs/curation/curation-guidelines#the-difference-between-declared-and-discovered-licenses
 
 Attribution is also known as Copyright Text. It is what could be displayed to
 comply with notice


### PR DESCRIPTION
# Description of the PR

Fixes #2182 by adding correct link to replace 404 link

# PR Checklist

- [x ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
