### PR TITLE
fix issues with certifier querying running into postgres parameter limit

### DIFF
--- a/internal/testing/backend/search_test.go
+++ b/internal/testing/backend/search_test.go
@@ -382,7 +382,7 @@ func TestQueryPackagesListForScan(t *testing.T) {
 				}
 			}
 
-			pkgIDsResponse, err := b.FindPackagesThatNeedScanning(ctx, model.PkgSpec{}, test.QueryType, test.lastScan)
+			pkgIDsResponse, err := b.FindPackagesThatNeedScanning(ctx, test.QueryType, test.lastScan)
 			if err != nil {
 				t.Fatalf("did not get expected query error: %v", err)
 			}

--- a/internal/testing/backend/search_test.go
+++ b/internal/testing/backend/search_test.go
@@ -381,7 +381,13 @@ func TestQueryPackagesListForScan(t *testing.T) {
 					t.Fatalf("did not get expected ingest error: %v", err)
 				}
 			}
-			got, err := b.QueryPackagesListForScan(ctx, model.PkgSpec{}, test.QueryType, test.lastScan, nil, ptrfrom.Int(10))
+
+			pkgIDsResponse, err := b.FindPackagesThatNeedScanning(ctx, model.PkgSpec{}, test.QueryType, test.lastScan)
+			if err != nil {
+				t.Fatalf("did not get expected query error: %v", err)
+			}
+
+			got, err := b.QueryPackagesListForScan(ctx, pkgIDsResponse, nil, ptrfrom.Int(10))
 			if err != nil {
 				t.Fatalf("did not get expected query error: %v", err)
 			}

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -265,6 +265,21 @@ func (mr *MockBackendMockRecorder) Delete(ctx, node any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBackend)(nil).Delete), ctx, node)
 }
 
+// FindPackagesThatNeedScanning mocks base method.
+func (m *MockBackend) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindPackagesThatNeedScanning", ctx, pkgSpec, queryType, lastScan)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindPackagesThatNeedScanning indicates an expected call of FindPackagesThatNeedScanning.
+func (mr *MockBackendMockRecorder) FindPackagesThatNeedScanning(ctx, pkgSpec, queryType, lastScan any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPackagesThatNeedScanning", reflect.TypeOf((*MockBackend)(nil).FindPackagesThatNeedScanning), ctx, pkgSpec, queryType, lastScan)
+}
+
 // FindSoftware mocks base method.
 func (m *MockBackend) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 	m.ctrl.T.Helper()
@@ -1391,18 +1406,18 @@ func (mr *MockBackendMockRecorder) PointOfContactList(ctx, pointOfContactSpec, a
 }
 
 // QueryPackagesListForScan mocks base method.
-func (m *MockBackend) QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) (*model.PackageConnection, error) {
+func (m *MockBackend) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryPackagesListForScan", ctx, pkgSpec, queryType, lastScan, after, first)
+	ret := m.ctrl.Call(m, "QueryPackagesListForScan", ctx, pkgIDs, after, first)
 	ret0, _ := ret[0].(*model.PackageConnection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryPackagesListForScan indicates an expected call of QueryPackagesListForScan.
-func (mr *MockBackendMockRecorder) QueryPackagesListForScan(ctx, pkgSpec, queryType, lastScan, after, first any) *gomock.Call {
+func (mr *MockBackendMockRecorder) QueryPackagesListForScan(ctx, pkgIDs, after, first any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryPackagesListForScan", reflect.TypeOf((*MockBackend)(nil).QueryPackagesListForScan), ctx, pkgSpec, queryType, lastScan, after, first)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryPackagesListForScan", reflect.TypeOf((*MockBackend)(nil).QueryPackagesListForScan), ctx, pkgIDs, after, first)
 }
 
 // Scorecards mocks base method.

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -266,18 +266,18 @@ func (mr *MockBackendMockRecorder) Delete(ctx, node any) *gomock.Call {
 }
 
 // FindPackagesThatNeedScanning mocks base method.
-func (m *MockBackend) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+func (m *MockBackend) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindPackagesThatNeedScanning", ctx, pkgSpec, queryType, lastScan)
+	ret := m.ctrl.Call(m, "FindPackagesThatNeedScanning", ctx, queryType, lastScan)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindPackagesThatNeedScanning indicates an expected call of FindPackagesThatNeedScanning.
-func (mr *MockBackendMockRecorder) FindPackagesThatNeedScanning(ctx, pkgSpec, queryType, lastScan any) *gomock.Call {
+func (mr *MockBackendMockRecorder) FindPackagesThatNeedScanning(ctx, queryType, lastScan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPackagesThatNeedScanning", reflect.TypeOf((*MockBackend)(nil).FindPackagesThatNeedScanning), ctx, pkgSpec, queryType, lastScan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPackagesThatNeedScanning", reflect.TypeOf((*MockBackend)(nil).FindPackagesThatNeedScanning), ctx, queryType, lastScan)
 }
 
 // FindSoftware mocks base method.

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -31,7 +31,7 @@ func (c *arangoClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []st
 	return nil, fmt.Errorf("not implemented: QueryPackagesListForScan")
 }
 
-func (c *arangoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+func (c *arangoClient) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
 

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -27,8 +27,12 @@ func (c *arangoClient) FindSoftwareList(ctx context.Context, searchText string, 
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
-func (c *arangoClient) QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastInterval *int, after *string, first *int) (*model.PackageConnection, error) {
+func (c *arangoClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {
 	return nil, fmt.Errorf("not implemented: QueryPackagesListForScan")
+}
+
+func (c *arangoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
 
 // TODO(lumjjb): add source when it is implemented in arango backend

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -142,7 +142,7 @@ type Backend interface {
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
-	FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error)
+	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -141,7 +141,8 @@ type Backend interface {
 	// Search queries: queries to help find data in GUAC based on text search
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
-	QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) (*model.PackageConnection, error)
+	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
+	FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/ent/backend/helpers.go
+++ b/pkg/assembler/backends/ent/backend/helpers.go
@@ -269,3 +269,28 @@ func getIDfromNode(node model.Node) (string, error) {
 		return "", fmt.Errorf("unknown type: %v", v)
 	}
 }
+
+// UUIDSlice attaches the methods of sort.Interface to []uuid.UUID
+type UUIDSlice []uuid.UUID
+
+func (u UUIDSlice) Len() int {
+	return len(u)
+}
+
+func (u UUIDSlice) Less(i, j int) bool {
+	return u[i].String() < u[j].String() // Compare UUIDs as strings
+}
+
+func (u UUIDSlice) Swap(i, j int) {
+	u[i], u[j] = u[j], u[i]
+}
+
+// findUUIDIndex finds the index of the specified UUID in the sorted slice
+func findUUIDIndex(uuids []uuid.UUID, target string) int {
+	for i, id := range uuids {
+		if id.String() == target {
+			return i
+		}
+	}
+	return -1 // Return -1 if not found
+}

--- a/pkg/assembler/backends/ent/backend/helpers.go
+++ b/pkg/assembler/backends/ent/backend/helpers.go
@@ -270,25 +270,10 @@ func getIDfromNode(node model.Node) (string, error) {
 	}
 }
 
-// UUIDSlice attaches the methods of sort.Interface to []uuid.UUID
-type UUIDSlice []uuid.UUID
-
-func (u UUIDSlice) Len() int {
-	return len(u)
-}
-
-func (u UUIDSlice) Less(i, j int) bool {
-	return u[i].String() < u[j].String() // Compare UUIDs as strings
-}
-
-func (u UUIDSlice) Swap(i, j int) {
-	u[i], u[j] = u[j], u[i]
-}
-
-// findUUIDIndex finds the index of the specified UUID in the sorted slice
-func findUUIDIndex(uuids []uuid.UUID, target string) int {
+// findTargetIndex finds the index of the specified UUID in the sorted slice
+func findTargetIndex(uuids []string, target string) int {
 	for i, id := range uuids {
-		if id.String() == target {
+		if id == target {
 			return i
 		}
 	}

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -255,9 +255,9 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgIDs []stri
 		return nil, nil
 	}
 
-	hasNextPage := false
-	if (startIndex + *first) < len(pkgIDs) {
-		hasNextPage = true
+	hasNextPage := true
+	if (startIndex + *first) > len(pkgIDs) {
+		hasNextPage = false
 	}
 
 	return constructPkgConn(pkgConn, len(pkgIDs), hasNextPage), nil

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -153,7 +153,7 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgSpec model
 		}
 
 		if queryType == model.QueryTypeVulnerability {
-			err := b.client.Debug().PackageVersion.Query().
+			err := b.client.PackageVersion.Query().
 				Where(packageQueryPredicates(&pkgSpec)).
 				GroupBy(packageversion.FieldID). // Group by Package ID
 				Aggregate(func(s *sql.Selector) string {
@@ -167,7 +167,7 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgSpec model
 				return nil, fmt.Errorf("failed aggregate packages based on certifyVuln with error: %w", err)
 			}
 		} else {
-			err := b.client.Debug().PackageVersion.Query().
+			err := b.client.PackageVersion.Query().
 				Where(packageQueryPredicates(&pkgSpec)).
 				GroupBy(packageversion.FieldID). // Group by Package ID
 				Aggregate(func(s *sql.Selector) string {
@@ -218,7 +218,7 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgSpec model
 				}
 			}
 			var queryErr error
-			pkgConn, queryErr = b.client.Debug().PackageVersion.Query().
+			pkgConn, queryErr = b.client.PackageVersion.Query().
 				Where(packageversion.IDIn(shortenedQueryList...)).
 				WithName(func(q *ent.PackageNameQuery) {}).
 				Paginate(ctx, afterCursor, first, nil, nil)

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -213,7 +213,7 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgSpec model
 
 			// Loop through the sorted list starting from the specified UUID
 			for i, id := range startAfterPackageIDList {
-				if i <= *first {
+				if i < *first {
 					shortenedQueryList = append(shortenedQueryList, id)
 				}
 			}

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -27,6 +27,8 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
+const guacType string = "guac"
+
 func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error) {
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
@@ -260,7 +262,7 @@ func (c *demoClient) searchPkgVersion(ctx context.Context, pkgNameNode *pkgName,
 	return pvs
 }
 
-func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
@@ -281,6 +283,9 @@ func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec m
 			pkgTypeNode, err := byKeykv[*pkgType](ctx, pkgTypeCol, tk, c)
 			if err != nil {
 				return nil, err
+			}
+			if pkgTypeNode.Type == guacType {
+				continue
 			}
 			for _, nsID := range pkgTypeNode.Namespaces {
 				pkgNS, err := byIDkv[*pkgNamespace](ctx, nsID, c)

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -259,7 +259,11 @@ func (c *demoClient) searchPkgVersion(ctx context.Context, pkgNameNode *pkgName,
 	return pvs
 }
 
-func (c *demoClient) QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) (*model.PackageConnection, error) {
+func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
+func (c *demoClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -333,7 +333,6 @@ func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec m
 								}
 							} else {
 								pkgIDs = append(pkgIDs, pkgVer.ThisID)
-
 							}
 						}
 					}
@@ -341,7 +340,7 @@ func (c *demoClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec m
 			}
 		}
 	}
-	return nil, nil
+	return pkgIDs, nil
 }
 
 func (c *demoClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -34,6 +34,6 @@ func (c *neo4jClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []str
 	return nil, fmt.Errorf("not implemented: QueryPackagesListForScan")
 }
 
-func (c *neo4jClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+func (c *neo4jClient) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -30,6 +30,10 @@ func (c *neo4jClient) FindSoftwareList(ctx context.Context, searchText string, a
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
-func (c *neo4jClient) QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastInterval *int, after *string, first *int) (*model.PackageConnection, error) {
+func (c *neo4jClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {
 	return nil, fmt.Errorf("not implemented: QueryPackagesListForScan")
+}
+
+func (c *neo4jClient) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -9578,7 +9578,9 @@ const (
 type FindPackagesThatNeedScanningResponse struct {
 	// findPackagesThatNeedScanning returns a list of package IDs
 	// for all packages that need to be re-scanned (based on the last scan in hours)
-	// or have never been scanned.
+	// or have never been scanned. By default it will filter out all packages that have
+	// the type "GUAC" as those are internal packages and will not be found
+	// by external service providers.
 	//
 	// queryType is used to specify if the last time scanned is checked for either
 	// certifyVuln or certifyLegal.
@@ -29954,13 +29956,9 @@ func (v *__DependencyListInput) GetFirst() *int { return v.First }
 
 // __FindPackagesThatNeedScanningInput is used internally by genqlient
 type __FindPackagesThatNeedScanningInput struct {
-	Filter    PkgSpec   `json:"filter"`
 	QueryType QueryType `json:"queryType"`
 	LastScan  *int      `json:"lastScan"`
 }
-
-// GetFilter returns __FindPackagesThatNeedScanningInput.Filter, and is useful for accessing the field via an interface.
-func (v *__FindPackagesThatNeedScanningInput) GetFilter() PkgSpec { return v.Filter }
 
 // GetQueryType returns __FindPackagesThatNeedScanningInput.QueryType, and is useful for accessing the field via an interface.
 func (v *__FindPackagesThatNeedScanningInput) GetQueryType() QueryType { return v.QueryType }
@@ -32706,15 +32704,14 @@ func DependencyList(
 
 // The query or mutation executed by FindPackagesThatNeedScanning.
 const FindPackagesThatNeedScanning_Operation = `
-query FindPackagesThatNeedScanning ($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int) {
-	findPackagesThatNeedScanning(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan)
+query FindPackagesThatNeedScanning ($queryType: QueryType!, $lastScan: Int) {
+	findPackagesThatNeedScanning(queryType: $queryType, lastScan: $lastScan)
 }
 `
 
 func FindPackagesThatNeedScanning(
 	ctx_ context.Context,
 	client_ graphql.Client,
-	filter PkgSpec,
 	queryType QueryType,
 	lastScan *int,
 ) (*FindPackagesThatNeedScanningResponse, error) {
@@ -32722,7 +32719,6 @@ func FindPackagesThatNeedScanning(
 		OpName: "FindPackagesThatNeedScanning",
 		Query:  FindPackagesThatNeedScanning_Operation,
 		Variables: &__FindPackagesThatNeedScanningInput{
-			Filter:    filter,
 			QueryType: queryType,
 			LastScan:  lastScan,
 		},

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -9574,6 +9574,22 @@ const (
 	EdgeVulnMetadataVulnerability        Edge = "VULN_METADATA_VULNERABILITY"
 )
 
+// FindPackagesThatNeedScanningResponse is returned by FindPackagesThatNeedScanning on success.
+type FindPackagesThatNeedScanningResponse struct {
+	// findPackagesThatNeedScanning returns a list of package IDs
+	// for all packages that need to be re-scanned (based on the last scan in hours)
+	// or have never been scanned.
+	//
+	// queryType is used to specify if the last time scanned is checked for either
+	// certifyVuln or certifyLegal.
+	FindPackagesThatNeedScanning []string `json:"findPackagesThatNeedScanning"`
+}
+
+// GetFindPackagesThatNeedScanning returns FindPackagesThatNeedScanningResponse.FindPackagesThatNeedScanning, and is useful for accessing the field via an interface.
+func (v *FindPackagesThatNeedScanningResponse) GetFindPackagesThatNeedScanning() []string {
+	return v.FindPackagesThatNeedScanning
+}
+
 // FindSoftwareFindSoftwareArtifact includes the requested fields of the GraphQL type Artifact.
 // The GraphQL type's documentation follows.
 //
@@ -27433,11 +27449,8 @@ func (v *QueryPackagesListForScanQueryPackagesListForScanPackageConnectionPageIn
 // QueryPackagesListForScanResponse is returned by QueryPackagesListForScan on success.
 type QueryPackagesListForScanResponse struct {
 	// queryPackagesListForScan returns a paginated results via PackageConnection
-	// for all packages that need to be re-scanned (based on the last scan in hours)
-	// or have never been scanned.
-	//
-	// queryType is used to specify if the last time scanned is checked for either
-	// certifyVuln or certifyLegal.
+	// for all packages that need to be re-scanned based on the list of PkgIDs that
+	// are found from findPackagesThatNeedScanning
 	QueryPackagesListForScan *QueryPackagesListForScanQueryPackagesListForScanPackageConnection `json:"queryPackagesListForScan"`
 }
 
@@ -29939,6 +29952,22 @@ func (v *__DependencyListInput) GetAfter() *string { return v.After }
 // GetFirst returns __DependencyListInput.First, and is useful for accessing the field via an interface.
 func (v *__DependencyListInput) GetFirst() *int { return v.First }
 
+// __FindPackagesThatNeedScanningInput is used internally by genqlient
+type __FindPackagesThatNeedScanningInput struct {
+	Filter    PkgSpec   `json:"filter"`
+	QueryType QueryType `json:"queryType"`
+	LastScan  *int      `json:"lastScan"`
+}
+
+// GetFilter returns __FindPackagesThatNeedScanningInput.Filter, and is useful for accessing the field via an interface.
+func (v *__FindPackagesThatNeedScanningInput) GetFilter() PkgSpec { return v.Filter }
+
+// GetQueryType returns __FindPackagesThatNeedScanningInput.QueryType, and is useful for accessing the field via an interface.
+func (v *__FindPackagesThatNeedScanningInput) GetQueryType() QueryType { return v.QueryType }
+
+// GetLastScan returns __FindPackagesThatNeedScanningInput.LastScan, and is useful for accessing the field via an interface.
+func (v *__FindPackagesThatNeedScanningInput) GetLastScan() *int { return v.LastScan }
+
 // __FindSoftwareInput is used internally by genqlient
 type __FindSoftwareInput struct {
 	SearchText string `json:"searchText"`
@@ -31331,21 +31360,13 @@ func (v *__PointOfContactsInput) GetFilter() PointOfContactSpec { return v.Filte
 
 // __QueryPackagesListForScanInput is used internally by genqlient
 type __QueryPackagesListForScanInput struct {
-	Filter    PkgSpec   `json:"filter"`
-	QueryType QueryType `json:"queryType"`
-	LastScan  *int      `json:"lastScan"`
-	After     *string   `json:"after"`
-	First     *int      `json:"first"`
+	PkgIDs []string `json:"pkgIDs"`
+	After  *string  `json:"after"`
+	First  *int     `json:"first"`
 }
 
-// GetFilter returns __QueryPackagesListForScanInput.Filter, and is useful for accessing the field via an interface.
-func (v *__QueryPackagesListForScanInput) GetFilter() PkgSpec { return v.Filter }
-
-// GetQueryType returns __QueryPackagesListForScanInput.QueryType, and is useful for accessing the field via an interface.
-func (v *__QueryPackagesListForScanInput) GetQueryType() QueryType { return v.QueryType }
-
-// GetLastScan returns __QueryPackagesListForScanInput.LastScan, and is useful for accessing the field via an interface.
-func (v *__QueryPackagesListForScanInput) GetLastScan() *int { return v.LastScan }
+// GetPkgIDs returns __QueryPackagesListForScanInput.PkgIDs, and is useful for accessing the field via an interface.
+func (v *__QueryPackagesListForScanInput) GetPkgIDs() []string { return v.PkgIDs }
 
 // GetAfter returns __QueryPackagesListForScanInput.After, and is useful for accessing the field via an interface.
 func (v *__QueryPackagesListForScanInput) GetAfter() *string { return v.After }
@@ -32672,6 +32693,43 @@ func DependencyList(
 	var err_ error
 
 	var data_ DependencyListResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by FindPackagesThatNeedScanning.
+const FindPackagesThatNeedScanning_Operation = `
+query FindPackagesThatNeedScanning ($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int) {
+	findPackagesThatNeedScanning(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan)
+}
+`
+
+func FindPackagesThatNeedScanning(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	filter PkgSpec,
+	queryType QueryType,
+	lastScan *int,
+) (*FindPackagesThatNeedScanningResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "FindPackagesThatNeedScanning",
+		Query:  FindPackagesThatNeedScanning_Operation,
+		Variables: &__FindPackagesThatNeedScanningInput{
+			Filter:    filter,
+			QueryType: queryType,
+			LastScan:  lastScan,
+		},
+	}
+	var err_ error
+
+	var data_ FindPackagesThatNeedScanningResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(
@@ -39139,8 +39197,8 @@ func PointOfContacts(
 
 // The query or mutation executed by QueryPackagesListForScan.
 const QueryPackagesListForScan_Operation = `
-query QueryPackagesListForScan ($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int, $after: ID, $first: Int) {
-	queryPackagesListForScan(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan, after: $after, first: $first) {
+query QueryPackagesListForScan ($pkgIDs: [ID!]!, $after: ID, $first: Int) {
+	queryPackagesListForScan(pkgIDs: $pkgIDs, after: $after, first: $first) {
 		totalCount
 		edges {
 			cursor
@@ -39182,9 +39240,7 @@ fragment AllPkgTree on Package {
 func QueryPackagesListForScan(
 	ctx_ context.Context,
 	client_ graphql.Client,
-	filter PkgSpec,
-	queryType QueryType,
-	lastScan *int,
+	pkgIDs []string,
 	after *string,
 	first *int,
 ) (*QueryPackagesListForScanResponse, error) {
@@ -39192,11 +39248,9 @@ func QueryPackagesListForScan(
 		OpName: "QueryPackagesListForScan",
 		Query:  QueryPackagesListForScan_Operation,
 		Variables: &__QueryPackagesListForScanInput{
-			Filter:    filter,
-			QueryType: queryType,
-			LastScan:  lastScan,
-			After:     after,
-			First:     first,
+			PkgIDs: pkgIDs,
+			After:  after,
+			First:  first,
 		},
 	}
 	var err_ error

--- a/pkg/assembler/clients/operations/search.graphql
+++ b/pkg/assembler/clients/operations/search.graphql
@@ -28,8 +28,8 @@ query FindSoftware($searchText: String!) {
   }
 }
 
-query FindPackagesThatNeedScanning($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int) {
-  findPackagesThatNeedScanning(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan)
+query FindPackagesThatNeedScanning($queryType: QueryType!, $lastScan: Int) {
+  findPackagesThatNeedScanning(queryType: $queryType, lastScan: $lastScan)
 }
 
 query QueryPackagesListForScan($pkgIDs: [ID!]!, $after: ID, $first: Int) {

--- a/pkg/assembler/clients/operations/search.graphql
+++ b/pkg/assembler/clients/operations/search.graphql
@@ -28,8 +28,12 @@ query FindSoftware($searchText: String!) {
   }
 }
 
-query QueryPackagesListForScan($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int, $after: ID, $first: Int) {
-  queryPackagesListForScan(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan, after: $after, first: $first) {
+query FindPackagesThatNeedScanning($filter: PkgSpec!, $queryType: QueryType!, $lastScan: Int) {
+  findPackagesThatNeedScanning(pkgSpec: $filter, queryType: $queryType, lastScan: $lastScan)
+}
+
+query QueryPackagesListForScan($pkgIDs: [ID!]!, $after: ID, $first: Int) {
+  queryPackagesListForScan(pkgIDs: $pkgIDs, after: $after, first: $first) {
     totalCount
     edges {
       cursor

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -114,7 +114,7 @@ type QueryResolver interface {
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
-	FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error)
+	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
 	Sources(ctx context.Context, sourceSpec model.SourceSpec) ([]*model.Source, error)
 	SourcesList(ctx context.Context, sourceSpec model.SourceSpec, after *string, first *int) (*model.SourceConnection, error)
 	VulnEqual(ctx context.Context, vulnEqualSpec model.VulnEqualSpec) ([]*model.VulnEqual, error)
@@ -5446,45 +5446,18 @@ func (ec *executionContext) field_Query_builders_argsBuilderSpec(
 func (ec *executionContext) field_Query_findPackagesThatNeedScanning_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	arg0, err := ec.field_Query_findPackagesThatNeedScanning_argsPkgSpec(ctx, rawArgs)
+	arg0, err := ec.field_Query_findPackagesThatNeedScanning_argsQueryType(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["pkgSpec"] = arg0
-	arg1, err := ec.field_Query_findPackagesThatNeedScanning_argsQueryType(ctx, rawArgs)
+	args["queryType"] = arg0
+	arg1, err := ec.field_Query_findPackagesThatNeedScanning_argsLastScan(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["queryType"] = arg1
-	arg2, err := ec.field_Query_findPackagesThatNeedScanning_argsLastScan(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["lastScan"] = arg2
+	args["lastScan"] = arg1
 	return args, nil
 }
-func (ec *executionContext) field_Query_findPackagesThatNeedScanning_argsPkgSpec(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (model.PkgSpec, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["pkgSpec"]
-	if !ok {
-		var zeroVal model.PkgSpec
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgSpec"))
-	if tmp, ok := rawArgs["pkgSpec"]; ok {
-		return ec.unmarshalNPkgSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, tmp)
-	}
-
-	var zeroVal model.PkgSpec
-	return zeroVal, nil
-}
-
 func (ec *executionContext) field_Query_findPackagesThatNeedScanning_argsQueryType(
 	ctx context.Context,
 	rawArgs map[string]interface{},
@@ -12562,7 +12535,7 @@ func (ec *executionContext) _Query_findPackagesThatNeedScanning(ctx context.Cont
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().FindPackagesThatNeedScanning(rctx, fc.Args["pkgSpec"].(model.PkgSpec), fc.Args["queryType"].(model.QueryType), fc.Args["lastScan"].(*int))
+		return ec.resolvers.Query().FindPackagesThatNeedScanning(rctx, fc.Args["queryType"].(model.QueryType), fc.Args["lastScan"].(*int))
 	})
 
 	if resTmp == nil {

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -113,7 +113,8 @@ type QueryResolver interface {
 	PkgEqualList(ctx context.Context, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) (*model.PkgEqualConnection, error)
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
-	QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) (*model.PackageConnection, error)
+	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
+	FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error)
 	Sources(ctx context.Context, sourceSpec model.SourceSpec) ([]*model.Source, error)
 	SourcesList(ctx context.Context, sourceSpec model.SourceSpec, after *string, first *int) (*model.SourceConnection, error)
 	VulnEqual(ctx context.Context, vulnEqualSpec model.VulnEqualSpec) ([]*model.VulnEqual, error)
@@ -5442,6 +5443,92 @@ func (ec *executionContext) field_Query_builders_argsBuilderSpec(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query_findPackagesThatNeedScanning_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_findPackagesThatNeedScanning_argsPkgSpec(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgSpec"] = arg0
+	arg1, err := ec.field_Query_findPackagesThatNeedScanning_argsQueryType(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["queryType"] = arg1
+	arg2, err := ec.field_Query_findPackagesThatNeedScanning_argsLastScan(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["lastScan"] = arg2
+	return args, nil
+}
+func (ec *executionContext) field_Query_findPackagesThatNeedScanning_argsPkgSpec(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (model.PkgSpec, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgSpec"]
+	if !ok {
+		var zeroVal model.PkgSpec
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgSpec"))
+	if tmp, ok := rawArgs["pkgSpec"]; ok {
+		return ec.unmarshalNPkgSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, tmp)
+	}
+
+	var zeroVal model.PkgSpec
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findPackagesThatNeedScanning_argsQueryType(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (model.QueryType, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["queryType"]
+	if !ok {
+		var zeroVal model.QueryType
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("queryType"))
+	if tmp, ok := rawArgs["queryType"]; ok {
+		return ec.unmarshalNQueryType2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐQueryType(ctx, tmp)
+	}
+
+	var zeroVal model.QueryType
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findPackagesThatNeedScanning_argsLastScan(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (*int, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["lastScan"]
+	if !ok {
+		var zeroVal *int
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("lastScan"))
+	if tmp, ok := rawArgs["lastScan"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query_findSoftwareList_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -6148,96 +6235,42 @@ func (ec *executionContext) field_Query_path_argsUsingOnly(
 func (ec *executionContext) field_Query_queryPackagesListForScan_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	arg0, err := ec.field_Query_queryPackagesListForScan_argsPkgSpec(ctx, rawArgs)
+	arg0, err := ec.field_Query_queryPackagesListForScan_argsPkgIDs(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["pkgSpec"] = arg0
-	arg1, err := ec.field_Query_queryPackagesListForScan_argsQueryType(ctx, rawArgs)
+	args["pkgIDs"] = arg0
+	arg1, err := ec.field_Query_queryPackagesListForScan_argsAfter(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["queryType"] = arg1
-	arg2, err := ec.field_Query_queryPackagesListForScan_argsLastScan(ctx, rawArgs)
+	args["after"] = arg1
+	arg2, err := ec.field_Query_queryPackagesListForScan_argsFirst(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["lastScan"] = arg2
-	arg3, err := ec.field_Query_queryPackagesListForScan_argsAfter(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["after"] = arg3
-	arg4, err := ec.field_Query_queryPackagesListForScan_argsFirst(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["first"] = arg4
+	args["first"] = arg2
 	return args, nil
 }
-func (ec *executionContext) field_Query_queryPackagesListForScan_argsPkgSpec(
+func (ec *executionContext) field_Query_queryPackagesListForScan_argsPkgIDs(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (model.PkgSpec, error) {
+) ([]string, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
-	_, ok := rawArgs["pkgSpec"]
+	_, ok := rawArgs["pkgIDs"]
 	if !ok {
-		var zeroVal model.PkgSpec
+		var zeroVal []string
 		return zeroVal, nil
 	}
 
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgSpec"))
-	if tmp, ok := rawArgs["pkgSpec"]; ok {
-		return ec.unmarshalNPkgSpec2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐPkgSpec(ctx, tmp)
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
 	}
 
-	var zeroVal model.PkgSpec
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_queryPackagesListForScan_argsQueryType(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (model.QueryType, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["queryType"]
-	if !ok {
-		var zeroVal model.QueryType
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("queryType"))
-	if tmp, ok := rawArgs["queryType"]; ok {
-		return ec.unmarshalNQueryType2githubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐQueryType(ctx, tmp)
-	}
-
-	var zeroVal model.QueryType
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_queryPackagesListForScan_argsLastScan(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["lastScan"]
-	if !ok {
-		var zeroVal *int
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("lastScan"))
-	if tmp, ok := rawArgs["lastScan"]; ok {
-		return ec.unmarshalOInt2ᚖint(ctx, tmp)
-	}
-
-	var zeroVal *int
+	var zeroVal []string
 	return zeroVal, nil
 }
 
@@ -12472,7 +12505,7 @@ func (ec *executionContext) _Query_queryPackagesListForScan(ctx context.Context,
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().QueryPackagesListForScan(rctx, fc.Args["pkgSpec"].(model.PkgSpec), fc.Args["queryType"].(model.QueryType), fc.Args["lastScan"].(*int), fc.Args["after"].(*string), fc.Args["first"].(*int))
+		return ec.resolvers.Query().QueryPackagesListForScan(rctx, fc.Args["pkgIDs"].([]string), fc.Args["after"].(*string), fc.Args["first"].(*int))
 	})
 
 	if resTmp == nil {
@@ -12509,6 +12542,58 @@ func (ec *executionContext) fieldContext_Query_queryPackagesListForScan(ctx cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_queryPackagesListForScan_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_findPackagesThatNeedScanning(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_findPackagesThatNeedScanning(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindPackagesThatNeedScanning(rctx, fc.Args["pkgSpec"].(model.PkgSpec), fc.Args["queryType"].(model.QueryType), fc.Args["lastScan"].(*int))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_findPackagesThatNeedScanning(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findPackagesThatNeedScanning_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -14712,6 +14797,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_queryPackagesListForScan(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findPackagesThatNeedScanning":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findPackagesThatNeedScanning(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -543,7 +543,7 @@ type ComplexityRoot struct {
 		CertifyVEXStatementList      func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
 		CertifyVuln                  func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
 		CertifyVulnList              func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
-		FindPackagesThatNeedScanning func(childComplexity int, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) int
+		FindPackagesThatNeedScanning func(childComplexity int, queryType model.QueryType, lastScan *int) int
 		FindSoftware                 func(childComplexity int, searchText string) int
 		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
 		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
@@ -3215,7 +3215,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.FindPackagesThatNeedScanning(childComplexity, args["pkgSpec"].(model.PkgSpec), args["queryType"].(model.QueryType), args["lastScan"].(*int)), true
+		return e.complexity.Query.FindPackagesThatNeedScanning(childComplexity, args["queryType"].(model.QueryType), args["lastScan"].(*int)), true
 
 	case "Query.findSoftware":
 		if e.complexity.Query.FindSoftware == nil {
@@ -7644,12 +7644,14 @@ extend type Query {
   """
   findPackagesThatNeedScanning returns a list of package IDs
   for all packages that need to be re-scanned (based on the last scan in hours)
-  or have never been scanned.
+  or have never been scanned. By default it will filter out all packages that have
+  the type "GUAC" as those are internal packages and will not be found
+  by external service providers.
 
   queryType is used to specify if the last time scanned is checked for either
   certifyVuln or certifyLegal.
   """
-  findPackagesThatNeedScanning(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int): [ID!]!
+  findPackagesThatNeedScanning(queryType: QueryType!, lastScan: Int): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/source.graphql", Input: `#

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -529,60 +529,61 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Artifacts                 func(childComplexity int, artifactSpec model.ArtifactSpec) int
-		ArtifactsList             func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
-		Builders                  func(childComplexity int, builderSpec model.BuilderSpec) int
-		BuildersList              func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
-		CertifyBad                func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
-		CertifyBadList            func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
-		CertifyGood               func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
-		CertifyGoodList           func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
-		CertifyLegal              func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
-		CertifyLegalList          func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
-		CertifyVEXStatement       func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
-		CertifyVEXStatementList   func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
-		CertifyVuln               func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
-		CertifyVulnList           func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
-		FindSoftware              func(childComplexity int, searchText string) int
-		FindSoftwareList          func(childComplexity int, searchText string, after *string, first *int) int
-		HasMetadata               func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
-		HasMetadataList           func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
-		HasSBOMList               func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
-		HasSLSAList               func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
-		HasSbom                   func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
-		HasSlsa                   func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
-		HasSourceAt               func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
-		HasSourceAtList           func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
-		HashEqual                 func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
-		HashEqualList             func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
-		IsDependency              func(childComplexity int, isDependencySpec model.IsDependencySpec) int
-		IsDependencyList          func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
-		IsOccurrence              func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
-		IsOccurrenceList          func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
-		LicenseList               func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
-		Licenses                  func(childComplexity int, licenseSpec model.LicenseSpec) int
-		Neighbors                 func(childComplexity int, node string, usingOnly []model.Edge) int
-		NeighborsList             func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
-		Node                      func(childComplexity int, node string) int
-		Nodes                     func(childComplexity int, nodes []string) int
-		Packages                  func(childComplexity int, pkgSpec model.PkgSpec) int
-		PackagesList              func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
-		Path                      func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
-		PkgEqual                  func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
-		PkgEqualList              func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
-		PointOfContact            func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
-		PointOfContactList        func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
-		QueryPackagesListForScan  func(childComplexity int, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) int
-		Scorecards                func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
-		ScorecardsList            func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
-		Sources                   func(childComplexity int, sourceSpec model.SourceSpec) int
-		SourcesList               func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
-		VulnEqual                 func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
-		VulnEqualList             func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
-		Vulnerabilities           func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
-		VulnerabilityList         func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
-		VulnerabilityMetadata     func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
-		VulnerabilityMetadataList func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
+		Artifacts                    func(childComplexity int, artifactSpec model.ArtifactSpec) int
+		ArtifactsList                func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
+		Builders                     func(childComplexity int, builderSpec model.BuilderSpec) int
+		BuildersList                 func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
+		CertifyBad                   func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
+		CertifyBadList               func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
+		CertifyGood                  func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
+		CertifyGoodList              func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
+		CertifyLegal                 func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
+		CertifyLegalList             func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
+		CertifyVEXStatement          func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
+		CertifyVEXStatementList      func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
+		CertifyVuln                  func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
+		CertifyVulnList              func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
+		FindPackagesThatNeedScanning func(childComplexity int, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) int
+		FindSoftware                 func(childComplexity int, searchText string) int
+		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
+		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
+		HasMetadataList              func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
+		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
+		HasSLSAList                  func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
+		HasSbom                      func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
+		HasSlsa                      func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
+		HasSourceAt                  func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
+		HasSourceAtList              func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
+		HashEqual                    func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
+		HashEqualList                func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
+		IsDependency                 func(childComplexity int, isDependencySpec model.IsDependencySpec) int
+		IsDependencyList             func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
+		IsOccurrence                 func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
+		IsOccurrenceList             func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
+		LicenseList                  func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
+		Licenses                     func(childComplexity int, licenseSpec model.LicenseSpec) int
+		Neighbors                    func(childComplexity int, node string, usingOnly []model.Edge) int
+		NeighborsList                func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
+		Node                         func(childComplexity int, node string) int
+		Nodes                        func(childComplexity int, nodes []string) int
+		Packages                     func(childComplexity int, pkgSpec model.PkgSpec) int
+		PackagesList                 func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
+		Path                         func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
+		PkgEqual                     func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
+		PkgEqualList                 func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
+		PointOfContact               func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
+		PointOfContactList           func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
+		QueryPackagesListForScan     func(childComplexity int, pkgIDs []string, after *string, first *int) int
+		Scorecards                   func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
+		ScorecardsList               func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
+		Sources                      func(childComplexity int, sourceSpec model.SourceSpec) int
+		SourcesList                  func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
+		VulnEqual                    func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
+		VulnEqualList                func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
+		Vulnerabilities              func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
+		VulnerabilityList            func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
+		VulnerabilityMetadata        func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
+		VulnerabilityMetadataList    func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
 	}
 
 	SLSA struct {
@@ -3204,6 +3205,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.CertifyVulnList(childComplexity, args["certifyVulnSpec"].(model.CertifyVulnSpec), args["after"].(*string), args["first"].(*int)), true
 
+	case "Query.findPackagesThatNeedScanning":
+		if e.complexity.Query.FindPackagesThatNeedScanning == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findPackagesThatNeedScanning_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FindPackagesThatNeedScanning(childComplexity, args["pkgSpec"].(model.PkgSpec), args["queryType"].(model.QueryType), args["lastScan"].(*int)), true
+
 	case "Query.findSoftware":
 		if e.complexity.Query.FindSoftware == nil {
 			break
@@ -3562,7 +3575,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.QueryPackagesListForScan(childComplexity, args["pkgSpec"].(model.PkgSpec), args["queryType"].(model.QueryType), args["lastScan"].(*int), args["after"].(*string), args["first"].(*int)), true
+		return e.complexity.Query.QueryPackagesListForScan(childComplexity, args["pkgIDs"].([]string), args["after"].(*string), args["first"].(*int)), true
 
 	case "Query.scorecards":
 		if e.complexity.Query.Scorecards == nil {
@@ -7622,16 +7635,21 @@ extend type Query {
   findSoftware(searchText: String!): [PackageSourceOrArtifact!]!
   "Returns a paginated results via CertifyBadConnection"
   findSoftwareList(searchText: String!, after: ID, first: Int): FindSoftwareConnection
-
   """
   queryPackagesListForScan returns a paginated results via PackageConnection 
+  for all packages that need to be re-scanned based on the list of PkgIDs that
+  are found from findPackagesThatNeedScanning
+  """
+  queryPackagesListForScan(pkgIDs: [ID!]!, after: ID, first: Int): PackageConnection
+  """
+  findPackagesThatNeedScanning returns a list of package IDs
   for all packages that need to be re-scanned (based on the last scan in hours)
   or have never been scanned.
 
   queryType is used to specify if the last time scanned is checked for either
   certifyVuln or certifyLegal.
   """
-  queryPackagesListForScan(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int, after: ID, first: Int): PackageConnection
+  findPackagesThatNeedScanning(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int): [ID!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/source.graphql", Input: `#

--- a/pkg/assembler/graphql/resolvers/search.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/search.resolvers.go
@@ -26,6 +26,6 @@ func (r *queryResolver) QueryPackagesListForScan(ctx context.Context, pkgIDs []s
 }
 
 // FindPackagesThatNeedScanning is the resolver for the findPackagesThatNeedScanning field.
-func (r *queryResolver) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
-	return r.Backend.FindPackagesThatNeedScanning(ctx, pkgSpec, queryType, lastScan)
+func (r *queryResolver) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
+	return r.Backend.FindPackagesThatNeedScanning(ctx, queryType, lastScan)
 }

--- a/pkg/assembler/graphql/resolvers/search.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/search.resolvers.go
@@ -21,6 +21,11 @@ func (r *queryResolver) FindSoftwareList(ctx context.Context, searchText string,
 }
 
 // QueryPackagesListForScan is the resolver for the queryPackagesListForScan field.
-func (r *queryResolver) QueryPackagesListForScan(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int, after *string, first *int) (*model.PackageConnection, error) {
-	return r.Backend.QueryPackagesListForScan(ctx, pkgSpec, queryType, lastScan, after, first)
+func (r *queryResolver) QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error) {
+	return r.Backend.QueryPackagesListForScan(ctx, pkgIDs, after, first)
+}
+
+// FindPackagesThatNeedScanning is the resolver for the findPackagesThatNeedScanning field.
+func (r *queryResolver) FindPackagesThatNeedScanning(ctx context.Context, pkgSpec model.PkgSpec, queryType model.QueryType, lastScan *int) ([]string, error) {
+	return r.Backend.FindPackagesThatNeedScanning(ctx, pkgSpec, queryType, lastScan)
 }

--- a/pkg/assembler/graphql/schema/search.graphql
+++ b/pkg/assembler/graphql/schema/search.graphql
@@ -76,14 +76,19 @@ extend type Query {
   findSoftware(searchText: String!): [PackageSourceOrArtifact!]!
   "Returns a paginated results via CertifyBadConnection"
   findSoftwareList(searchText: String!, after: ID, first: Int): FindSoftwareConnection
-
   """
   queryPackagesListForScan returns a paginated results via PackageConnection 
+  for all packages that need to be re-scanned based on the list of PkgIDs that
+  are found from findPackagesThatNeedScanning
+  """
+  queryPackagesListForScan(pkgIDs: [ID!]!, after: ID, first: Int): PackageConnection
+  """
+  findPackagesThatNeedScanning returns a list of package IDs
   for all packages that need to be re-scanned (based on the last scan in hours)
   or have never been scanned.
 
   queryType is used to specify if the last time scanned is checked for either
   certifyVuln or certifyLegal.
   """
-  queryPackagesListForScan(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int, after: ID, first: Int): PackageConnection
+  findPackagesThatNeedScanning(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int): [ID!]!
 }

--- a/pkg/assembler/graphql/schema/search.graphql
+++ b/pkg/assembler/graphql/schema/search.graphql
@@ -85,10 +85,12 @@ extend type Query {
   """
   findPackagesThatNeedScanning returns a list of package IDs
   for all packages that need to be re-scanned (based on the last scan in hours)
-  or have never been scanned.
+  or have never been scanned. By default it will filter out all packages that have
+  the type "GUAC" as those are internal packages and will not be found
+  by external service providers.
 
   queryType is used to specify if the last time scanned is checked for either
   certifyVuln or certifyLegal.
   """
-  findPackagesThatNeedScanning(pkgSpec: PkgSpec!, queryType: QueryType!, lastScan: Int): [ID!]!
+  findPackagesThatNeedScanning(queryType: QueryType!, lastScan: Int): [ID!]!
 }

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -46,11 +46,13 @@ type packageQuery struct {
 	queryType    generated.QueryType
 }
 
-var getPackages func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastInterval *int, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
+var getPackages func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
+var findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
 
 // NewPackageQuery initializes the packageQuery to query from the graph database
 func NewPackageQuery(client graphql.Client, queryType generated.QueryType, batchSize, serviceBatchSize int, addedLatency *time.Duration, lastScan *int) certifier.QueryComponents {
 	getPackages = generated.QueryPackagesListForScan
+	findPackagesThatNeedScanning = generated.FindPackagesThatNeedScanning
 	return &packageQuery{
 		client:           client,
 		batchSize:        batchSize,
@@ -142,8 +144,16 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, nodeChan chan<- *Pac
 	var afterCursor *string
 
 	first := p.batchSize
+
+	pkgScanResults, err := findPackagesThatNeedScanning(ctx, p.client, generated.PkgSpec{}, p.queryType, p.lastScan)
+	if err != nil {
+		return fmt.Errorf("findPackagesThatNeedScanning query failed with error: %w", err)
+	}
+
+	pkgIDs := pkgScanResults.FindPackagesThatNeedScanning
+
 	for {
-		pkgConn, err := getPackages(ctx, p.client, generated.PkgSpec{}, p.queryType, p.lastScan, afterCursor, &first)
+		pkgConn, err := getPackages(ctx, p.client, pkgIDs, afterCursor, &first)
 		if err != nil {
 			return fmt.Errorf("failed to query packages with error: %w", err)
 		}

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -149,7 +149,7 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, nodeChan chan<- *Pac
 		}
 
 		if pkgConn == nil || pkgConn.QueryPackagesListForScan == nil {
-			continue
+			break
 		}
 		pkgEdges := pkgConn.QueryPackagesListForScan.Edges
 

--- a/pkg/certifier/components/root_package/root_package.go
+++ b/pkg/certifier/components/root_package/root_package.go
@@ -47,7 +47,7 @@ type packageQuery struct {
 }
 
 var getPackages func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
-var findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
+var findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
 
 // NewPackageQuery initializes the packageQuery to query from the graph database
 func NewPackageQuery(client graphql.Client, queryType generated.QueryType, batchSize, serviceBatchSize int, addedLatency *time.Duration, lastScan *int) certifier.QueryComponents {
@@ -145,7 +145,7 @@ func (p *packageQuery) getPackageNodes(ctx context.Context, nodeChan chan<- *Pac
 
 	first := p.batchSize
 
-	pkgScanResults, err := findPackagesThatNeedScanning(ctx, p.client, generated.PkgSpec{}, p.queryType, p.lastScan)
+	pkgScanResults, err := findPackagesThatNeedScanning(ctx, p.client, p.queryType, p.lastScan)
 	if err != nil {
 		return fmt.Errorf("findPackagesThatNeedScanning query failed with error: %w", err)
 	}

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -114,14 +114,14 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		name                         string
 		lastScan                     int
 		getPackages                  func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
-		findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
+		findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
 		wantPackNode                 []*PackageNode
 		wantErr                      bool
 	}{
 		{
 			name:     "django:",
 			lastScan: 0,
-			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
+			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
 				return &generated.FindPackagesThatNeedScanningResponse{
 					FindPackagesThatNeedScanning: []string{},
 				}, nil
@@ -151,7 +151,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:     "multiple packages",
 			lastScan: 0,
-			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
+			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
 				return &generated.FindPackagesThatNeedScanningResponse{
 					FindPackagesThatNeedScanning: []string{},
 				}, nil

--- a/pkg/certifier/components/root_package/root_package_test.go
+++ b/pkg/certifier/components/root_package/root_package_test.go
@@ -111,16 +111,22 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 	})
 
 	tests := []struct {
-		name         string
-		lastScan     int
-		getPackages  func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastInterval *int, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
-		wantPackNode []*PackageNode
-		wantErr      bool
+		name                         string
+		lastScan                     int
+		getPackages                  func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error)
+		findPackagesThatNeedScanning func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error)
+		wantPackNode                 []*PackageNode
+		wantErr                      bool
 	}{
 		{
 			name:     "django:",
 			lastScan: 0,
-			getPackages: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastInterval *int, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error) {
+			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
+				return &generated.FindPackagesThatNeedScanningResponse{
+					FindPackagesThatNeedScanning: []string{},
+				}, nil
+			},
+			getPackages: func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error) {
 				return &generated.QueryPackagesListForScanResponse{
 					QueryPackagesListForScan: &generated.QueryPackagesListForScanQueryPackagesListForScanPackageConnection{
 						TotalCount: 1,
@@ -145,7 +151,12 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 		}, {
 			name:     "multiple packages",
 			lastScan: 0,
-			getPackages: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastInterval *int, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error) {
+			findPackagesThatNeedScanning: func(ctx_ context.Context, client_ graphql.Client, filter generated.PkgSpec, queryType generated.QueryType, lastScan *int) (*generated.FindPackagesThatNeedScanningResponse, error) {
+				return &generated.FindPackagesThatNeedScanningResponse{
+					FindPackagesThatNeedScanning: []string{},
+				}, nil
+			},
+			getPackages: func(ctx_ context.Context, client_ graphql.Client, pkgIDs []string, after *string, first *int) (*generated.QueryPackagesListForScanResponse, error) {
 				return &generated.QueryPackagesListForScanResponse{
 					QueryPackagesListForScan: &generated.QueryPackagesListForScanQueryPackagesListForScanPackageConnection{
 						TotalCount: 2,
@@ -186,6 +197,7 @@ func Test_packageQuery_GetComponents(t *testing.T) {
 				queryType:    generated.QueryTypeVulnerability,
 			}
 			getPackages = tt.getPackages
+			findPackagesThatNeedScanning = tt.findPackagesThatNeedScanning
 
 			// compChan to collect query components
 			compChan := make(chan interface{}, 1)

--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -64,11 +64,12 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 	var certLegalIngest []assembler.CertifyLegalIngest
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 
-	if len(purls) > 249 {
+	// the limit for the batch size that is allowed for clearly defined
+	if len(purls) > 250 {
 		i := 0
 		var batchPurls []string
 		for _, purl := range purls {
-			if i < 248 {
+			if i < 249 {
 				batchPurls = append(batchPurls, purl)
 				i++
 			} else {

--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -64,12 +64,40 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 	var certLegalIngest []assembler.CertifyLegalIngest
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 
-	batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, purls)
-	if err != nil {
-		return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
+	if len(purls) > 249 {
+		i := 0
+		var batchPurls []string
+		for _, purl := range purls {
+			if i < 248 {
+				batchPurls = append(batchPurls, purl)
+				i++
+			} else {
+				batchPurls = append(batchPurls, purl)
+				batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, batchPurls)
+				if err != nil {
+					return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
+				}
+				certLegalIngest = append(certLegalIngest, batchedCL...)
+				hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
+				batchPurls = make([]string, 0)
+			}
+		}
+		if len(batchPurls) > 0 {
+			batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, batchPurls)
+			if err != nil {
+				return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
+			}
+			certLegalIngest = append(certLegalIngest, batchedCL...)
+			hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
+		}
+	} else {
+		batchedCL, batchedHSA, err := runQueryOnBatchedPurls(ctx, cdParser, purls)
+		if err != nil {
+			return nil, nil, fmt.Errorf("runQueryOnBatchedPurls failed with error: %w", err)
+		}
+		certLegalIngest = append(certLegalIngest, batchedCL...)
+		hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
 	}
-	certLegalIngest = append(certLegalIngest, batchedCL...)
-	hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
 
 	return certLegalIngest, hasSourceAtIngest, nil
 }


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/2186

Fixes issue error where certifier query runs into the postgres limit:
```
{"level":"error","ts":1728485503.8269422,"caller":"certify/certify.go:74","msg":"GetComponents failed with error: failed to query packages with error: input: queryPackagesListForScan failed package query with error: pq: got 941325 parameters but PostgreSQL only supports 65535 parameters\n","guac-version":"v0.9.1",
```

To do this, I had to break the query `queryPackagesListForScan` into two pieces:
- `findPackagesThatNeedScanning` will return a list of package IDs that require rescanning (minus package type that are `guac`
- `queryPackagesListForScan` will now just go through that list (and support the limit of 65535 parameters) and return the packages for the certifier to use.

also 

Fix the issue where the payload size is too big:

```
"error scanning purls for licenses runQueryOnBatchedPurls failed with error: failed get definition from clearly defined with error: generateDefinitions failed with error: failed get package definition from clearly defined with error: clearly defined POST request failed with error: unexpected status code: 413",
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
