### PR TITLE
Feat/oci registry collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ go.work
 container_files/pg/
 
 dist/
+**/__debug_bin*

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.1 // indirect
 	github.com/onsi/gomega v1.29.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
@@ -328,6 +327,7 @@ require (
 	github.com/nats-io/nats.go v1.37.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.1-0.20240823215434-d232e9efa9f5
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/openvex/go-vex v0.2.5
 	github.com/ossf/scorecard/v4 v4.13.1
 	github.com/package-url/packageurl-go v0.1.3

--- a/internal/testing/mockRegistry/mock_registry.go
+++ b/internal/testing/mockRegistry/mock_registry.go
@@ -1,0 +1,935 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types/descriptor"
+	v1 "github.com/regclient/regclient/types/oci/v1"
+)
+
+// RegistryContent represents the content stored in the mock registry
+type RegistryContent struct {
+	// Map of repository names to their content
+	Repositories map[string]*RepositoryContent
+	// Optional custom error responses
+	ErrorResponses map[string]ErrorResponse
+	// Optional custom headers for responses
+	CustomHeaders map[string]map[string]string
+}
+
+// RepositoryContent represents content within a repository
+type RepositoryContent struct {
+	// Map of tag names to manifest digests
+	Tags map[string]string
+	// Map of manifest digests to their content
+	Manifests map[string]ManifestContent
+	// Map of blob digests to their content
+	Blobs map[string][]byte
+	// Map of upload UUIDs to their partial content
+	Uploads map[string]*UploadState
+	// Optional minimum chunk size for uploads
+	MinChunkSize int64
+}
+
+// ManifestContent represents a manifest and its metadata
+type ManifestContent struct {
+	Content      []byte
+	MediaType    string
+	Digest       digest.Digest
+	Referrers    []descriptor.Descriptor
+	ArtifactType string
+}
+
+// UploadState tracks the state of a blob upload
+type UploadState struct {
+	Data        []byte
+	Offset      int64
+	ID          string
+	DigestValue string
+}
+
+// ErrorResponse represents a custom error response
+type ErrorResponse struct {
+	Code       int
+	ErrorCodes []ErrorCode
+}
+
+// ErrorCode represents an individual error in the response
+type ErrorCode struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Detail  map[string]any `json:"detail,omitempty"`
+}
+
+// MockRegistry provides a mock OCI registry implementation (distribution-spec)
+type MockRegistry struct {
+	server  *httptest.Server
+	content *RegistryContent
+}
+
+// NewMockRegistry creates a new mock registry server
+func NewMockRegistry(content *RegistryContent) *MockRegistry {
+	m := &MockRegistry{content: content}
+	m.server = httptest.NewServer(m.handler())
+	return m
+}
+
+// URL returns the URL of the mock registry
+func (m *MockRegistry) URL() string {
+	return m.server.URL
+}
+
+// Close shuts down the mock registry server
+func (m *MockRegistry) Close() {
+	m.server.Close()
+}
+
+func (m *MockRegistry) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check for custom error responses first
+		if m.content.ErrorResponses != nil {
+			if errResp, exists := m.content.ErrorResponses[r.URL.Path]; exists {
+				m.writeError(w, errResp.Code, errResp.ErrorCodes)
+				return
+			}
+		}
+
+		// Add custom headers if configured
+		if m.content.CustomHeaders != nil {
+			if headers, exists := m.content.CustomHeaders[r.URL.Path]; exists {
+				for k, v := range headers {
+					w.Header().Set(k, v)
+				}
+			}
+		}
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v2/":
+			m.handleAPIVersion(w, r)
+		case r.Method == "GET" && r.URL.Path == "/v2/_catalog":
+			m.handleCatalog(w, r)
+		case regexp.MustCompile(`^/v2/(.*)/tags/list`).MatchString(r.URL.Path):
+			m.handleTagsList(w, r)
+		case regexp.MustCompile(`^/v2/(.*)/manifests/(.*)`).MatchString(r.URL.Path):
+			m.handleManifests(w, r)
+		case regexp.MustCompile(`^/v2/(.*)/blobs/uploads/[a-zA-Z0-9-_]*$`).MatchString(r.URL.Path):
+			if r.Method == "POST" {
+				m.handleBlobUpload(w, r)
+			} else {
+				m.handleBlobUploadState(w, r)
+			}
+		case regexp.MustCompile(`^/v2/(.*)/blobs/uploads/`).MatchString(r.URL.Path):
+			m.handleBlobUploadState(w, r)
+		case regexp.MustCompile(`^/v2/(.*)/blobs/(.*)`).MatchString(r.URL.Path):
+			m.handleBlobs(w, r)
+		case regexp.MustCompile(`^/v2/(.*)/referrers/(.*)`).MatchString(r.URL.Path):
+			m.handleReferrers(w, r)
+		default:
+			m.writeError(w, http.StatusNotFound, []ErrorCode{{
+				Code:    "NAME_UNKNOWN",
+				Message: "repository name not known to registry",
+			}})
+		}
+	})
+}
+
+func (m *MockRegistry) handleAPIVersion(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *MockRegistry) handleCatalog(w http.ResponseWriter, r *http.Request) {
+	repos := make([]string, 0, len(m.content.Repositories))
+	for repo := range m.content.Repositories {
+		repos = append(repos, repo)
+	}
+
+	response := struct {
+		Repositories []string `json:"repositories"`
+	}{
+		Repositories: repos,
+	}
+
+	m.writeJSON(w, http.StatusOK, "", response)
+}
+
+func (m *MockRegistry) handleTagsList(w http.ResponseWriter, r *http.Request) {
+	matches := regexp.MustCompile(`^/v2/(.*)/tags/list`).FindStringSubmatch(r.URL.Path)
+	if len(matches) != 2 {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return
+	}
+
+	repoName := matches[1]
+	repo, exists := m.content.Repositories[repoName]
+	if !exists {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return
+	}
+
+	tags := make([]string, 0, len(repo.Tags))
+	for tag := range repo.Tags {
+		tags = append(tags, tag)
+	}
+
+	response := struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{
+		Name: repoName,
+		Tags: tags,
+	}
+
+	m.writeJSON(w, http.StatusOK, "", response)
+}
+
+func (m *MockRegistry) handleManifests(w http.ResponseWriter, r *http.Request) {
+	matches := regexp.MustCompile(`^/v2/(.*)/manifests/(.*)`).FindStringSubmatch(r.URL.Path)
+	if len(matches) != 3 {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return
+	}
+
+	repoName := matches[1]
+	reference := matches[2]
+
+	repo, exists := m.content.Repositories[repoName]
+	if !exists {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return
+	}
+
+	switch r.Method {
+	case "GET", "HEAD":
+		// Handle manifest retrieval by tag or digest
+		var manifest ManifestContent
+		if digest, err := digest.Parse(reference); err == nil {
+			// Reference is a digest
+			manifest = repo.Manifests[digest.String()]
+		} else {
+			// Reference is a tag
+			digestStr, exists := repo.Tags[reference]
+			if !exists {
+				m.writeError(w, http.StatusNotFound, []ErrorCode{{
+					Code:    "MANIFEST_UNKNOWN",
+					Message: "manifest unknown to registry",
+				}})
+				return
+			}
+			manifest = repo.Manifests[digestStr]
+		}
+
+		w.Header().Set("Content-Type", manifest.MediaType)
+		w.Header().Set("Docker-Content-Digest", manifest.Digest.String())
+		if r.Method == "GET" {
+			_, err := w.Write(manifest.Content)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+
+	case "PUT":
+		// Handle manifest upload
+		body, err := readAllBody(r)
+		if err != nil {
+			m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+				Code:    "MANIFEST_INVALID",
+				Message: "failed to read manifest body",
+			}})
+			return
+		}
+
+		dgst := digest.FromBytes(body)
+		manifest := ManifestContent{
+			Content:   body,
+			MediaType: r.Header.Get("Content-Type"),
+			Digest:    dgst,
+		}
+
+		// Parse manifest to check for subject field
+		var manifestObj struct {
+			Subject *descriptor.Descriptor `json:"subject,omitempty"`
+		}
+		if err := json.Unmarshal(body, &manifestObj); err == nil && manifestObj.Subject != nil {
+			w.Header().Set("OCI-Subject", manifestObj.Subject.Digest.String())
+		}
+
+		repo.Manifests[dgst.String()] = manifest
+		if strings.Contains(reference, ":") {
+			// Reference is likely a digest
+		} else {
+			repo.Tags[reference] = dgst.String()
+		}
+
+		w.Header().Set("Location", fmt.Sprintf("/v2/%s/manifests/%s", repoName, dgst))
+		w.WriteHeader(http.StatusCreated)
+
+	case "DELETE":
+		// Handle manifest deletion
+		_, exists := repo.Manifests[reference]
+		if !exists {
+			delete(repo.Tags, reference)
+		}
+
+		if exists {
+			// Delete the manifest
+			delete(repo.Manifests, reference)
+
+			// Remove this manifest from any referrers lists
+			for _, otherManifest := range repo.Manifests {
+				updatedReferrers := make([]descriptor.Descriptor, 0, len(otherManifest.Referrers))
+				for _, ref := range otherManifest.Referrers {
+					if ref.Digest.String() != reference {
+						updatedReferrers = append(updatedReferrers, ref)
+					}
+				}
+				otherManifest.Referrers = updatedReferrers
+			}
+		}
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *MockRegistry) handleReferrers(w http.ResponseWriter, r *http.Request) {
+	matches := regexp.MustCompile(`^/v2/(.*)/referrers/(.*)`).FindStringSubmatch(r.URL.Path)
+	if len(matches) != 3 {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "NAME_INVALID",
+			Message: "invalid repository name",
+		}})
+		return
+	}
+
+	repoName := matches[1]
+	digestStr := matches[2]
+
+	// Validate digest format
+	if _, err := digest.Parse(digestStr); err != nil {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "DIGEST_INVALID",
+			Message: "invalid digest format",
+		}})
+		return
+	}
+
+	repo, exists := m.content.Repositories[repoName]
+	if !exists {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return
+	}
+
+	manifest, exists := repo.Manifests[digestStr]
+	if !exists {
+		// Return empty list per spec
+		index := v1.Index{
+			Versioned: v1.ManifestSchemaVersion,
+			MediaType: "application/vnd.oci.image.index.v1+json",
+			Manifests: []descriptor.Descriptor{},
+		}
+		m.writeJSON(w, http.StatusOK, "application/vnd.oci.image.index.v1+json", index)
+		return
+	}
+
+	// Build referrers list, excluding any manifests that have been deleted
+	descriptors := make([]descriptor.Descriptor, 0, len(manifest.Referrers))
+	for _, ref := range manifest.Referrers {
+		// Only include referrer if it still exists in the repository
+		if _, exists := repo.Manifests[ref.Digest.String()]; exists {
+			descriptors = append(descriptors, ref)
+		}
+	}
+
+	// Filter by artifactType if requested
+	artifactType := r.URL.Query().Get("artifactType")
+	if artifactType != "" {
+		w.Header().Set("OCI-Filters-Applied", "artifactType")
+		filtered := make([]descriptor.Descriptor, 0)
+		for _, ref := range descriptors {
+			if ref.ArtifactType == artifactType {
+				filtered = append(filtered, ref)
+			}
+		}
+		descriptors = filtered
+	}
+
+	index := v1.Index{
+		Versioned: v1.ManifestSchemaVersion,
+		MediaType: "application/vnd.oci.image.index.v1+json",
+		Manifests: descriptors,
+	}
+
+	m.writeJSON(w, http.StatusOK, "application/vnd.oci.image.index.v1+json", index)
+}
+
+// Helper functions for reading bodies and writing responses
+func readAllBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func (m *MockRegistry) handleBlobs(w http.ResponseWriter, r *http.Request) {
+	repoName, ok := extractRepoName(`^/v2/(.*)/blobs/(.*)`, r.URL.Path)
+	if !ok {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "NAME_INVALID",
+			Message: "invalid repository name",
+		}})
+		return
+	}
+
+	repo, ok := m.getRepository(w, repoName)
+	if !ok {
+		return
+	}
+
+	matches := regexp.MustCompile(`^/v2/.*?/blobs/(.*)`).FindStringSubmatch(r.URL.Path)
+	if len(matches) != 2 {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "DIGEST_INVALID",
+			Message: "invalid digest",
+		}})
+		return
+	}
+	digest := matches[1]
+
+	switch r.Method {
+	case "HEAD", "GET":
+		blob, exists := repo.Blobs[digest]
+		if !exists {
+			m.writeError(w, http.StatusNotFound, []ErrorCode{{
+				Code:    "BLOB_UNKNOWN",
+				Message: "blob unknown to registry",
+			}})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Docker-Content-Digest", digest)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(blob)))
+
+		if r.Method == "HEAD" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Handle range requests
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader != "" {
+			if err := m.handleBlobRange(w, r, blob); err != nil {
+				m.writeError(w, http.StatusRequestedRangeNotSatisfiable, []ErrorCode{{
+					Code:    "UNSUPPORTED",
+					Message: "invalid range request",
+				}})
+				return
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(blob)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+	case "DELETE":
+		_, exists := repo.Blobs[digest]
+		if !exists {
+			m.writeError(w, http.StatusNotFound, []ErrorCode{{
+				Code:    "BLOB_UNKNOWN",
+				Message: "blob unknown to registry",
+			}})
+			return
+		}
+		delete(repo.Blobs, digest)
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *MockRegistry) handleBlobRange(w http.ResponseWriter, r *http.Request, blob []byte) error {
+	ranges, err := parseRangeHeader(r.Header.Get("Range"), int64(len(blob)))
+	if err != nil {
+		return err
+	}
+
+	// We'll handle only the first range for simplicity
+	if len(ranges) > 0 {
+		rng := ranges[0]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.Start, rng.End, len(blob)))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", rng.End-rng.Start+1))
+		w.WriteHeader(http.StatusPartialContent)
+		_, err := w.Write(blob[rng.Start : rng.End+1])
+		return err
+	}
+	return fmt.Errorf("no valid ranges")
+}
+
+func (m *MockRegistry) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
+	repoName, ok := extractRepoName(`^/v2/([^/]+)/blobs/uploads/`, r.URL.Path)
+	if !ok {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "NAME_INVALID",
+			Message: "invalid repository name",
+		}})
+		return
+	}
+
+	repo, ok := m.getRepository(w, repoName)
+	if !ok {
+		return
+	}
+
+	switch r.Method {
+	case "POST":
+		// Handle mount request if specified
+		if mountDigest := r.URL.Query().Get("mount"); mountDigest != "" {
+			fromRepo := r.URL.Query().Get("from")
+			if m.handleBlobMount(w, repoName, fromRepo, mountDigest) {
+				return
+			}
+			// Mount failed, fall through to regular upload
+		}
+
+		// Handle single POST upload if digest is specified
+		if digest := r.URL.Query().Get("digest"); digest != "" {
+			m.handleMonolithicUpload(w, r, repo, repoName, digest)
+			return
+		}
+
+		// Initialize chunked upload
+		uploadID := generateUploadID()
+		location := fmt.Sprintf("/v2/%s/blobs/uploads/%s", repoName, uploadID)
+
+		if repo.Uploads == nil {
+			repo.Uploads = make(map[string]*UploadState)
+		}
+
+		repo.Uploads[uploadID] = &UploadState{
+			Data:   make([]byte, 0),
+			Offset: 0,
+			ID:     uploadID,
+		}
+
+		w.Header().Set("Location", location)
+		w.Header().Set("Range", "0-0")
+		if repo.MinChunkSize > 0 {
+			w.Header().Set("OCI-Chunk-Min-Length", fmt.Sprintf("%d", repo.MinChunkSize))
+		}
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *MockRegistry) handleBlobUploadState(w http.ResponseWriter, r *http.Request) {
+	repoName, ok := extractRepoName(`^/v2/([^/]+)/blobs/uploads/`, r.URL.Path)
+	if !ok {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "NAME_INVALID",
+			Message: "invalid repository name",
+		}})
+		return
+	}
+
+	repo, ok := m.getRepository(w, repoName)
+	if !ok {
+		return
+	}
+
+	matches := regexp.MustCompile(`^/v2/.*?/blobs/uploads/(.*)`).FindStringSubmatch(r.URL.Path)
+	if len(matches) != 2 {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "BLOB_UPLOAD_INVALID",
+			Message: "invalid upload ID",
+		}})
+		return
+	}
+	uploadID := matches[1]
+
+	uploadState, exists := repo.Uploads[uploadID]
+	if !exists {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "BLOB_UPLOAD_UNKNOWN",
+			Message: "upload unknown to registry",
+		}})
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		// Return current upload status
+		w.Header().Set("Docker-Upload-UUID", uploadID)
+		if uploadState.Offset == 0 {
+			w.Header().Set("Range", "0-0")
+		} else {
+			w.Header().Set("Range", fmt.Sprintf("0-%d", uploadState.Offset-1))
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	case "PATCH":
+		// Handle chunk upload
+		contentRange := r.Header.Get("Content-Range")
+		if contentRange != "" {
+			if err := m.handleChunkUpload(w, r, repo, uploadState); err != nil {
+				m.writeError(w, http.StatusRequestedRangeNotSatisfiable, []ErrorCode{{
+					Code:    "BLOB_UPLOAD_INVALID",
+					Message: err.Error(),
+				}})
+				return
+			}
+		} else {
+			// Append chunk to end
+			chunk, err := readAllBody(r)
+			if err != nil {
+				m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+					Code:    "BLOB_UPLOAD_INVALID",
+					Message: "failed to read upload body",
+				}})
+				return
+			}
+
+			uploadState.Data = append(uploadState.Data, chunk...)
+			uploadState.Offset = int64(len(uploadState.Data))
+		}
+
+		w.Header().Set("Location", r.URL.Path)
+		w.Header().Set("Range", fmt.Sprintf("0-%d", uploadState.Offset-1))
+		w.Header().Set("Docker-Upload-UUID", uploadID)
+		w.WriteHeader(http.StatusAccepted)
+
+	case "PUT":
+		// Complete upload
+		digestStr := r.URL.Query().Get("digest")
+		if digestStr == "" {
+			m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+				Code:    "DIGEST_INVALID",
+				Message: "digest parameter missing",
+			}})
+			return
+		}
+
+		// Handle final chunk if provided
+		if r.ContentLength > 0 {
+			chunk, err := readAllBody(r)
+			if err != nil {
+				m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+					Code:    "BLOB_UPLOAD_INVALID",
+					Message: "failed to read upload body",
+				}})
+				return
+			}
+			uploadState.Data = append(uploadState.Data, chunk...)
+		}
+
+		// Verify digest
+		computedDigest := digest.FromBytes(uploadState.Data)
+		if computedDigest.String() != digestStr {
+			m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+				Code:    "DIGEST_INVALID",
+				Message: "provided digest does not match uploaded content",
+			}})
+			return
+		}
+
+		// Store blob
+		repo.Blobs[digestStr] = uploadState.Data
+		delete(repo.Uploads, uploadID)
+
+		w.Header().Set("Docker-Content-Digest", digestStr)
+		w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", repoName, digestStr))
+		w.WriteHeader(http.StatusCreated)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *MockRegistry) handleBlobMount(w http.ResponseWriter, targetRepo string, sourceRepo string, digest string) bool {
+	if sourceRepo == "" {
+		// Try to find blob in any repository
+		for repoName, repo := range m.content.Repositories {
+			if repoName == targetRepo {
+				continue
+			}
+			if blob, exists := repo.Blobs[digest]; exists {
+				m.content.Repositories[targetRepo].Blobs[digest] = blob
+				w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", targetRepo, digest))
+				w.WriteHeader(http.StatusCreated)
+				return true
+			}
+		}
+		return false
+	}
+
+	sourceRepoContent, exists := m.content.Repositories[sourceRepo]
+	if !exists {
+		return false
+	}
+
+	blob, exists := sourceRepoContent.Blobs[digest]
+	if !exists {
+		return false
+	}
+
+	m.content.Repositories[targetRepo].Blobs[digest] = blob
+	w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", targetRepo, digest))
+	w.WriteHeader(http.StatusCreated)
+	return true
+}
+
+func (m *MockRegistry) handleMonolithicUpload(w http.ResponseWriter, r *http.Request, repo *RepositoryContent, repoName string, digestStr string) {
+	body, err := readAllBody(r)
+	if err != nil {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "BLOB_UPLOAD_INVALID",
+			Message: "failed to read upload body",
+		}})
+		return
+	}
+
+	computedDigest := digest.FromBytes(body)
+	if computedDigest.String() != digestStr {
+		m.writeError(w, http.StatusBadRequest, []ErrorCode{{
+			Code:    "DIGEST_INVALID",
+			Message: "provided digest does not match uploaded content",
+		}})
+		return
+	}
+
+	repo.Blobs[digestStr] = body
+	w.Header().Set("Docker-Content-Digest", digestStr)
+	w.Header().Set("Location", fmt.Sprintf("/v2/%s/blobs/%s", repoName, digestStr))
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (m *MockRegistry) handleChunkUpload(w http.ResponseWriter, r *http.Request, repo *RepositoryContent, uploadState *UploadState) error {
+	// Parse Content-Range header
+	contentRange := r.Header.Get("Content-Range")
+	matches := regexp.MustCompile(`^([0-9]+)-([0-9]+)$`).FindStringSubmatch(contentRange)
+	if len(matches) != 3 {
+		return fmt.Errorf("invalid Content-Range format")
+	}
+
+	start, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid start position in Content-Range")
+	}
+
+	end, err := strconv.ParseInt(matches[2], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid end position in Content-Range")
+	}
+
+	// Validate range
+	if start > end {
+		return fmt.Errorf("invalid range: start position greater than end position")
+	}
+
+	// Validate chunk size if minimum is specified
+	chunkSize := end - start + 1
+	if repo.MinChunkSize > 0 && chunkSize < repo.MinChunkSize {
+		return fmt.Errorf("chunk size %d is smaller than minimum allowed size %d", chunkSize, repo.MinChunkSize)
+	}
+
+	// Verify the range starts at the current offset
+	if start != uploadState.Offset {
+		return fmt.Errorf("invalid range: expected start position %d, got %d", uploadState.Offset, start)
+	}
+
+	// Read chunk data
+	chunk, err := readAllBody(r)
+	if err != nil {
+		return fmt.Errorf("failed to read chunk data: %v", err)
+	}
+
+	// Verify chunk size matches Content-Range
+	if int64(len(chunk)) != chunkSize {
+		return fmt.Errorf("chunk size %d does not match Content-Range size %d", len(chunk), chunkSize)
+	}
+
+	// Handle first chunk
+	if start == 0 {
+		uploadState.Data = chunk
+	} else {
+		// Append chunk to existing data
+		// Ensure we have enough capacity
+		if int64(len(uploadState.Data)) < end+1 {
+			newData := make([]byte, end+1)
+			copy(newData, uploadState.Data)
+			uploadState.Data = newData
+		}
+		copy(uploadState.Data[start:], chunk)
+	}
+
+	uploadState.Offset = end + 1
+	return nil
+}
+
+// Helper function to extract repository name from a path pattern
+func extractRepoName(pattern string, path string) (string, bool) {
+	matches := regexp.MustCompile(pattern).FindStringSubmatch(path)
+	if len(matches) < 2 {
+		return "", false
+	}
+	return matches[1], true
+}
+
+func (m *MockRegistry) writeJSON(w http.ResponseWriter, status int, contentType string, v interface{}) {
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(v)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (m *MockRegistry) writeError(w http.ResponseWriter, status int, errors []ErrorCode) {
+	response := struct {
+		Errors []ErrorCode `json:"errors"`
+	}{
+		Errors: errors,
+	}
+	m.writeJSON(w, status, "", response)
+}
+
+// Helper function to look up repository
+func (m *MockRegistry) getRepository(w http.ResponseWriter, repoName string) (*RepositoryContent, bool) {
+	repo, exists := m.content.Repositories[repoName]
+	if !exists {
+		m.writeError(w, http.StatusNotFound, []ErrorCode{{
+			Code:    "NAME_UNKNOWN",
+			Message: "repository name not known to registry",
+		}})
+		return nil, false
+	}
+	return repo, true
+}
+
+// Helper function to generate unique upload IDs
+func generateUploadID() string {
+	return fmt.Sprintf("upload-%d", time.Now().UnixNano())
+}
+
+// Range represents a byte range
+type Range struct {
+	Start, End int64
+}
+
+// parseRangeHeader parses the Range header string
+func parseRangeHeader(rangeHeader string, size int64) ([]Range, error) {
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		return nil, fmt.Errorf("invalid range header format")
+	}
+
+	var ranges []Range
+	for _, rng := range strings.Split(strings.TrimPrefix(rangeHeader, "bytes="), ",") {
+		r, err := parseRange(strings.TrimSpace(rng), size)
+		if err != nil {
+			return nil, err
+		}
+		ranges = append(ranges, r)
+	}
+	return ranges, nil
+}
+
+// parseRange parses a single range value
+func parseRange(r string, size int64) (Range, error) {
+	parts := strings.Split(r, "-")
+	if len(parts) != 2 {
+		return Range{}, fmt.Errorf("invalid range format")
+	}
+
+	start, end := int64(-1), int64(-1)
+	if parts[0] != "" {
+		s, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return Range{}, err
+		}
+		start = s
+	}
+	if parts[1] != "" {
+		e, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return Range{}, err
+		}
+		end = e
+	}
+
+	if start == -1 {
+		if end == -1 {
+			return Range{}, fmt.Errorf("invalid range: both start and end are missing")
+		}
+		// suffix-length case: -500 means last 500 bytes
+		start = size - end
+		end = size - 1
+	} else {
+		if end == -1 {
+			end = size - 1
+		}
+	}
+
+	if start < 0 || end < 0 || start > end || end >= size {
+		return Range{}, fmt.Errorf("invalid range: out of bounds")
+	}
+
+	return Range{Start: start, End: end}, nil
+}

--- a/internal/testing/mockRegistry/mock_registry_test.go
+++ b/internal/testing/mockRegistry/mock_registry_test.go
@@ -1,0 +1,920 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockregistry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient/types/descriptor"
+	v1 "github.com/regclient/regclient/types/oci/v1"
+)
+
+func TestMockRegistry_APIVersion(t *testing.T) {
+	registry := NewMockRegistry(&RegistryContent{})
+	defer registry.Close()
+
+	// Test GET /v2/
+	resp, err := http.Get(registry.URL() + "/v2/")
+	if err != nil {
+		t.Fatalf("Failed to get API version: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+	if v := resp.Header.Get("Docker-Distribution-API-Version"); v != "registry/2.0" {
+		t.Errorf("Expected API version registry/2.0, got %s", v)
+	}
+}
+
+func TestMockRegistry_Catalog(t *testing.T) {
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"repo1": {},
+			"repo2": {},
+		},
+	}
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	resp, err := http.Get(registry.URL() + "/v2/_catalog")
+	if err != nil {
+		t.Fatalf("Failed to get catalog: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	var catalog struct {
+		Repositories []string `json:"repositories"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if len(catalog.Repositories) != 2 {
+		t.Errorf("Expected 2 repositories, got %d", len(catalog.Repositories))
+	}
+}
+
+func TestMockRegistry_Tags(t *testing.T) {
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"repo1": {
+				Tags: map[string]string{
+					"latest": "sha256:digest1",
+					"v1.0":   "sha256:digest2",
+				},
+			},
+		},
+	}
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	tests := []struct {
+		name         string
+		path         string
+		expectedCode int
+		expectedTags []string
+	}{
+		{
+			name:         "existing repository",
+			path:         "/v2/repo1/tags/list",
+			expectedCode: http.StatusOK,
+			expectedTags: []string{"latest", "v1.0"},
+		},
+		{
+			name:         "non-existent repository",
+			path:         "/v2/missing/tags/list",
+			expectedCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(registry.URL() + tt.path)
+			if err != nil {
+				t.Fatalf("Failed to get tags: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
+			}
+
+			if tt.expectedTags != nil {
+				var tagList struct {
+					Name string   `json:"name"`
+					Tags []string `json:"tags"`
+				}
+				if err := json.NewDecoder(resp.Body).Decode(&tagList); err != nil {
+					t.Fatalf("Failed to decode response: %v", err)
+				}
+
+				if len(tagList.Tags) != len(tt.expectedTags) {
+					t.Errorf("Expected %d tags, got %d", len(tt.expectedTags), len(tagList.Tags))
+				}
+			}
+		})
+	}
+}
+
+func TestMockRegistry_Manifests(t *testing.T) {
+	// Create a test manifest
+	manifest := v1.Manifest{
+		Versioned: v1.ManifestSchemaVersion,
+		Config: descriptor.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    digest.FromString("config"),
+			Size:      1,
+		},
+	}
+	manifestBytes, _ := json.Marshal(manifest)
+	manifestDigest := digest.FromBytes(manifestBytes)
+
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"repo1": {
+				Tags: map[string]string{
+					"latest": manifestDigest.String(),
+				},
+				Manifests: map[string]ManifestContent{
+					manifestDigest.String(): {
+						Content:   manifestBytes,
+						MediaType: "application/vnd.oci.image.manifest.v1+json",
+						Digest:    manifestDigest,
+					},
+				},
+			},
+		},
+	}
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		body         []byte
+		expectedCode int
+	}{
+		{
+			name:         "get manifest by tag",
+			method:       "GET",
+			path:         "/v2/repo1/manifests/latest",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "get manifest by digest",
+			method:       "GET",
+			path:         fmt.Sprintf("/v2/repo1/manifests/%s", manifestDigest),
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "head manifest",
+			method:       "HEAD",
+			path:         "/v2/repo1/manifests/latest",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "manifest not found",
+			method:       "GET",
+			path:         "/v2/repo1/manifests/missing",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "put manifest",
+			method:       "PUT",
+			path:         "/v2/repo1/manifests/newtag",
+			body:         manifestBytes,
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:         "delete manifest",
+			method:       "DELETE",
+			path:         "/v2/repo1/manifests/latest",
+			expectedCode: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body io.Reader
+			if tt.body != nil {
+				body = bytes.NewReader(tt.body)
+			}
+			req, err := http.NewRequest(tt.method, registry.URL()+tt.path, body)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+
+			if tt.method == "PUT" {
+				req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to do request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestMockRegistry_Blobs(t *testing.T) {
+	blobContent := []byte("test blob content")
+	blobDigest := digest.FromBytes(blobContent)
+
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"repo1": {
+				Blobs: map[string][]byte{
+					blobDigest.String(): blobContent,
+				},
+			},
+		},
+	}
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		headers      map[string]string
+		expectedCode int
+	}{
+		{
+			name:         "get blob",
+			method:       "GET",
+			path:         fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest),
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "head blob",
+			method:       "HEAD",
+			path:         fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest),
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "get blob with range",
+			method: "GET",
+			path:   fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest),
+			headers: map[string]string{
+				"Range": "bytes=0-5",
+			},
+			expectedCode: http.StatusPartialContent,
+		},
+		{
+			name:         "blob not found",
+			method:       "GET",
+			path:         "/v2/repo1/blobs/sha256:missing",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "delete blob",
+			method:       "DELETE",
+			path:         fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest),
+			expectedCode: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, registry.URL()+tt.path, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to do request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
+			}
+
+			if tt.method == "GET" && tt.expectedCode == http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("Failed to read response body: %v", err)
+				}
+				if !bytes.Equal(body, blobContent) {
+					t.Errorf("Expected blob content %q, got %q", blobContent, body)
+				}
+			}
+		})
+	}
+}
+
+func TestMockRegistry_BlobUpload(t *testing.T) {
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"repo1": {
+				Blobs:        map[string][]byte{},
+				Uploads:      map[string]*UploadState{},
+				MinChunkSize: 5,
+			},
+		},
+	}
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	t.Run("chunked upload full flow", func(t *testing.T) {
+		// Start upload
+		resp, err := http.Post(registry.URL()+"/v2/repo1/blobs/uploads/", "", nil)
+		if err != nil {
+			t.Fatalf("Failed to start upload: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusAccepted {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 202, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		location := resp.Header.Get("Location")
+		if location == "" {
+			t.Fatal("No upload location returned")
+		}
+
+		// Verify empty upload state
+		req, err := http.NewRequest(http.MethodGet, registry.URL()+location, nil)
+		if err != nil {
+			t.Fatalf("Failed to create GET request: %v", err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to get upload state: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("Expected status 204, got %d", resp.StatusCode)
+		}
+		if resp.Header.Get("Range") != "0-0" {
+			t.Errorf("Expected Range: 0-0, got %s", resp.Header.Get("Range"))
+		}
+
+		// Upload content in chunks
+		content := []byte("test blob content")
+		chunks := [][]byte{
+			content[:5],
+			content[5:10],
+			content[10:],
+		}
+
+		// Upload chunks
+		currentRange := 0
+		for i, chunk := range chunks {
+			req, err := http.NewRequest(http.MethodPatch, registry.URL()+location, bytes.NewReader(chunk))
+			if err != nil {
+				t.Fatalf("Failed to create PATCH request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/octet-stream")
+			req.Header.Set("Content-Range", fmt.Sprintf("%d-%d", currentRange, currentRange+len(chunk)-1))
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to upload chunk %d: %v", i, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusAccepted {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("Chunk %d: expected status 202, got %d: %s", i, resp.StatusCode, string(body))
+			}
+
+			currentRange += len(chunk)
+		}
+
+		// Complete upload
+		blobDigest := digest.FromBytes(content)
+		completeURL := fmt.Sprintf("%s%s?digest=%s", registry.URL(), location, blobDigest)
+		req, err = http.NewRequest(http.MethodPut, completeURL, nil)
+		if err != nil {
+			t.Fatalf("Failed to create PUT request: %v", err)
+		}
+
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to complete upload: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 201, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		// Verify blob can be retrieved
+		resp, err = http.Get(registry.URL() + fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest))
+		if err != nil {
+			t.Fatalf("Failed to get blob: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+
+		gotContent, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read blob content: %v", err)
+		}
+
+		if !bytes.Equal(gotContent, content) {
+			t.Errorf("Expected content %q, got %q", content, gotContent)
+		}
+	})
+
+	t.Run("monolithic upload", func(t *testing.T) {
+		content := []byte("direct upload content")
+		blobDigest := digest.FromBytes(content)
+
+		// Direct upload with digest
+		url := fmt.Sprintf("%s/v2/repo1/blobs/uploads/?digest=%s", registry.URL(), blobDigest)
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(content))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(content)))
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to do request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 201, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		// Verify blob was stored
+		resp, err = http.Get(registry.URL() + fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest))
+		if err != nil {
+			t.Fatalf("Failed to get blob: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+
+		gotContent, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read blob content: %v", err)
+		}
+
+		if !bytes.Equal(gotContent, content) {
+			t.Errorf("Expected content %q, got %q", content, gotContent)
+		}
+	})
+
+	t.Run("blob mount", func(t *testing.T) {
+		// First upload a blob to repo2
+		content := &RegistryContent{
+			Repositories: map[string]*RepositoryContent{
+				"repo1": {Blobs: map[string][]byte{}},
+				"repo2": {Blobs: map[string][]byte{}},
+			},
+		}
+		registry := NewMockRegistry(content)
+		defer registry.Close()
+
+		blobContent := []byte("blob to mount")
+		blobDigest := digest.FromBytes(blobContent)
+
+		// Upload to repo2
+		url := fmt.Sprintf("%s/v2/repo2/blobs/uploads/?digest=%s", registry.URL(), blobDigest)
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(blobContent))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to do request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("Failed to upload blob to source repo: %d", resp.StatusCode)
+		}
+
+		// Try to mount from repo2 to repo1
+		url = fmt.Sprintf("%s/v2/repo1/blobs/uploads/?mount=%s&from=repo2", registry.URL(), blobDigest)
+		req, err = http.NewRequest(http.MethodPost, url, nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to do request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("Expected status 201, got %d", resp.StatusCode)
+		}
+
+		// Verify blob exists in repo1
+		resp, err = http.Get(registry.URL() + fmt.Sprintf("/v2/repo1/blobs/%s", blobDigest))
+		if err != nil {
+			t.Fatalf("Failed to get blob: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid digest", func(t *testing.T) {
+		content := []byte("invalid digest test")
+		wrongDigest := "sha256:wrong"
+
+		url := fmt.Sprintf("%s/v2/repo1/blobs/uploads/?digest=%s", registry.URL(), wrongDigest)
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(content))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to do request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("chunk size validation", func(t *testing.T) {
+		// Start upload
+		resp, err := http.Post(registry.URL()+"/v2/repo1/blobs/uploads/", "", nil)
+		if err != nil {
+			t.Fatalf("Failed to start upload: %v", err)
+		}
+		defer resp.Body.Close()
+
+		location := resp.Header.Get("Location")
+		if location == "" {
+			t.Fatal("No upload location returned")
+		}
+
+		// Try to upload chunk smaller than MinChunkSize
+		smallChunk := []byte("tiny")
+		req, err := http.NewRequest(http.MethodPatch, registry.URL()+location, bytes.NewReader(smallChunk))
+		if err != nil {
+			t.Fatalf("Failed to create PATCH request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Content-Range", fmt.Sprintf("0-%d", len(smallChunk)-1))
+
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to upload chunk: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+			t.Errorf("Expected status 416, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestMockRegistry_Referrers(t *testing.T) {
+	// Set up base manifest and blob
+	imageLayerBytes := []byte("test layer content")
+	imageLayerDigest := digest.FromBytes(imageLayerBytes)
+
+	imageManifest := v1.Manifest{
+		Versioned: v1.ManifestSchemaVersion,
+		Config: descriptor.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    digest.FromString("test config"),
+			Size:      1,
+		},
+		Layers: []descriptor.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    imageLayerDigest,
+				Size:      int64(len(imageLayerBytes)),
+			},
+		},
+	}
+	imageBytes, _ := json.Marshal(imageManifest)
+	imageDigest := digest.FromBytes(imageBytes)
+
+	// Create various types of referrers
+	sbomContent := []byte("test SBOM content")
+	sbomDigest := digest.FromBytes(sbomContent)
+
+	sigContent := []byte("test signature content")
+	sigDigest := digest.FromBytes(sigContent)
+
+	customContent := []byte("test custom artifact")
+	customDigest := digest.FromBytes(customContent)
+
+	content := &RegistryContent{
+		Repositories: map[string]*RepositoryContent{
+			"test-repo": {
+				Manifests: map[string]ManifestContent{
+					imageDigest.String(): {
+						Content:   imageBytes,
+						MediaType: "application/vnd.oci.image.manifest.v1+json",
+						Digest:    imageDigest,
+						Referrers: []descriptor.Descriptor{
+							{
+								MediaType:    "application/vnd.oci.image.manifest.v1+json",
+								Digest:       sbomDigest,
+								Size:         int64(len(sbomContent)),
+								ArtifactType: "application/vnd.example.sbom.v1+json",
+								Annotations: map[string]string{
+									"org.opencontainers.image.created": "2024-01-01T00:00:00Z",
+								},
+							},
+							{
+								MediaType:    "application/vnd.oci.image.manifest.v1+json",
+								Digest:       sigDigest,
+								Size:         int64(len(sigContent)),
+								ArtifactType: "application/vnd.example.signature.v1+json",
+								Annotations: map[string]string{
+									"org.opencontainers.image.created": "2024-01-01T00:00:00Z",
+								},
+							},
+							{
+								MediaType:    "application/vnd.oci.image.manifest.v1+json",
+								Digest:       customDigest,
+								Size:         int64(len(customContent)),
+								ArtifactType: "application/vnd.example.custom.v1+json",
+								Annotations: map[string]string{
+									"org.opencontainers.image.created": "2024-01-01T00:00:00Z",
+									"custom.metadata":                  "test value",
+								},
+							},
+						},
+					},
+					sbomDigest.String(): {
+						Content:      sbomContent,
+						MediaType:    "application/vnd.oci.image.manifest.v1+json",
+						Digest:       sbomDigest,
+						ArtifactType: "application/vnd.example.sbom.v1+json",
+					},
+					sigDigest.String(): {
+						Content:      sigContent,
+						MediaType:    "application/vnd.oci.image.manifest.v1+json",
+						Digest:       sigDigest,
+						ArtifactType: "application/vnd.example.signature.v1+json",
+					},
+					customDigest.String(): {
+						Content:      customContent,
+						MediaType:    "application/vnd.oci.image.manifest.v1+json",
+						Digest:       customDigest,
+						ArtifactType: "application/vnd.example.custom.v1+json",
+					},
+				},
+				Blobs: map[string][]byte{
+					imageLayerDigest.String(): imageLayerBytes,
+				},
+			},
+			"empty-repo": {
+				Manifests: map[string]ManifestContent{},
+				Blobs:     map[string][]byte{},
+			},
+		},
+	}
+
+	registry := NewMockRegistry(content)
+	defer registry.Close()
+
+	tests := []struct {
+		name          string
+		path          string
+		query         string
+		expectedCode  int
+		validateResp  func(t *testing.T, body []byte)
+		expectHeaders map[string]string
+	}{
+		{
+			name:         "get all referrers",
+			path:         fmt.Sprintf("/v2/test-repo/referrers/%s", imageDigest),
+			expectedCode: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var index v1.Index
+				if err := json.Unmarshal(body, &index); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+				if len(index.Manifests) != 3 {
+					t.Errorf("Expected 3 referrers, got %d", len(index.Manifests))
+				}
+			},
+			expectHeaders: map[string]string{
+				"Content-Type": "application/vnd.oci.image.index.v1+json",
+			},
+		},
+		{
+			name:         "filter by artifact type",
+			path:         fmt.Sprintf("/v2/test-repo/referrers/%s", imageDigest),
+			query:        "?artifactType=application/vnd.example.sbom.v1%2Bjson",
+			expectedCode: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var index v1.Index
+				if err := json.Unmarshal(body, &index); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+				if len(index.Manifests) != 1 {
+					t.Errorf("Expected 1 referrer, got %d", len(index.Manifests))
+				}
+				if index.Manifests[0].ArtifactType != "application/vnd.example.sbom.v1+json" {
+					t.Errorf("Expected SBOM artifact type, got %s", index.Manifests[0].ArtifactType)
+				}
+			},
+			expectHeaders: map[string]string{
+				"Content-Type":        "application/vnd.oci.image.index.v1+json",
+				"OCI-Filters-Applied": "artifactType",
+			},
+		},
+		{
+			name:         "referrers with invalid digest format",
+			path:         "/v2/test-repo/referrers/invalid-digest",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "nonexistent repository",
+			path:         fmt.Sprintf("/v2/nonexistent/referrers/%s", imageDigest),
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "empty repository",
+			path:         fmt.Sprintf("/v2/empty-repo/referrers/%s", imageDigest),
+			expectedCode: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var index v1.Index
+				if err := json.Unmarshal(body, &index); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+				if len(index.Manifests) != 0 {
+					t.Errorf("Expected empty referrers list, got %d entries", len(index.Manifests))
+				}
+			},
+		},
+		{
+			name:         "manifest with no referrers",
+			path:         fmt.Sprintf("/v2/test-repo/referrers/%s", sbomDigest),
+			expectedCode: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var index v1.Index
+				if err := json.Unmarshal(body, &index); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+				if len(index.Manifests) != 0 {
+					t.Errorf("Expected empty referrers list, got %d entries", len(index.Manifests))
+				}
+			},
+		},
+		{
+			name:         "validate required descriptor fields",
+			path:         fmt.Sprintf("/v2/test-repo/referrers/%s", imageDigest),
+			expectedCode: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var index v1.Index
+				if err := json.Unmarshal(body, &index); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+				for _, m := range index.Manifests {
+					if m.MediaType == "" {
+						t.Error("MediaType is required")
+					}
+					if m.Digest == "" {
+						t.Error("Digest is required")
+					}
+					if m.Size == 0 {
+						t.Error("Size is required")
+					}
+					if m.ArtifactType == "" {
+						t.Error("ArtifactType should be set")
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := registry.URL() + tt.path
+			if tt.query != "" {
+				url += tt.query
+			}
+
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Fatalf("Failed to send request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
+			}
+
+			if tt.validateResp != nil && resp.StatusCode == http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("Failed to read response body: %v", err)
+				}
+				tt.validateResp(t, body)
+			}
+
+			for header, expectedValue := range tt.expectHeaders {
+				if got := resp.Header.Get(header); got != expectedValue {
+					t.Errorf("Expected header %s=%s, got %s", header, expectedValue, got)
+				}
+			}
+		})
+	}
+
+	// Test referrer deletion
+	t.Run("referrer list update after manifest deletion", func(t *testing.T) {
+		// First verify the SBOM referrer exists
+		url := fmt.Sprintf("%s/v2/test-repo/referrers/%s", registry.URL(), imageDigest)
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("Failed to get referrers: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Failed to get initial referrers: %d", resp.StatusCode)
+		}
+
+		// Delete the SBOM manifest
+		url = fmt.Sprintf("%s/v2/test-repo/manifests/%s", registry.URL(), sbomDigest)
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
+		if err != nil {
+			t.Fatalf("Failed to create delete request: %v", err)
+		}
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to delete manifest: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusAccepted {
+			t.Fatalf("Failed to delete manifest: %d", resp.StatusCode)
+		}
+
+		// Verify the SBOM is no longer in the referrers list
+		url = fmt.Sprintf("%s/v2/test-repo/referrers/%s", registry.URL(), imageDigest)
+		resp, err = http.Get(url)
+		if err != nil {
+			t.Fatalf("Failed to get referrers after delete: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var index v1.Index
+		if err := json.NewDecoder(resp.Body).Decode(&index); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		for _, m := range index.Manifests {
+			if m.Digest == sbomDigest {
+				t.Error("SBOM manifest should not be in referrers list after deletion")
+			}
+		}
+	})
+}

--- a/pkg/collectsub/datasource/datasource.go
+++ b/pkg/collectsub/datasource/datasource.go
@@ -36,6 +36,7 @@ type CollectSource interface {
 
 type DataSources struct {
 	OciDataSources []Source
+	OciRegistryDataSources []Source
 	// NOTE: Git data sources should follow the URI scheme as defined in:
 	// https://spdx.github.io/spdx-spec/v2.3/package-information/#771-description
 	// <vcs_tool>+<transport>://<host_name>[/<path_to_repository>][@<revision_tag_or_branch>][#<sub_path>]

--- a/pkg/handler/collector/collector.go
+++ b/pkg/handler/collector/collector.go
@@ -73,6 +73,14 @@ func RegisterDocumentCollector(c Collector, collectorType string) error {
 	return nil
 }
 
+func DeregisterDocumentCollector(collectorType string) error {
+	if _, ok := documentCollectors[collectorType]; !ok {
+		return fmt.Errorf("the document collector %s does not exist", collectorType)
+	}
+	delete(documentCollectors, collectorType)
+	return nil
+}
+
 func AddChildLogger(logger *zap.SugaredLogger, d *processor.Document) {
 	key := events.GetKey(d.Blob)
 	childLogger := logger.With(zap.String(logging.DocumentHash, key))

--- a/pkg/handler/collector/oci/oci.go
+++ b/pkg/handler/collector/oci/oci.go
@@ -70,6 +70,8 @@ type ociCollector struct {
 	checkedDigest     sync.Map
 	poll              bool
 	interval          time.Duration
+	// rcOpts are the regclient options
+	rcOpts []regclient.Opt
 }
 
 // NewOCICollector initializes the oci collector by passing in the repo and tag being collected.
@@ -77,12 +79,16 @@ type ociCollector struct {
 // repos in a given registry. For further details see issue #298
 //
 // Interval should be set to about 5 mins or more for production so that it doesn't clobber registries.
-func NewOCICollector(ctx context.Context, collectDataSource datasource.CollectSource, poll bool, interval time.Duration) *ociCollector {
+func NewOCICollector(ctx context.Context, collectDataSource datasource.CollectSource, poll bool, interval time.Duration, rcOpts ...regclient.Opt) *ociCollector {
+	if rcOpts == nil {
+		rcOpts = getRegClientOptions()
+	}
 	return &ociCollector{
 		collectDataSource: collectDataSource,
 		checkedDigest:     sync.Map{},
 		poll:              poll,
 		interval:          interval,
+		rcOpts:            rcOpts,
 	}
 }
 
@@ -157,18 +163,13 @@ func (o *ociCollector) populateRepoRefs(ctx context.Context, repoRefs map[string
 }
 
 func (o *ociCollector) getRefsAndFetch(ctx context.Context, repo string, imageRefs []ref.Ref, docChannel chan<- *processor.Document) error {
-	rcOpts := []regclient.Opt{}
-	rcOpts = append(rcOpts, regclient.WithDockerCreds())
-	rcOpts = append(rcOpts, regclient.WithDockerCerts())
-	rcOpts = append(rcOpts, regclient.WithUserAgent(version.UserAgent))
-
 	if len(imageRefs) > 0 {
 		for _, r := range imageRefs {
 			if hasNoIdentifier(r) {
 				return errors.New("image identifier not specified to fetch")
 			}
 
-			rc := regclient.New(rcOpts...)
+			rc := regclient.New(o.rcOpts...)
 			defer rc.Close(ctx, r)
 
 			if err := o.fetchOCIArtifacts(ctx, repo, rc, r, docChannel); err != nil {
@@ -181,7 +182,7 @@ func (o *ociCollector) getRefsAndFetch(ctx context.Context, repo string, imageRe
 			return err
 		}
 
-		rc := regclient.New(rcOpts...)
+		rc := regclient.New(o.rcOpts...)
 		defer rc.Close(ctx, r)
 
 		tags, err := rc.TagList(ctx, r)
@@ -525,4 +526,12 @@ func hasNoDigest(r ref.Ref) bool {
 // or digest)
 func hasNoIdentifier(r ref.Ref) bool {
 	return hasNoTag(r) && hasNoDigest(r)
+}
+
+func getRegClientOptions() []regclient.Opt {
+	rcOpts := []regclient.Opt{}
+	rcOpts = append(rcOpts, regclient.WithDockerCreds())
+	rcOpts = append(rcOpts, regclient.WithDockerCerts())
+	rcOpts = append(rcOpts, regclient.WithUserAgent(version.UserAgent))
+	return rcOpts
 }

--- a/pkg/handler/collector/oci/oci_registry.go
+++ b/pkg/handler/collector/oci/oci_registry.go
@@ -1,0 +1,162 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/pkg/errors"
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/errs"
+)
+
+const (
+	OCIRegistryCollector = "OCIRegistryCollector"
+)
+
+type ociRegistryCollector struct {
+	collectDataSource datasource.CollectSource
+	checkedDigest     sync.Map
+	poll              bool
+	interval          time.Duration
+	// rcOpts are the regclient options
+	rcOpts []regclient.Opt
+}
+
+// NewOCIRegistryCollector initializes the oci registry collector that will collect from all
+// repos in the given registry
+func NewOCIRegistryCollector(ctx context.Context, collectDataSource datasource.CollectSource, poll bool, interval time.Duration, rcOpts ...regclient.Opt) *ociRegistryCollector {
+	if rcOpts == nil {
+		rcOpts = getRegClientOptions()
+	}
+	return &ociRegistryCollector{
+		collectDataSource: collectDataSource,
+		checkedDigest:     sync.Map{},
+		poll:              poll,
+		interval:          interval,
+		rcOpts:            rcOpts,
+	}
+}
+
+// RetrieveArtifacts get the artifacts from all repositories in the registry based on polling or one time
+func (o *ociRegistryCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	if o.poll {
+		for {
+			if err := o.retrieveRegistryArtifacts(ctx, docChannel); err != nil {
+				return fmt.Errorf("failed to retrieve registry artifacts: %w", err)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(o.interval):
+			}
+		}
+	} else {
+		if err := o.retrieveRegistryArtifacts(ctx, docChannel); err != nil {
+			return fmt.Errorf("failed to retrieve registry artifacts: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (o *ociRegistryCollector) retrieveRegistryArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
+	ds, err := o.collectDataSource.GetDataSources(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve datasource: %w", err)
+	}
+
+	rc := regclient.New(o.rcOpts...)
+
+	// Process each registry from the data sources
+	for _, r := range ds.OciRegistryDataSources {
+		registry := r.Value
+		// Get list of repositories in the registry
+		repos, err := o.listRepositories(ctx, rc, registry)
+		if err != nil {
+			logger.Errorf("failed to list repositories for registry %s: %v", registry, err)
+			continue
+		}
+
+		// Create new data source for repositories
+		repoSources := make([]datasource.Source, len(repos))
+		for i, repo := range repos {
+			repoSources[i] = datasource.Source{
+				Value: fmt.Sprintf("%s/%s", registry, repo),
+			}
+		}
+
+		repoDataSource, err := inmemsource.NewInmemDataSources(&datasource.DataSources{
+			OciDataSources: repoSources,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to create repository datasource: %w", err)
+		}
+
+		// Create OCI collector for repositories
+		ociCollector := NewOCICollector(ctx, repoDataSource, false, o.interval, o.rcOpts...)
+		if err := ociCollector.RetrieveArtifacts(ctx, docChannel); err != nil {
+			logger.Errorf("failed to retrieve artifacts from repository %s: %v", registry, err)
+			continue
+		}
+
+		// Sync collected digests
+		o.syncCollectedDigests(&ociCollector.checkedDigest)
+	}
+
+	return nil
+}
+
+func (o *ociRegistryCollector) listRepositories(ctx context.Context, rc *regclient.RegClient, registry string) ([]string, error) {
+	rl, err := rc.RepoList(ctx, registry)
+	if err != nil {
+		if errors.Is(err, errs.ErrNotImplemented) {
+			return nil, fmt.Errorf("registry %s does not support _catalog API: %w", registry, err)
+		}
+		return nil, fmt.Errorf("failed to list repositories: %w", err)
+	}
+
+	if rl == nil || len(rl.Repositories) == 0 {
+		return nil, fmt.Errorf("no repositories found in registry %s", registry)
+	}
+
+	return rl.Repositories, nil
+}
+
+func (o *ociRegistryCollector) syncCollectedDigests(sourceDigests *sync.Map) {
+	sourceDigests.Range(func(key, value interface{}) bool {
+		if k, ok := key.(string); ok {
+			if v, ok := value.([]string); ok {
+				o.checkedDigest.Store(k, v)
+			}
+		}
+		return true
+	})
+}
+
+// Type is the collector type of the collector
+func (o *ociRegistryCollector) Type() string {
+	return OCIRegistryCollector
+}

--- a/pkg/handler/collector/oci/oci_registry_test.go
+++ b/pkg/handler/collector/oci/oci_registry_test.go
@@ -1,0 +1,245 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	mockregistry "github.com/guacsec/guac/internal/testing/mockRegistry"
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/config"
+	"github.com/regclient/regclient/types/descriptor"
+	v1 "github.com/regclient/regclient/types/oci/v1"
+)
+
+func TestOCIRegistryCollectionPipeline(t *testing.T) {
+	ctx := context.Background()
+
+	// Create mock registry content
+	imageLayerBytes := []byte("mock image layer content")
+	imageLayerDigest := digest.FromBytes(imageLayerBytes)
+
+	sbomBlobBytes := []byte("mock SBOM content")
+	sbomBlobDigest := digest.FromBytes(sbomBlobBytes)
+
+	// Create image manifest
+	imageManifest := v1.Manifest{
+		Versioned: v1.ManifestSchemaVersion,
+		Config: descriptor.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    digest.FromString("mock image config"),
+			Size:      1,
+		},
+		Layers: []descriptor.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    imageLayerDigest,
+				Size:      int64(len(imageLayerBytes)),
+			},
+		},
+	}
+	imageBytes, err := json.Marshal(imageManifest)
+	if err != nil {
+		t.Fatalf("Failed to marshal image manifest: %v", err)
+	}
+	imageDigest := digest.FromBytes(imageBytes)
+
+	// Create SBOM manifest
+	sbomManifest := v1.Manifest{
+		Versioned: v1.ManifestSchemaVersion,
+		Config: descriptor.Descriptor{
+			MediaType: "application/vnd.example.sbom.config.v1+json",
+			Digest:    digest.FromString("mock sbom config"),
+			Size:      1,
+		},
+		ArtifactType: SpdxJson,
+		Layers: []descriptor.Descriptor{
+			{
+				MediaType: "application/vnd.example.sbom.layer.v1+json",
+				Digest:    sbomBlobDigest,
+				Size:      int64(len(sbomBlobBytes)),
+			},
+		},
+		Annotations: map[string]string{
+			"org.opencontainers.image.ref.name": "latest.sbom",
+		},
+		Subject: &descriptor.Descriptor{
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Digest:    imageDigest,
+			Size:      int64(len(imageBytes)),
+		},
+	}
+	sbomBytes, err := json.Marshal(sbomManifest)
+	if err != nil {
+		t.Fatalf("Failed to marshal sbom manifest: %v", err)
+	}
+	sbomDigest := digest.FromBytes(sbomBytes)
+
+	// Initialize mock registry content
+	content := &mockregistry.RegistryContent{
+		Repositories: map[string]*mockregistry.RepositoryContent{
+			"ubuntu": {
+				Tags: map[string]string{
+					"latest":      imageDigest.String(),
+					"latest.sbom": sbomDigest.String(),
+				},
+				Manifests: map[string]mockregistry.ManifestContent{
+					imageDigest.String(): {
+						Content:   imageBytes,
+						MediaType: "application/vnd.oci.image.manifest.v1+json",
+						Digest:    imageDigest,
+						Referrers: []descriptor.Descriptor{
+							{
+								MediaType:    "application/vnd.oci.image.manifest.v1+json",
+								Digest:       sbomDigest,
+								Size:         int64(len(sbomBytes)),
+								ArtifactType: SpdxJson,
+								Annotations: map[string]string{
+									"org.opencontainers.image.ref.name": "sbom",
+								},
+							},
+						},
+					},
+					sbomDigest.String(): {
+						Content:   sbomBytes,
+						MediaType: "application/vnd.oci.image.manifest.v1+json",
+						Digest:    sbomDigest,
+						ArtifactType: SpdxJson,
+					},
+				},
+				Blobs: map[string][]byte{
+					imageLayerDigest.String(): imageLayerBytes,
+					sbomBlobDigest.String():   sbomBlobBytes,
+				},
+			},
+		},
+	}
+
+	// Create mock registry
+	registry := mockregistry.NewMockRegistry(content)
+	defer registry.Close()
+
+	// Extract host from registry URL
+	parsedURL, err := url.Parse(registry.URL())
+	if err != nil {
+		t.Fatalf("Failed to parse mock registry URL: %v", err)
+	}
+	registryHost := parsedURL.Host
+
+	// Create collect data source
+	ds := toRegistryDataSource(t, []string{registryHost})
+
+	// Configure registry client options
+	rcOpts := getRegClientOptions()
+	rcOpts = append(rcOpts,
+		regclient.WithConfigHost([]config.Host{{
+			Name:     registryHost,
+			Hostname: registryHost,
+			TLS:      config.TLSDisabled,
+		}}...),
+	)
+
+	// Create and register collector
+	g := NewOCIRegistryCollector(ctx, ds, false, 0, rcOpts...)
+
+	if err := collector.RegisterDocumentCollector(g, OCIRegistryCollector); err != nil &&
+		!errors.Is(err, collector.ErrCollectorOverwrite) {
+		t.Fatalf("could not register collector: %v", err)
+	}
+	defer func() {
+		if err := collector.DeregisterDocumentCollector(OCIRegistryCollector); err != nil {
+			t.Fatalf("could not deregister collector: %v", err)
+		}
+	}()
+
+	// Run collection with timeout
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var collectedDocs []*processor.Document
+	em := func(d *processor.Document) error {
+		collectedDocs = append(collectedDocs, d)
+		return nil
+	}
+	eh := func(err error) bool {
+		if err != nil {
+			t.Fatalf("Collector error handler error: %v", err)
+		}
+		return true
+	}
+
+	if err := collector.Collect(ctx, em, eh); err != nil {
+		t.Fatalf("Collector error: %v", err)
+	}
+
+	// Validate results
+	if len(collectedDocs) != 1 {
+		t.Fatalf("Expected 1 collected document, got %d", len(collectedDocs))
+	}
+
+	doc := collectedDocs[0]
+
+	// Validate document properties
+	if doc.Type != processor.DocumentSPDX {
+		t.Errorf("doc.Type = %v, want %v", doc.Type, processor.DocumentSPDX)
+	}
+	if doc.Format != processor.FormatJSON {
+		t.Errorf("doc.Format = %v, want %v", doc.Format, processor.FormatJSON)
+	}
+	if doc.Encoding != "" {
+		t.Errorf("doc.Encoding = %v, want empty string", doc.Encoding)
+	}
+	if doc.SourceInformation.Collector != OCICollector {
+		t.Errorf("doc.SourceInformation.Collector = %v, want %v", doc.SourceInformation.Collector, OCICollector)
+	}
+
+	expectedSource := fmt.Sprintf("%s/ubuntu@%s", registryHost, sbomDigest)
+	if doc.SourceInformation.Source != expectedSource {
+		t.Errorf("doc.SourceInformation.Source = %v, want %v", doc.SourceInformation.Source, expectedSource)
+	}
+
+	expectedDocRef := strings.ReplaceAll(sbomBlobDigest.String(), ":", "_")
+	if doc.SourceInformation.DocumentRef != expectedDocRef {
+		t.Errorf("doc.SourceInformation.DocumentRef = %v, want %v", doc.SourceInformation.DocumentRef, expectedDocRef)
+	}
+}
+
+func toRegistryDataSource(t *testing.T, ociRegistryValues []string) datasource.CollectSource {
+	values := []datasource.Source{}
+	for _, v := range ociRegistryValues {
+		values = append(values, datasource.Source{Value: v})
+	}
+
+	ds, err := inmemsource.NewInmemDataSources(&datasource.DataSources{
+		OciRegistryDataSources: values,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return ds
+}


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
This is my attempt at progressing #1279 cc @ridhoq 
I think this feature is still one we want to add long-term

Partial fix for #298, this should be merged first and then #2241 will fix the issue.

A couple of thoughts I've had along the way:
- It seems like a call to `/v2/_catalog` requires authentication for many registries (e.g. ghcr.io, ghr.io to name two)
- My understanding is that `regclient` silently fails on a 401 response from the registry and doesn't seek to reconcile it by attempting login with local creds even when we pass WithDockerCreds in. I'm not sure if that is still the case. Relevant issue: https://github.com/regclient/regclient/issues/748#issuecomment-2122725832
- Another useful issue/comment for context: https://github.com/regclient/regclient/issues/792#issuecomment-2329783099
- In my drafting of testing for the feature, I could only get `mcr.microsoft.com` to return a list of repos (see https://mcr.microsoft.com/v2/_catalog for this list) however the call returns around 2k+ repos with some having upwards of 100+ tags, so unless we implement some kind of concurrency, I think unit testing might be infeasible. Also, it looks like mcr doesn't yet support limits (e.g. https://mcr.microsoft.com/v2/_catalog?n=5).

Any guidance on the testing or concurrency would be appreciated!

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
