### PR TITLE
Fix Flaky E2e Test

### DIFF
--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -145,8 +145,8 @@ for command in "${ingestion_commands[@]}"; do
   echo @@@@ Running ingestion command: "$command" | tee -a "$LOG_FILE"
   eval "$command"
 
-  echo @@@@ Waiting
-  sleep 60
+  echo @@@@ Waiting for 5 minutes
+  sleep 300
 
   if [ $? -ne 0 ]; then
     echo "Error: Command '$command' failed" | tee -a "$LOG_FILE"


### PR DESCRIPTION
# Description of the PR

* The e2e tests are currently flaky (i.e. https://github.com/guacsec/guac/actions/runs/11241018691/job/31251648421). The issue is that there is a race condition, so we have increased the wait time from 1 minute to 5 minutes.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
