### PR TITLE
fix ite6 vuln attestation to use the right predicatetype

### DIFF
--- a/internal/testing/testdata/exampledata/certify-novuln.json
+++ b/internal/testing/testdata/exampledata/certify-novuln.json
@@ -6,7 +6,7 @@
         "digest": {"sha256": "3a2bd2c5cc4c978e8aefd8bd0ef335fb42ee31d1"}
       }
   ],
-  "predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+  "predicateType": "https://in-toto.io/attestation/vulns/v0.1",
   "predicate": {
     "invocation": {
       "parameters": [""],

--- a/internal/testing/testdata/exampledata/certify-vuln.json
+++ b/internal/testing/testdata/exampledata/certify-vuln.json
@@ -5,7 +5,7 @@
         "uri": "pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1"
       }
   ],
-  "predicateType": "https://in-toto.io/attestation/vuln/v0.1",
+  "predicateType": "https://in-toto.io/attestation/vulns/v0.1",
   "predicate": {
     "invocation": {
       "parameters": [""],

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1891,7 +1891,7 @@ var (
 			  "uri":"pkg:maven/org.apache.commons/commons-text@1.9"
 		   }
 		],
-		"predicate_type":"https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
 		   "invocation":{
 			  "uri":"guac",
@@ -1920,7 +1920,7 @@ var (
 			  "uri":"pkg:oci/vul-secondLevel-latest?repository_url=gcr.io"
 		   }
 		],
-		"predicate_type":"https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
 		   "invocation":{
 			  "uri":"guac",
@@ -1943,7 +1943,7 @@ var (
 			  "uri":"pkg:oci/vul-image-latest?repository_url=gcr.io"
 		   }
 		],
-		"predicate_type":"https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
 		   "invocation":{
 			  "uri":"guac",
@@ -1966,7 +1966,7 @@ var (
 			  "uri":"pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1"
 		   }
 		],
-		"predicate_type":"https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
 		   "invocation":{
 			  "uri":"guac",
@@ -2027,7 +2027,7 @@ var (
 				"uri": "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar"
 			}
 		],
-		"predicate_type": "https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
 			"invocation": {
 				"uri": "guac",
@@ -2051,7 +2051,7 @@ var (
 				"uri": "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar"
 			}
 		],
-		"predicate_type": "https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
 			"invocation": {
 				"uri": "guac",
@@ -2075,7 +2075,7 @@ var (
 				"uri": "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar"
 			}
 		],
-		"predicate_type": "https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
 			"invocation": {
 				"uri": "guac",
@@ -2099,7 +2099,7 @@ var (
 				"uri": "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
 			}
 		],
-		"predicate_type": "https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
 			"invocation": {
 				"uri": "guac",
@@ -2128,7 +2128,7 @@ var (
 				"uri": "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar"
 			}
 		],
-		"predicate_type": "https://in-toto.io/attestation/vuln/v0.1",
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
 			"invocation": {
 				"uri": "guac",

--- a/pkg/certifier/attestation/attestation_vuln.go
+++ b/pkg/certifier/attestation/attestation_vuln.go
@@ -27,7 +27,7 @@ import (
 // Currently, the predicate is defined here but the intention is to upstream this to
 // https://github.com/in-toto/attestation in the near future once the quirks are worked out.
 const (
-	PredicateVuln = "https://in-toto.io/attestation/vuln/v0.1"
+	PredicateVuln = "https://in-toto.io/attestation/vulns/v0.1"
 )
 
 // VulnerabilityStatement defines the statement header and the vulnerability predicate

--- a/pkg/handler/processor/guesser/type_ite6.go
+++ b/pkg/handler/processor/guesser/type_ite6.go
@@ -39,7 +39,7 @@ func (_ *ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.Format
 				return processor.DocumentITE6Generic
 			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/certify/v0.1") {
 				return processor.DocumentITE6Generic
-			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vuln/v0.1") {
+			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.1") {
 				return processor.DocumentITE6Vul
 			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/clearlydefined/v0.1") {
 				return processor.DocumentITE6ClearlyDefined

--- a/pkg/ingestor/parser/vuln/vuln.go
+++ b/pkg/ingestor/parser/vuln/vuln.go
@@ -15,7 +15,7 @@
 
 // Package vuln attestation parser parses the attestation defined by by
 // the certifier using the predicate type
-// "https://in-toto.io/attestation/vuln/v0.1" Three different types of ingest
+// "https://in-toto.io/attestation/vulns/v0.1" Three different types of ingest
 // predicates are created.
 //
 // - IsOccurences are created mapping between any package


### PR DESCRIPTION
# Description of the PR

Fixes #2188 
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
