### PR TITLE
Fix: missing null check in certifyLegal blobstore backend

### DIFF
--- a/pkg/assembler/backends/keyvalue/certifyLegal.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal.go
@@ -547,6 +547,11 @@ func (c *demoClient) CertifyLegal(ctx context.Context, filter *model.CertifyLega
 				if err != nil {
 					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 				}
+
+				if legal == nil {
+					continue
+				}
+				
 				out = append(out, legal)
 			}
 		}


### PR DESCRIPTION
# Description of the PR

Fixes #2192 by adding the missing null check

Verification of fix:

![Screenshot 2024-10-11 125510](https://github.com/user-attachments/assets/a0aef7ba-337c-4987-a5c0-6f7548e8856e)

# PR Checklist

- [ x ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
