### PR TITLE
update vuln attestation to (opiniatedly) follow intoto/vulns v0.1 spec

### DIFF
--- a/internal/testing/dochelper/dochelper.go
+++ b/internal/testing/dochelper/dochelper.go
@@ -23,7 +23,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation/vuln"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
@@ -173,8 +173,11 @@ func DocEqualWithTimestamp(gotDoc, wantDoc *processor.Document) (bool, error) {
 	}
 
 	// change the timestamp to match else it will fail to compare
-	want.Predicate.Metadata.ScannedOn = &testTime
-	got.Predicate.Metadata.ScannedOn = &testTime
+	want.Predicate.Metadata.ScanStartedOn = &testTime
+	got.Predicate.Metadata.ScanStartedOn = &testTime
+
+	want.Predicate.Metadata.ScanFinishedOn = &testTime
+	got.Predicate.Metadata.ScanFinishedOn = &testTime
 
 	return reflect.DeepEqual(want, got), nil
 }

--- a/internal/testing/testdata/exampledata/certify-novuln.json
+++ b/internal/testing/testdata/exampledata/certify-novuln.json
@@ -8,22 +8,13 @@
   ],
   "predicateType": "https://in-toto.io/attestation/vulns/v0.1",
   "predicate": {
-    "invocation": {
-      "parameters": [""],
-      "uri": "guac",
-      "event_id": "",
-      "producer_id": "guac"
-    },
     "scanner": {
       "uri": "osv.dev",
-      "version": "0.0.14",
-      "db": {
-        "uri": "",
-        "version": ""
-      }
+      "version": "0.0.14"
     },
     "metadata": {
-      "scannedOn": "2022-11-21T17:45:50.52Z"
+      "scanStartedOn": "2022-11-21T17:45:50.52Z",
+      "scanFinishedOn": "2022-11-21T17:45:50.52Z"
     }
   }
 }

--- a/internal/testing/testdata/exampledata/certify-vuln.json
+++ b/internal/testing/testdata/exampledata/certify-vuln.json
@@ -7,41 +7,26 @@
   ],
   "predicateType": "https://in-toto.io/attestation/vulns/v0.1",
   "predicate": {
-    "invocation": {
-      "parameters": [""],
-      "uri": "guac",
-      "event_id": "",
-      "producer_id": "guac"
-    },
     "scanner": {
       "uri": "osv.dev",
       "version": "0.0.14",
-      "db": {
-        "uri": "",
-        "version": ""
-      },
       "result": [{
-            "vulnerability_id": "GHSA-7rjr-3q55-vv33",
-            "aliases": [""]
+            "id": "GHSA-7rjr-3q55-vv33"
         }, {
-            "vulnerability_id": "GHSA-8489-44mv-ggj8",
-            "aliases": [""]
+            "id": "GHSA-8489-44mv-ggj8"
         }, {
-            "vulnerability_id": "GHSA-fxph-q3j8-mv87",
-            "aliases": [""]
+            "id": "GHSA-fxph-q3j8-mv87"
         }, {
-            "vulnerability_id": "GHSA-jfh8-c2jp-5v3q",
-            "aliases": [""]
+            "id": "GHSA-jfh8-c2jp-5v3q"
         }, {
-            "vulnerability_id": "GHSA-p6xc-xr62-6r2g",
-            "aliases": [""]
+            "id": "GHSA-p6xc-xr62-6r2g"
         }, {
-            "vulnerability_id": "GHSA-vwqq-5vrc-xw9h",
-            "aliases": [""]
+            "id": "GHSA-vwqq-5vrc-xw9h"
         }]
     },
     "metadata": {
-      "scannedOn": "2022-11-21T17:45:50.52Z"
+      "scanStartedOn": "2022-11-21T17:45:50.52Z",
+      "scanFinishedOn": "2022-11-21T17:45:50.52Z"
     }
   }
 }

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -1893,10 +1893,6 @@ var (
 		],
 		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
-		   "invocation":{
-			  "uri":"guac",
-			  "producer_id":"guacsec/guac"
-		   },
 		   "scanner":{
 			  "uri":"osv.dev",
 			  "version":"0.0.14",
@@ -1904,12 +1900,13 @@ var (
 			  },
 			  "result":[
 				 {
-					"vulnerability_id":"GHSA-599f-7c49-w659"
+					"id":"GHSA-599f-7c49-w659"
 				 }
 			  ]
 		   },
 		   "metadata":{
-			  "scannedOn":"2022-11-22T13:18:58.063182-05:00"
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+                          "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 		   }
 		}
 	 }`
@@ -1922,17 +1919,13 @@ var (
 		],
 		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
-		   "invocation":{
-			  "uri":"guac",
-			  "producer_id":"guacsec/guac"
-		   },
 		   "scanner": {
 			"uri": "osv.dev",
-			"version": "0.0.14",
-			"db": {}
+			"version": "0.0.14"
 		   },
 		   "metadata":{
-			  "scannedOn":"2022-11-22T13:19:18.825699-05:00"
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 		   }
 		}
 	 }`
@@ -1945,17 +1938,13 @@ var (
 		],
 		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
-		   "invocation":{
-			  "uri":"guac",
-			  "producer_id":"guacsec/guac"
-		   },
 		   "scanner": {
 			"uri": "osv.dev",
-			"version": "0.0.14",
-			"db": {}
+			"version": "0.0.14"
 		   },
 		   "metadata":{
-			  "scannedOn":"2022-11-22T13:19:18.825699-05:00"
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 		   }
 		}
 	 }`
@@ -1968,10 +1957,6 @@ var (
 		],
 		"predicate_type":"https://in-toto.io/attestation/vulns/v0.1",
 		"predicate":{
-		   "invocation":{
-			  "uri":"guac",
-			  "producer_id":"guacsec/guac"
-		   },
 		   "scanner":{
 			  "uri":"osv.dev",
 			  "version":"0.0.14",
@@ -1979,27 +1964,28 @@ var (
 			  },
 			  "result":[
 				 {
-					"vulnerability_id":"GHSA-7rjr-3q55-vv33"
+					"id":"GHSA-7rjr-3q55-vv33"
 				 },
 				 {
-					"vulnerability_id":"GHSA-8489-44mv-ggj8"
+					"id":"GHSA-8489-44mv-ggj8"
 				 },
 				 {
-					"vulnerability_id":"GHSA-fxph-q3j8-mv87"
+					"id":"GHSA-fxph-q3j8-mv87"
 				 },
 				 {
-					"vulnerability_id":"GHSA-jfh8-c2jp-5v3q"
+					"id":"GHSA-jfh8-c2jp-5v3q"
 				 },
 				 {
-					"vulnerability_id":"GHSA-p6xc-xr62-6r2g"
+					"id":"GHSA-p6xc-xr62-6r2g"
 				 },
 				 {
-					"vulnerability_id":"GHSA-vwqq-5vrc-xw9h"
+					"id":"GHSA-vwqq-5vrc-xw9h"
 				 }
 			  ]
 		   },
 		   "metadata":{
-			  "scannedOn":"2022-11-22T13:18:31.607996-05:00"
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 		   }
 		}
 	 }`
@@ -2029,17 +2015,13 @@ var (
 		],
 		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
-			"invocation": {
-				"uri": "guac",
-				"producer_id": "guacsec/guac"
-			},
 			"scanner": {
 				"uri": "osv.dev",
-				"version": "0.0.14",
-				"db": {}
+				"version": "0.0.14"
 			},
 			"metadata": {
-				"scannedOn": "2023-02-15T11:10:08.986308-08:00"
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 			}
 		}
 	}`
@@ -2053,17 +2035,13 @@ var (
 		],
 		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
-			"invocation": {
-				"uri": "guac",
-				"producer_id": "guacsec/guac"
-			},
 			"scanner": {
 				"uri": "osv.dev",
-				"version": "0.0.14",
-				"db": {}
+				"version": "0.0.14"
 			},
 			"metadata": {
-				"scannedOn": "2023-02-15T11:10:08.986401-08:00"
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 			}
 		}
 	}`
@@ -2077,17 +2055,13 @@ var (
 		],
 		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
-			"invocation": {
-				"uri": "guac",
-				"producer_id": "guacsec/guac"
-			},
 			"scanner": {
 				"uri": "osv.dev",
-				"version": "0.0.14",
-				"db": {}
+				"version": "0.0.14"
 			},
 			"metadata": {
-				"scannedOn": "2023-02-15T11:10:08.98646-08:00"
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
 			}
 		}
 	}`
@@ -2101,22 +2075,18 @@ var (
 		],
 		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
-			"invocation": {
-				"uri": "guac",
-				"producer_id": "guacsec/guac"
-			},
 			"scanner": {
 				"uri": "osv.dev",
 				"version": "0.0.14",
-				"db": {},
 				"result": [
 					{
-						"vulnerability_id": "GHSA-9ph3-v2vh-3qx7"
+						"id": "GHSA-9ph3-v2vh-3qx7"
 					}
 				]
 			},
 			"metadata": {
-				"scannedOn": "2023-02-15T11:10:08.986506-08:00"
+				"scanStartedOn":"2023-02-15T11:10:08.986506-08:00",
+				"scanFinishedOn":"2023-02-15T11:10:08.986506-08:00"
 			}
 		}
 	}`
@@ -2130,22 +2100,18 @@ var (
 		],
 		"predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
 		"predicate": {
-			"invocation": {
-				"uri": "guac",
-				"producer_id": "guacsec/guac"
-			},
 			"scanner": {
 				"uri": "osv.dev",
 				"version": "0.0.14",
-				"db": {},
 				"result": [
 					{
-						"vulnerability_id": "GHSA-53jx-vvf9-4x38"
+						"id": "GHSA-53jx-vvf9-4x38"
 					}
 				]
 			},
 			"metadata": {
-				"scannedOn": "2023-02-15T11:10:08.986592-08:00"
+				"scanStartedOn":"2023-02-15T11:10:08.986506-08:00",
+				"scanFinishedOn":"2023-02-15T11:10:08.986506-08:00"
 			}
 		}
 	}`

--- a/pkg/certifier/attestation/license/attestation_license.go
+++ b/pkg/certifier/attestation/license/attestation_license.go
@@ -151,3 +151,7 @@ type ClearlyDefinedPredicate struct {
 	Definition Definition `json:"definition,omitempty"`
 	Metadata   Metadata   `json:"metadata,omitempty"`
 }
+
+type Metadata struct {
+	ScannedOn *time.Time `json:"scannedOn,omitempty"`
+}

--- a/pkg/certifier/attestation/vuln/attestation_vuln.go
+++ b/pkg/certifier/attestation/vuln/attestation_vuln.go
@@ -39,20 +39,36 @@ type VulnerabilityStatement struct {
 
 // Metadata defines when the last scan was done
 type Metadata struct {
-	ScannedOn *time.Time `json:"scannedOn,omitempty"`
+	ScanStartedOn *time.Time `json:"scanStartedOn,omitempty"`
+	ScanFinishedOn *time.Time `json:"scanFinishedOn,omitempty"`
 }
 
 // Result defines the Vulnerability ID and its alias. There can be multiple
 // results per artifact
+// TODO: The spec has a discrepency that needs to be resolved, we are following
+// the example json in the spec since that seems to be what 2 examples we've seen
+// are using. Tracking https://github.com/in-toto/attestation/issues/391
 type Result struct {
-	VulnerabilityId string   `json:"vulnerability_id,omitempty"`
-	Aliases         []string `json:"aliases,omitempty"`
+	Id string `json:"id,omitempty"`
+	Severity []Severity `json:"severity,omitempty"`
+}
+
+type Severity struct {
+	// required
+	Method string `json:"method,omitempty"`
+	// required
+	Score string `json:"score,omitempty"`
+	// ambiguous type definition ins spec, look at
+	// https://github.com/in-toto/attestation/issues/390https://github.com/in-toto/attestation/issues/390
+	Annotations []map[string]interface{} `json:"annotations,omitempty"`
 }
 
 // DB defines the scanner database used at the time of scan
 type DB struct {
 	Uri     string `json:"uri,omitempty"`
 	Version string `json:"version,omitempty"`
+	// required
+	LastUpdate *time.Time `json:"lastUpdate,omitempty"`
 }
 
 // Scanner defines the scanner that was used to scan the artifacts and
@@ -61,20 +77,14 @@ type Scanner struct {
 	Uri      string   `json:"uri,omitempty"`
 	Version  string   `json:"version,omitempty"`
 	Database DB       `json:"db,omitempty"`
+	// required
 	Result   []Result `json:"result,omitempty"`
-}
-
-// Invocation defines how the scan was initiated and by which producer
-type Invocation struct {
-	Parameters []string `json:"parameters,omitempty"`
-	Uri        string   `json:"uri,omitempty"`
-	EventID    string   `json:"event_id,omitempty"`
-	ProducerID string   `json:"producer_id,omitempty"`
 }
 
 // VulnerabilityPredicate defines predicate definition of the vulnerability attestation
 type VulnerabilityPredicate struct {
-	Invocation Invocation `json:"invocation,omitempty"`
+	// required
 	Scanner    Scanner    `json:"scanner,omitempty"`
+	// required
 	Metadata   Metadata   `json:"metadata,omitempty"`
 }

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/guacsec/guac/pkg/certifier"
-	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation/vuln"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/clients"
 	"github.com/guacsec/guac/pkg/events"
@@ -151,16 +151,13 @@ func createAttestation(purl string, vulns []osv_scanner.MinimalVulnerability, cu
 			PredicateType: attestation_vuln.PredicateVuln,
 		},
 		Predicate: attestation_vuln.VulnerabilityPredicate{
-			Invocation: attestation_vuln.Invocation{
-				Uri:        INVOC_URI,
-				ProducerID: PRODUCER_ID,
-			},
 			Scanner: attestation_vuln.Scanner{
 				Uri:     URI,
 				Version: VERSION,
 			},
 			Metadata: attestation_vuln.Metadata{
-				ScannedOn: &currentTime,
+				ScanStartedOn: &currentTime,
+				ScanFinishedOn: &currentTime,
 			},
 		},
 	}
@@ -170,7 +167,7 @@ func createAttestation(purl string, vulns []osv_scanner.MinimalVulnerability, cu
 
 	for _, vuln := range vulns {
 		attestation.Predicate.Scanner.Result = append(attestation.Predicate.Scanner.Result, attestation_vuln.Result{
-			VulnerabilityId: vuln.ID,
+			Id: vuln.ID,
 		})
 	}
 	return attestation

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	osv_scanner "github.com/google/osv-scanner/pkg/osv"
-	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation/vuln"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	attestationv1 "github.com/in-toto/attestation/go/v1"
 
@@ -247,17 +247,14 @@ func Test_createAttestation(t *testing.T) {
 				Subject:       []*attestationv1.ResourceDescriptor{{Name: ""}},
 			},
 			Predicate: attestation_vuln.VulnerabilityPredicate{
-				Invocation: attestation_vuln.Invocation{
-					Uri:        INVOC_URI,
-					ProducerID: PRODUCER_ID,
-				},
 				Scanner: attestation_vuln.Scanner{
 					Uri:     URI,
 					Version: VERSION,
-					Result:  []attestation_vuln.Result{{VulnerabilityId: "testId"}},
+					Result:  []attestation_vuln.Result{{Id: "testId"}},
 				},
 				Metadata: attestation_vuln.Metadata{
-					ScannedOn: &currentTime,
+					ScanStartedOn: &currentTime,
+					ScanFinishedOn: &currentTime,
 				},
 			},
 		},
@@ -277,8 +274,10 @@ func deepEqualIgnoreTimestamp(a, b *attestation_vuln.VulnerabilityStatement) boo
 	// create a copy of a and b, and set the ScannedOn field to nil because the timestamps will be different
 	aCopy := a
 	bCopy := b
-	aCopy.Predicate.Metadata.ScannedOn = nil
-	bCopy.Predicate.Metadata.ScannedOn = nil
+	aCopy.Predicate.Metadata.ScanStartedOn = nil
+	bCopy.Predicate.Metadata.ScanStartedOn = nil
+	aCopy.Predicate.Metadata.ScanFinishedOn = nil
+	bCopy.Predicate.Metadata.ScanFinishedOn = nil
 
 	// use DeepEqual to compare the copies
 	return reflect.DeepEqual(aCopy, bCopy)

--- a/pkg/ingestor/parser/clearlydefined/clearlydefined.go
+++ b/pkg/ingestor/parser/clearlydefined/clearlydefined.go
@@ -25,7 +25,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
-	"github.com/guacsec/guac/pkg/certifier/attestation"
+	attestation_license "github.com/guacsec/guac/pkg/certifier/attestation/license"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 )
@@ -72,15 +72,15 @@ func (c *parser) Parse(ctx context.Context, doc *processor.Document) error {
 	return nil
 }
 
-func parseLegalCertifyPredicate(p []byte) (*attestation.ClearlyDefinedStatement, error) {
-	predicate := attestation.ClearlyDefinedStatement{}
+func parseLegalCertifyPredicate(p []byte) (*attestation_license.ClearlyDefinedStatement, error) {
+	predicate := attestation_license.ClearlyDefinedStatement{}
 	if err := json.Unmarshal(p, &predicate); err != nil {
 		return nil, err
 	}
 	return &predicate, nil
 }
 
-func (c *parser) parseSubject(s *attestation.ClearlyDefinedStatement) error {
+func (c *parser) parseSubject(s *attestation_license.ClearlyDefinedStatement) error {
 	for _, sub := range s.Statement.Subject {
 		p, err := helpers.PurlToPkg(sub.Uri)
 		if err != nil {
@@ -107,7 +107,7 @@ The “licensed” -> “facets” -> “core” -> “attribution” -> “part
 “described” -> “sourceLocation” can be used to create a HasSourceAt GUAC node. */
 
 // parseClearlyDefined parses the attestation to collect the license information
-func (c *parser) parseClearlyDefined(_ context.Context, s *attestation.ClearlyDefinedStatement) error {
+func (c *parser) parseClearlyDefined(_ context.Context, s *attestation_license.ClearlyDefinedStatement) error {
 	if s.Predicate.Definition.Licensed.Declared != "" {
 		discoveredLicenses := make([]generated.LicenseInputSpec, 0)
 		var discoveredLicenseStr string = ""

--- a/pkg/ingestor/parser/vuln/vuln.go
+++ b/pkg/ingestor/parser/vuln/vuln.go
@@ -40,7 +40,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler"
 	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/assembler/helpers"
-	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation"
+	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation/vuln"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 )
@@ -74,7 +74,7 @@ func (c *parser) Parse(ctx context.Context, doc *processor.Document) error {
 	c.initializeVulnParser()
 	statement, err := parseVulnCertifyPredicate(doc.Blob)
 	if err != nil {
-		return fmt.Errorf("failed to parse slsa predicate: %w", err)
+		return fmt.Errorf("failed to parse vulns predicate: %w", err)
 	}
 	ps, err := parseSubject(statement)
 	if err != nil {
@@ -114,7 +114,7 @@ func parseSubject(s *attestation_vuln.VulnerabilityStatement) ([]*generated.PkgI
 
 func parseMetadata(s *attestation_vuln.VulnerabilityStatement) *generated.ScanMetadataInput {
 	return &generated.ScanMetadataInput{
-		TimeScanned:    *s.Predicate.Metadata.ScannedOn,
+		TimeScanned:    *s.Predicate.Metadata.ScanFinishedOn,
 		DbUri:          s.Predicate.Scanner.Database.Uri,
 		DbVersion:      s.Predicate.Scanner.Database.Version,
 		ScannerUri:     s.Predicate.Scanner.Uri,
@@ -127,13 +127,13 @@ func parseVulns(_ context.Context, s *attestation_vuln.VulnerabilityStatement) (
 	[]assembler.VulnEqualIngest, error) {
 	var vs []*generated.VulnerabilityInputSpec
 	var ivs []assembler.VulnEqualIngest
-	for _, id := range s.Predicate.Scanner.Result {
+	for _, res := range s.Predicate.Scanner.Result {
 		v := &generated.VulnerabilityInputSpec{
 			Type:            "osv",
-			VulnerabilityID: strings.ToLower(id.VulnerabilityId),
+			VulnerabilityID: strings.ToLower(res.Id),
 		}
 		vs = append(vs, v)
-		vuln, err := helpers.CreateVulnInput(id.VulnerabilityId)
+		vuln, err := helpers.CreateVulnInput(res.Id)
 		if err != nil {
 			return nil, nil, fmt.Errorf("createVulnInput failed with error: %w", err)
 		}


### PR DESCRIPTION
# Description of the PR

Update vuln implementation to follow more closely to https://github.com/in-toto/attestation/blob/main/spec/predicates/vuln.md

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
