### PR TITLE
update batch size on clearly defined and fix bug that when ingesting licenses

### DIFF
--- a/cmd/guaccollect/cmd/license.go
+++ b/cmd/guaccollect/cmd/license.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	cdQuerySize = 248
+	cdQuerySize = 499
 )
 
 type cdOptions struct {

--- a/pkg/certifier/clearlydefined/clearlydefined.go
+++ b/pkg/certifier/clearlydefined/clearlydefined.go
@@ -76,7 +76,6 @@ func NewClearlyDefinedHTTPClient(limiter *rate.Limiter) *http.Client {
 
 // getDefinitions uses the coordinates to query clearly defined for license definition
 func getDefinitions(ctx context.Context, client *http.Client, purls []string, coordinates []string) (map[string]*attestation.Definition, error) {
-
 	coordinateToPurl := make(map[string]string)
 	for i, purl := range purls {
 		coordinateToPurl[coordinates[i]] = purl

--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -64,12 +64,12 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 	var certLegalIngest []assembler.CertifyLegalIngest
 	var hasSourceAtIngest []assembler.HasSourceAtIngest
 
-	// the limit for the batch size that is allowed for clearly defined
-	if len(purls) > 250 {
+	// the limit for the batch size that is allowed for clearly defined otherwise you receive a 400 or 414
+	if len(purls) > 500 {
 		i := 0
 		var batchPurls []string
 		for _, purl := range purls {
-			if i < 249 {
+			if i < 499 {
 				batchPurls = append(batchPurls, purl)
 				i++
 			} else {
@@ -81,6 +81,7 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 				certLegalIngest = append(certLegalIngest, batchedCL...)
 				hasSourceAtIngest = append(hasSourceAtIngest, batchedHSA...)
 				batchPurls = make([]string, 0)
+				i = 0
 			}
 		}
 		if len(batchPurls) > 0 {


### PR DESCRIPTION
# Description of the PR

Change query size for clearlyDefined and fix bug that caused rate limit to be hit.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
