### PR TITLE
update queries to hit index

### DIFF
--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -404,6 +404,7 @@ func certifyLegalQuery(filter model.CertifyLegalSpec) predicate.CertifyLegal {
 		if filter.Subject.Package != nil {
 			if filter.Subject.Package.ID != nil {
 				predicates = append(predicates, optionalPredicate(filter.Subject.Package.ID, packageIDEQ))
+				predicates = append(predicates, certifylegal.SourceIDIsNil())
 			} else {
 				predicates = append(predicates,
 					certifylegal.HasPackageWith(packageVersionQuery(filter.Subject.Package)))
@@ -411,6 +412,7 @@ func certifyLegalQuery(filter model.CertifyLegalSpec) predicate.CertifyLegal {
 		} else if filter.Subject.Source != nil {
 			if filter.Subject.Source.ID != nil {
 				predicates = append(predicates, optionalPredicate(filter.Subject.Source.ID, sourceIDEQ))
+				predicates = append(predicates, certifylegal.PackageIDIsNil())
 			} else {
 				predicates = append(predicates,
 					certifylegal.HasSourceWith(sourceQuery(filter.Subject.Source)),

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -403,6 +403,7 @@ func isOccurrenceQuery(filter *model.IsOccurrenceSpec) predicate.Occurrence {
 		if filter.Subject.Package != nil {
 			if filter.Subject.Package.ID != nil {
 				predicates = append(predicates, optionalPredicate(filter.Subject.Package.ID, packageIDEQ))
+				predicates = append(predicates, occurrence.SourceIDIsNil())
 			} else {
 				predicates = append(predicates,
 					occurrence.HasPackageWith(packageVersionQuery(filter.Subject.Package)))
@@ -410,6 +411,7 @@ func isOccurrenceQuery(filter *model.IsOccurrenceSpec) predicate.Occurrence {
 		} else if filter.Subject.Source != nil {
 			if filter.Subject.Source.ID != nil {
 				predicates = append(predicates, optionalPredicate(filter.Subject.Source.ID, sourceIDEQ))
+				predicates = append(predicates, occurrence.PackageIDIsNil())
 			} else {
 				predicates = append(predicates,
 					occurrence.HasSourceWith(

--- a/pkg/assembler/backends/ent/backend/sbom.go
+++ b/pkg/assembler/backends/ent/backend/sbom.go
@@ -344,6 +344,7 @@ func hasSBOMQuery(spec model.HasSBOMSpec) predicate.BillOfMaterials {
 		if spec.Subject.Package != nil {
 			if spec.Subject.Package.ID != nil {
 				predicates = append(predicates, optionalPredicate(spec.Subject.Package.ID, packageIDEQ))
+				predicates = append(predicates, billofmaterials.ArtifactIDIsNil())
 			} else {
 				predicates = append(predicates,
 					billofmaterials.HasPackageWith(packageVersionQuery(spec.Subject.Package)))
@@ -352,6 +353,7 @@ func hasSBOMQuery(spec model.HasSBOMSpec) predicate.BillOfMaterials {
 			if spec.Subject.Artifact.ID != nil {
 				predicates = append(predicates,
 					optionalPredicate(spec.Subject.Artifact.ID, artifactIDEQ))
+				predicates = append(predicates, billofmaterials.PackageIDIsNil())
 			} else {
 				predicates = append(predicates,
 					billofmaterials.HasArtifactWith(artifactQueryPredicates(spec.Subject.Artifact)))


### PR DESCRIPTION

# Description of the PR

update query to ensure index is hit for certifyLegal, occurence and hasSBOM


# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
