### PR TITLE
Fixed Issue: #2195 500 error when sending empty JSON payload to Graph...

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v3.2.1
         with:
           go-version: '1.21'
-      - uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+      - uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v3.2.1
         with:
           go-version: '1.21'
-      - uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+      - uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -228,7 +228,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v3.2.1
         with:
           go-version: '1.21'
-      - uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+      - uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v3.2.1
         with:
           go-version: '1.21'
-      - uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
+      - uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/pkg/assembler/backends/ent/migrate/migrations/20241017140224_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20241017140224_ent_diff.sql
@@ -1,0 +1,2 @@
+-- Create index "certifyvuln_vulnerability_id" to table: "certify_vulns"
+CREATE INDEX "certifyvuln_vulnerability_id" ON "certify_vulns" ("vulnerability_id");

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3eRFoV2cM7hzSkmdDQ8HwhoF99Mp0L9r4o4UFWTzXe4=
+h1:Ru5VFYpW/024wBxj0NuPPYqNe+IcDzjNmi/bBoLOQgw=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -9,3 +9,4 @@ h1:3eRFoV2cM7hzSkmdDQ8HwhoF99Mp0L9r4o4UFWTzXe4=
 20240826162616_ent_diff.sql h1:VyzOoAHvz3Ct8o/nva5qmyFzPOVmrJnXlrwpUCwoCHw=
 20240918165345.sql h1:wpfJhr9rJSWWzbTA85rnLppDjGscJVaFpE1uZJXpScY=
 20240919142722_ent_diff.sql h1:hcb42aHj5QUwbd7HXsUFnnAzHIckdXfGRDNYa24rns8=
+20241017140224_ent_diff.sql h1:BrrQdJnjtZJ9FYOXc5PgEafQ6N3ADdydFPevjdyTqnU=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -398,6 +398,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{CertifyVulnsColumns[10]},
 			},
+			{
+				Name:    "certifyvuln_vulnerability_id",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyVulnsColumns[9]},
+			},
 		},
 	}
 	// DependenciesColumns holds the columns for the "dependencies" table.

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -61,6 +61,7 @@ func (CertifyVuln) Edges() []ent.Edge {
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned", "document_ref").Edges("vulnerability", "package").Unique(),
-		index.Fields("package_id"), // speed up frequently run queries to check when CV nodes affect certain package IDs
+		index.Fields("package_id"),       // speed up frequently run queries to check when CV nodes affect certain package IDs
+		index.Fields("vulnerability_id"), // speed up frequently run queries to check when CV nodes have a vulnerability
 	}
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -292,8 +292,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 		var graphqlRequest struct {
 			OperationName string `json:"operationName"`
 		}
-		// Check if the body is valid JSON
-		if !json.Valid(bodyCopy) {
+		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
 			err_msg := fmt.Sprintf("Provided input json couldn't be parsed. likely it was empty or was wrongly structured; error message: %v", err.Error())
 			http.Error(w, err_msg, http.StatusBadRequest)
 			return

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -278,6 +278,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 
 		// Create a copy of the request body
 		body, err := io.ReadAll(r.Body)
+
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -291,6 +292,11 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 		// Parse the operation name from the request body copy
 		var graphqlRequest struct {
 			OperationName string `json:"operationName"`
+		}
+		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
+			err_msg := fmt.Sprintf("Provided input json couldn't be parsed. likely it was empty or was wrongly structured; error message: %v", err.Error())
+			http.Error(w, err_msg, http.StatusBadRequest)
+			return
 		}
 		if err := json.Unmarshal(bodyCopy, &graphqlRequest); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -293,7 +293,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 			OperationName string `json:"operationName"`
 		}
 		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
-			err_msg := fmt.Sprintf("Provided input json couldn't be parsed. likely it was empty or was wrongly structured; error message: %v", err.Error())
+			err_msg := fmt.Sprintf("The JSON parsing failed due to the following error: '%v'. Please review your input for syntax errors or missing elements.", err.Error())
 			http.Error(w, err_msg, http.StatusBadRequest)
 			return
 		}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -293,8 +293,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 			OperationName string `json:"operationName"`
 		}
 		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
-			err_msg := fmt.Sprintf("The JSON parsing failed due to the following error: '%v'. Please review your input for syntax errors or missing elements.", err.Error())
-			http.Error(w, err_msg, http.StatusBadRequest)
+			http.Error(w, "invalid JSON body!", http.StatusBadRequest)
 			return
 		}
 		if err := json.Unmarshal(bodyCopy, &graphqlRequest); err != nil {

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -278,7 +278,6 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 
 		// Create a copy of the request body
 		body, err := io.ReadAll(r.Body)
-
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -293,7 +293,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 			OperationName string `json:"operationName"`
 		}
 		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
-			http.Error(w, "invalid JSON body p", http.StatusBadRequest)
+			http.Error(w, "invalid JSON body please check your request!", http.StatusBadRequest)
 			return
 		}
 		if err := json.Unmarshal(bodyCopy, &graphqlRequest); err != nil {

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -293,7 +293,7 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 			OperationName string `json:"operationName"`
 		}
 		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
-			http.Error(w, "invalid JSON body!", http.StatusBadRequest)
+			http.Error(w, "invalid JSON body p", http.StatusBadRequest)
 			return
 		}
 		if err := json.Unmarshal(bodyCopy, &graphqlRequest); err != nil {

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -292,7 +292,8 @@ func (pc *prometheusCollector) MeasureGraphQLResponseDuration(next http.Handler)
 		var graphqlRequest struct {
 			OperationName string `json:"operationName"`
 		}
-		if !json.Valid(bodyCopy) { // Check if the body is valid JSON
+		// Check if the body is valid JSON
+		if !json.Valid(bodyCopy) {
 			err_msg := fmt.Sprintf("Provided input json couldn't be parsed. likely it was empty or was wrongly structured; error message: %v", err.Error())
 			http.Error(w, err_msg, http.StatusBadRequest)
 			return


### PR DESCRIPTION
Fixed Issue: #2195 500 error when sending empty JSON payload to Graph…
# Description of the PR
This pull request addresses an issue where the GraphQL server returned a 500 internal server error when an empty or invalid JSON payload was sent to the /query endpoint.

### Changes:

- Error handling: Updated the server to return a 400 bad request instead of 500 for invalid JSON input.
- Error message: Improved the error message to provide more context about the issue.



<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
