### PR TITLE
update hasSBOM to filter deps.dev by default, also return only values specified

### DIFF
--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -356,18 +356,18 @@ func (mr *MockBackendMockRecorder) HasSBOM(ctx, hasSBOMSpec any) *gomock.Call {
 }
 
 // HasSBOMList mocks base method.
-func (m *MockBackend) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error) {
+func (m *MockBackend) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasSBOMList", ctx, hasSBOMSpec, after, first)
+	ret := m.ctrl.Call(m, "HasSBOMList", ctx, hasSBOMSpec, after, first, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
 	ret0, _ := ret[0].(*model.HasSBOMConnection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasSBOMList indicates an expected call of HasSBOMList.
-func (mr *MockBackendMockRecorder) HasSBOMList(ctx, hasSBOMSpec, after, first any) *gomock.Call {
+func (mr *MockBackendMockRecorder) HasSBOMList(ctx, hasSBOMSpec, after, first, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSBOMList", reflect.TypeOf((*MockBackend)(nil).HasSBOMList), ctx, hasSBOMSpec, after, first)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSBOMList", reflect.TypeOf((*MockBackend)(nil).HasSBOMList), ctx, hasSBOMSpec, after, first, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
 }
 
 // HasSLSAList mocks base method.

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -356,7 +356,7 @@ func (mr *MockBackendMockRecorder) HasSBOM(ctx, hasSBOMSpec any) *gomock.Call {
 }
 
 // HasSBOMList mocks base method.
-func (m *MockBackend) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
+func (m *MockBackend) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasSBOMList", ctx, hasSBOMSpec, after, first, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
 	ret0, _ := ret[0].(*model.HasSBOMConnection)

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -29,7 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 )
 
-func (c *arangoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error) {
+func (c *arangoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
 	return nil, fmt.Errorf("not implemented: HasSBOMList")
 }
 

--- a/pkg/assembler/backends/arangodb/hasSBOM.go
+++ b/pkg/assembler/backends/arangodb/hasSBOM.go
@@ -29,7 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/helpers"
 )
 
-func (c *arangoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
+func (c *arangoClient) HasSBOMList(ctx context.Context, spec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error) {
 	return nil, fmt.Errorf("not implemented: HasSBOMList")
 }
 

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -49,7 +49,7 @@ type Backend interface {
 	CertifyVulnList(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) (*model.CertifyVulnConnection, error)
 	PointOfContactList(ctx context.Context, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) (*model.PointOfContactConnection, error)
 	HashEqualList(ctx context.Context, hashEqualSpec model.HashEqualSpec, after *string, first *int) (*model.HashEqualConnection, error)
-	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error)
+	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error)
 	HasSLSAList(ctx context.Context, hasSLSASpec model.HasSLSASpec, after *string, first *int) (*model.HasSLSAConnection, error)
 	HasSourceAtList(ctx context.Context, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) (*model.HasSourceAtConnection, error)
 	IsDependencyList(ctx context.Context, isDependencySpec model.IsDependencySpec, after *string, first *int) (*model.IsDependencyConnection, error)

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -49,7 +49,7 @@ type Backend interface {
 	CertifyVulnList(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) (*model.CertifyVulnConnection, error)
 	PointOfContactList(ctx context.Context, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) (*model.PointOfContactConnection, error)
 	HashEqualList(ctx context.Context, hashEqualSpec model.HashEqualSpec, after *string, first *int) (*model.HashEqualConnection, error)
-	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error)
+	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error)
 	HasSLSAList(ctx context.Context, hasSLSASpec model.HasSLSASpec, after *string, first *int) (*model.HasSLSAConnection, error)
 	HasSourceAtList(ctx context.Context, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) (*model.HasSourceAtConnection, error)
 	IsDependencyList(ctx context.Context, isDependencySpec model.IsDependencySpec, after *string, first *int) (*model.IsDependencyConnection, error)

--- a/pkg/assembler/backends/keyvalue/hasSBOM.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM.go
@@ -325,10 +325,20 @@ func (c *demoClient) convHasSBOM(ctx context.Context, in *hasSBOMStruct, getIncl
 
 // Query HasSBOM
 
-func (c *demoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
+func (c *demoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error) {
 	funcName := "HasSBOM"
 	c.m.RLock()
 	defer c.m.RUnlock()
+
+	if getIncludedSoftware == nil {
+		getIncludedSoftware = ptrfrom.Bool(true)
+	}
+	if getIncludedDependencies == nil {
+		getIncludedDependencies = ptrfrom.Bool(true)
+	}
+	if getIncludedOccurrences == nil {
+		getIncludedOccurrences = ptrfrom.Bool(true)
+	}
 
 	if hasSBOMSpec.ID != nil {
 		link, err := byIDkv[*hasSBOMStruct](ctx, *hasSBOMSpec.ID, c)
@@ -337,7 +347,7 @@ func (c *demoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMS
 			return nil, nil
 		}
 		// If found by id, ignore rest of fields in spec and return as a match
-		hs, err := c.convHasSBOM(ctx, link, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
+		hs, err := c.convHasSBOM(ctx, link, *getIncludedSoftware, *getIncludedDependencies, *getIncludedOccurrences)
 		if err != nil {
 			return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 		}
@@ -392,7 +402,7 @@ func (c *demoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMS
 			if err != nil {
 				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 			}
-			hs, err := c.hasSBOMIfMatch(ctx, &hasSBOMSpec, link, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
+			hs, err := c.hasSBOMIfMatch(ctx, &hasSBOMSpec, link, *getIncludedSoftware, *getIncludedDependencies, *getIncludedOccurrences)
 			if err != nil {
 				return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 			}
@@ -447,7 +457,7 @@ func (c *demoClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMS
 				if err != nil {
 					return nil, err
 				}
-				hs, err := c.hasSBOMIfMatch(ctx, &hasSBOMSpec, link, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
+				hs, err := c.hasSBOMIfMatch(ctx, &hasSBOMSpec, link, *getIncludedSoftware, *getIncludedDependencies, *getIncludedOccurrences)
 				if err != nil {
 					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 				}

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -30,7 +30,7 @@ const (
 	uri string = "uri"
 )
 
-func (c *neo4jClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error) {
+func (c *neo4jClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
 	return nil, fmt.Errorf("not implemented: HasSBOMList")
 }
 

--- a/pkg/assembler/backends/neo4j/hasSBOM.go
+++ b/pkg/assembler/backends/neo4j/hasSBOM.go
@@ -30,7 +30,7 @@ const (
 	uri string = "uri"
 )
 
-func (c *neo4jClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
+func (c *neo4jClient) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error) {
 	return nil, fmt.Errorf("not implemented: HasSBOMList")
 }
 

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -10816,7 +10816,8 @@ func (v *HasSBOMListHasSBOMListHasSBOMConnectionPageInfo) GetHasNextPage() bool 
 type HasSBOMListResponse struct {
 	// Returns a paginated results via HasSBOMConnection
 	// will by default filter out all deps.dev hasSBOM.
-	// It will also allow for output to be modified based on desired output
+	// It will also allow for output to be modified based on desired output.
+	// If not specified, it will return all values
 	HasSBOMList *HasSBOMListHasSBOMListHasSBOMConnection `json:"HasSBOMList"`
 }
 
@@ -30005,9 +30006,9 @@ type __HasSBOMListInput struct {
 	Filter                  HasSBOMSpec `json:"filter"`
 	After                   *string     `json:"after"`
 	First                   *int        `json:"first"`
-	GetIncludedSoftware     bool        `json:"getIncludedSoftware"`
-	GetIncludedDependencies bool        `json:"getIncludedDependencies"`
-	GetIncludedOccurrences  bool        `json:"getIncludedOccurrences"`
+	GetIncludedSoftware     *bool       `json:"getIncludedSoftware"`
+	GetIncludedDependencies *bool       `json:"getIncludedDependencies"`
+	GetIncludedOccurrences  *bool       `json:"getIncludedOccurrences"`
 }
 
 // GetFilter returns __HasSBOMListInput.Filter, and is useful for accessing the field via an interface.
@@ -30020,13 +30021,13 @@ func (v *__HasSBOMListInput) GetAfter() *string { return v.After }
 func (v *__HasSBOMListInput) GetFirst() *int { return v.First }
 
 // GetGetIncludedSoftware returns __HasSBOMListInput.GetIncludedSoftware, and is useful for accessing the field via an interface.
-func (v *__HasSBOMListInput) GetGetIncludedSoftware() bool { return v.GetIncludedSoftware }
+func (v *__HasSBOMListInput) GetGetIncludedSoftware() *bool { return v.GetIncludedSoftware }
 
 // GetGetIncludedDependencies returns __HasSBOMListInput.GetIncludedDependencies, and is useful for accessing the field via an interface.
-func (v *__HasSBOMListInput) GetGetIncludedDependencies() bool { return v.GetIncludedDependencies }
+func (v *__HasSBOMListInput) GetGetIncludedDependencies() *bool { return v.GetIncludedDependencies }
 
 // GetGetIncludedOccurrences returns __HasSBOMListInput.GetIncludedOccurrences, and is useful for accessing the field via an interface.
-func (v *__HasSBOMListInput) GetGetIncludedOccurrences() bool { return v.GetIncludedOccurrences }
+func (v *__HasSBOMListInput) GetGetIncludedOccurrences() *bool { return v.GetIncludedOccurrences }
 
 // __HasSBOMsInput is used internally by genqlient
 type __HasSBOMsInput struct {
@@ -33047,7 +33048,7 @@ func HasMetadataList(
 
 // The query or mutation executed by HasSBOMList.
 const HasSBOMList_Operation = `
-query HasSBOMList ($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean!, $getIncludedDependencies: Boolean!, $getIncludedOccurrences: Boolean!) {
+query HasSBOMList ($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean, $getIncludedDependencies: Boolean, $getIncludedOccurrences: Boolean) {
 	HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first, getIncludedSoftware: $getIncludedSoftware, getIncludedDependencies: $getIncludedDependencies, getIncludedOccurrences: $getIncludedOccurrences) {
 		totalCount
 		edges {
@@ -33178,9 +33179,9 @@ func HasSBOMList(
 	filter HasSBOMSpec,
 	after *string,
 	first *int,
-	getIncludedSoftware bool,
-	getIncludedDependencies bool,
-	getIncludedOccurrences bool,
+	getIncludedSoftware *bool,
+	getIncludedDependencies *bool,
+	getIncludedOccurrences *bool,
 ) (*HasSBOMListResponse, error) {
 	req_ := &graphql.Request{
 		OpName: "HasSBOMList",

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -10815,6 +10815,8 @@ func (v *HasSBOMListHasSBOMListHasSBOMConnectionPageInfo) GetHasNextPage() bool 
 // HasSBOMListResponse is returned by HasSBOMList on success.
 type HasSBOMListResponse struct {
 	// Returns a paginated results via HasSBOMConnection
+	// will by default filter out all deps.dev hasSBOM.
+	// It will also allow for output to be modified based on desired output
 	HasSBOMList *HasSBOMListHasSBOMListHasSBOMConnection `json:"HasSBOMList"`
 }
 
@@ -11046,7 +11048,7 @@ func (v *HasSBOMsHasSBOM) __premarshalJSON() (*__premarshalHasSBOMsHasSBOM, erro
 
 // HasSBOMsResponse is returned by HasSBOMs on success.
 type HasSBOMsResponse struct {
-	// Returns all SBOM certifications.
+	// Returns all SBOM certifications (by default it filters out all deps.dev hasSBOMs).
 	HasSBOM []HasSBOMsHasSBOM `json:"HasSBOM"`
 }
 
@@ -30000,9 +30002,12 @@ func (v *__HasMetadataListInput) GetFirst() *int { return v.First }
 
 // __HasSBOMListInput is used internally by genqlient
 type __HasSBOMListInput struct {
-	Filter HasSBOMSpec `json:"filter"`
-	After  *string     `json:"after"`
-	First  *int        `json:"first"`
+	Filter                  HasSBOMSpec `json:"filter"`
+	After                   *string     `json:"after"`
+	First                   *int        `json:"first"`
+	GetIncludedSoftware     bool        `json:"getIncludedSoftware"`
+	GetIncludedDependencies bool        `json:"getIncludedDependencies"`
+	GetIncludedOccurrences  bool        `json:"getIncludedOccurrences"`
 }
 
 // GetFilter returns __HasSBOMListInput.Filter, and is useful for accessing the field via an interface.
@@ -30013,6 +30018,15 @@ func (v *__HasSBOMListInput) GetAfter() *string { return v.After }
 
 // GetFirst returns __HasSBOMListInput.First, and is useful for accessing the field via an interface.
 func (v *__HasSBOMListInput) GetFirst() *int { return v.First }
+
+// GetGetIncludedSoftware returns __HasSBOMListInput.GetIncludedSoftware, and is useful for accessing the field via an interface.
+func (v *__HasSBOMListInput) GetGetIncludedSoftware() bool { return v.GetIncludedSoftware }
+
+// GetGetIncludedDependencies returns __HasSBOMListInput.GetIncludedDependencies, and is useful for accessing the field via an interface.
+func (v *__HasSBOMListInput) GetGetIncludedDependencies() bool { return v.GetIncludedDependencies }
+
+// GetGetIncludedOccurrences returns __HasSBOMListInput.GetIncludedOccurrences, and is useful for accessing the field via an interface.
+func (v *__HasSBOMListInput) GetGetIncludedOccurrences() bool { return v.GetIncludedOccurrences }
 
 // __HasSBOMsInput is used internally by genqlient
 type __HasSBOMsInput struct {
@@ -33033,8 +33047,8 @@ func HasMetadataList(
 
 // The query or mutation executed by HasSBOMList.
 const HasSBOMList_Operation = `
-query HasSBOMList ($filter: HasSBOMSpec!, $after: ID, $first: Int) {
-	HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first) {
+query HasSBOMList ($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean!, $getIncludedDependencies: Boolean!, $getIncludedOccurrences: Boolean!) {
+	HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first, getIncludedSoftware: $getIncludedSoftware, getIncludedDependencies: $getIncludedDependencies, getIncludedOccurrences: $getIncludedOccurrences) {
 		totalCount
 		edges {
 			cursor
@@ -33164,14 +33178,20 @@ func HasSBOMList(
 	filter HasSBOMSpec,
 	after *string,
 	first *int,
+	getIncludedSoftware bool,
+	getIncludedDependencies bool,
+	getIncludedOccurrences bool,
 ) (*HasSBOMListResponse, error) {
 	req_ := &graphql.Request{
 		OpName: "HasSBOMList",
 		Query:  HasSBOMList_Operation,
 		Variables: &__HasSBOMListInput{
-			Filter: filter,
-			After:  after,
-			First:  first,
+			Filter:                  filter,
+			After:                   after,
+			First:                   first,
+			GetIncludedSoftware:     getIncludedSoftware,
+			GetIncludedDependencies: getIncludedDependencies,
+			GetIncludedOccurrences:  getIncludedOccurrences,
 		},
 	}
 	var err_ error

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -50,7 +50,7 @@ query HasSBOMs($filter: HasSBOMSpec!) {
     ...AllHasSBOMTree
   }
 }
-query HasSBOMList($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean!, $getIncludedDependencies: Boolean!, $getIncludedOccurrences: Boolean!) {
+query HasSBOMList($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean, $getIncludedDependencies: Boolean, $getIncludedOccurrences: Boolean) {
   HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first, getIncludedSoftware: $getIncludedSoftware, getIncludedDependencies: $getIncludedDependencies, getIncludedOccurrences: $getIncludedOccurrences) {
     totalCount
     edges {

--- a/pkg/assembler/clients/operations/hasSBOM.graphql
+++ b/pkg/assembler/clients/operations/hasSBOM.graphql
@@ -50,9 +50,8 @@ query HasSBOMs($filter: HasSBOMSpec!) {
     ...AllHasSBOMTree
   }
 }
-
-query HasSBOMList($filter: HasSBOMSpec!, $after: ID, $first: Int) {
-  HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first) {
+query HasSBOMList($filter: HasSBOMSpec!, $after: ID, $first: Int, $getIncludedSoftware: Boolean!, $getIncludedDependencies: Boolean!, $getIncludedOccurrences: Boolean!) {
+  HasSBOMList(hasSBOMSpec: $filter, after: $after, first: $first, getIncludedSoftware: $getIncludedSoftware, getIncludedDependencies: $getIncludedDependencies, getIncludedOccurrences: $getIncludedOccurrences) {
     totalCount
     edges {
       cursor

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -87,7 +87,7 @@ type QueryResolver interface {
 	PointOfContact(ctx context.Context, pointOfContactSpec model.PointOfContactSpec) ([]*model.PointOfContact, error)
 	PointOfContactList(ctx context.Context, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) (*model.PointOfContactConnection, error)
 	HasSbom(ctx context.Context, hasSBOMSpec model.HasSBOMSpec) ([]*model.HasSbom, error)
-	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error)
+	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error)
 	HasSlsa(ctx context.Context, hasSLSASpec model.HasSLSASpec) ([]*model.HasSlsa, error)
 	HasSLSAList(ctx context.Context, hasSLSASpec model.HasSLSASpec, after *string, first *int) (*model.HasSLSAConnection, error)
 	HasSourceAt(ctx context.Context, hasSourceAtSpec model.HasSourceAtSpec) ([]*model.HasSourceAt, error)
@@ -4249,6 +4249,21 @@ func (ec *executionContext) field_Query_HasSBOMList_args(ctx context.Context, ra
 		return nil, err
 	}
 	args["first"] = arg2
+	arg3, err := ec.field_Query_HasSBOMList_argsGetIncludedSoftware(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["getIncludedSoftware"] = arg3
+	arg4, err := ec.field_Query_HasSBOMList_argsGetIncludedDependencies(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["getIncludedDependencies"] = arg4
+	arg5, err := ec.field_Query_HasSBOMList_argsGetIncludedOccurrences(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["getIncludedOccurrences"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Query_HasSBOMList_argsHasSBOMSpec(
@@ -4314,6 +4329,72 @@ func (ec *executionContext) field_Query_HasSBOMList_argsFirst(
 	}
 
 	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedSoftware(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (bool, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["getIncludedSoftware"]
+	if !ok {
+		var zeroVal bool
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedSoftware"))
+	if tmp, ok := rawArgs["getIncludedSoftware"]; ok {
+		return ec.unmarshalNBoolean2bool(ctx, tmp)
+	}
+
+	var zeroVal bool
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedDependencies(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (bool, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["getIncludedDependencies"]
+	if !ok {
+		var zeroVal bool
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedDependencies"))
+	if tmp, ok := rawArgs["getIncludedDependencies"]; ok {
+		return ec.unmarshalNBoolean2bool(ctx, tmp)
+	}
+
+	var zeroVal bool
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedOccurrences(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (bool, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["getIncludedOccurrences"]
+	if !ok {
+		var zeroVal bool
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedOccurrences"))
+	if tmp, ok := rawArgs["getIncludedOccurrences"]; ok {
+		return ec.unmarshalNBoolean2bool(ctx, tmp)
+	}
+
+	var zeroVal bool
 	return zeroVal, nil
 }
 
@@ -10940,7 +11021,7 @@ func (ec *executionContext) _Query_HasSBOMList(ctx context.Context, field graphq
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().HasSBOMList(rctx, fc.Args["hasSBOMSpec"].(model.HasSBOMSpec), fc.Args["after"].(*string), fc.Args["first"].(*int))
+		return ec.resolvers.Query().HasSBOMList(rctx, fc.Args["hasSBOMSpec"].(model.HasSBOMSpec), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["getIncludedSoftware"].(bool), fc.Args["getIncludedDependencies"].(bool), fc.Args["getIncludedOccurrences"].(bool))
 	})
 
 	if resTmp == nil {

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -87,7 +87,7 @@ type QueryResolver interface {
 	PointOfContact(ctx context.Context, pointOfContactSpec model.PointOfContactSpec) ([]*model.PointOfContact, error)
 	PointOfContactList(ctx context.Context, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) (*model.PointOfContactConnection, error)
 	HasSbom(ctx context.Context, hasSBOMSpec model.HasSBOMSpec) ([]*model.HasSbom, error)
-	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error)
+	HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error)
 	HasSlsa(ctx context.Context, hasSLSASpec model.HasSLSASpec) ([]*model.HasSlsa, error)
 	HasSLSAList(ctx context.Context, hasSLSASpec model.HasSLSASpec, after *string, first *int) (*model.HasSLSAConnection, error)
 	HasSourceAt(ctx context.Context, hasSourceAtSpec model.HasSourceAtSpec) ([]*model.HasSourceAt, error)
@@ -4335,66 +4335,66 @@ func (ec *executionContext) field_Query_HasSBOMList_argsFirst(
 func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedSoftware(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (bool, error) {
+) (*bool, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["getIncludedSoftware"]
 	if !ok {
-		var zeroVal bool
+		var zeroVal *bool
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedSoftware"))
 	if tmp, ok := rawArgs["getIncludedSoftware"]; ok {
-		return ec.unmarshalNBoolean2bool(ctx, tmp)
+		return ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 	}
 
-	var zeroVal bool
+	var zeroVal *bool
 	return zeroVal, nil
 }
 
 func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedDependencies(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (bool, error) {
+) (*bool, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["getIncludedDependencies"]
 	if !ok {
-		var zeroVal bool
+		var zeroVal *bool
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedDependencies"))
 	if tmp, ok := rawArgs["getIncludedDependencies"]; ok {
-		return ec.unmarshalNBoolean2bool(ctx, tmp)
+		return ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 	}
 
-	var zeroVal bool
+	var zeroVal *bool
 	return zeroVal, nil
 }
 
 func (ec *executionContext) field_Query_HasSBOMList_argsGetIncludedOccurrences(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (bool, error) {
+) (*bool, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["getIncludedOccurrences"]
 	if !ok {
-		var zeroVal bool
+		var zeroVal *bool
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("getIncludedOccurrences"))
 	if tmp, ok := rawArgs["getIncludedOccurrences"]; ok {
-		return ec.unmarshalNBoolean2bool(ctx, tmp)
+		return ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 	}
 
-	var zeroVal bool
+	var zeroVal *bool
 	return zeroVal, nil
 }
 
@@ -11021,7 +11021,7 @@ func (ec *executionContext) _Query_HasSBOMList(ctx context.Context, field graphq
 	}()
 	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().HasSBOMList(rctx, fc.Args["hasSBOMSpec"].(model.HasSBOMSpec), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["getIncludedSoftware"].(bool), fc.Args["getIncludedDependencies"].(bool), fc.Args["getIncludedOccurrences"].(bool))
+		return ec.resolvers.Query().HasSBOMList(rctx, fc.Args["hasSBOMSpec"].(model.HasSBOMSpec), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["getIncludedSoftware"].(*bool), fc.Args["getIncludedDependencies"].(*bool), fc.Args["getIncludedOccurrences"].(*bool))
 	})
 
 	if resTmp == nil {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -548,7 +548,7 @@ type ComplexityRoot struct {
 		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
 		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
 		HasMetadataList              func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
-		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) int
+		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) int
 		HasSLSAList                  func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
 		HasSbom                      func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
 		HasSlsa                      func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
@@ -3275,7 +3275,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.HasSBOMList(childComplexity, args["hasSBOMSpec"].(model.HasSBOMSpec), args["after"].(*string), args["first"].(*int), args["getIncludedSoftware"].(bool), args["getIncludedDependencies"].(bool), args["getIncludedOccurrences"].(bool)), true
+		return e.complexity.Query.HasSBOMList(childComplexity, args["hasSBOMSpec"].(model.HasSBOMSpec), args["after"].(*string), args["first"].(*int), args["getIncludedSoftware"].(*bool), args["getIncludedDependencies"].(*bool), args["getIncludedOccurrences"].(*bool)), true
 
 	case "Query.HasSLSAList":
 		if e.complexity.Query.HasSLSAList == nil {
@@ -5987,9 +5987,10 @@ extend type Query {
   """
   Returns a paginated results via HasSBOMConnection
   will by default filter out all deps.dev hasSBOM.
-  It will also allow for output to be modified based on desired output
+  It will also allow for output to be modified based on desired output.
+  If not specified, it will return all values
   """
-  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean!, getIncludedDependencies: Boolean!, getIncludedOccurrences: Boolean!): HasSBOMConnection
+  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean, getIncludedDependencies: Boolean, getIncludedOccurrences: Boolean): HasSBOMConnection
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -548,7 +548,7 @@ type ComplexityRoot struct {
 		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
 		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
 		HasMetadataList              func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
-		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
+		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) int
 		HasSLSAList                  func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
 		HasSbom                      func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
 		HasSlsa                      func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
@@ -3275,7 +3275,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.HasSBOMList(childComplexity, args["hasSBOMSpec"].(model.HasSBOMSpec), args["after"].(*string), args["first"].(*int)), true
+		return e.complexity.Query.HasSBOMList(childComplexity, args["hasSBOMSpec"].(model.HasSBOMSpec), args["after"].(*string), args["first"].(*int), args["getIncludedSoftware"].(bool), args["getIncludedDependencies"].(bool), args["getIncludedOccurrences"].(bool)), true
 
 	case "Query.HasSLSAList":
 		if e.complexity.Query.HasSLSAList == nil {
@@ -5982,10 +5982,14 @@ type HasSBOMEdge {
 }
 
 extend type Query {
-  "Returns all SBOM certifications."
+  "Returns all SBOM certifications (by default it filters out all deps.dev hasSBOMs)."
   HasSBOM(hasSBOMSpec: HasSBOMSpec!): [HasSBOM!]!
-  "Returns a paginated results via HasSBOMConnection"
-  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int): HasSBOMConnection
+  """
+  Returns a paginated results via HasSBOMConnection
+  will by default filter out all deps.dev hasSBOM.
+  It will also allow for output to be modified based on desired output
+  """
+  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean!, getIncludedDependencies: Boolean!, getIncludedOccurrences: Boolean!): HasSBOMConnection
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
@@ -66,7 +66,7 @@ func (r *queryResolver) HasSbom(ctx context.Context, hasSBOMSpec model.HasSBOMSp
 }
 
 // HasSBOMList is the resolver for the HasSBOMList field.
-func (r *queryResolver) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
+func (r *queryResolver) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware *bool, getIncludedDependencies *bool, getIncludedOccurrences *bool) (*model.HasSBOMConnection, error) {
 	if err := validatePackageOrArtifactQueryFilter(hasSBOMSpec.Subject); err != nil {
 		return nil, gqlerror.Errorf("%v :: %s", "HasSBOM", err)
 	}

--- a/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hasSBOM.resolvers.go
@@ -66,9 +66,9 @@ func (r *queryResolver) HasSbom(ctx context.Context, hasSBOMSpec model.HasSBOMSp
 }
 
 // HasSBOMList is the resolver for the HasSBOMList field.
-func (r *queryResolver) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) (*model.HasSBOMConnection, error) {
+func (r *queryResolver) HasSBOMList(ctx context.Context, hasSBOMSpec model.HasSBOMSpec, after *string, first *int, getIncludedSoftware bool, getIncludedDependencies bool, getIncludedOccurrences bool) (*model.HasSBOMConnection, error) {
 	if err := validatePackageOrArtifactQueryFilter(hasSBOMSpec.Subject); err != nil {
 		return nil, gqlerror.Errorf("%v :: %s", "HasSBOM", err)
 	}
-	return r.Backend.HasSBOMList(ctx, hasSBOMSpec, after, first)
+	return r.Backend.HasSBOMList(ctx, hasSBOMSpec, after, first, getIncludedSoftware, getIncludedDependencies, getIncludedOccurrences)
 }

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -121,9 +121,10 @@ extend type Query {
   """
   Returns a paginated results via HasSBOMConnection
   will by default filter out all deps.dev hasSBOM.
-  It will also allow for output to be modified based on desired output
+  It will also allow for output to be modified based on desired output.
+  If not specified, it will return all values
   """
-  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean!, getIncludedDependencies: Boolean!, getIncludedOccurrences: Boolean!): HasSBOMConnection
+  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean, getIncludedDependencies: Boolean, getIncludedOccurrences: Boolean): HasSBOMConnection
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/schema/hasSBOM.graphql
+++ b/pkg/assembler/graphql/schema/hasSBOM.graphql
@@ -116,10 +116,14 @@ type HasSBOMEdge {
 }
 
 extend type Query {
-  "Returns all SBOM certifications."
+  "Returns all SBOM certifications (by default it filters out all deps.dev hasSBOMs)."
   HasSBOM(hasSBOMSpec: HasSBOMSpec!): [HasSBOM!]!
-  "Returns a paginated results via HasSBOMConnection"
-  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int): HasSBOMConnection
+  """
+  Returns a paginated results via HasSBOMConnection
+  will by default filter out all deps.dev hasSBOM.
+  It will also allow for output to be modified based on desired output
+  """
+  HasSBOMList(hasSBOMSpec: HasSBOMSpec!, after: ID, first: Int, getIncludedSoftware: Boolean!, getIncludedDependencies: Boolean!, getIncludedOccurrences: Boolean!): HasSBOMConnection
 }
 
 extend type Mutation {


### PR DESCRIPTION
# Description of the PR

This by default changes the `hasSBOM` queries to filter our deps.dev collector SBOMs. It also adds the ability to filter out the returned values to make the query more efficient.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
