### PR TITLE
fix #2206 add http handler to display version string

### DIFF
--- a/cmd/guacgql/cmd/server.go
+++ b/cmd/guacgql/cmd/server.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/guacsec/guac/pkg/version"
 	"net/http"
 	"os"
 	"os/signal"
@@ -101,6 +102,7 @@ func startServer(cmd *cobra.Command) {
 	}
 
 	http.HandleFunc("/healthz", healthHandler)
+	http.HandleFunc("/version", versionHandler)
 
 	http.Handle("/query", srvHandler)
 	proto := "http"
@@ -189,6 +191,12 @@ func getGraphqlServer(ctx context.Context) (*handler.Server, error) {
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = fmt.Fprint(w, "Server is healthy")
+}
+
+func versionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprint(w, version.Version)
 }
 
 func getArango(_ context.Context) backends.BackendArgs {

--- a/cmd/guacgql/cmd/server_test.go
+++ b/cmd/guacgql/cmd/server_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/guacsec/guac/pkg/version"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_versionHandler(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(versionHandler))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(t, err)
+
+	actualData, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+
+	err = res.Body.Close()
+	assert.NoError(t, err)
+
+	actualStr := string(actualData)
+	assert.Equal(t, version.Version, actualStr)
+}


### PR DESCRIPTION
# Description of the PR

Fixes #2206 

implements a simple `/version` endpoint, returning the server's version.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- n/a [ ] If GraphQL schema is changed, `make generate` has been run
- n/a [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- n/a [ ] If OpenAPI spec is changed, `make generate` has been run
- n/a [ ] If ent schema is changed, `make generate` has been run
- n/a [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- n/a [ ] All CI checks are passing (tests and formatting)
- n/a [ ] All dependent PRs have already been merged
