### PR TITLE
Add IsDependency batch querying

### DIFF
--- a/internal/testing/backend/certifyLegal_test.go
+++ b/internal/testing/backend/certifyLegal_test.go
@@ -602,6 +602,105 @@ func TestLegal(t *testing.T) {
 	}
 }
 
+func TestBatchQueryPkgIDCertifyLegal(t *testing.T) {
+	ctx := context.Background()
+	b := setupTest(t)
+	type call struct {
+		PkgSrc model.PackageOrSourceInputs
+		Dec    [][]*model.IDorLicenseInput
+		Dis    [][]*model.IDorLicenseInput
+		Legal  []*model.CertifyLegalInputSpec
+	}
+	tests := []struct {
+		Name     string
+		InPkg    []*model.PkgInputSpec
+		InSrc    []*model.SourceInputSpec
+		InLic    []*model.LicenseInputSpec
+		Calls    []call
+		ExpLegal []*model.CertifyLegal
+	}{
+		{
+			Name:  "HappyPath",
+			InPkg: []*model.PkgInputSpec{testdata.P1, testdata.P2, testdata.P3, testdata.P4},
+			InLic: []*model.LicenseInputSpec{testdata.L1, testdata.L2, testdata.L3, testdata.L4},
+			Calls: []call{
+				{
+					PkgSrc: model.PackageOrSourceInputs{
+						Packages: []*model.IDorPkgInput{{PackageInput: testdata.P1}, {PackageInput: testdata.P2}, {PackageInput: testdata.P3}, {PackageInput: testdata.P4}},
+					},
+					Dec: [][]*model.IDorLicenseInput{{{LicenseInput: testdata.L1}}, {{LicenseInput: testdata.L2}}, {{LicenseInput: testdata.L3}}, {{LicenseInput: testdata.L4}}},
+					Dis: [][]*model.IDorLicenseInput{{{LicenseInput: testdata.L1}}, {{LicenseInput: testdata.L2}}, {}, {}},
+					Legal: []*model.CertifyLegalInputSpec{
+						{Justification: "test justification"},
+						{Justification: "test justification"},
+						{Justification: "test justification"},
+						{Justification: "test justification"},
+					},
+				},
+			},
+			ExpLegal: []*model.CertifyLegal{
+				{
+					Subject:            testdata.P1out,
+					DeclaredLicenses:   []*model.License{testdata.L1out},
+					DiscoveredLicenses: []*model.License{testdata.L1out},
+					Justification:      "test justification",
+				},
+				{
+					Subject:            testdata.P2out,
+					DeclaredLicenses:   []*model.License{testdata.L2out},
+					DiscoveredLicenses: []*model.License{testdata.L2out},
+					Justification:      "test justification",
+				},
+				{
+					Subject:          testdata.P3out,
+					DeclaredLicenses: []*model.License{testdata.L3out},
+					Justification:    "test justification",
+				},
+				{
+					Subject:          testdata.P4out,
+					DeclaredLicenses: []*model.License{testdata.L4out},
+					Justification:    "test justification",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var pkgIDs []string
+			for _, p := range test.InPkg {
+				if pkgID, err := b.IngestPackage(ctx, model.IDorPkgInput{PackageInput: p}); err != nil {
+					t.Fatalf("Could not ingest package: %v", err)
+				} else {
+					pkgIDs = append(pkgIDs, pkgID.PackageVersionID)
+				}
+			}
+			for _, s := range test.InSrc {
+				if _, err := b.IngestSource(ctx, model.IDorSourceInput{SourceInput: s}); err != nil {
+					t.Fatalf("Could not ingest source: %v", err)
+				}
+			}
+			for _, a := range test.InLic {
+				if _, err := b.IngestLicense(ctx, &model.IDorLicenseInput{LicenseInput: a}); err != nil {
+					t.Fatalf("Could not ingest license: %v", err)
+				}
+			}
+			for _, o := range test.Calls {
+				_, err := b.IngestCertifyLegals(ctx, o.PkgSrc, o.Dec, o.Dis, o.Legal)
+				if err != nil {
+					t.Fatalf("did not get expected ingest error: %v", err)
+				}
+			}
+			got, err := b.BatchQueryPkgIDCertifyLegal(ctx, pkgIDs)
+			if err != nil {
+				t.Fatalf("did not get expected query error: %v", err)
+			}
+			if diff := cmp.Diff(test.ExpLegal, got, commonOpts); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestLegals(t *testing.T) {
 	ctx := context.Background()
 	b := setupTest(t)

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -96,12 +96,14 @@ var skipMatrix = map[string]map[string]bool{
 	"TestVEXBulkIngest": {arango: true, redis: true},
 	"TestFindSoftware":  {redis: true, arango: true},
 	// remove these once its implemented for the other backends
-	"TestDeleteCertifyVuln":           {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSBOM":               {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSLSAs":              {arango: true, memmap: true, redis: true, tikv: true},
-	"TestQueryPackagesListForScan":    {arango: true, redis: true, tikv: true},
-	"TestBatchQueryPkgIDCertifyVuln":  {arango: true, redis: true, tikv: true},
-	"TestBatchQueryPkgIDCertifyLegal": {arango: true, redis: true, tikv: true},
+	"TestDeleteCertifyVuln":              {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSBOM":                  {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSLSAs":                 {arango: true, memmap: true, redis: true, tikv: true},
+	"TestQueryPackagesListForScan":       {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyVuln":     {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyLegal":    {arango: true, redis: true, tikv: true},
+	"TestBatchQuerySubjectPkgDependency": {arango: true, redis: true, tikv: true},
+	"TestBatchQueryDepPkgDependency":     {arango: true, redis: true, tikv: true},
 }
 
 type backend interface {

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -96,10 +96,12 @@ var skipMatrix = map[string]map[string]bool{
 	"TestVEXBulkIngest": {arango: true, redis: true},
 	"TestFindSoftware":  {redis: true, arango: true},
 	// remove these once its implemented for the other backends
-	"TestDeleteCertifyVuln":        {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSBOM":            {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSLSAs":           {arango: true, memmap: true, redis: true, tikv: true},
-	"TestQueryPackagesListForScan": {arango: true, redis: true, tikv: true},
+	"TestDeleteCertifyVuln":           {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSBOM":               {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSLSAs":              {arango: true, memmap: true, redis: true, tikv: true},
+	"TestQueryPackagesListForScan":    {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyVuln":  {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyLegal": {arango: true, redis: true, tikv: true},
 }
 
 type backend interface {

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -70,6 +70,36 @@ func (mr *MockBackendMockRecorder) ArtifactsList(ctx, artifactSpec, after, first
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArtifactsList", reflect.TypeOf((*MockBackend)(nil).ArtifactsList), ctx, artifactSpec, after, first)
 }
 
+// BatchQueryPkgIDCertifyLegal mocks base method.
+func (m *MockBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQueryPkgIDCertifyLegal", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.CertifyLegal)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQueryPkgIDCertifyLegal indicates an expected call of BatchQueryPkgIDCertifyLegal.
+func (mr *MockBackendMockRecorder) BatchQueryPkgIDCertifyLegal(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryPkgIDCertifyLegal", reflect.TypeOf((*MockBackend)(nil).BatchQueryPkgIDCertifyLegal), ctx, pkgIDs)
+}
+
+// BatchQueryPkgIDCertifyVuln mocks base method.
+func (m *MockBackend) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQueryPkgIDCertifyVuln", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.CertifyVuln)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQueryPkgIDCertifyVuln indicates an expected call of BatchQueryPkgIDCertifyVuln.
+func (mr *MockBackendMockRecorder) BatchQueryPkgIDCertifyVuln(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryPkgIDCertifyVuln", reflect.TypeOf((*MockBackend)(nil).BatchQueryPkgIDCertifyVuln), ctx, pkgIDs)
+}
+
 // Builders mocks base method.
 func (m *MockBackend) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
 	m.ctrl.T.Helper()
@@ -263,36 +293,6 @@ func (m *MockBackend) Delete(ctx context.Context, node string) (bool, error) {
 func (mr *MockBackendMockRecorder) Delete(ctx, node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBackend)(nil).Delete), ctx, node)
-}
-
-// FindAllLicenses mocks base method.
-func (m *MockBackend) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAllLicenses", ctx, pkgIDs, after, first)
-	ret0, _ := ret[0].(*model.CertifyVulnConnection)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindAllLicenses indicates an expected call of FindAllLicenses.
-func (mr *MockBackendMockRecorder) FindAllLicenses(ctx, pkgIDs, after, first any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllLicenses", reflect.TypeOf((*MockBackend)(nil).FindAllLicenses), ctx, pkgIDs, after, first)
-}
-
-// FindAllVulnerabilities mocks base method.
-func (m *MockBackend) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAllVulnerabilities", ctx, pkgIDs, after, first)
-	ret0, _ := ret[0].(*model.CertifyVulnConnection)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindAllVulnerabilities indicates an expected call of FindAllVulnerabilities.
-func (mr *MockBackendMockRecorder) FindAllVulnerabilities(ctx, pkgIDs, after, first any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllVulnerabilities", reflect.TypeOf((*MockBackend)(nil).FindAllVulnerabilities), ctx, pkgIDs, after, first)
 }
 
 // FindPackagesThatNeedScanning mocks base method.

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -265,6 +265,36 @@ func (mr *MockBackendMockRecorder) Delete(ctx, node any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBackend)(nil).Delete), ctx, node)
 }
 
+// FindAllLicenses mocks base method.
+func (m *MockBackend) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAllLicenses", ctx, pkgIDs, after, first)
+	ret0, _ := ret[0].(*model.CertifyVulnConnection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAllLicenses indicates an expected call of FindAllLicenses.
+func (mr *MockBackendMockRecorder) FindAllLicenses(ctx, pkgIDs, after, first any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllLicenses", reflect.TypeOf((*MockBackend)(nil).FindAllLicenses), ctx, pkgIDs, after, first)
+}
+
+// FindAllVulnerabilities mocks base method.
+func (m *MockBackend) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAllVulnerabilities", ctx, pkgIDs, after, first)
+	ret0, _ := ret[0].(*model.CertifyVulnConnection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAllVulnerabilities indicates an expected call of FindAllVulnerabilities.
+func (mr *MockBackendMockRecorder) FindAllVulnerabilities(ctx, pkgIDs, after, first any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllVulnerabilities", reflect.TypeOf((*MockBackend)(nil).FindAllVulnerabilities), ctx, pkgIDs, after, first)
+}
+
 // FindPackagesThatNeedScanning mocks base method.
 func (m *MockBackend) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -70,6 +70,21 @@ func (mr *MockBackendMockRecorder) ArtifactsList(ctx, artifactSpec, after, first
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArtifactsList", reflect.TypeOf((*MockBackend)(nil).ArtifactsList), ctx, artifactSpec, after, first)
 }
 
+// BatchQueryDepPkgDependency mocks base method.
+func (m *MockBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQueryDepPkgDependency", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.IsDependency)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQueryDepPkgDependency indicates an expected call of BatchQueryDepPkgDependency.
+func (mr *MockBackendMockRecorder) BatchQueryDepPkgDependency(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryDepPkgDependency", reflect.TypeOf((*MockBackend)(nil).BatchQueryDepPkgDependency), ctx, pkgIDs)
+}
+
 // BatchQueryPkgIDCertifyLegal mocks base method.
 func (m *MockBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
 	m.ctrl.T.Helper()
@@ -98,6 +113,21 @@ func (m *MockBackend) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []s
 func (mr *MockBackendMockRecorder) BatchQueryPkgIDCertifyVuln(ctx, pkgIDs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryPkgIDCertifyVuln", reflect.TypeOf((*MockBackend)(nil).BatchQueryPkgIDCertifyVuln), ctx, pkgIDs)
+}
+
+// BatchQuerySubjectPkgDependency mocks base method.
+func (m *MockBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQuerySubjectPkgDependency", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.IsDependency)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQuerySubjectPkgDependency indicates an expected call of BatchQuerySubjectPkgDependency.
+func (mr *MockBackendMockRecorder) BatchQuerySubjectPkgDependency(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQuerySubjectPkgDependency", reflect.TypeOf((*MockBackend)(nil).BatchQuerySubjectPkgDependency), ctx, pkgIDs)
 }
 
 // Builders mocks base method.

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -43,6 +43,14 @@ func (c *arangoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs [
 	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
 
+func (c *arangoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *arangoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}
+
 // TODO(lumjjb): add source when it is implemented in arango backend
 func (c *arangoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -35,12 +35,12 @@ func (c *arangoClient) FindPackagesThatNeedScanning(ctx context.Context, queryTy
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
 
-func (c *arangoClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *arangoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyVuln")
 }
 
-func (c *arangoClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *arangoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
 
 // TODO(lumjjb): add source when it is implemented in arango backend

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -35,6 +35,14 @@ func (c *arangoClient) FindPackagesThatNeedScanning(ctx context.Context, queryTy
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
 
+func (c *arangoClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
+func (c *arangoClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
 // TODO(lumjjb): add source when it is implemented in arango backend
 func (c *arangoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -138,13 +138,15 @@ type Backend interface {
 	Nodes(ctx context.Context, nodes []string) ([]model.Node, error)
 	Path(ctx context.Context, subject string, target string, maxPathLength int, usingOnly []model.Edge) ([]model.Node, error)
 
+	// Batch Query
+	BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error)
+	BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error)
+
 	// Search queries: queries to help find data in GUAC based on text search
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
 	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
-	FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
-	FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -143,6 +143,8 @@ type Backend interface {
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
 	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
+	FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
+	FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
 }
 
 // BackendArgs interface allows each backend to specify the arguments needed to

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -141,6 +141,8 @@ type Backend interface {
 	// Batch Query
 	BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error)
 	BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error)
+	BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
+	BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
 
 	// Search queries: queries to help find data in GUAC based on text search
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -365,3 +365,11 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 	}
 	return collectedCertLegal, nil
 }
+
+func (b *EntBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (b *EntBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -34,11 +34,11 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcename"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/helpers"
 )
 
 const (
 	guacType string = "guac"
-	noVulnID string = "110d9f78-db10-52ba-99e2-4f65cca5e6c1"
 )
 
 // FindSoftware takes in a searchText string and looks for software
@@ -296,12 +296,8 @@ func (b *EntBackend) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []st
 
 	// static ID for noVuln that is generated from type = novuln and vulnid = ""
 	// this is generated via:
-	// vulnIDs := helpers.GetKey[*model.VulnerabilityInputSpec, helpers.VulnIds](spec.VulnerabilityInput, helpers.VulnServerKey)
-	// vulnID := generateUUIDKey([]byte(vulnIDs.VulnerabilityID))
-	noVulnID, err := uuid.Parse(noVulnID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse ID to UUID with error: %w", err)
-	}
+	vulnIDs := helpers.GetKey[*model.VulnerabilityInputSpec, helpers.VulnIds](&model.VulnerabilityInputSpec{Type: NoVuln, VulnerabilityID: ""}, helpers.VulnServerKey)
+	noVulnID := generateUUIDKey([]byte(vulnIDs.VulnerabilityID))
 	var queryList []uuid.UUID
 	// Loop through the sorted list starting from the specified UUID
 	for _, id := range pkgIDs {

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -354,7 +354,10 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 		Where(certifylegal.And(predicates...)).
 		WithPackage(func(q *ent.PackageVersionQuery) {
 			q.WithName(func(q *ent.PackageNameQuery) {})
-		}).All(ctx)
+		}).
+		WithSource(func(q *ent.SourceNameQuery) {}).
+		WithDeclaredLicenses().
+		WithDiscoveredLicenses().All(ctx)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed certifyLegal query based on package IDs with error: %w", err)

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -244,7 +244,7 @@ func (b *EntBackend) QueryPackagesListForScan(ctx context.Context, pkgIDs []stri
 		}
 	}
 	var queryErr error
-	pkgConn, queryErr = b.client.Debug().PackageVersion.Query().
+	pkgConn, queryErr = b.client.PackageVersion.Query().
 		Where(packageversion.IDIn(shortenedQueryList...)).
 		WithName(func(q *ent.PackageNameQuery) {}).
 		Paginate(ctx, afterCursor, first, nil, nil)
@@ -317,7 +317,7 @@ func (b *EntBackend) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []st
 
 	predicates = append(predicates, certifyvuln.PackageIDIn(queryList...), certifyvuln.VulnerabilityIDNEQ(noVulnID))
 
-	certVulnConn, err := b.client.Debug().CertifyVuln.Query().
+	certVulnConn, err := b.client.CertifyVuln.Query().
 		Where(certifyvuln.And(predicates...)).
 		WithVulnerability(func(query *ent.VulnerabilityIDQuery) {}).
 		WithPackage(func(q *ent.PackageVersionQuery) {
@@ -350,7 +350,7 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 	var predicates []predicate.CertifyLegal
 
 	predicates = append(predicates, certifylegal.PackageIDIn(queryList...), certifylegal.SourceIDIsNil())
-	certLegalConn, err := b.client.Debug().CertifyLegal.Query().
+	certLegalConn, err := b.client.CertifyLegal.Query().
 		Where(certifylegal.And(predicates...)).
 		WithPackage(func(q *ent.PackageVersionQuery) {
 			q.WithName(func(q *ent.PackageNameQuery) {})

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/certifylegal"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/certifyvuln"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/dependency"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagename"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
@@ -367,7 +368,31 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 }
 
 func (b *EntBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+	var queryList []uuid.UUID
+
+	for _, id := range pkgIDs {
+		globalID := fromGlobalID(id)
+		convertedID, err := uuid.Parse(globalID.id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ID to UUID with error: %w", err)
+		}
+		queryList = append(queryList, convertedID)
+	}
+
+	idDepConn, err := b.client.Dependency.Query().
+		Where(dependency.PackageIDIn(queryList...)).
+		WithPackage(withPackageVersionTree()).
+		WithDependentPackageVersion(withPackageVersionTree()).All(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed isDependency subject query based on package IDs with error: %w", err)
+	}
+
+	var collectedIsDependency []*model.IsDependency
+	for _, entIsDep := range idDepConn {
+		collectedIsDependency = append(collectedIsDependency, toModelIsDependencyWithBackrefs(entIsDep))
+	}
+	return collectedIsDependency, nil
 }
 
 func (b *EntBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {

--- a/pkg/assembler/backends/ent/gql_collection.go
+++ b/pkg/assembler/backends/ent/gql_collection.go
@@ -2289,7 +2289,7 @@ func (pv *PackageVersionQuery) collectField(ctx context.Context, oneNode bool, o
 	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 
-		case "name":
+		case "namespaces":
 			var (
 				alias = field.Alias
 				path  = append(path, alias)

--- a/pkg/assembler/backends/ent/schema/packageversion.go
+++ b/pkg/assembler/backends/ent/schema/packageversion.go
@@ -16,6 +16,7 @@
 package schema
 
 import (
+	"entgo.io/contrib/entgql"
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/entsql"
@@ -49,7 +50,7 @@ func (PackageVersion) Fields() []ent.Field {
 // Edges of the PackageVersion.
 func (PackageVersion) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("name", PackageName.Type).Required().Field("name_id").Ref("versions").Unique(),
+		edge.From("name", PackageName.Type).Required().Field("name_id").Ref("versions").Unique().Annotations(entgql.MapsTo("namespaces")),
 		edge.From("occurrences", Occurrence.Type).Ref("package"),
 		edge.From("sbom", BillOfMaterials.Type).Ref("package"),
 		edge.From("vuln", CertifyVuln.Type).Ref("package"),

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -33,6 +33,14 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
+func (c *demoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *demoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}
+
 func (c *demoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
 	var collectedCertVulns []*model.CertifyVuln
 	for _, pkgID := range pkgIDs {

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -34,11 +34,27 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 }
 
 func (c *demoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
-	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyVuln")
+	var collectedCertVulns []*model.CertifyVuln
+	for _, pkgID := range pkgIDs {
+		certVuln, err := c.CertifyVuln(ctx, &model.CertifyVulnSpec{Package: &model.PkgSpec{ID: &pkgID}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query CertifyVuln for pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedCertVulns = append(collectedCertVulns, certVuln...)
+	}
+	return collectedCertVulns, nil
 }
 
 func (c *demoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
-	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
+	var collectedCertLegal []*model.CertifyLegal
+	for _, pkgID := range pkgIDs {
+		certLegal, err := c.CertifyLegal(ctx, &model.CertifyLegalSpec{Subject: &model.PackageOrSourceSpec{Package: &model.PkgSpec{ID: &pkgID}}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query CertifyLegal for pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedCertLegal = append(collectedCertLegal, certLegal...)
+	}
+	return collectedCertLegal, nil
 }
 
 func (c *demoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -34,11 +34,27 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 }
 
 func (c *demoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+	var collectedIsDep []*model.IsDependency
+	for _, pkgID := range pkgIDs {
+		isDep, err := c.IsDependency(ctx, &model.IsDependencySpec{Package: &model.PkgSpec{ID: &pkgID}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query IsDependency for pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedIsDep = append(collectedIsDep, isDep...)
+	}
+	return collectedIsDep, nil
 }
 
 func (c *demoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+	var collectedIsDep []*model.IsDependency
+	for _, pkgID := range pkgIDs {
+		isDep, err := c.IsDependency(ctx, &model.IsDependencySpec{DependencyPackage: &model.PkgSpec{ID: &pkgID}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query IsDependency for dependency pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedIsDep = append(collectedIsDep, isDep...)
+	}
+	return collectedIsDep, nil
 }
 
 func (c *demoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -33,6 +33,14 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
+func (c *demoClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
+func (c *demoClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
 func (c *demoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 	scanner := c.kv.Keys("artifacts")
 	var res []model.PackageSourceOrArtifact

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -33,12 +33,12 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
-func (c *demoClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *demoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyVuln")
 }
 
-func (c *demoClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *demoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
 
 func (c *demoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -38,10 +38,10 @@ func (c *neo4jClient) FindPackagesThatNeedScanning(ctx context.Context, queryTyp
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
 
-func (c *neo4jClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *neo4jClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyVuln")
 }
 
-func (c *neo4jClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+func (c *neo4jClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -45,3 +45,11 @@ func (c *neo4jClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []s
 func (c *neo4jClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
 	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
+
+func (c *neo4jClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *neo4jClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -37,3 +37,11 @@ func (c *neo4jClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []str
 func (c *neo4jClient) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
 }
+
+func (c *neo4jClient) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}
+
+func (c *neo4jClient) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return nil, fmt.Errorf("not implemented: FindPackagesThatNeedScanning")
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -78,12 +78,14 @@ type QueryResolver interface {
 	CertifyGoodList(ctx context.Context, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) (*model.CertifyGoodConnection, error)
 	CertifyLegal(ctx context.Context, certifyLegalSpec model.CertifyLegalSpec) ([]*model.CertifyLegal, error)
 	CertifyLegalList(ctx context.Context, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) (*model.CertifyLegalConnection, error)
+	BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error)
 	Scorecards(ctx context.Context, scorecardSpec model.CertifyScorecardSpec) ([]*model.CertifyScorecard, error)
 	ScorecardsList(ctx context.Context, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) (*model.CertifyScorecardConnection, error)
 	CertifyVEXStatement(ctx context.Context, certifyVEXStatementSpec model.CertifyVEXStatementSpec) ([]*model.CertifyVEXStatement, error)
 	CertifyVEXStatementList(ctx context.Context, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) (*model.VEXConnection, error)
 	CertifyVuln(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec) ([]*model.CertifyVuln, error)
 	CertifyVulnList(ctx context.Context, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) (*model.CertifyVulnConnection, error)
+	BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error)
 	PointOfContact(ctx context.Context, pointOfContactSpec model.PointOfContactSpec) ([]*model.PointOfContact, error)
 	PointOfContactList(ctx context.Context, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) (*model.PointOfContactConnection, error)
 	HasSbom(ctx context.Context, hasSBOMSpec model.HasSBOMSpec) ([]*model.HasSbom, error)
@@ -115,8 +117,6 @@ type QueryResolver interface {
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
 	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
-	FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
-	FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
 	Sources(ctx context.Context, sourceSpec model.SourceSpec) ([]*model.Source, error)
 	SourcesList(ctx context.Context, sourceSpec model.SourceSpec, after *string, first *int) (*model.SourceConnection, error)
 	VulnEqual(ctx context.Context, vulnEqualSpec model.VulnEqualSpec) ([]*model.VulnEqual, error)
@@ -3525,6 +3525,70 @@ func (ec *executionContext) field_Mutation_ingestVulnerability_argsVuln(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyLegal_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQueryPkgIDCertifyLegal_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyLegal_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQueryPkgIDCertifyVuln_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query_CertifyBadList_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5442,178 +5506,6 @@ func (ec *executionContext) field_Query_builders_argsBuilderSpec(
 	}
 
 	var zeroVal model.BuilderSpec
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllLicenses_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	arg0, err := ec.field_Query_findAllLicenses_argsPkgIDs(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["pkgIDs"] = arg0
-	arg1, err := ec.field_Query_findAllLicenses_argsAfter(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["after"] = arg1
-	arg2, err := ec.field_Query_findAllLicenses_argsFirst(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["first"] = arg2
-	return args, nil
-}
-func (ec *executionContext) field_Query_findAllLicenses_argsPkgIDs(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["pkgIDs"]
-	if !ok {
-		var zeroVal []string
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
-	if tmp, ok := rawArgs["pkgIDs"]; ok {
-		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
-	}
-
-	var zeroVal []string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllLicenses_argsAfter(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["after"]
-	if !ok {
-		var zeroVal *string
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
-	if tmp, ok := rawArgs["after"]; ok {
-		return ec.unmarshalOID2ᚖstring(ctx, tmp)
-	}
-
-	var zeroVal *string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllLicenses_argsFirst(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["first"]
-	if !ok {
-		var zeroVal *int
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
-	if tmp, ok := rawArgs["first"]; ok {
-		return ec.unmarshalOInt2ᚖint(ctx, tmp)
-	}
-
-	var zeroVal *int
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllVulnerabilities_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	arg0, err := ec.field_Query_findAllVulnerabilities_argsPkgIDs(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["pkgIDs"] = arg0
-	arg1, err := ec.field_Query_findAllVulnerabilities_argsAfter(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["after"] = arg1
-	arg2, err := ec.field_Query_findAllVulnerabilities_argsFirst(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["first"] = arg2
-	return args, nil
-}
-func (ec *executionContext) field_Query_findAllVulnerabilities_argsPkgIDs(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) ([]string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["pkgIDs"]
-	if !ok {
-		var zeroVal []string
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
-	if tmp, ok := rawArgs["pkgIDs"]; ok {
-		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
-	}
-
-	var zeroVal []string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllVulnerabilities_argsAfter(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (*string, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["after"]
-	if !ok {
-		var zeroVal *string
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
-	if tmp, ok := rawArgs["after"]; ok {
-		return ec.unmarshalOID2ᚖstring(ctx, tmp)
-	}
-
-	var zeroVal *string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_findAllVulnerabilities_argsFirst(
-	ctx context.Context,
-	rawArgs map[string]interface{},
-) (*int, error) {
-	// We won't call the directive if the argument is null.
-	// Set call_argument_directives_with_null to true to call directives
-	// even if the argument is null.
-	_, ok := rawArgs["first"]
-	if !ok {
-		var zeroVal *int
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
-	if tmp, ok := rawArgs["first"]; ok {
-		return ec.unmarshalOInt2ᚖint(ctx, tmp)
-	}
-
-	var zeroVal *int
 	return zeroVal, nil
 }
 
@@ -10522,6 +10414,84 @@ func (ec *executionContext) fieldContext_Query_CertifyLegalList(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_BatchQueryPkgIDCertifyLegal(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQueryPkgIDCertifyLegal(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQueryPkgIDCertifyLegal(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CertifyLegal)
+	fc.Result = res
+	return ec.marshalNCertifyLegal2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyLegalᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQueryPkgIDCertifyLegal(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyLegal_id(ctx, field)
+			case "subject":
+				return ec.fieldContext_CertifyLegal_subject(ctx, field)
+			case "declaredLicense":
+				return ec.fieldContext_CertifyLegal_declaredLicense(ctx, field)
+			case "declaredLicenses":
+				return ec.fieldContext_CertifyLegal_declaredLicenses(ctx, field)
+			case "discoveredLicense":
+				return ec.fieldContext_CertifyLegal_discoveredLicense(ctx, field)
+			case "discoveredLicenses":
+				return ec.fieldContext_CertifyLegal_discoveredLicenses(ctx, field)
+			case "attribution":
+				return ec.fieldContext_CertifyLegal_attribution(ctx, field)
+			case "justification":
+				return ec.fieldContext_CertifyLegal_justification(ctx, field)
+			case "timeScanned":
+				return ec.fieldContext_CertifyLegal_timeScanned(ctx, field)
+			case "origin":
+				return ec.fieldContext_CertifyLegal_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_CertifyLegal_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_CertifyLegal_documentRef(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyLegal", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQueryPkgIDCertifyLegal_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_scorecards(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_scorecards(ctx, field)
 	if err != nil {
@@ -10885,6 +10855,68 @@ func (ec *executionContext) fieldContext_Query_CertifyVulnList(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_CertifyVulnList_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_BatchQueryPkgIDCertifyVuln(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQueryPkgIDCertifyVuln(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQueryPkgIDCertifyVuln(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CertifyVuln)
+	fc.Result = res
+	return ec.marshalNCertifyVuln2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQueryPkgIDCertifyVuln(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CertifyVuln_id(ctx, field)
+			case "package":
+				return ec.fieldContext_CertifyVuln_package(ctx, field)
+			case "vulnerability":
+				return ec.fieldContext_CertifyVuln_vulnerability(ctx, field)
+			case "metadata":
+				return ec.fieldContext_CertifyVuln_metadata(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyVuln", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQueryPkgIDCertifyVuln_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -12747,120 +12779,6 @@ func (ec *executionContext) fieldContext_Query_findPackagesThatNeedScanning(ctx 
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_findAllVulnerabilities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_findAllVulnerabilities(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().FindAllVulnerabilities(rctx, fc.Args["pkgIDs"].([]string), fc.Args["after"].(*string), fc.Args["first"].(*int))
-	})
-
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.CertifyVulnConnection)
-	fc.Result = res
-	return ec.marshalOCertifyVulnConnection2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnConnection(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_findAllVulnerabilities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "totalCount":
-				return ec.fieldContext_CertifyVulnConnection_totalCount(ctx, field)
-			case "pageInfo":
-				return ec.fieldContext_CertifyVulnConnection_pageInfo(ctx, field)
-			case "edges":
-				return ec.fieldContext_CertifyVulnConnection_edges(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyVulnConnection", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_findAllVulnerabilities_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_findAllLicenses(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_findAllLicenses(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().FindAllLicenses(rctx, fc.Args["pkgIDs"].([]string), fc.Args["after"].(*string), fc.Args["first"].(*int))
-	})
-
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.CertifyVulnConnection)
-	fc.Result = res
-	return ec.marshalOCertifyVulnConnection2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnConnection(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_findAllLicenses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "totalCount":
-				return ec.fieldContext_CertifyVulnConnection_totalCount(ctx, field)
-			case "pageInfo":
-				return ec.fieldContext_CertifyVulnConnection_pageInfo(ctx, field)
-			case "edges":
-				return ec.fieldContext_CertifyVulnConnection_edges(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type CertifyVulnConnection", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_findAllLicenses_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_sources(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_sources(ctx, field)
 	if err != nil {
@@ -14326,6 +14244,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQueryPkgIDCertifyLegal":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQueryPkgIDCertifyLegal(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "scorecards":
 			field := field
 
@@ -14440,6 +14380,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_CertifyVulnList(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQueryPkgIDCertifyVuln":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQueryPkgIDCertifyVuln(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -15080,44 +15042,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "findAllVulnerabilities":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_findAllVulnerabilities(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "findAllLicenses":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_findAllLicenses(ctx, field)
 				return res
 			}
 

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -115,6 +115,8 @@ type QueryResolver interface {
 	FindSoftwareList(ctx context.Context, searchText string, after *string, first *int) (*model.FindSoftwareConnection, error)
 	QueryPackagesListForScan(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.PackageConnection, error)
 	FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error)
+	FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
+	FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error)
 	Sources(ctx context.Context, sourceSpec model.SourceSpec) ([]*model.Source, error)
 	SourcesList(ctx context.Context, sourceSpec model.SourceSpec, after *string, first *int) (*model.SourceConnection, error)
 	VulnEqual(ctx context.Context, vulnEqualSpec model.VulnEqualSpec) ([]*model.VulnEqual, error)
@@ -5440,6 +5442,178 @@ func (ec *executionContext) field_Query_builders_argsBuilderSpec(
 	}
 
 	var zeroVal model.BuilderSpec
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllLicenses_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_findAllLicenses_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	arg1, err := ec.field_Query_findAllLicenses_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Query_findAllLicenses_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg2
+	return args, nil
+}
+func (ec *executionContext) field_Query_findAllLicenses_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllLicenses_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (*string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["after"]
+	if !ok {
+		var zeroVal *string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOID2ᚖstring(ctx, tmp)
+	}
+
+	var zeroVal *string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllLicenses_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (*int, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["first"]
+	if !ok {
+		var zeroVal *int
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllVulnerabilities_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_findAllVulnerabilities_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	arg1, err := ec.field_Query_findAllVulnerabilities_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Query_findAllVulnerabilities_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg2
+	return args, nil
+}
+func (ec *executionContext) field_Query_findAllVulnerabilities_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllVulnerabilities_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (*string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["after"]
+	if !ok {
+		var zeroVal *string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOID2ᚖstring(ctx, tmp)
+	}
+
+	var zeroVal *string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_findAllVulnerabilities_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (*int, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["first"]
+	if !ok {
+		var zeroVal *int
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
 	return zeroVal, nil
 }
 
@@ -12573,6 +12747,120 @@ func (ec *executionContext) fieldContext_Query_findPackagesThatNeedScanning(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_findAllVulnerabilities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_findAllVulnerabilities(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindAllVulnerabilities(rctx, fc.Args["pkgIDs"].([]string), fc.Args["after"].(*string), fc.Args["first"].(*int))
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.CertifyVulnConnection)
+	fc.Result = res
+	return ec.marshalOCertifyVulnConnection2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_findAllVulnerabilities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_CertifyVulnConnection_totalCount(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_CertifyVulnConnection_pageInfo(ctx, field)
+			case "edges":
+				return ec.fieldContext_CertifyVulnConnection_edges(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyVulnConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findAllVulnerabilities_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_findAllLicenses(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_findAllLicenses(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FindAllLicenses(rctx, fc.Args["pkgIDs"].([]string), fc.Args["after"].(*string), fc.Args["first"].(*int))
+	})
+
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.CertifyVulnConnection)
+	fc.Result = res
+	return ec.marshalOCertifyVulnConnection2ᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐCertifyVulnConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_findAllLicenses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_CertifyVulnConnection_totalCount(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_CertifyVulnConnection_pageInfo(ctx, field)
+			case "edges":
+				return ec.fieldContext_CertifyVulnConnection_edges(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CertifyVulnConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findAllLicenses_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_sources(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_sources(ctx, field)
 	if err != nil {
@@ -14792,6 +15080,44 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findAllVulnerabilities":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findAllVulnerabilities(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findAllLicenses":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findAllLicenses(ctx, field)
 				return res
 			}
 

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -98,6 +98,8 @@ type QueryResolver interface {
 	HashEqualList(ctx context.Context, hashEqualSpec model.HashEqualSpec, after *string, first *int) (*model.HashEqualConnection, error)
 	IsDependency(ctx context.Context, isDependencySpec model.IsDependencySpec) ([]*model.IsDependency, error)
 	IsDependencyList(ctx context.Context, isDependencySpec model.IsDependencySpec, after *string, first *int) (*model.IsDependencyConnection, error)
+	BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
+	BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
 	IsOccurrence(ctx context.Context, isOccurrenceSpec model.IsOccurrenceSpec) ([]*model.IsOccurrence, error)
 	IsOccurrenceList(ctx context.Context, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) (*model.IsOccurrenceConnection, error)
 	Licenses(ctx context.Context, licenseSpec model.LicenseSpec) ([]*model.License, error)
@@ -3525,6 +3527,38 @@ func (ec *executionContext) field_Mutation_ingestVulnerability_argsVuln(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query_BatchQueryDepPkgDependency_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQueryDepPkgDependency_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQueryDepPkgDependency_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyLegal_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -3568,6 +3602,38 @@ func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_args(ctx cont
 	return args, nil
 }
 func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_BatchQuerySubjectPkgDependency_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQuerySubjectPkgDependency_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQuerySubjectPkgDependency_argsPkgIDs(
 	ctx context.Context,
 	rawArgs map[string]interface{},
 ) ([]string, error) {
@@ -11683,6 +11749,146 @@ func (ec *executionContext) fieldContext_Query_IsDependencyList(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_BatchQuerySubjectPkgDependency(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQuerySubjectPkgDependency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQuerySubjectPkgDependency(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.IsDependency)
+	fc.Result = res
+	return ec.marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQuerySubjectPkgDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsDependency_id(ctx, field)
+			case "package":
+				return ec.fieldContext_IsDependency_package(ctx, field)
+			case "dependencyPackage":
+				return ec.fieldContext_IsDependency_dependencyPackage(ctx, field)
+			case "dependencyType":
+				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
+			case "justification":
+				return ec.fieldContext_IsDependency_justification(ctx, field)
+			case "origin":
+				return ec.fieldContext_IsDependency_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQuerySubjectPkgDependency_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_BatchQueryDepPkgDependency(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQueryDepPkgDependency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQueryDepPkgDependency(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.IsDependency)
+	fc.Result = res
+	return ec.marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQueryDepPkgDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsDependency_id(ctx, field)
+			case "package":
+				return ec.fieldContext_IsDependency_package(ctx, field)
+			case "dependencyPackage":
+				return ec.fieldContext_IsDependency_dependencyPackage(ctx, field)
+			case "dependencyType":
+				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
+			case "justification":
+				return ec.fieldContext_IsDependency_justification(ctx, field)
+			case "origin":
+				return ec.fieldContext_IsDependency_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQueryDepPkgDependency_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_IsOccurrence(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_IsOccurrence(ctx, field)
 	if err != nil {
@@ -14648,6 +14854,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_IsDependencyList(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQuerySubjectPkgDependency":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQuerySubjectPkgDependency(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQueryDepPkgDependency":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQueryDepPkgDependency(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5183,7 +5183,7 @@ extend type Query {
   CertifyLegal(certifyLegalSpec: CertifyLegalSpec!): [CertifyLegal!]!
   "Returns a paginated results via CertifyLegalConnection"
   CertifyLegalList(certifyLegalSpec: CertifyLegalSpec!, after: ID, first: Int): CertifyLegalConnection
-  "Batch queries via pkgIDs to find all CertifyLegal"
+  "Batch queries via pkgVersion IDs to find all CertifyLegal"
   BatchQueryPkgIDCertifyLegal(pkgIDs: [ID!]!): [CertifyLegal!]!
 }
 
@@ -5678,7 +5678,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgIDs to find all CertifyVulns that contain vulnerabilities"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns that contain vulnerabilities"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -543,6 +543,8 @@ type ComplexityRoot struct {
 		CertifyVEXStatementList      func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
 		CertifyVuln                  func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
 		CertifyVulnList              func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
+		FindAllLicenses              func(childComplexity int, pkgIDs []string, after *string, first *int) int
+		FindAllVulnerabilities       func(childComplexity int, pkgIDs []string, after *string, first *int) int
 		FindPackagesThatNeedScanning func(childComplexity int, queryType model.QueryType, lastScan *int) int
 		FindSoftware                 func(childComplexity int, searchText string) int
 		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
@@ -3204,6 +3206,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.CertifyVulnList(childComplexity, args["certifyVulnSpec"].(model.CertifyVulnSpec), args["after"].(*string), args["first"].(*int)), true
+
+	case "Query.findAllLicenses":
+		if e.complexity.Query.FindAllLicenses == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findAllLicenses_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FindAllLicenses(childComplexity, args["pkgIDs"].([]string), args["after"].(*string), args["first"].(*int)), true
+
+	case "Query.findAllVulnerabilities":
+		if e.complexity.Query.FindAllVulnerabilities == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findAllVulnerabilities_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FindAllVulnerabilities(childComplexity, args["pkgIDs"].([]string), args["after"].(*string), args["first"].(*int)), true
 
 	case "Query.findPackagesThatNeedScanning":
 		if e.complexity.Query.FindPackagesThatNeedScanning == nil {
@@ -7652,6 +7678,9 @@ extend type Query {
   certifyVuln or certifyLegal.
   """
   findPackagesThatNeedScanning(queryType: QueryType!, lastScan: Int): [ID!]!
+
+  findAllVulnerabilities(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
+  findAllLicenses(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
 }
 `, BuiltIn: false},
 	{Name: "../schema/source.graphql", Input: `#

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -529,63 +529,65 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Artifacts                    func(childComplexity int, artifactSpec model.ArtifactSpec) int
-		ArtifactsList                func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
-		BatchQueryPkgIDCertifyLegal  func(childComplexity int, pkgIDs []string) int
-		BatchQueryPkgIDCertifyVuln   func(childComplexity int, pkgIDs []string) int
-		Builders                     func(childComplexity int, builderSpec model.BuilderSpec) int
-		BuildersList                 func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
-		CertifyBad                   func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
-		CertifyBadList               func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
-		CertifyGood                  func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
-		CertifyGoodList              func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
-		CertifyLegal                 func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
-		CertifyLegalList             func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
-		CertifyVEXStatement          func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
-		CertifyVEXStatementList      func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
-		CertifyVuln                  func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
-		CertifyVulnList              func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
-		FindPackagesThatNeedScanning func(childComplexity int, queryType model.QueryType, lastScan *int) int
-		FindSoftware                 func(childComplexity int, searchText string) int
-		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
-		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
-		HasMetadataList              func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
-		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
-		HasSLSAList                  func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
-		HasSbom                      func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
-		HasSlsa                      func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
-		HasSourceAt                  func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
-		HasSourceAtList              func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
-		HashEqual                    func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
-		HashEqualList                func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
-		IsDependency                 func(childComplexity int, isDependencySpec model.IsDependencySpec) int
-		IsDependencyList             func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
-		IsOccurrence                 func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
-		IsOccurrenceList             func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
-		LicenseList                  func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
-		Licenses                     func(childComplexity int, licenseSpec model.LicenseSpec) int
-		Neighbors                    func(childComplexity int, node string, usingOnly []model.Edge) int
-		NeighborsList                func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
-		Node                         func(childComplexity int, node string) int
-		Nodes                        func(childComplexity int, nodes []string) int
-		Packages                     func(childComplexity int, pkgSpec model.PkgSpec) int
-		PackagesList                 func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
-		Path                         func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
-		PkgEqual                     func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
-		PkgEqualList                 func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
-		PointOfContact               func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
-		PointOfContactList           func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
-		QueryPackagesListForScan     func(childComplexity int, pkgIDs []string, after *string, first *int) int
-		Scorecards                   func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
-		ScorecardsList               func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
-		Sources                      func(childComplexity int, sourceSpec model.SourceSpec) int
-		SourcesList                  func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
-		VulnEqual                    func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
-		VulnEqualList                func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
-		Vulnerabilities              func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
-		VulnerabilityList            func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
-		VulnerabilityMetadata        func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
-		VulnerabilityMetadataList    func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
+		Artifacts                      func(childComplexity int, artifactSpec model.ArtifactSpec) int
+		ArtifactsList                  func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
+		BatchQueryDepPkgDependency     func(childComplexity int, pkgIDs []string) int
+		BatchQueryPkgIDCertifyLegal    func(childComplexity int, pkgIDs []string) int
+		BatchQueryPkgIDCertifyVuln     func(childComplexity int, pkgIDs []string) int
+		BatchQuerySubjectPkgDependency func(childComplexity int, pkgIDs []string) int
+		Builders                       func(childComplexity int, builderSpec model.BuilderSpec) int
+		BuildersList                   func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
+		CertifyBad                     func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
+		CertifyBadList                 func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
+		CertifyGood                    func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
+		CertifyGoodList                func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
+		CertifyLegal                   func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
+		CertifyLegalList               func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
+		CertifyVEXStatement            func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
+		CertifyVEXStatementList        func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
+		CertifyVuln                    func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
+		CertifyVulnList                func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
+		FindPackagesThatNeedScanning   func(childComplexity int, queryType model.QueryType, lastScan *int) int
+		FindSoftware                   func(childComplexity int, searchText string) int
+		FindSoftwareList               func(childComplexity int, searchText string, after *string, first *int) int
+		HasMetadata                    func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
+		HasMetadataList                func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
+		HasSBOMList                    func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
+		HasSLSAList                    func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
+		HasSbom                        func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
+		HasSlsa                        func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
+		HasSourceAt                    func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
+		HasSourceAtList                func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
+		HashEqual                      func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
+		HashEqualList                  func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
+		IsDependency                   func(childComplexity int, isDependencySpec model.IsDependencySpec) int
+		IsDependencyList               func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
+		IsOccurrence                   func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
+		IsOccurrenceList               func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
+		LicenseList                    func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
+		Licenses                       func(childComplexity int, licenseSpec model.LicenseSpec) int
+		Neighbors                      func(childComplexity int, node string, usingOnly []model.Edge) int
+		NeighborsList                  func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
+		Node                           func(childComplexity int, node string) int
+		Nodes                          func(childComplexity int, nodes []string) int
+		Packages                       func(childComplexity int, pkgSpec model.PkgSpec) int
+		PackagesList                   func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
+		Path                           func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
+		PkgEqual                       func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
+		PkgEqualList                   func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
+		PointOfContact                 func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
+		PointOfContactList             func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
+		QueryPackagesListForScan       func(childComplexity int, pkgIDs []string, after *string, first *int) int
+		Scorecards                     func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
+		ScorecardsList                 func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
+		Sources                        func(childComplexity int, sourceSpec model.SourceSpec) int
+		SourcesList                    func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
+		VulnEqual                      func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
+		VulnEqualList                  func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
+		Vulnerabilities                func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
+		VulnerabilityList              func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
+		VulnerabilityMetadata          func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
+		VulnerabilityMetadataList      func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
 	}
 
 	SLSA struct {
@@ -3063,6 +3065,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.ArtifactsList(childComplexity, args["artifactSpec"].(model.ArtifactSpec), args["after"].(*string), args["first"].(*int)), true
 
+	case "Query.BatchQueryDepPkgDependency":
+		if e.complexity.Query.BatchQueryDepPkgDependency == nil {
+			break
+		}
+
+		args, err := ec.field_Query_BatchQueryDepPkgDependency_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.BatchQueryDepPkgDependency(childComplexity, args["pkgIDs"].([]string)), true
+
 	case "Query.BatchQueryPkgIDCertifyLegal":
 		if e.complexity.Query.BatchQueryPkgIDCertifyLegal == nil {
 			break
@@ -3086,6 +3100,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.BatchQueryPkgIDCertifyVuln(childComplexity, args["pkgIDs"].([]string)), true
+
+	case "Query.BatchQuerySubjectPkgDependency":
+		if e.complexity.Query.BatchQuerySubjectPkgDependency == nil {
+			break
+		}
+
+		args, err := ec.field_Query_BatchQuerySubjectPkgDependency_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.BatchQuerySubjectPkgDependency(childComplexity, args["pkgIDs"].([]string)), true
 
 	case "Query.builders":
 		if e.complexity.Query.Builders == nil {
@@ -6542,6 +6568,10 @@ extend type Query {
   IsDependency(isDependencySpec: IsDependencySpec!): [IsDependency!]!
   "Returns a paginated results via IsDependencyConnection"
   IsDependencyList(isDependencySpec: IsDependencySpec!, after: ID, first: Int): IsDependencyConnection
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the subject pkg ID"
+  BatchQuerySubjectPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the dependency pkg ID"
+  BatchQueryDepPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/resolvers/certifyLegal.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyLegal.resolvers.go
@@ -64,3 +64,8 @@ func (r *queryResolver) CertifyLegalList(ctx context.Context, certifyLegalSpec m
 
 	return r.Backend.CertifyLegalList(ctx, certifyLegalSpec, after, first)
 }
+
+// BatchQueryPkgIDCertifyLegal is the resolver for the BatchQueryPkgIDCertifyLegal field.
+func (r *queryResolver) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
+	return r.Backend.BatchQueryPkgIDCertifyLegal(ctx, pkgIDs)
+}

--- a/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/certifyVuln.resolvers.go
@@ -163,3 +163,8 @@ func (r *queryResolver) CertifyVulnList(ctx context.Context, certifyVulnSpec mod
 		return r.Backend.CertifyVulnList(ctx, certifyVulnSpec, after, first)
 	}
 }
+
+// BatchQueryPkgIDCertifyVuln is the resolver for the BatchQueryPkgIDCertifyVuln field.
+func (r *queryResolver) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
+	return r.Backend.BatchQueryPkgIDCertifyVuln(ctx, pkgIDs)
+}

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
@@ -59,3 +59,13 @@ func (r *queryResolver) IsDependencyList(ctx context.Context, isDependencySpec m
 
 	return r.Backend.IsDependencyList(ctx, isDependencySpec, after, first)
 }
+
+// BatchQuerySubjectPkgDependency is the resolver for the BatchQuerySubjectPkgDependency field.
+func (r *queryResolver) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return r.Backend.BatchQuerySubjectPkgDependency(ctx, pkgIDs)
+}
+
+// BatchQueryDepPkgDependency is the resolver for the BatchQueryDepPkgDependency field.
+func (r *queryResolver) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return r.Backend.BatchQueryDepPkgDependency(ctx, pkgIDs)
+}

--- a/pkg/assembler/graphql/resolvers/search.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/search.resolvers.go
@@ -29,13 +29,3 @@ func (r *queryResolver) QueryPackagesListForScan(ctx context.Context, pkgIDs []s
 func (r *queryResolver) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	return r.Backend.FindPackagesThatNeedScanning(ctx, queryType, lastScan)
 }
-
-// FindAllVulnerabilities is the resolver for the findAllVulnerabilities field.
-func (r *queryResolver) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return r.Backend.FindAllVulnerabilities(ctx, pkgIDs, after, first)
-}
-
-// FindAllLicenses is the resolver for the findAllLicenses field.
-func (r *queryResolver) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
-	return r.Backend.FindAllLicenses(ctx, pkgIDs, after, first)
-}

--- a/pkg/assembler/graphql/resolvers/search.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/search.resolvers.go
@@ -29,3 +29,13 @@ func (r *queryResolver) QueryPackagesListForScan(ctx context.Context, pkgIDs []s
 func (r *queryResolver) FindPackagesThatNeedScanning(ctx context.Context, queryType model.QueryType, lastScan *int) ([]string, error) {
 	return r.Backend.FindPackagesThatNeedScanning(ctx, queryType, lastScan)
 }
+
+// FindAllVulnerabilities is the resolver for the findAllVulnerabilities field.
+func (r *queryResolver) FindAllVulnerabilities(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return r.Backend.FindAllVulnerabilities(ctx, pkgIDs, after, first)
+}
+
+// FindAllLicenses is the resolver for the findAllLicenses field.
+func (r *queryResolver) FindAllLicenses(ctx context.Context, pkgIDs []string, after *string, first *int) (*model.CertifyVulnConnection, error) {
+	return r.Backend.FindAllLicenses(ctx, pkgIDs, after, first)
+}

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -128,7 +128,7 @@ extend type Query {
   CertifyLegal(certifyLegalSpec: CertifyLegalSpec!): [CertifyLegal!]!
   "Returns a paginated results via CertifyLegalConnection"
   CertifyLegalList(certifyLegalSpec: CertifyLegalSpec!, after: ID, first: Int): CertifyLegalConnection
-  "Batch queries via pkgIDs to find all CertifyLegal"
+  "Batch queries via pkgVersion IDs to find all CertifyLegal"
   BatchQueryPkgIDCertifyLegal(pkgIDs: [ID!]!): [CertifyLegal!]!
 }
 

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -128,6 +128,8 @@ extend type Query {
   CertifyLegal(certifyLegalSpec: CertifyLegalSpec!): [CertifyLegal!]!
   "Returns a paginated results via CertifyLegalConnection"
   CertifyLegalList(certifyLegalSpec: CertifyLegalSpec!, after: ID, first: Int): CertifyLegalConnection
+  "Batch queries via pkgIDs to find all CertifyLegal"
+  BatchQueryPkgIDCertifyLegal(pkgIDs: [ID!]!): [CertifyLegal!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -129,7 +129,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgIDs to find all CertifyVulns that contain vulnerabilities"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns that contain vulnerabilities"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -129,6 +129,8 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
+  "Batch queries via pkgIDs to find all CertifyVulns that contain vulnerabilities"
+  BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -106,6 +106,10 @@ extend type Query {
   IsDependency(isDependencySpec: IsDependencySpec!): [IsDependency!]!
   "Returns a paginated results via IsDependencyConnection"
   IsDependencyList(isDependencySpec: IsDependencySpec!, after: ID, first: Int): IsDependencyConnection
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the subject pkg ID"
+  BatchQuerySubjectPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the dependency pkg ID"
+  BatchQueryDepPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/schema/search.graphql
+++ b/pkg/assembler/graphql/schema/search.graphql
@@ -93,4 +93,7 @@ extend type Query {
   certifyVuln or certifyLegal.
   """
   findPackagesThatNeedScanning(queryType: QueryType!, lastScan: Int): [ID!]!
+
+  findAllVulnerabilities(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
+  findAllLicenses(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
 }

--- a/pkg/assembler/graphql/schema/search.graphql
+++ b/pkg/assembler/graphql/schema/search.graphql
@@ -93,7 +93,4 @@ extend type Query {
   certifyVuln or certifyLegal.
   """
   findPackagesThatNeedScanning(queryType: QueryType!, lastScan: Int): [ID!]!
-
-  findAllVulnerabilities(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
-  findAllLicenses(pkgIDs: [ID!]!, after: ID, first: Int): CertifyVulnConnection
 }


### PR DESCRIPTION
# Description of the PR

Add `BatchQuerySubjectPkgDependency` and `BatchQueryDepPkgDependency` for isDependency queries.

Depends on https://github.com/guacsec/guac/pull/2218, will rebase once that is merged!

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
