### PR TITLE
Add IsDependency batch querying

### DIFF
--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -96,12 +96,14 @@ var skipMatrix = map[string]map[string]bool{
 	"TestVEXBulkIngest": {arango: true, redis: true},
 	"TestFindSoftware":  {redis: true, arango: true},
 	// remove these once its implemented for the other backends
-	"TestDeleteCertifyVuln":           {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSBOM":               {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSLSAs":              {arango: true, memmap: true, redis: true, tikv: true},
-	"TestQueryPackagesListForScan":    {arango: true, redis: true, tikv: true},
-	"TestBatchQueryPkgIDCertifyVuln":  {arango: true, redis: true, tikv: true},
-	"TestBatchQueryPkgIDCertifyLegal": {arango: true, redis: true, tikv: true},
+	"TestDeleteCertifyVuln":              {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSBOM":                  {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteHasSLSAs":                 {arango: true, memmap: true, redis: true, tikv: true},
+	"TestQueryPackagesListForScan":       {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyVuln":     {arango: true, redis: true, tikv: true},
+	"TestBatchQueryPkgIDCertifyLegal":    {arango: true, redis: true, tikv: true},
+	"TestBatchQuerySubjectPkgDependency": {arango: true, redis: true, tikv: true},
+	"TestBatchQueryDepPkgDependency":     {arango: true, redis: true, tikv: true},
 }
 
 type backend interface {

--- a/internal/testing/mocks/backend.go
+++ b/internal/testing/mocks/backend.go
@@ -70,6 +70,21 @@ func (mr *MockBackendMockRecorder) ArtifactsList(ctx, artifactSpec, after, first
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArtifactsList", reflect.TypeOf((*MockBackend)(nil).ArtifactsList), ctx, artifactSpec, after, first)
 }
 
+// BatchQueryDepPkgDependency mocks base method.
+func (m *MockBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQueryDepPkgDependency", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.IsDependency)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQueryDepPkgDependency indicates an expected call of BatchQueryDepPkgDependency.
+func (mr *MockBackendMockRecorder) BatchQueryDepPkgDependency(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryDepPkgDependency", reflect.TypeOf((*MockBackend)(nil).BatchQueryDepPkgDependency), ctx, pkgIDs)
+}
+
 // BatchQueryPkgIDCertifyLegal mocks base method.
 func (m *MockBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
 	m.ctrl.T.Helper()
@@ -98,6 +113,21 @@ func (m *MockBackend) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []s
 func (mr *MockBackendMockRecorder) BatchQueryPkgIDCertifyVuln(ctx, pkgIDs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQueryPkgIDCertifyVuln", reflect.TypeOf((*MockBackend)(nil).BatchQueryPkgIDCertifyVuln), ctx, pkgIDs)
+}
+
+// BatchQuerySubjectPkgDependency mocks base method.
+func (m *MockBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchQuerySubjectPkgDependency", ctx, pkgIDs)
+	ret0, _ := ret[0].([]*model.IsDependency)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BatchQuerySubjectPkgDependency indicates an expected call of BatchQuerySubjectPkgDependency.
+func (mr *MockBackendMockRecorder) BatchQuerySubjectPkgDependency(ctx, pkgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchQuerySubjectPkgDependency", reflect.TypeOf((*MockBackend)(nil).BatchQuerySubjectPkgDependency), ctx, pkgIDs)
 }
 
 // Builders mocks base method.

--- a/pkg/assembler/backends/arangodb/search.go
+++ b/pkg/assembler/backends/arangodb/search.go
@@ -43,6 +43,14 @@ func (c *arangoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs [
 	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
 
+func (c *arangoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *arangoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}
+
 // TODO(lumjjb): add source when it is implemented in arango backend
 func (c *arangoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 

--- a/pkg/assembler/backends/backends.go
+++ b/pkg/assembler/backends/backends.go
@@ -141,6 +141,8 @@ type Backend interface {
 	// Batch Query
 	BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error)
 	BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error)
+	BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
+	BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
 
 	// Search queries: queries to help find data in GUAC based on text search
 	FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error)

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -365,3 +365,11 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 	}
 	return collectedCertLegal, nil
 }
+
+func (b *EntBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (b *EntBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -29,6 +29,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/artifact"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/certifylegal"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/certifyvuln"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/dependency"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagename"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
@@ -367,7 +368,31 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 }
 
 func (b *EntBackend) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+	var queryList []uuid.UUID
+
+	for _, id := range pkgIDs {
+		globalID := fromGlobalID(id)
+		convertedID, err := uuid.Parse(globalID.id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ID to UUID with error: %w", err)
+		}
+		queryList = append(queryList, convertedID)
+	}
+
+	idDepConn, err := b.client.Dependency.Query().
+		Where(dependency.PackageIDIn(queryList...)).
+		WithPackage(withPackageVersionTree()).
+		WithDependentPackageVersion(withPackageVersionTree()).All(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed isDependency subject query based on package IDs with error: %w", err)
+	}
+
+	var collectedIsDependency []*model.IsDependency
+	for _, entIsDep := range idDepConn {
+		collectedIsDependency = append(collectedIsDependency, toModelIsDependencyWithBackrefs(entIsDep))
+	}
+	return collectedIsDependency, nil
 }
 
 func (b *EntBackend) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -33,6 +33,30 @@ func (c *demoClient) FindSoftwareList(ctx context.Context, searchText string, af
 	return nil, fmt.Errorf("not implemented: FindSoftwareList")
 }
 
+func (c *demoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	var collectedIsDep []*model.IsDependency
+	for _, pkgID := range pkgIDs {
+		isDep, err := c.IsDependency(ctx, &model.IsDependencySpec{Package: &model.PkgSpec{ID: &pkgID}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query IsDependency for pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedIsDep = append(collectedIsDep, isDep...)
+	}
+	return collectedIsDep, nil
+}
+
+func (c *demoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	var collectedIsDep []*model.IsDependency
+	for _, pkgID := range pkgIDs {
+		isDep, err := c.IsDependency(ctx, &model.IsDependencySpec{DependencyPackage: &model.PkgSpec{ID: &pkgID}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to query IsDependency for dependency pkgID: %s, with error: %w", pkgID, err)
+		}
+		collectedIsDep = append(collectedIsDep, isDep...)
+	}
+	return collectedIsDep, nil
+}
+
 func (c *demoClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []string) ([]*model.CertifyVuln, error) {
 	var collectedCertVulns []*model.CertifyVuln
 	for _, pkgID := range pkgIDs {
@@ -55,14 +79,6 @@ func (c *demoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 		collectedCertLegal = append(collectedCertLegal, certLegal...)
 	}
 	return collectedCertLegal, nil
-}
-
-func (c *demoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
-}
-
-func (c *demoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
-	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
 }
 
 func (c *demoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {

--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -57,6 +57,14 @@ func (c *demoClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 	return collectedCertLegal, nil
 }
 
+func (c *demoClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *demoClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}
+
 func (c *demoClient) FindSoftware(ctx context.Context, searchText string) ([]model.PackageSourceOrArtifact, error) {
 	scanner := c.kv.Keys("artifacts")
 	var res []model.PackageSourceOrArtifact

--- a/pkg/assembler/backends/neo4j/search.go
+++ b/pkg/assembler/backends/neo4j/search.go
@@ -45,3 +45,11 @@ func (c *neo4jClient) BatchQueryPkgIDCertifyVuln(ctx context.Context, pkgIDs []s
 func (c *neo4jClient) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []string) ([]*model.CertifyLegal, error) {
 	return nil, fmt.Errorf("not implemented: BatchQueryPkgIDCertifyLegal")
 }
+
+func (c *neo4jClient) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQuerySubjectPkgDependency")
+}
+
+func (c *neo4jClient) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return nil, fmt.Errorf("not implemented: BatchQueryDepPkgDependency")
+}

--- a/pkg/assembler/graphql/generated/artifact.generated.go
+++ b/pkg/assembler/graphql/generated/artifact.generated.go
@@ -98,6 +98,8 @@ type QueryResolver interface {
 	HashEqualList(ctx context.Context, hashEqualSpec model.HashEqualSpec, after *string, first *int) (*model.HashEqualConnection, error)
 	IsDependency(ctx context.Context, isDependencySpec model.IsDependencySpec) ([]*model.IsDependency, error)
 	IsDependencyList(ctx context.Context, isDependencySpec model.IsDependencySpec, after *string, first *int) (*model.IsDependencyConnection, error)
+	BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
+	BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error)
 	IsOccurrence(ctx context.Context, isOccurrenceSpec model.IsOccurrenceSpec) ([]*model.IsOccurrence, error)
 	IsOccurrenceList(ctx context.Context, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) (*model.IsOccurrenceConnection, error)
 	Licenses(ctx context.Context, licenseSpec model.LicenseSpec) ([]*model.License, error)
@@ -3525,6 +3527,38 @@ func (ec *executionContext) field_Mutation_ingestVulnerability_argsVuln(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query_BatchQueryDepPkgDependency_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQueryDepPkgDependency_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQueryDepPkgDependency_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyLegal_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -3568,6 +3602,38 @@ func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_args(ctx cont
 	return args, nil
 }
 func (ec *executionContext) field_Query_BatchQueryPkgIDCertifyVuln_argsPkgIDs(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) ([]string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["pkgIDs"]
+	if !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("pkgIDs"))
+	if tmp, ok := rawArgs["pkgIDs"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_BatchQuerySubjectPkgDependency_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Query_BatchQuerySubjectPkgDependency_argsPkgIDs(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["pkgIDs"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_BatchQuerySubjectPkgDependency_argsPkgIDs(
 	ctx context.Context,
 	rawArgs map[string]interface{},
 ) ([]string, error) {
@@ -11683,6 +11749,146 @@ func (ec *executionContext) fieldContext_Query_IsDependencyList(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_BatchQuerySubjectPkgDependency(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQuerySubjectPkgDependency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQuerySubjectPkgDependency(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.IsDependency)
+	fc.Result = res
+	return ec.marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQuerySubjectPkgDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsDependency_id(ctx, field)
+			case "package":
+				return ec.fieldContext_IsDependency_package(ctx, field)
+			case "dependencyPackage":
+				return ec.fieldContext_IsDependency_dependencyPackage(ctx, field)
+			case "dependencyType":
+				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
+			case "justification":
+				return ec.fieldContext_IsDependency_justification(ctx, field)
+			case "origin":
+				return ec.fieldContext_IsDependency_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQuerySubjectPkgDependency_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_BatchQueryDepPkgDependency(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_BatchQueryDepPkgDependency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp := ec._fieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().BatchQueryDepPkgDependency(rctx, fc.Args["pkgIDs"].([]string))
+	})
+
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.IsDependency)
+	fc.Result = res
+	return ec.marshalNIsDependency2ᚕᚖgithubᚗcomᚋguacsecᚋguacᚋpkgᚋassemblerᚋgraphqlᚋmodelᚐIsDependencyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_BatchQueryDepPkgDependency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_IsDependency_id(ctx, field)
+			case "package":
+				return ec.fieldContext_IsDependency_package(ctx, field)
+			case "dependencyPackage":
+				return ec.fieldContext_IsDependency_dependencyPackage(ctx, field)
+			case "dependencyType":
+				return ec.fieldContext_IsDependency_dependencyType(ctx, field)
+			case "justification":
+				return ec.fieldContext_IsDependency_justification(ctx, field)
+			case "origin":
+				return ec.fieldContext_IsDependency_origin(ctx, field)
+			case "collector":
+				return ec.fieldContext_IsDependency_collector(ctx, field)
+			case "documentRef":
+				return ec.fieldContext_IsDependency_documentRef(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IsDependency", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_BatchQueryDepPkgDependency_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_IsOccurrence(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_IsOccurrence(ctx, field)
 	if err != nil {
@@ -14648,6 +14854,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_IsDependencyList(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQuerySubjectPkgDependency":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQuerySubjectPkgDependency(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "BatchQueryDepPkgDependency":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_BatchQueryDepPkgDependency(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -529,63 +529,65 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Artifacts                    func(childComplexity int, artifactSpec model.ArtifactSpec) int
-		ArtifactsList                func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
-		BatchQueryPkgIDCertifyLegal  func(childComplexity int, pkgIDs []string) int
-		BatchQueryPkgIDCertifyVuln   func(childComplexity int, pkgIDs []string) int
-		Builders                     func(childComplexity int, builderSpec model.BuilderSpec) int
-		BuildersList                 func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
-		CertifyBad                   func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
-		CertifyBadList               func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
-		CertifyGood                  func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
-		CertifyGoodList              func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
-		CertifyLegal                 func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
-		CertifyLegalList             func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
-		CertifyVEXStatement          func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
-		CertifyVEXStatementList      func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
-		CertifyVuln                  func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
-		CertifyVulnList              func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
-		FindPackagesThatNeedScanning func(childComplexity int, queryType model.QueryType, lastScan *int) int
-		FindSoftware                 func(childComplexity int, searchText string) int
-		FindSoftwareList             func(childComplexity int, searchText string, after *string, first *int) int
-		HasMetadata                  func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
-		HasMetadataList              func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
-		HasSBOMList                  func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
-		HasSLSAList                  func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
-		HasSbom                      func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
-		HasSlsa                      func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
-		HasSourceAt                  func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
-		HasSourceAtList              func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
-		HashEqual                    func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
-		HashEqualList                func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
-		IsDependency                 func(childComplexity int, isDependencySpec model.IsDependencySpec) int
-		IsDependencyList             func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
-		IsOccurrence                 func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
-		IsOccurrenceList             func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
-		LicenseList                  func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
-		Licenses                     func(childComplexity int, licenseSpec model.LicenseSpec) int
-		Neighbors                    func(childComplexity int, node string, usingOnly []model.Edge) int
-		NeighborsList                func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
-		Node                         func(childComplexity int, node string) int
-		Nodes                        func(childComplexity int, nodes []string) int
-		Packages                     func(childComplexity int, pkgSpec model.PkgSpec) int
-		PackagesList                 func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
-		Path                         func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
-		PkgEqual                     func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
-		PkgEqualList                 func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
-		PointOfContact               func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
-		PointOfContactList           func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
-		QueryPackagesListForScan     func(childComplexity int, pkgIDs []string, after *string, first *int) int
-		Scorecards                   func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
-		ScorecardsList               func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
-		Sources                      func(childComplexity int, sourceSpec model.SourceSpec) int
-		SourcesList                  func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
-		VulnEqual                    func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
-		VulnEqualList                func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
-		Vulnerabilities              func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
-		VulnerabilityList            func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
-		VulnerabilityMetadata        func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
-		VulnerabilityMetadataList    func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
+		Artifacts                      func(childComplexity int, artifactSpec model.ArtifactSpec) int
+		ArtifactsList                  func(childComplexity int, artifactSpec model.ArtifactSpec, after *string, first *int) int
+		BatchQueryDepPkgDependency     func(childComplexity int, pkgIDs []string) int
+		BatchQueryPkgIDCertifyLegal    func(childComplexity int, pkgIDs []string) int
+		BatchQueryPkgIDCertifyVuln     func(childComplexity int, pkgIDs []string) int
+		BatchQuerySubjectPkgDependency func(childComplexity int, pkgIDs []string) int
+		Builders                       func(childComplexity int, builderSpec model.BuilderSpec) int
+		BuildersList                   func(childComplexity int, builderSpec model.BuilderSpec, after *string, first *int) int
+		CertifyBad                     func(childComplexity int, certifyBadSpec model.CertifyBadSpec) int
+		CertifyBadList                 func(childComplexity int, certifyBadSpec model.CertifyBadSpec, after *string, first *int) int
+		CertifyGood                    func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec) int
+		CertifyGoodList                func(childComplexity int, certifyGoodSpec model.CertifyGoodSpec, after *string, first *int) int
+		CertifyLegal                   func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec) int
+		CertifyLegalList               func(childComplexity int, certifyLegalSpec model.CertifyLegalSpec, after *string, first *int) int
+		CertifyVEXStatement            func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec) int
+		CertifyVEXStatementList        func(childComplexity int, certifyVEXStatementSpec model.CertifyVEXStatementSpec, after *string, first *int) int
+		CertifyVuln                    func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec) int
+		CertifyVulnList                func(childComplexity int, certifyVulnSpec model.CertifyVulnSpec, after *string, first *int) int
+		FindPackagesThatNeedScanning   func(childComplexity int, queryType model.QueryType, lastScan *int) int
+		FindSoftware                   func(childComplexity int, searchText string) int
+		FindSoftwareList               func(childComplexity int, searchText string, after *string, first *int) int
+		HasMetadata                    func(childComplexity int, hasMetadataSpec model.HasMetadataSpec) int
+		HasMetadataList                func(childComplexity int, hasMetadataSpec model.HasMetadataSpec, after *string, first *int) int
+		HasSBOMList                    func(childComplexity int, hasSBOMSpec model.HasSBOMSpec, after *string, first *int) int
+		HasSLSAList                    func(childComplexity int, hasSLSASpec model.HasSLSASpec, after *string, first *int) int
+		HasSbom                        func(childComplexity int, hasSBOMSpec model.HasSBOMSpec) int
+		HasSlsa                        func(childComplexity int, hasSLSASpec model.HasSLSASpec) int
+		HasSourceAt                    func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec) int
+		HasSourceAtList                func(childComplexity int, hasSourceAtSpec model.HasSourceAtSpec, after *string, first *int) int
+		HashEqual                      func(childComplexity int, hashEqualSpec model.HashEqualSpec) int
+		HashEqualList                  func(childComplexity int, hashEqualSpec model.HashEqualSpec, after *string, first *int) int
+		IsDependency                   func(childComplexity int, isDependencySpec model.IsDependencySpec) int
+		IsDependencyList               func(childComplexity int, isDependencySpec model.IsDependencySpec, after *string, first *int) int
+		IsOccurrence                   func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec) int
+		IsOccurrenceList               func(childComplexity int, isOccurrenceSpec model.IsOccurrenceSpec, after *string, first *int) int
+		LicenseList                    func(childComplexity int, licenseSpec model.LicenseSpec, after *string, first *int) int
+		Licenses                       func(childComplexity int, licenseSpec model.LicenseSpec) int
+		Neighbors                      func(childComplexity int, node string, usingOnly []model.Edge) int
+		NeighborsList                  func(childComplexity int, node string, usingOnly []model.Edge, after *string, first *int) int
+		Node                           func(childComplexity int, node string) int
+		Nodes                          func(childComplexity int, nodes []string) int
+		Packages                       func(childComplexity int, pkgSpec model.PkgSpec) int
+		PackagesList                   func(childComplexity int, pkgSpec model.PkgSpec, after *string, first *int) int
+		Path                           func(childComplexity int, subject string, target string, maxPathLength int, usingOnly []model.Edge) int
+		PkgEqual                       func(childComplexity int, pkgEqualSpec model.PkgEqualSpec) int
+		PkgEqualList                   func(childComplexity int, pkgEqualSpec model.PkgEqualSpec, after *string, first *int) int
+		PointOfContact                 func(childComplexity int, pointOfContactSpec model.PointOfContactSpec) int
+		PointOfContactList             func(childComplexity int, pointOfContactSpec model.PointOfContactSpec, after *string, first *int) int
+		QueryPackagesListForScan       func(childComplexity int, pkgIDs []string, after *string, first *int) int
+		Scorecards                     func(childComplexity int, scorecardSpec model.CertifyScorecardSpec) int
+		ScorecardsList                 func(childComplexity int, scorecardSpec model.CertifyScorecardSpec, after *string, first *int) int
+		Sources                        func(childComplexity int, sourceSpec model.SourceSpec) int
+		SourcesList                    func(childComplexity int, sourceSpec model.SourceSpec, after *string, first *int) int
+		VulnEqual                      func(childComplexity int, vulnEqualSpec model.VulnEqualSpec) int
+		VulnEqualList                  func(childComplexity int, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) int
+		Vulnerabilities                func(childComplexity int, vulnSpec model.VulnerabilitySpec) int
+		VulnerabilityList              func(childComplexity int, vulnSpec model.VulnerabilitySpec, after *string, first *int) int
+		VulnerabilityMetadata          func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec) int
+		VulnerabilityMetadataList      func(childComplexity int, vulnerabilityMetadataSpec model.VulnerabilityMetadataSpec, after *string, first *int) int
 	}
 
 	SLSA struct {
@@ -3063,6 +3065,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.ArtifactsList(childComplexity, args["artifactSpec"].(model.ArtifactSpec), args["after"].(*string), args["first"].(*int)), true
 
+	case "Query.BatchQueryDepPkgDependency":
+		if e.complexity.Query.BatchQueryDepPkgDependency == nil {
+			break
+		}
+
+		args, err := ec.field_Query_BatchQueryDepPkgDependency_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.BatchQueryDepPkgDependency(childComplexity, args["pkgIDs"].([]string)), true
+
 	case "Query.BatchQueryPkgIDCertifyLegal":
 		if e.complexity.Query.BatchQueryPkgIDCertifyLegal == nil {
 			break
@@ -3086,6 +3100,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.BatchQueryPkgIDCertifyVuln(childComplexity, args["pkgIDs"].([]string)), true
+
+	case "Query.BatchQuerySubjectPkgDependency":
+		if e.complexity.Query.BatchQuerySubjectPkgDependency == nil {
+			break
+		}
+
+		args, err := ec.field_Query_BatchQuerySubjectPkgDependency_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.BatchQuerySubjectPkgDependency(childComplexity, args["pkgIDs"].([]string)), true
 
 	case "Query.builders":
 		if e.complexity.Query.Builders == nil {
@@ -6542,6 +6568,10 @@ extend type Query {
   IsDependency(isDependencySpec: IsDependencySpec!): [IsDependency!]!
   "Returns a paginated results via IsDependencyConnection"
   IsDependencyList(isDependencySpec: IsDependencySpec!, after: ID, first: Int): IsDependencyConnection
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the subject pkg ID"
+  BatchQuerySubjectPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the dependency pkg ID"
+  BatchQueryDepPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
 }
 
 extend type Mutation {

--- a/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/isDependency.resolvers.go
@@ -59,3 +59,13 @@ func (r *queryResolver) IsDependencyList(ctx context.Context, isDependencySpec m
 
 	return r.Backend.IsDependencyList(ctx, isDependencySpec, after, first)
 }
+
+// BatchQuerySubjectPkgDependency is the resolver for the BatchQuerySubjectPkgDependency field.
+func (r *queryResolver) BatchQuerySubjectPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return r.Backend.BatchQuerySubjectPkgDependency(ctx, pkgIDs)
+}
+
+// BatchQueryDepPkgDependency is the resolver for the BatchQueryDepPkgDependency field.
+func (r *queryResolver) BatchQueryDepPkgDependency(ctx context.Context, pkgIDs []string) ([]*model.IsDependency, error) {
+	return r.Backend.BatchQueryDepPkgDependency(ctx, pkgIDs)
+}

--- a/pkg/assembler/graphql/schema/isDependency.graphql
+++ b/pkg/assembler/graphql/schema/isDependency.graphql
@@ -106,6 +106,10 @@ extend type Query {
   IsDependency(isDependencySpec: IsDependencySpec!): [IsDependency!]!
   "Returns a paginated results via IsDependencyConnection"
   IsDependencyList(isDependencySpec: IsDependencySpec!, after: ID, first: Int): IsDependencyConnection
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the subject pkg ID"
+  BatchQuerySubjectPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
+  "Batch queries via pkgVersion IDs to find to find all isDependency nodes that have the dependency pkg ID"
+  BatchQueryDepPkgDependency(pkgIDs: [ID!]!): [IsDependency!]!
 }
 
 extend type Mutation {


### PR DESCRIPTION
# Description of the PR

Add `BatchQuerySubjectPkgDependency` and `BatchQueryDepPkgDependency` for isDependency queries.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
