### PR TITLE
Export getGraphqlServer and accept initialized backend

### DIFF
--- a/pkg/assembler/server/server.go
+++ b/pkg/assembler/server/server.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	"github.com/guacsec/guac/pkg/assembler/graphql/generated"
+	"github.com/guacsec/guac/pkg/assembler/graphql/resolvers"
+)
+
+func GetGraphqlServer(ctx context.Context, backend backends.Backend) *handler.Server {
+	topResolver := resolvers.Resolver{Backend: backend}
+	config := generated.Config{Resolvers: &topResolver}
+	config.Directives.Filter = resolvers.Filter
+	srv := handler.NewDefaultServer(generated.NewExecutableSchema(config))
+	return srv
+}

--- a/pkg/assembler/server/server_test.go
+++ b/pkg/assembler/server/server_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+
+	"github.com/guacsec/guac/internal/testing/stablememmap"
+	"github.com/guacsec/guac/pkg/assembler/backends"
+)
+
+func TestGetGraphqlServer(t *testing.T) {
+	ctx := context.Background()
+
+	store := stablememmap.GetStore()
+	backend, err := backends.Get("keyvalue", ctx, store)
+	if err != nil {
+		t.Errorf("Error getting backend: %v", err)
+	}
+
+	srv := GetGraphqlServer(ctx, backend)
+	if srv == nil {
+		t.Errorf("Expected GetGraphqlServer to return a non-nil server")
+	}
+}


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2240 

Some notes:
- I intended to restrict this PR to refactoring only instead of altering functionality, so if there is any change to functionality it was not intentional, and we should probably flag and revert.
- The main change here is: a refactor of `getGraphqlServer` to allow it to be used programmatically by out-of-tree backends, allows the backend to be passed in as-is without relying on parsing of the flags for config.

cc @ridhoq 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
