### PR TITLE
Add CertifyLegal to query known package

### DIFF
--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -41,6 +41,7 @@ const (
 	hasSBOMStr          string = "hasSBOM"
 	hasSLSAStr          string = "hasSLSA"
 	certifyVulnStr      string = "certifyVuln"
+	certifyLegalStr     string = "certifyLegal"
 	vexLinkStr          string = "vexLink"
 	badLinkStr          string = "badLink"
 	goodLinkStr         string = "goodLink"
@@ -61,17 +62,18 @@ type queryKnownOptions struct {
 }
 
 type neighbors struct {
-	hashEquals   []*model.NeighborsNeighborsHashEqual
-	scorecards   []*model.NeighborsNeighborsCertifyScorecard
-	occurrences  []*model.NeighborsNeighborsIsOccurrence
-	hasSrcAt     []*model.NeighborsNeighborsHasSourceAt
-	hasSBOMs     []*model.NeighborsNeighborsHasSBOM
-	hasSLSAs     []*model.NeighborsNeighborsHasSLSA
-	certifyVulns []*model.NeighborsNeighborsCertifyVuln
-	vexLinks     []*model.NeighborsNeighborsCertifyVEXStatement
-	badLinks     []*model.NeighborsNeighborsCertifyBad
-	goodLinks    []*model.NeighborsNeighborsCertifyGood
-	pkgEquals    []*model.NeighborsNeighborsPkgEqual
+	hashEquals    []*model.NeighborsNeighborsHashEqual
+	scorecards    []*model.NeighborsNeighborsCertifyScorecard
+	occurrences   []*model.NeighborsNeighborsIsOccurrence
+	hasSrcAt      []*model.NeighborsNeighborsHasSourceAt
+	hasSBOMs      []*model.NeighborsNeighborsHasSBOM
+	hasSLSAs      []*model.NeighborsNeighborsHasSLSA
+	certifyVulns  []*model.NeighborsNeighborsCertifyVuln
+	certifyLegals []*model.NeighborsNeighborsCertifyLegal
+	vexLinks      []*model.NeighborsNeighborsCertifyVEXStatement
+	badLinks      []*model.NeighborsNeighborsCertifyBad
+	goodLinks     []*model.NeighborsNeighborsCertifyGood
+	pkgEquals     []*model.NeighborsNeighborsPkgEqual
 }
 
 var (
@@ -180,6 +182,8 @@ var queryKnownCmd = &cobra.Command{
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, occurrenceStr, packageSubjectType))
 			t.AppendSeparator()
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, certifyVulnStr, packageSubjectType))
+			t.AppendSeparator()
+			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, certifyLegalStr, artifactSubjectType))
 			t.AppendSeparator()
 			t.AppendRows(getOutputBasedOnNode(ctx, gqlclient, pkgVersionNeighbors, hasSBOMStr, packageSubjectType))
 			t.AppendSeparator()
@@ -323,6 +327,9 @@ func queryKnownNeighbors(ctx context.Context, gqlclient graphql.Client, subjectQ
 		case *model.NeighborsNeighborsPkgEqual:
 			collectedNeighbors.pkgEquals = append(collectedNeighbors.pkgEquals, v)
 			path = append(path, v.Id)
+		case *model.NeighborsNeighborsCertifyLegal:
+			collectedNeighbors.certifyLegals = append(collectedNeighbors.certifyLegals, v)
+			path = append(path, v.Id)
 		default:
 			continue
 		}
@@ -448,6 +455,16 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 	case pkgEqualStr:
 		for _, equal := range collectedNeighbors.pkgEquals {
 			tableRows = append(tableRows, table.Row{pkgEqualStr, equal.Id, ""})
+		}
+	case certifyLegalStr:
+		for _, legal := range collectedNeighbors.certifyLegals {
+			tableRows = append(tableRows, table.Row{
+				certifyLegalStr,
+				legal.Id,
+				"Declared License: " + legal.DeclaredLicense +
+				",\nDiscovered License: " + legal.DiscoveredLicense +
+				",\nOrigin: " + legal.Origin,
+			})
 		}
 	}
 


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2253 

Example using the demo stack and demo docs after collection with add license on ingest flag set:

```
❯ go run ./cmd/guacone/main.go query known package "pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1"

{"level":"info","ts":1730698004.0871081,"caller":"logging/logger.go:79","msg":"Logging at info level","guac-version":"v0.0.1-custom"}
{"level":"info","ts":1730698004.087162,"caller":"cli/init.go:65","msg":"Using config file: /home/rob/go/src/guacsec/guac/guac.yaml","guac-version":"v0.0.1-custom"}
+------------------------------------------------+
| Package Name Nodes                             |
+-----------+-----------+------------------------+
| NODE TYPE | NODE ID # | ADDITIONAL INFORMATION |
+-----------+-----------+------------------------+
+-----------+-----------+------------------------+
Visualizer url: http://localhost:3000/?path=25409,25408,4450
+----------------------------------------------------------------------------------------------+
| Package Version Nodes                                                                        |
+--------------+-----------+-------------------------------------------------------------------+
| NODE TYPE    | NODE ID # | ADDITIONAL INFORMATION                                            |
+--------------+-----------+-------------------------------------------------------------------+
| hasSrcAt     | 167073    | Source: sourcearchive+https://org.apache.logging.log4j/log4j-core |
+--------------+-----------+-------------------------------------------------------------------+
| certifyVuln  | 41980     | vulnerability ID: ghsa-7rjr-3q55-vv33                             |
| certifyVuln  | 41981     | vulnerability ID: ghsa-8489-44mv-ggj8                             |
| certifyVuln  | 41982     | vulnerability ID: ghsa-fxph-q3j8-mv87                             |
| certifyVuln  | 41983     | vulnerability ID: ghsa-jfh8-c2jp-5v3q                             |
| certifyVuln  | 41984     | vulnerability ID: ghsa-p6xc-xr62-6r2g                             |
| certifyVuln  | 41985     | vulnerability ID: ghsa-vwqq-5vrc-xw9h                             |
| certifyVuln  | 166892    | vulnerability ID: ghsa-7rjr-3q55-vv33                             |
| certifyVuln  | 166893    | vulnerability ID: ghsa-8489-44mv-ggj8                             |
| certifyVuln  | 166894    | vulnerability ID: ghsa-fxph-q3j8-mv87                             |
| certifyVuln  | 166895    | vulnerability ID: ghsa-jfh8-c2jp-5v3q                             |
| certifyVuln  | 166896    | vulnerability ID: ghsa-p6xc-xr62-6r2g                             |
| certifyVuln  | 166897    | vulnerability ID: ghsa-vwqq-5vrc-xw9h                             |
+--------------+-----------+-------------------------------------------------------------------+
| certifyLegal | 42719     | declared: NONE, discovered: NONE                                  |
| certifyLegal | 167585    | declared: Apache-2.0, discovered: Apache-2.0                      |
+--------------+-----------+-------------------------------------------------------------------+
| hasSBOM      | 183697    | SBOM Download Location: deps.dev                                  |
+--------------+-----------+-------------------------------------------------------------------+
Visualizer url: http://localhost:3000/?path=25410,25409,25408,4450,167073,41980,41981,41982,41983,41984,41985,166892,166893,166894,166895,166896,166897,183697,42719,167585
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
