### PR TITLE
clearly defined url encode/add hyphen for namespace

### DIFF
--- a/pkg/misc/coordinates/coordinates.go
+++ b/pkg/misc/coordinates/coordinates.go
@@ -126,7 +126,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: "pod",
 			Provider:       "cocoapods",
-			Namespace:      "-",
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -134,7 +134,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: "crate",
 			Provider:       "cratesio",
-			Namespace:      "-",
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -142,7 +142,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       "packagist",
-			Namespace:      pkg.Namespace,
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -174,9 +174,9 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		}
 
 		// subdir is the associated platform
-		var Namespace string
+		var namespace string
 		if subdir, ok := qualifiers["subdir"]; ok {
-			Namespace = subdir
+			namespace = subdir
 		} else {
 			return nil, fmt.Errorf("failed to find subdir for conda")
 		}
@@ -184,7 +184,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       Provider,
-			Namespace:      Namespace,
+			Namespace:      emptyToHyphen(namespace),
 			Name:           pkg.Name,
 			Revision:       Revision,
 		}, nil
@@ -220,7 +220,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       "rubygems",
-			Namespace:      "-",
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -228,7 +228,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: "git",
 			Provider:       pkg.Type,
-			Namespace:      pkg.Namespace,
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -256,7 +256,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: "maven",
 			Provider:       Provider,
-			Namespace:      pkg.Namespace,
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -264,7 +264,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       "npmjs",
-			Namespace:      pkg.Namespace,
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -272,7 +272,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       "nuget",
-			Namespace:      "-",
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -284,7 +284,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: pkg.Type,
 			Provider:       "pypi",
-			Namespace:      "-",
+			Namespace:      emptyToHyphen(pkg.Namespace),
 			Name:           pkg.Name,
 			Revision:       pkg.Version,
 		}, nil
@@ -297,5 +297,13 @@ func (c *Coordinate) ToString() string {
 		return fmt.Sprintf("%s/%s/%s/%s/%22%22", c.CoordinateType, c.Provider, c.Namespace, c.Name)
 	} else {
 		return fmt.Sprintf("%s/%s/%s/%s/%s", c.CoordinateType, c.Provider, c.Namespace, c.Name, c.Revision)
+	}
+}
+
+func emptyToHyphen(namespace string) string {
+	if namespace == "" {
+		return "-"
+	} else {
+		return namespace
 	}
 }

--- a/pkg/misc/coordinates/coordinates.go
+++ b/pkg/misc/coordinates/coordinates.go
@@ -236,7 +236,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 		return &Coordinate{
 			CoordinateType: "go",
 			Provider:       pkg.Type,
-			Namespace:      strings.ReplaceAll(pkg.Namespace, "/", "%2f"),
+			Namespace:      emptyToHyphen(strings.ReplaceAll(pkg.Namespace, "/", "%2f")),
 			Name:           pkg.Name,
 			Revision:       "v" + pkg.Version,
 		}, nil

--- a/pkg/misc/coordinates/coordinates_test.go
+++ b/pkg/misc/coordinates/coordinates_test.go
@@ -148,6 +148,18 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				Revision:       "244fd47e07d1004",
 			},
 			wantErr: false,
+		},
+		{
+			Name:    "github",
+			purlUri: "pkg:github/purl-spec@244fd47e07d1004#everybody/loves/dogs",
+			want: &Coordinate{
+				CoordinateType: "git",
+				Provider:       "github",
+				Namespace:      "-",
+				Name:           "purl-spec",
+				Revision:       "244fd47e07d1004",
+			},
+			wantErr: false,
 		}, {
 			Name:    "golang",
 			purlUri: "pkg:golang/cloud.google.com/go/compute@1.23.0",
@@ -157,6 +169,18 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				Namespace:      "cloud.google.com%2fgo",
 				Name:           "compute",
 				Revision:       "v1.23.0",
+			},
+			wantErr: false,
+		},
+		{
+			Name:    "golang",
+			purlUri: "pkg:golang/context@234fd47e07d1004f0aed9c#api",
+			want: &Coordinate{
+				CoordinateType: "go",
+				Provider:       "golang",
+				Namespace:      "-",
+				Name:           "context",
+				Revision:       "234fd47e07d1004f0aed9c",
 			},
 			wantErr: false,
 		}, {
@@ -234,7 +258,7 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				t.Errorf("ConvertPurlToCoordinate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(*got, *tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ConvertPurlToCoordinate() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/misc/coordinates/coordinates_test.go
+++ b/pkg/misc/coordinates/coordinates_test.go
@@ -180,7 +180,7 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				Provider:       "golang",
 				Namespace:      "-",
 				Name:           "context",
-				Revision:       "234fd47e07d1004f0aed9c",
+				Revision:       "v234fd47e07d1004f0aed9c",
 			},
 			wantErr: false,
 		}, {

--- a/pkg/misc/coordinates/coordinates_test.go
+++ b/pkg/misc/coordinates/coordinates_test.go
@@ -234,7 +234,7 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				t.Errorf("ConvertPurlToCoordinate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(*got, *tt.want) {
 				t.Errorf("ConvertPurlToCoordinate() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
# Description of the PR

Fix golang coordinate generation based on notes: https://docs.clearlydefined.io/docs/get-involved/using-data#special-notes


Another example:
```
github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
```
would map to these coordinates
```
github.com%2fsatori/go.uuid/v1.2.1-0.20181028125025-b2ce2384e17b
```

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
