### PR TITLE
plumbing to enable deps.dev on ingest

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -48,6 +48,7 @@ type options struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 func ingest(cmd *cobra.Command, args []string) {
@@ -110,6 +111,7 @@ func ingest(cmd *cobra.Command, args []string) {
 			opts.queryVulnOnIngestion,
 			opts.queryLicenseOnIngestion,
 			opts.queryEOLOnIngestion,
+			opts.queryDepsDevOnIngestion,
 		); err != nil {
 			var urlErr *url.Error
 			if errors.As(err, &urlErr) {

--- a/cmd/guacone/cmd/deps_dev.go
+++ b/cmd/guacone/cmd/deps_dev.go
@@ -97,6 +97,9 @@ var depsDevCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				// since this is a deps.dev collector, by we don't query deps.dev on ingestion
+				/* queryDepsDevOnIngestion = */
+				false,
 			); err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)

--- a/cmd/guacone/cmd/files.go
+++ b/cmd/guacone/cmd/files.go
@@ -54,6 +54,7 @@ type fileOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 var filesCmd = &cobra.Command{
@@ -71,6 +72,7 @@ var filesCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -140,6 +142,7 @@ var filesCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				opts.queryDepsDevOnIngestion,
 			); err != nil {
 				gotErr = true
 				filesWithErrors = append(filesWithErrors, d.SourceInformation.Source)
@@ -173,7 +176,7 @@ var filesCmd = &cobra.Command{
 }
 
 func validateFilesFlags(keyPath, keyID, graphqlEndpoint, headerFile, csubAddr string, csubTls, csubTlsSkipVerify bool,
-	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, args []string) (fileOptions, error) {
+	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, queryDepsDevOnIngestion bool, args []string) (fileOptions, error) {
 	var opts fileOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.headerFile = headerFile
@@ -202,6 +205,7 @@ func validateFilesFlags(keyPath, keyID, graphqlEndpoint, headerFile, csubAddr st
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevOnIngestion
 	return opts, nil
 }
 

--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -43,6 +43,7 @@ type gcsOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 const gcsCredentialsPathFlag = "gcp-credentials-path"
@@ -63,6 +64,7 @@ var gcsCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -123,8 +125,8 @@ var gcsCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				opts.queryDepsDevOnIngestion,
 			)
-
 			if err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)
@@ -154,7 +156,7 @@ var gcsCmd = &cobra.Command{
 }
 
 func validateGCSFlags(gqlEndpoint, headerFile, csubAddr, credentialsPath string, csubTls, csubTlsSkipVerify bool,
-	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, args []string) (gcsOptions, error) {
+	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, queryDepsDevOnIngestion bool, args []string) (gcsOptions, error) {
 	var opts gcsOptions
 	opts.graphqlEndpoint = gqlEndpoint
 	opts.headerFile = headerFile
@@ -176,6 +178,7 @@ func validateGCSFlags(gqlEndpoint, headerFile, csubAddr, credentialsPath string,
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevOnIngestion
 	return opts, nil
 }
 

--- a/cmd/guacone/cmd/github.go
+++ b/cmd/guacone/cmd/github.go
@@ -70,6 +70,7 @@ type githubOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 var githubCmd = &cobra.Command{
@@ -93,6 +94,7 @@ var githubCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -166,8 +168,8 @@ var githubCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				opts.queryDepsDevOnIngestion,
 			)
-
 			if err != nil {
 				errFound = true
 				return fmt.Errorf("unable to ingest document: %w", err)
@@ -220,7 +222,7 @@ var githubCmd = &cobra.Command{
 }
 
 func validateGithubFlags(graphqlEndpoint, headerFile, githubMode, sbomName, workflowFileName, csubAddr string, csubTls,
-	csubTlsSkipVerify, useCsub, poll bool, queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, args []string) (githubOptions, error) {
+	csubTlsSkipVerify, useCsub, poll bool, queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, queryDepsDevOnIngestion bool, args []string) (githubOptions, error) {
 	var opts githubOptions
 	opts.graphqlEndpoint = graphqlEndpoint
 	opts.headerFile = headerFile
@@ -231,6 +233,7 @@ func validateGithubFlags(graphqlEndpoint, headerFile, githubMode, sbomName, work
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevOnIngestion
 
 	if useCsub {
 		csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)

--- a/cmd/guacone/cmd/known.go
+++ b/cmd/guacone/cmd/known.go
@@ -462,8 +462,8 @@ func getOutputBasedOnNode(ctx context.Context, gqlclient graphql.Client, collect
 				certifyLegalStr,
 				legal.Id,
 				"Declared License: " + legal.DeclaredLicense +
-				",\nDiscovered License: " + legal.DiscoveredLicense +
-				",\nOrigin: " + legal.Origin,
+					",\nDiscovered License: " + legal.DiscoveredLicense +
+					",\nOrigin: " + legal.Origin,
 			})
 		}
 	}

--- a/cmd/guacone/cmd/license.go
+++ b/cmd/guacone/cmd/license.go
@@ -54,6 +54,7 @@ type cdOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 	// sets artificial latency on the certifier (default to nil)
 	addedLatency *time.Duration
 	// sets the batch size for pagination query for the certifier
@@ -78,6 +79,7 @@ var cdCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			viper.GetString("certifier-latency"),
 			viper.GetInt("certifier-batch-size"),
 			viper.GetInt("last-scan"),
@@ -134,6 +136,7 @@ var cdCmd = &cobra.Command{
 							opts.queryVulnOnIngestion,
 							opts.queryLicenseOnIngestion,
 							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
 						)
 						if err != nil {
 							stop = true
@@ -155,6 +158,7 @@ var cdCmd = &cobra.Command{
 							opts.queryVulnOnIngestion,
 							opts.queryLicenseOnIngestion,
 							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
 						)
 						if err != nil {
 							stop = true
@@ -183,6 +187,7 @@ var cdCmd = &cobra.Command{
 						opts.queryVulnOnIngestion,
 						opts.queryLicenseOnIngestion,
 						opts.queryEOLOnIngestion,
+						opts.queryDepsDevOnIngestion,
 					)
 					if err != nil {
 						atomic.StoreInt32(&gotErr, 1)
@@ -201,6 +206,7 @@ var cdCmd = &cobra.Command{
 					opts.queryVulnOnIngestion,
 					opts.queryLicenseOnIngestion,
 					opts.queryEOLOnIngestion,
+					opts.queryDepsDevOnIngestion,
 				)
 				if err != nil {
 					atomic.StoreInt32(&gotErr, 1)
@@ -269,6 +275,7 @@ func validateCDFlags(
 	queryVulnIngestion bool,
 	queryLicenseIngestion bool,
 	queryEOLIngestion bool,
+	queryDepsDevIngestion bool,
 	certifierLatencyStr string,
 	batchSize int, lastScan int,
 ) (cdOptions, error) {
@@ -306,6 +313,7 @@ func validateCDFlags(
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevIngestion
 
 	return opts, nil
 }

--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -44,6 +44,7 @@ type ociOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 var ociCmd = &cobra.Command{
@@ -60,6 +61,7 @@ var ociCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			args)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -101,8 +103,8 @@ var ociCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				opts.queryDepsDevOnIngestion,
 			)
-
 			if err != nil {
 				gotErr = true
 				return fmt.Errorf("unable to ingest document: %w", err)
@@ -132,13 +134,14 @@ var ociCmd = &cobra.Command{
 }
 
 func validateOCIFlags(gqlEndpoint, headerFile, csubAddr string, csubTls, csubTlsSkipVerify bool,
-	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, args []string) (ociOptions, error) {
+	queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, queryDepsDevOnIngestion bool, args []string) (ociOptions, error) {
 	var opts ociOptions
 	opts.graphqlEndpoint = gqlEndpoint
 	opts.headerFile = headerFile
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevOnIngestion
 
 	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
 	if err != nil {

--- a/cmd/guacone/cmd/osv.go
+++ b/cmd/guacone/cmd/osv.go
@@ -54,6 +54,7 @@ type osvOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 	// sets artificial latency on the certifier (default to nil)
 	addedLatency *time.Duration
 	// sets the batch size for pagination query for the certifier
@@ -78,6 +79,7 @@ var osvCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			viper.GetString("certifier-latency"),
 			viper.GetInt("certifier-batch-size"),
 			viper.GetInt("last-scan"),
@@ -135,6 +137,7 @@ var osvCmd = &cobra.Command{
 							opts.queryVulnOnIngestion,
 							opts.queryLicenseOnIngestion,
 							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
 						)
 						if err != nil {
 							stop = true
@@ -157,6 +160,7 @@ var osvCmd = &cobra.Command{
 							opts.queryVulnOnIngestion,
 							opts.queryLicenseOnIngestion,
 							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
 						)
 						if err != nil {
 							stop = true
@@ -185,6 +189,7 @@ var osvCmd = &cobra.Command{
 						opts.queryVulnOnIngestion,
 						opts.queryLicenseOnIngestion,
 						opts.queryEOLOnIngestion,
+						opts.queryDepsDevOnIngestion,
 					)
 					if err != nil {
 						atomic.StoreInt32(&gotErr, 1)
@@ -203,6 +208,7 @@ var osvCmd = &cobra.Command{
 					opts.queryVulnOnIngestion,
 					opts.queryLicenseOnIngestion,
 					opts.queryEOLOnIngestion,
+					opts.queryDepsDevOnIngestion,
 				)
 				if err != nil {
 					atomic.StoreInt32(&gotErr, 1)
@@ -272,6 +278,7 @@ func validateOSVFlags(
 	queryVulnIngestion bool,
 	queryLicenseIngestion bool,
 	queryEOLIngestion bool,
+	queryDepsDevIngestion bool,
 	certifierLatencyStr string,
 	batchSize int, lastScan int,
 ) (osvOptions, error) {
@@ -309,6 +316,7 @@ func validateOSVFlags(
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevIngestion
 
 	return opts, nil
 }

--- a/cmd/guacone/cmd/s3.go
+++ b/cmd/guacone/cmd/s3.go
@@ -52,6 +52,7 @@ type s3Options struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 }
 
 var s3Cmd = &cobra.Command{
@@ -98,6 +99,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 		)
 		if err != nil {
 			fmt.Printf("failed to validate flags: %v\n", err)
@@ -148,6 +150,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 				s3Opts.queryVulnOnIngestion,
 				s3Opts.queryLicenseOnIngestion,
 				s3Opts.queryEOLOnIngestion,
+				s3Opts.queryDepsDevOnIngestion,
 			)
 
 			if err != nil {
@@ -195,7 +198,7 @@ $ guacone collect s3 --s3-url http://localhost:9000 --s3-bucket guac-test --poll
 }
 
 func validateS3Opts(graphqlEndpoint, headerFile, csubAddr, s3url, s3bucket, s3path, region, s3item, mp, mpEndpoint, queues string,
-	csubTls, csubTlsSkipVerify, poll bool, queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool) (s3Options, error) {
+	csubTls, csubTlsSkipVerify, poll bool, queryVulnIngestion bool, queryLicenseIngestion bool, queryEOLIngestion bool, queryDepsDevIngestion bool) (s3Options, error) {
 	var opts s3Options
 
 	if poll {
@@ -219,7 +222,7 @@ func validateS3Opts(graphqlEndpoint, headerFile, csubAddr, s3url, s3bucket, s3pa
 	}
 
 	opts = s3Options{s3url, s3bucket, s3path, s3item, region, queues, mp, mpEndpoint, poll, graphqlEndpoint, headerFile,
-		csubClientOptions, queryVulnIngestion, queryLicenseIngestion, queryEOLIngestion}
+		csubClientOptions, queryVulnIngestion, queryLicenseIngestion, queryEOLIngestion, queryDepsDevIngestion}
 
 	return opts, nil
 }

--- a/cmd/guacone/cmd/scorecard.go
+++ b/cmd/guacone/cmd/scorecard.go
@@ -50,6 +50,7 @@ type scorecardOptions struct {
 	queryVulnOnIngestion    bool
 	queryLicenseOnIngestion bool
 	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
 	// sets artificial latency on the certifier (default to nil)
 	addedLatency *time.Duration
 	// sets the batch size for pagination query for the certifier
@@ -71,6 +72,7 @@ var scorecardCmd = &cobra.Command{
 			viper.GetBool("add-vuln-on-ingest"),
 			viper.GetBool("add-license-on-ingest"),
 			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
 			viper.GetString("certifier-latency"),
 			viper.GetInt("certifier-batch-size"),
 		)
@@ -143,8 +145,8 @@ var scorecardCmd = &cobra.Command{
 				opts.queryVulnOnIngestion,
 				opts.queryLicenseOnIngestion,
 				opts.queryEOLOnIngestion,
+				opts.queryDepsDevOnIngestion,
 			)
-
 			if err != nil {
 				return fmt.Errorf("unable to ingest document: %v", err)
 			}
@@ -202,6 +204,7 @@ func validateScorecardFlags(
 	queryVulnIngestion bool,
 	queryLicenseIngestion bool,
 	queryEOLOnIngestion bool,
+	queryDepsDevIngestion bool,
 	certifierLatencyStr string,
 	batchSize int,
 ) (scorecardOptions, error) {
@@ -236,6 +239,7 @@ func validateScorecardFlags(
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLOnIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevIngestion
 	return opts, nil
 }
 

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -45,11 +45,12 @@ func Ingest(
 	scanForVulns bool,
 	scanForLicense bool,
 	scanForEOL bool,
+	scanForDepsDev bool,
 ) (*helpers.AssemblerIngestedIDs, error) {
 	logger := d.ChildLogger
 	// Get pipeline of components
 	processorFunc := GetProcessor(ctx)
-	ingestorFunc := GetIngestor(ctx, scanForVulns, scanForLicense, scanForEOL)
+	ingestorFunc := GetIngestor(ctx, scanForVulns, scanForLicense, scanForEOL, scanForDepsDev)
 	collectSubEmitFunc := GetCollectSubEmit(ctx, csubClient)
 	assemblerFunc := GetAssembler(ctx, d.ChildLogger, graphqlEndpoint, transport)
 
@@ -89,11 +90,12 @@ func MergedIngest(
 	scanForVulns bool,
 	scanForLicense bool,
 	scanForEOL bool,
+	scanForDepsDev bool,
 ) error {
 	logger := logging.FromContext(ctx)
 	// Get pipeline of components
 	processorFunc := GetProcessor(ctx)
-	ingestorFunc := GetIngestor(ctx, scanForVulns, scanForLicense, scanForEOL)
+	ingestorFunc := GetIngestor(ctx, scanForVulns, scanForLicense, scanForEOL, scanForDepsDev)
 	collectSubEmitFunc := GetCollectSubEmit(ctx, csubClient)
 	assemblerFunc := GetAssembler(ctx, logger, graphqlEndpoint, transport)
 
@@ -166,7 +168,7 @@ func GetProcessor(ctx context.Context) func(*processor.Document) (processor.Docu
 	}
 }
 
-func GetIngestor(ctx context.Context, scanForVulns bool, scanForLicense bool, scanForEOL bool) func(processor.DocumentTree) ([]assembler.IngestPredicates, []*parser_common.IdentifierStrings, error) {
+func GetIngestor(ctx context.Context, scanForVulns bool, scanForLicense bool, scanForEOL bool, scanForDepsDev bool) func(processor.DocumentTree) ([]assembler.IngestPredicates, []*parser_common.IdentifierStrings, error) {
 	return func(doc processor.DocumentTree) ([]assembler.IngestPredicates, []*parser_common.IdentifierStrings, error) {
 		return parser.ParseDocumentTree(ctx, doc, scanForVulns, scanForLicense, scanForEOL)
 	}

--- a/pkg/ingestor/parser/common/scanner/scanner.go
+++ b/pkg/ingestor/parser/common/scanner/scanner.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/guacsec/guac/pkg/assembler"
 	cd_certifier "github.com/guacsec/guac/pkg/certifier/clearlydefined"
-	osv_certifier "github.com/guacsec/guac/pkg/certifier/osv"
 	eol_certifier "github.com/guacsec/guac/pkg/certifier/eol"
+	osv_certifier "github.com/guacsec/guac/pkg/certifier/osv"
 	"github.com/guacsec/guac/pkg/ingestor/parser/clearlydefined"
 	"github.com/guacsec/guac/pkg/ingestor/parser/common"
 	"github.com/guacsec/guac/pkg/ingestor/parser/eol"
@@ -104,6 +104,10 @@ func PurlsLicenseScan(ctx context.Context, purls []string) ([]assembler.CertifyL
 	}
 
 	return certLegalIngest, hasSourceAtIngest, nil
+}
+
+func PurlsDepsDevScan(ctx context.Context, purls []string) ([]assembler.CertifyScorecardIngest, []assembler.HasSourceAtIngest, error) {
+	return nil, nil, fmt.Errorf("Unimplemented")
 }
 
 // runQueryOnBatchedPurls runs EvaluateClearlyDefinedDefinition from the clearly defined

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -77,7 +77,7 @@ func RegisterDocumentParser(p func() common.DocumentParser, d processor.Document
 }
 
 // ParseDocumentTree takes the DocumentTree and create graph inputs (nodes and edges) per document node.
-func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree, scanForVulns bool, scanForLicense bool, scanForEOL bool) ([]assembler.IngestPredicates, []*common.IdentifierStrings, error) {
+func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree, scanForVulns bool, scanForLicense bool, scanForEOL bool, scanForDepsDev bool) ([]assembler.IngestPredicates, []*common.IdentifierStrings, error) {
 	var wg sync.WaitGroup
 
 	assemblerInputs := []assembler.IngestPredicates{}
@@ -119,6 +119,28 @@ func ParseDocumentTree(ctx context.Context, docTree processor.DocumentTree, scan
 				if len(assemblerInputs) > 0 {
 					assemblerInputs[0].VulnEqual = append(assemblerInputs[0].VulnEqual, vulnEquals...)
 					assemblerInputs[0].CertifyVuln = append(assemblerInputs[0].CertifyVuln, certVulns...)
+				}
+			}
+		}()
+	}
+
+	if scanForDepsDev {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// scan purls via deps.dev on initial ingestion to capture additional deps.dev information
+			var purls []string
+			for _, idString := range identifierStrings {
+				purls = append(purls, idString.PurlStrings...)
+			}
+
+			certScorecard, hasSrcAt, err := scanner.PurlsDepsDevScan(ctx, purls)
+			if err != nil {
+				logger.Errorf("error scanning purls for vulnerabilities %v", err)
+			} else {
+				if len(assemblerInputs) > 0 {
+					assemblerInputs[0].CertifyScorecard = append(assemblerInputs[0].CertifyScorecard, certScorecard...)
+					assemblerInputs[0].HasSourceAt = append(assemblerInputs[0].HasSourceAt, hasSrcAt...)
 				}
 			}
 		}()

--- a/pkg/ingestor/parser/parser_test.go
+++ b/pkg/ingestor/parser/parser_test.go
@@ -293,7 +293,7 @@ func TestParseDocumentTree(t *testing.T) {
 
 			_ = RegisterDocumentParser(f, test.registerDocType) // Ignoring error because it is mutating a global variable
 
-			got, got1, err := ParseDocumentTree(ctx, test.docTree, true, true, true)
+			got, got1, err := ParseDocumentTree(ctx, test.docTree, true, true, true, false)
 
 			if (err != nil) != test.wantErr {
 				t.Errorf("ParseDocumentTree() error = %v, wantErr %v", err, test.wantErr)


### PR DESCRIPTION
# Description of the PR

Add plumbing to enable deps.dev on scan. 
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
