### PR TITLE
Fix zizmor audits

### DIFF
--- a/.github/workflows/db-performance-test.yaml
+++ b/.github/workflows/db-performance-test.yaml
@@ -51,12 +51,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
+        with:
+          persist-credentials: false
       - name: Checkout guac-data
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'guacsec/guac-data'
           ref: 'main'
           path: 'guac-data'
+          persist-credentials: false
       - name: Download artifact files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
+        with:
+          persist-credentials: false
 
       - name: Get GitHub App token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
+        with:
+          persist-credentials: false
       - name: setup-go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # tag=v3.2.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,9 +24,6 @@ on:
 
 permissions:
   actions: read # for detecting the Github Actions environment.
-  contents: write # To upload assets to release.
-  packages: write # To publish container images to GHCR
-  id-token: write # needed for signing the images with GitHub OIDC Token
 
 jobs:
   goreleaser:
@@ -40,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -106,6 +104,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
@@ -133,9 +133,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
+        with:
+          persist-credentials: false
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
@@ -186,9 +190,14 @@ jobs:
     name: generate compose tarball
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write # To upload assets to release.
+      packages: write # To publish container images to GHCR
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
+        with:
+          persist-credentials: false
       - name: Create and publish compose tarball
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-local-build.yaml
+++ b/.github/workflows/reusable-local-build.yaml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
       - name: Set up Go

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# Configuration file for zizmor: https://github.com/woodruffw/zizmor
+rules:
+  template-injection:
+    ignore:
+      # Values of `matrix.database` are defined in the workflow file
+      - db-performance-test.yaml:98:9
+      # For the next three, exploiting template injection would require first
+      # compromising the guac-data repo in a way that causes guacone to produce
+      # exploit-triggering text
+      - db-performance-test.yaml:152:9
+      - db-performance-test.yaml:158:9
+      - db-performance-test.yaml:167:9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,5 @@ rules:
       - db-performance-test.yaml:152:9
       - db-performance-test.yaml:158:9
       - db-performance-test.yaml:167:9
+      # `env.NIGHTLY_RELEASE_TAG` is defined in the workflow file
+      - nightly-release.yaml:54:9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,3 +12,9 @@ rules:
       - db-performance-test.yaml:167:9
       # `env.NIGHTLY_RELEASE_TAG` is defined in the workflow file
       - nightly-release.yaml:54:9
+      # The release workflow only runs against well-defined tags and requires
+      # maintainer action to trigger, so using `github.ref_name` in a template
+      # is low-risk
+      - release.yaml:201:9
+      - release.yaml:217:9
+      - release.yaml:228:9


### PR DESCRIPTION
Address most of the zizmor audits (except scorecard, which has an open question with the Scorecard project)

Fixes #2269 
Fixes #2270 
Fixes #2271 
Fixes #2272 
Fixes #2274 

(Opened as a single PR because several of them involve changes to the new zizmor.yml file)

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
