### PR TITLE
Attempt to fix tilt-ci flakiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,11 @@ jobs:
       labels: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # Fix flakiness with tilt-ci that may be potentially related to https://github.com/tilt-dev/tilt/issues/2079
+      - name: Increase inotify max user watches
+        shell: bash
+        run: |
+          sudo sysctl fs.inotify.max_user_watches=524288 && sudo sysctl -p
       - name: Install tools
         shell: bash
         run: |


### PR DESCRIPTION
# Description of the PR


Flakiness in tilt CI may be related to https://github.com/tilt-dev/tilt/issues/2079. Addressing by increasing sysctl for inotify watchers.
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
