### PR TITLE
skip clearly defined tests for now because of flake

### DIFF
--- a/pkg/certifier/clearlydefined/clearlydefined_test.go
+++ b/pkg/certifier/clearlydefined/clearlydefined_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestClearlyDefined(t *testing.T) {
+	// skip tests because of flake: https://github.com/guacsec/guac/issues/2290
+	t.Skip("Skipping clearly defined tests since it is flaky")
 	ctx := logging.WithLogger(context.Background())
 
 	tests := []struct {
@@ -172,6 +174,9 @@ func TestClearlyDefined(t *testing.T) {
 }
 
 func TestCDCertifierRateLimiter(t *testing.T) {
+	// skip tests because of flake: https://github.com/guacsec/guac/issues/2290
+	t.Skip("Skipping clearly defined tests since it is flaky")
+
 	// Set up the logger
 	var logBuffer bytes.Buffer
 	encoderConfig := zap.NewProductionEncoderConfig()


### PR DESCRIPTION
# Description of the PR

Workaround for https://github.com/guacsec/guac/issues/2290

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
