### PR TITLE
skip scanner cd test due to service timeout

### DIFF
--- a/pkg/ingestor/parser/common/scanner/scanner_test.go
+++ b/pkg/ingestor/parser/common/scanner/scanner_test.go
@@ -341,6 +341,8 @@ func TestPurlsToScan(t *testing.T) {
 }
 
 func TestPurlsLicenseScan(t *testing.T) {
+	// skip tests because of flake: https://github.com/guacsec/guac/issues/2290
+	t.Skip("Skipping clearly defined tests since it is flaky")
 	lvUnknown := "UNKNOWN"
 	ctx := logging.WithLogger(context.Background())
 	tm, _ := time.Parse(time.RFC3339, "2022-11-21T17:45:50.52Z")


### PR DESCRIPTION
# Description of the PR

Related to issue https://github.com/guacsec/guac/issues/2290

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
