### PR TITLE
Adjust workflow permissions for signing and publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   actions: read # for detecting the Github Actions environment.
+  packages: read # for reading from GHCR
 
 jobs:
   goreleaser:
@@ -32,6 +33,9 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
       image: ${{ steps.hash.outputs.image }}
       digest: ${{ steps.hash.outputs.digest }}
+    permissions:
+      packages: write # To publish container images to GHCR
+      id-token: write # To use our OIDC token
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -101,6 +105,9 @@ jobs:
   build-atlas:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      packages: write # To publish container images to GHCR
+      id-token: write # To use our OIDC token
     steps:
       - name: Check out the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -177,6 +184,8 @@ jobs:
     name: generate provenance for container
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write # To use our GitHub token
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0 # must use semver here
     with:
       image: ${{ needs.goreleaser.outputs.image }}
@@ -193,6 +202,7 @@ jobs:
     permissions:
       contents: write # To upload assets to release.
       packages: write # To publish container images to GHCR
+      id-token: write # To use our GitHub token
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3


### PR DESCRIPTION
# Description of the PR

I may have been overly-permissive in id-token grants, but it's an improvement and I wanted to minimize the risk of breaking things.

Fixes #2315 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
