### PR TITLE
fix: handles the case where empty pkgIDs slice is passed

### DIFF
--- a/pkg/assembler/backends/keyvalue/search.go
+++ b/pkg/assembler/backends/keyvalue/search.go
@@ -469,6 +469,11 @@ func (c *demoClient) QueryPackagesListForScan(ctx context.Context, pkgIDs []stri
 	c.m.RLock()
 	defer c.m.RUnlock()
 
+	// return nothing if empty pkgIDs slice is passed
+	if len(pkgIDs) == 0 {
+		return nil, nil
+	}
+
 	var edges []*model.PackageEdge
 	for _, pkgID := range pkgIDs {
 		p, err := c.buildPackageResponse(ctx, pkgID, nil)


### PR DESCRIPTION
# Description of the PR

Fixes: https://github.com/kusaridev/helm-charts/issues/58

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
