### PR TITLE
Give SLSA generator necessary permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -176,8 +176,9 @@ jobs:
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
-      contents: read
-      id-token: write
+      id-token: write # To sign the provenance
+      contents: write # To upload assets to release
+      actions: read # To read the workflow path
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # must use semver here
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
@@ -188,8 +189,9 @@ jobs:
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
-      contents: read
-      id-token: write # To use our GitHub token
+      id-token: write # To sign the provenance
+      contents: write # To upload assets to release
+      actions: read # To read the workflow path
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0 # must use semver here
     with:
       image: ${{ needs.goreleaser.outputs.image }}


### PR DESCRIPTION
Based on https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/go/README.md#workflow-example

Fixes #2315

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
