### PR TITLE
Fix flag defaults not registered in guacrest binary

### DIFF
--- a/cmd/guacrest/cmd/root.go
+++ b/cmd/guacrest/cmd/root.go
@@ -24,6 +24,10 @@ import (
 	"github.com/guacsec/guac/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	// to register the ent backend flag defaults, i.e. --db-driver and --db-address
+	"github.com/guacsec/guac/pkg/assembler/backends"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
 )
 
 var flags = struct {
@@ -81,8 +85,6 @@ func init() {
 
 		// configuration of direct database connection
 		"db-direct-connection",
-		"db-driver",
-		"db-address",
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flags: %v", err)
@@ -92,6 +94,12 @@ func init() {
 	rootCmd.Flags().AddFlagSet(set)
 	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+
+	// Register backend-specific flags
+	if err := backends.RegisterFlags(rootCmd); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to register backend flags: %v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2330

verification that it solves the issue with `make start-service`:

![Screenshot 2024-12-10 164619](https://github.com/user-attachments/assets/bb5302b7-600d-4a25-94e7-fc767d39b683)


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
