### PR TITLE
Grant write permissions to the sbom generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,6 +143,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write # needed for signing the images with GitHub OIDC Token
+      packages: write # needed to upload signatures
+      contents: write # To upload assets to release
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3


### PR DESCRIPTION
Allows the container SBOM signatures to be uploaded.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
