### PR TITLE
[FIX] Update batch query vulns to return all values, including novulns

### DIFF
--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -1517,11 +1516,6 @@ func TestIngestCertifyVulns(t *testing.T) {
 	}
 }
 
-var ignoreTimeStamp = cmp.FilterPath(func(p cmp.Path) bool {
-	// Match if the path is "Metadata.TimeScanned"
-	return p.String() == "Metadata.TimeScanned"
-}, cmp.Ignore())
-
 func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 	ctx := context.Background()
 	b := setupTest(t)
@@ -1553,7 +1547,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    time.Now().UTC(),
+							TimeScanned:    testdata.T1,
 						},
 						{
 							Collector:      "test collector",
@@ -1562,7 +1556,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    time.Now().UTC(),
+							TimeScanned:    testdata.T1,
 						},
 						{
 							Collector:      "test collector",
@@ -1571,7 +1565,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    time.Now().UTC(),
+							TimeScanned:    testdata.T1,
 						},
 						{
 							Collector:      "test collector",
@@ -1580,7 +1574,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    time.Now().UTC(),
+							TimeScanned:    testdata.T1,
 						},
 					},
 				},
@@ -1653,7 +1647,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 
 			}
 
-			if diff := cmp.Diff(test.ExpVuln, got, commonOpts, ignoreTimeStamp); diff != "" {
+			if diff := cmp.Diff(test.ExpVuln, got, commonOpts); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -1516,6 +1517,11 @@ func TestIngestCertifyVulns(t *testing.T) {
 	}
 }
 
+var ignoreTimeStamp = cmp.FilterPath(func(p cmp.Path) bool {
+	// Match if the path is "Metadata.TimeScanned"
+	return p.String() == "Metadata.TimeScanned"
+}, cmp.Ignore())
+
 func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 	ctx := context.Background()
 	b := setupTest(t)
@@ -1547,7 +1553,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    testdata.T1,
+							TimeScanned:    time.Now().UTC(),
 						},
 						{
 							Collector:      "test collector",
@@ -1556,7 +1562,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    testdata.T1,
+							TimeScanned:    time.Now().UTC(),
 						},
 						{
 							Collector:      "test collector",
@@ -1565,7 +1571,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    testdata.T1,
+							TimeScanned:    time.Now().UTC(),
 						},
 						{
 							Collector:      "test collector",
@@ -1574,7 +1580,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 							ScannerURI:     "test scanner uri",
 							DbVersion:      "2023.01.01",
 							DbURI:          "test db uri",
-							TimeScanned:    testdata.T1,
+							TimeScanned:    time.Now().UTC(),
 						},
 					},
 				},
@@ -1647,7 +1653,7 @@ func TestBatchQueryPkgIDCertifyVuln(t *testing.T) {
 
 			}
 
-			if diff := cmp.Diff(test.ExpVuln, got, commonOpts); diff != "" {
+			if diff := cmp.Diff(test.ExpVuln, got, commonOpts, ignoreTimeStamp); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5704,7 +5704,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp) that contain vulnerabilities"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp, including any ` + "`" + `novuln` + "`" + `)"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -129,7 +129,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp) that contain vulnerabilities"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp, including any `novuln`)"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 


### PR DESCRIPTION
# Description of the PR

Due to the error in OSV: 
https://github.com/google/osv.dev/issues/2972

That batch query reported older vulnerabilites that were no longer valid. Return all certifyVulns (including `noVuln` type), and let the client determine which is most valid and up to date.



# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
