### PR TITLE
fix issue where guac.yaml was not being read for backend configuration

### DIFF
--- a/pkg/assembler/backends/arangodb/backend.go
+++ b/pkg/assembler/backends/arangodb/backend.go
@@ -137,6 +137,11 @@ func registerFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind flags: %w", err)
 	}
 
+	// set values from guac.yaml if present
+	flags.user = viper.GetString("arango-user")
+	flags.pass = viper.GetString("arango-pass")
+	flags.addr = viper.GetString("arango-addr")
+
 	return nil
 }
 

--- a/pkg/assembler/backends/ent/backend/backend.go
+++ b/pkg/assembler/backends/ent/backend/backend.go
@@ -63,6 +63,13 @@ func registerFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind flags: %w", err)
 	}
 
+	// set values from guac.yaml if present
+	flags.dbAddress = viper.GetString("db-address")
+	flags.dbDriver = viper.GetString("db-driver")
+	flags.dbDebug = viper.GetBool("db-debug")
+	flags.dbMigrate = viper.GetBool("db-migrate")
+	flags.dbConnTime = viper.GetString("db-conn-time")
+
 	return nil
 }
 

--- a/pkg/assembler/backends/keyvalue/backend.go
+++ b/pkg/assembler/backends/keyvalue/backend.go
@@ -54,6 +54,11 @@ func registerFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind flags: %w", err)
 	}
 
+	// set values from guac.yaml if present
+	flags.kvStore = viper.GetString("kv-store")
+	flags.kvRedis = viper.GetString("kv-redis")
+	flags.kvTiKV = viper.GetString("kv-tikv")
+
 	return nil
 }
 

--- a/pkg/assembler/backends/neo4j/backend.go
+++ b/pkg/assembler/backends/neo4j/backend.go
@@ -76,6 +76,12 @@ func registerFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind flags: %w", err)
 	}
 
+	// set values from guac.yaml if present
+	flags.user = viper.GetString("neo4j-user")
+	flags.pass = viper.GetString("neo4j-pass")
+	flags.addr = viper.GetString("neo4j-addr")
+	flags.realm = viper.GetString("neo4j-realm")
+
 	return nil
 }
 

--- a/pkg/assembler/backends/neptune/neptune.go
+++ b/pkg/assembler/backends/neptune/neptune.go
@@ -71,6 +71,13 @@ func registerFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to bind flags: %w", err)
 	}
 
+	// set values from guac.yaml if present
+	flags.endpoint = viper.GetString("neptune-endpoint")
+	flags.port = viper.GetInt("neptune-port")
+	flags.region = viper.GetString("neptune-region")
+	flags.user = viper.GetString("neptune-user")
+	flags.realm = viper.GetString("neptune-realm")
+
 	return nil
 }
 

--- a/pkg/assembler/backends/register.go
+++ b/pkg/assembler/backends/register.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/guacsec/guac/pkg/cli"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 )
@@ -48,10 +49,10 @@ func Register(name string, gb GBFunc, fr FlagRegistrarFunc, fp FlagParserFunc) {
 
 // RegisterFlags registers all backend-specific flags to the given command
 func RegisterFlags(cmd *cobra.Command) error {
-	var err error
+	// initialize viper to read in guac.yaml configuration file
+	cli.InitConfig()
 	for _, register := range flagRegistrar {
-		err = register(cmd)
-		if err != nil {
+		if err := register(cmd); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
# Description of the PR

Introduced as part of PR: https://github.com/guacsec/guac/pull/2247, guac.yaml was not being properly read in for the backend configuration. This PR fixes this issues to allow for proper configuration set via guac.yaml.

FYI @robert-cronin 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
