### PR TITLE
Add "add-depsdev-on-ingest" flag info to cli store

### DIFF
--- a/cmd/guacingest/cmd/ingest.go
+++ b/cmd/guacingest/cmd/ingest.go
@@ -65,6 +65,7 @@ func ingest(cmd *cobra.Command, args []string) {
 		viper.GetBool("add-vuln-on-ingest"),
 		viper.GetBool("add-license-on-ingest"),
 		viper.GetBool("add-eol-on-ingest"),
+		viper.GetBool("add-depsdev-on-ingest"),
 		viper.GetBool("enable-otel"),
 		args)
 	if err != nil {
@@ -164,6 +165,7 @@ func validateFlags(
 	queryVulnIngestion bool,
 	queryLicenseIngestion bool,
 	queryEOLIngestion bool,
+	queryDepsDevIngestion bool,
 	enableOtel bool,
 	args []string,
 ) (options, error) {
@@ -180,6 +182,7 @@ func validateFlags(
 	opts.queryVulnOnIngestion = queryVulnIngestion
 	opts.queryLicenseOnIngestion = queryLicenseIngestion
 	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevIngestion
 	opts.enableOtel = enableOtel
 
 	return opts, nil

--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -32,7 +32,7 @@ func init() {
 
 	set, err := cli.BuildFlags([]string{"gql-addr", "header-file", "csub-addr", "csub-tls",
 		"csub-tls-skip-verify", "add-vuln-on-ingest", "add-license-on-ingest",
-		"add-eol-on-ingest"})
+		"add-eol-on-ingest", "add-depsdev-on-ingest"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)

--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -70,6 +70,9 @@ func init() {
 	// the ingestor will query and ingest endoflife.date for EOL
 	set.Bool("add-eol-on-ingest", false, "if enabled, the ingestor will query and ingest endoflife.date for EOL data. Warning: This will increase ingestion times")
 
+	// the ingestor will query and ingest deps.dev data for scorecards and source association
+	set.Bool("add-depsdev-on-ingest", false, "if enabled, the ingestor will query and ingest deps.dev scorecards and source association data. Warning: This will increase ingestion times")
+
 	set.String("gql-addr", "http://localhost:8080/query", "endpoint used to connect to graphQL server")
 
 	set.String("rest-api-server-port", "8081", "port to serve the REST API from")


### PR DESCRIPTION
# Description of the PR

Add "add-depsdev-on-ingest" flag info to cli store

Addressing https://github.com/guacsec/guac/pull/2385#discussion_r1892498433
# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
