### PR TITLE
add missing add-eol-on-ingest flag to guacone

### DIFF
--- a/cmd/guacone/cmd/root.go
+++ b/cmd/guacone/cmd/root.go
@@ -31,7 +31,8 @@ func init() {
 	cobra.OnInitialize(cli.InitConfig)
 
 	set, err := cli.BuildFlags([]string{"gql-addr", "header-file", "csub-addr", "csub-tls",
-		"csub-tls-skip-verify", "add-vuln-on-ingest", "add-license-on-ingest"})
+		"csub-tls-skip-verify", "add-vuln-on-ingest", "add-license-on-ingest",
+		"add-eol-on-ingest"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
# Description of the PR
fixes #2390


# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
