### PR TITLE
Add EOL processor so the certifier will run

### DIFF
--- a/pkg/handler/processor/ite6/ite6.go
+++ b/pkg/handler/processor/ite6/ite6.go
@@ -34,7 +34,8 @@ func (e *ITE6Processor) ValidateSchema(i *processor.Document) error {
 	if i.Type != processor.DocumentITE6Generic &&
 		i.Type != processor.DocumentITE6SLSA &&
 		i.Type != processor.DocumentITE6Vul &&
-		i.Type != processor.DocumentITE6ClearlyDefined {
+		i.Type != processor.DocumentITE6ClearlyDefined &&
+		i.Type != processor.DocumentITE6EOL {
 		return fmt.Errorf("expected ITE6 document type, actual document type: %v", i.Type)
 	}
 

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -59,6 +59,7 @@ func init() {
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6SLSA)
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Vul)
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6ClearlyDefined)
+	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6EOL)
 	_ = RegisterDocumentProcessor(&dsse.DSSEProcessor{}, processor.DocumentDSSE)
 	_ = RegisterDocumentProcessor(&spdx.SPDXProcessor{}, processor.DocumentSPDX)
 	_ = RegisterDocumentProcessor(&csaf.CSAFProcessor{}, processor.DocumentCsaf)


### PR DESCRIPTION
# Description of the PR

Fixes #2392 

The certifier runs, but it's not clear that it actually creates EOL records, so there may be more work needed:

```bash
{"level":"info","ts":1734644073.8196108,"caller":"logging/logger.go:79","msg":"Logging at info level","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644073.819721,"caller":"cli/init.go:65","msg":"Using config file: /Users/bcotton/guacsec/guac/guac.yaml","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644073.819968,"caller":"certify/certify.go:109","msg":"Starting certifier run: 2024-12-19 21:34:33.819871 +0000 UTC","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644073.820145,"caller":"root_package/root_package.go:76","msg":"last-scan set to: 4 hours, last scan time set to: 2024-12-19 17:34:33.82011 +0000 UTC","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.032643,"caller":"helpers/bulk.go:47","msg":"assembling Package: 298","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.0532742,"caller":"helpers/bulk.go:63","msg":"assembling Source: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.054917,"caller":"helpers/bulk.go:73","msg":"assembling Artifact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.055767,"caller":"helpers/bulk.go:88","msg":"assembling Materials (Artifact): 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.056044,"caller":"helpers/bulk.go:97","msg":"assembling Builder: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.056617,"caller":"helpers/bulk.go:106","msg":"assembling Vulnerability: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.05739,"caller":"helpers/bulk.go:115","msg":"assembling Licenses: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.0576808,"caller":"helpers/bulk.go:122","msg":"assembling CertifyScorecard: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057701,"caller":"helpers/bulk.go:128","msg":"assembling IsDependency: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057705,"caller":"helpers/bulk.go:137","msg":"assembling IsOccurrence: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057718,"caller":"helpers/bulk.go:146","msg":"assembling HasSLSA: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.0577211,"caller":"helpers/bulk.go:152","msg":"assembling CertifyVuln: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057724,"caller":"helpers/bulk.go:158","msg":"assembling VulnMetadata: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.0577269,"caller":"helpers/bulk.go:164","msg":"assembling VulnEqual: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.05773,"caller":"helpers/bulk.go:170","msg":"assembling HasSourceAt: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057733,"caller":"helpers/bulk.go:176","msg":"assembling CertifyBad: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057736,"caller":"helpers/bulk.go:182","msg":"assembling CertifyGood: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057739,"caller":"helpers/bulk.go:188","msg":"assembling PointOfContact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.057742,"caller":"helpers/bulk.go:194","msg":"assembling HasMetadata: 298","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.081208,"caller":"helpers/bulk.go:200","msg":"assembling HasSBOM: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.081228,"caller":"helpers/bulk.go:211","msg":"assembling VEX : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.0812318,"caller":"helpers/bulk.go:217","msg":"assembling HashEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.081235,"caller":"helpers/bulk.go:223","msg":"assembling PkgEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.081238,"caller":"helpers/bulk.go:229","msg":"assembling CertifyLegal : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644104.081245,"caller":"ingestor/ingestor.go:161","msg":"[260.634042ms] completed docs 298","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.101032,"caller":"helpers/bulk.go:47","msg":"assembling Package: 302","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.112735,"caller":"helpers/bulk.go:63","msg":"assembling Source: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1154518,"caller":"helpers/bulk.go:73","msg":"assembling Artifact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.115872,"caller":"helpers/bulk.go:88","msg":"assembling Materials (Artifact): 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.116278,"caller":"helpers/bulk.go:97","msg":"assembling Builder: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1167722,"caller":"helpers/bulk.go:106","msg":"assembling Vulnerability: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117099,"caller":"helpers/bulk.go:115","msg":"assembling Licenses: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117434,"caller":"helpers/bulk.go:122","msg":"assembling CertifyScorecard: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117441,"caller":"helpers/bulk.go:128","msg":"assembling IsDependency: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117444,"caller":"helpers/bulk.go:137","msg":"assembling IsOccurrence: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1174479,"caller":"helpers/bulk.go:146","msg":"assembling HasSLSA: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1174521,"caller":"helpers/bulk.go:152","msg":"assembling CertifyVuln: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117455,"caller":"helpers/bulk.go:158","msg":"assembling VulnMetadata: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1174579,"caller":"helpers/bulk.go:164","msg":"assembling VulnEqual: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117462,"caller":"helpers/bulk.go:170","msg":"assembling HasSourceAt: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117465,"caller":"helpers/bulk.go:176","msg":"assembling CertifyBad: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1174688,"caller":"helpers/bulk.go:182","msg":"assembling CertifyGood: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117472,"caller":"helpers/bulk.go:188","msg":"assembling PointOfContact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.117476,"caller":"helpers/bulk.go:194","msg":"assembling HasMetadata: 302","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.132092,"caller":"helpers/bulk.go:200","msg":"assembling HasSBOM: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.132108,"caller":"helpers/bulk.go:211","msg":"assembling VEX : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1321118,"caller":"helpers/bulk.go:217","msg":"assembling HashEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.132116,"caller":"helpers/bulk.go:223","msg":"assembling PkgEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1321201,"caller":"helpers/bulk.go:229","msg":"assembling CertifyLegal : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644134.1321259,"caller":"ingestor/ingestor.go:161","msg":"[49.830792ms] completed docs 302","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.679137,"caller":"certify/certify.go:114","msg":"Certifier run completed: 2024-12-19 21:35:42.679123 +0000 UTC","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.679241,"caller":"cmd/eol.go:202","msg":"All certifiers completed","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.6943848,"caller":"helpers/bulk.go:47","msg":"assembling Package: 86","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7015822,"caller":"helpers/bulk.go:63","msg":"assembling Source: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7022212,"caller":"helpers/bulk.go:73","msg":"assembling Artifact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.702743,"caller":"helpers/bulk.go:88","msg":"assembling Materials (Artifact): 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7032151,"caller":"helpers/bulk.go:97","msg":"assembling Builder: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7037299,"caller":"helpers/bulk.go:106","msg":"assembling Vulnerability: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7042181,"caller":"helpers/bulk.go:115","msg":"assembling Licenses: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704639,"caller":"helpers/bulk.go:122","msg":"assembling CertifyScorecard: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704651,"caller":"helpers/bulk.go:128","msg":"assembling IsDependency: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704656,"caller":"helpers/bulk.go:137","msg":"assembling IsOccurrence: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704661,"caller":"helpers/bulk.go:146","msg":"assembling HasSLSA: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7046669,"caller":"helpers/bulk.go:152","msg":"assembling CertifyVuln: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704671,"caller":"helpers/bulk.go:158","msg":"assembling VulnMetadata: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7046762,"caller":"helpers/bulk.go:164","msg":"assembling VulnEqual: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704681,"caller":"helpers/bulk.go:170","msg":"assembling HasSourceAt: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7046862,"caller":"helpers/bulk.go:176","msg":"assembling CertifyBad: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704691,"caller":"helpers/bulk.go:182","msg":"assembling CertifyGood: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7046971,"caller":"helpers/bulk.go:188","msg":"assembling PointOfContact: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.704703,"caller":"helpers/bulk.go:194","msg":"assembling HasMetadata: 86","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.71112,"caller":"helpers/bulk.go:200","msg":"assembling HasSBOM: 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7111309,"caller":"helpers/bulk.go:211","msg":"assembling VEX : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.711136,"caller":"helpers/bulk.go:217","msg":"assembling HashEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.711141,"caller":"helpers/bulk.go:223","msg":"assembling PkgEqual : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7111459,"caller":"helpers/bulk.go:229","msg":"assembling CertifyLegal : 0","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.711155,"caller":"ingestor/ingestor.go:161","msg":"[31.795208ms] completed docs 86","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
{"level":"info","ts":1734644142.7111669,"caller":"cmd/eol.go:211","msg":"completed ingesting 686 documents","guac-version":"v0.12.3-1-g279cf5b8-dirty"}
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
