### PR TITLE
Add eol to e2e and fix certifier logic

### DIFF
--- a/demo/graphql/queries.gql
+++ b/demo/graphql/queries.gql
@@ -292,3 +292,14 @@ query CertifyLegalQ1 {
         ...allCertifyLegalTree
     }
 }
+
+
+query EndOfLifeQ1 {
+    HasMetadata(hasMetadataSpec: {subject: {package: {type: "deb", namespace: "debian", name: "openssl", version: "1.1.1n-0+deb11u3"}}}) @filter(keyName: "key", operation: CONTAINS, value: "endoflife") {
+        subject {
+            ...allPkgTree
+        }
+    		key
+    		value
+    }
+}

--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -97,13 +97,13 @@ wipe_data() {
   fi
 }
 
-go run ${GUAC_DIR}"/cmd/guacingest" --add-vuln-on-ingest=true --add-license-on-ingest &
+go run ${GUAC_DIR}"/cmd/guacingest" --add-vuln-on-ingest=true --add-license-on-ingest --add-eol-on-ingest &
 go run ${GUAC_DIR}"/cmd/guacone" collect deps_dev -p &
 go run ${GUAC_DIR}"/cmd/guaccsub" &
 
 # Define ingestion commands
 declare -a ingestion_commands=(
-  "go run ${GUAC_DIR}/cmd/guacone collect files ${GUAC_DIR}/guac-data/docs/ --add-vuln-on-ingest=true --add-license-on-ingest"
+  "go run ${GUAC_DIR}/cmd/guacone collect files ${GUAC_DIR}/guac-data/docs/ --add-vuln-on-ingest=true --add-license-on-ingest --add-eol-on-ingest"
   "go run ${GUAC_DIR}/cmd/guaccollect files ${GUAC_DIR}/guac-data/docs/ --service-poll=false"
 )
 
@@ -121,6 +121,12 @@ queryValues["CertifyVulnQ1"]='del(.. | .id?) | del(.. | .timeScanned?)'
 queryValues["ArtifactsQ1"]='.artifacts |= sort'
 queryValues["PkgQ9"]='.packages[].namespaces |= sort_by(.namespace) | .packages[].namespaces[].names[].versions |= sort_by(.id) | .packages[].namespaces[].names[].versions[].qualifiers |= sort_by(.key) | del(.. | .id?)'
 queryValues["CertifyLegalQ1"]='del(.. | .id?) | del(.. | .timeScanned?) | del(.. | .origin?)'
+queryValues["EndOfLifeQ1"]='
+  (.HasMetadata[] | select(.key == "endoflife") | .subject.namespaces[].names[].versions[].qualifiers) |= sort_by(.key)
+  | del(.. | .id?)
+  | del(.. | .timeScanned?)
+  | del(.. | .origin?)
+'
 
 # Define an indexed array to maintain the order of the queries
 queryOrder=(
@@ -136,6 +142,7 @@ queryOrder=(
   "ArtifactsQ1"
   "PkgQ9"
   "CertifyLegalQ1"
+  "EndOfLifeQ1"
 )
 
 queries="${GUAC_DIR}/demo/graphql/queries.gql"

--- a/internal/testing/e2e/expectEndOfLifeQ1.json
+++ b/internal/testing/e2e/expectEndOfLifeQ1.json
@@ -1,0 +1,72 @@
+{
+  "HasMetadata": [
+    {
+      "subject": {
+        "type": "deb",
+        "namespaces": [
+          {
+            "namespace": "debian",
+            "names": [
+              {
+                "name": "openssl",
+                "versions": [
+                  {
+                    "purl": "pkg:deb/debian/openssl@1.1.1n-0%2Bdeb11u3?arch=amd64&distro=debian-11",
+                    "version": "1.1.1n-0+deb11u3",
+                    "qualifiers": [
+                      {
+                        "key": "arch",
+                        "value": "amd64"
+                      },
+                      {
+                        "key": "distro",
+                        "value": "debian-11"
+                      }
+                    ],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "key": "endoflife",
+      "value": "product:openssl,cycle:1.1.1,version:1.1.1n-0+deb11u3,isEOL:true,eolDate:2023-09-11,lts:true,latest:1.1.1w,releaseDate:2018-09-11"
+    },
+    {
+      "subject": {
+        "type": "deb",
+        "namespaces": [
+          {
+            "namespace": "debian",
+            "names": [
+              {
+                "name": "openssl",
+                "versions": [
+                  {
+                    "purl": "pkg:deb/debian/openssl@1.1.1n-0%2Bdeb11u3?arch=arm64&distro=debian-11",
+                    "version": "1.1.1n-0+deb11u3",
+                    "qualifiers": [
+                      {
+                        "key": "arch",
+                        "value": "arm64"
+                      },
+                      {
+                        "key": "distro",
+                        "value": "debian-11"
+                      }
+                    ],
+                    "subpath": ""
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "key": "endoflife",
+      "value": "product:openssl,cycle:1.1.1,version:1.1.1n-0+deb11u3,isEOL:true,eolDate:2023-09-11,lts:true,latest:1.1.1w,releaseDate:2018-09-11"
+    }
+  ]
+}

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -168,10 +168,8 @@ func (b *EntBackend) FindPackagesThatNeedScanning(ctx context.Context, queryType
 			Aggregate(func(s *sql.Selector) string {
 				t := sql.Table(hasmetadata.Table)
 				s.LeftJoin(t).On(s.C(packageversion.FieldID), t.C(hasmetadata.FieldPackageVersionID))
-				s.Where(sql.And(
-					sql.NotNull(t.C(hasmetadata.FieldTimestamp)),
-					sql.EQ(t.C(hasmetadata.FieldKey), "endoflife"),
-				))
+				// only consider "endoflife" metadata
+				s.Where(sql.EQ(t.C(hasmetadata.FieldKey), "endoflife"))
 				return sql.As(sql.Max(t.C(hasmetadata.FieldTimestamp)), "max")
 			}).
 			Scan(ctx, &pkgLatestScan)

--- a/pkg/ingestor/parser/common/scanner/scanner_test.go
+++ b/pkg/ingestor/parser/common/scanner/scanner_test.go
@@ -555,7 +555,7 @@ func TestPurlsEOLScan(t *testing.T) {
 						PkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						HasMetadata: &generated.HasMetadataInputSpec{
 							Key:           "endoflife",
-							Value:         "product:python,cycle:3.13,version:3.9.5,isEOL:false,eolDate:2029-10-31,lts:false,latest:3.13.0,releaseDate:2024-10-07",
+							Value:         "product:python,cycle:3.9,version:3.9.5,isEOL:false,eolDate:2025-10-31,lts:false,latest:3.9.21,releaseDate:2020-10-05",
 							Justification: "Retrieved from endoflife.date",
 							Origin:        "GUAC EOL Certifier",
 							Collector:     "GUAC",
@@ -616,7 +616,7 @@ func TestPurlsEOLScan(t *testing.T) {
 						PkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						HasMetadata: &generated.HasMetadataInputSpec{
 							Key:           "endoflife",
-							Value:         "product:python,cycle:3.13,version:3.9.5,isEOL:false,eolDate:2029-10-31,lts:false,latest:3.13.0,releaseDate:2024-10-07",
+							Value:         "product:python,cycle:3.9,version:3.9.5,isEOL:false,eolDate:2025-10-31,lts:false,latest:3.9.21,releaseDate:2020-10-05",
 							Justification: "Retrieved from endoflife.date",
 							Origin:        "GUAC EOL Certifier",
 							Collector:     "GUAC",


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2395 

In addition to adding the e2e test query, this PR will also address some issues with the EOL certifier logic. For example, the parsing of purls now uses standard helper methods and the check for whether a node has EOL data is now more specific to mitigate false positives.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
