### PR TITLE
Add missing use-csub flag to oci collector

### DIFF
--- a/cmd/guacone/cmd/oci.go
+++ b/cmd/guacone/cmd/oci.go
@@ -65,7 +65,7 @@ type ociRegistryOptions struct {
 var ociCmd = &cobra.Command{
 	Use:   "image [flags] image_path1 image_path2...",
 	Short: "takes images to download sbom and attestation stored in OCI to add to GUAC graph, this command talks directly to the graphQL endpoint",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, csubClient, err := validateOCIFlags(
 			viper.GetString("gql-addr"),
@@ -331,6 +331,23 @@ func validateOCIRegistryFlags(gqlEndpoint, headerFile, csubAddr string, csubTls,
 }
 
 func init() {
+	set, err := cli.BuildFlags([]string{"use-csub"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+
+	ociCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(ociCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
 	collectCmd.AddCommand(ociCmd)
+
+	ociRegistryCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(ociRegistryCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
 	collectCmd.AddCommand(ociRegistryCmd)
 }


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2423 

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
