### PR TITLE
Rework `CertifyVuln` and `CertifyLegal` to upsert and not create duplicate entires

### DIFF
--- a/internal/testing/backend/certifyLegal_test.go
+++ b/internal/testing/backend/certifyLegal_test.go
@@ -387,7 +387,7 @@ func TestLegal(t *testing.T) {
 						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
 					},
 					Legal: &model.CertifyLegalInputSpec{
-						Attribution: "Copyright Jeff",
+						Attribution: "Copyright Bob",
 					},
 				},
 				{
@@ -395,7 +395,7 @@ func TestLegal(t *testing.T) {
 						Package: &model.IDorPkgInput{PackageInput: testdata.P1},
 					},
 					Legal: &model.CertifyLegalInputSpec{
-						Attribution: "Copyright Bob",
+						Attribution: "Copyright Jeff",
 					},
 				},
 			},

--- a/internal/testing/backend/certifyVuln_test.go
+++ b/internal/testing/backend/certifyVuln_test.go
@@ -844,22 +844,6 @@ func TestIngestCertifyVulnerability(t *testing.T) {
 						ScannerURI:     "test scanner uri",
 						DbVersion:      "2023.08.01",
 						DbURI:          "test db uri",
-						TimeScanned:    testdata.T1,
-					},
-				},
-				{
-					Package: testdata.P2out,
-					Vulnerability: &model.Vulnerability{
-						Type:             "ghsa",
-						VulnerabilityIDs: []*model.VulnerabilityID{testdata.G1out},
-					},
-					Metadata: &model.ScanMetadata{
-						Collector:      "test collector",
-						Origin:         "test origin",
-						ScannerVersion: "v1.0.0",
-						ScannerURI:     "test scanner uri",
-						DbVersion:      "2023.08.01",
-						DbURI:          "test db uri",
 						TimeScanned:    testTime,
 					},
 				},

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -114,11 +114,11 @@ type backend interface {
 }
 
 var testBackends = map[string]backend{
-	// memmap: newMemMap(),
-	// arango: newArango(),
-	// redis:  newRedis(),
-	ent: newEnt(),
-	//tikv:   newTikv(),
+	memmap: newMemMap(),
+	arango: newArango(),
+	redis:  newRedis(),
+	ent:    newEnt(),
+	tikv:   newTikv(),
 }
 
 var currentBackend string

--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -114,11 +114,11 @@ type backend interface {
 }
 
 var testBackends = map[string]backend{
-	memmap: newMemMap(),
-	arango: newArango(),
-	redis:  newRedis(),
-	ent:    newEnt(),
-	tikv:   newTikv(),
+	// memmap: newMemMap(),
+	// arango: newArango(),
+	// redis:  newRedis(),
+	ent: newEnt(),
+	//tikv:   newTikv(),
 }
 
 var currentBackend string

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -175,7 +175,6 @@ func (b *EntBackend) IngestCertifyLegal(ctx context.Context, subject model.Packa
 		}
 
 		seen := make(map[string]bool)
-
 		certifyLegalCreate, err := generateCertifyLegalCreate(ctx, tx, spec, subject.Package, subject.Source, declaredLicenses, discoveredLicenses, seen)
 		if err != nil {
 			return nil, gqlerror.Errorf("generateCertifyLegalCreate :: %s", err)
@@ -337,6 +336,8 @@ func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.Certi
 		}
 
 		certifyLegalCreate.SetID(*certifyLegalID)
+	} else {
+		return nil, fmt.Errorf("pkg or source not specified for certifyLegal")
 	}
 
 	return certifyLegalCreate, nil
@@ -469,7 +470,7 @@ func certifyLegalQuery(filter model.CertifyLegalSpec) predicate.CertifyLegal {
 }
 
 func canonicalCertifyLegalString(cl *model.CertifyLegalInputSpec) string {
-	return fmt.Sprintf("%s::%s::%s::%s::%s::%s::%s:%s", cl.DeclaredLicense, cl.DiscoveredLicense, cl.Attribution, cl.Justification, cl.TimeScanned.UTC(), cl.Origin, cl.Collector, cl.DocumentRef)
+	return fmt.Sprintf("%s::%s::%s::%s::%s::%s", cl.DeclaredLicense, cl.DiscoveredLicense, cl.Attribution, cl.Justification, cl.Origin, cl.Collector)
 }
 
 // guacCertifyLegalKey generates an uuid based on the hash of the inputspec and inputs. certifyLegal ID has to be set for bulk ingestion

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -143,10 +143,8 @@ func certifyLegalConflictColumns() []string {
 	return []string{
 		certifylegal.FieldDeclaredLicense,
 		certifylegal.FieldJustification,
-		certifylegal.FieldTimeScanned,
 		certifylegal.FieldOrigin,
 		certifylegal.FieldCollector,
-		certifylegal.FieldDocumentRef,
 		certifylegal.FieldDeclaredLicensesHash,
 		certifylegal.FieldDiscoveredLicensesHash,
 	}
@@ -176,7 +174,9 @@ func (b *EntBackend) IngestCertifyLegal(ctx context.Context, subject model.Packa
 			return nil, gqlerror.Errorf("%v :: %s", "IngestCertifyLegal", "subject must be either a package or source")
 		}
 
-		certifyLegalCreate, err := generateCertifyLegalCreate(ctx, tx, spec, subject.Package, subject.Source, declaredLicenses, discoveredLicenses)
+		seen := make(map[string]bool)
+
+		certifyLegalCreate, err := generateCertifyLegalCreate(ctx, tx, spec, subject.Package, subject.Source, declaredLicenses, discoveredLicenses, seen)
 		if err != nil {
 			return nil, gqlerror.Errorf("generateCertifyLegalCreate :: %s", err)
 		}
@@ -186,7 +186,7 @@ func (b *EntBackend) IngestCertifyLegal(ctx context.Context, subject model.Packa
 				sql.ConflictColumns(certifyLegalConflictColumns...),
 				sql.ConflictWhere(conflictWhere),
 			).
-			Ignore().
+			UpdateNewValues().
 			ID(ctx); err != nil {
 
 			return nil, errors.Wrap(err, "upsert certify legal node")
@@ -201,7 +201,9 @@ func (b *EntBackend) IngestCertifyLegal(ctx context.Context, subject model.Packa
 	return certifyLegalGlobalID(*recordID), nil
 }
 
-func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.CertifyLegalInputSpec, pkg *model.IDorPkgInput, src *model.IDorSourceInput, declaredLicenses []*model.IDorLicenseInput, discoveredLicenses []*model.IDorLicenseInput) (*ent.CertifyLegalCreate, error) {
+func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.CertifyLegalInputSpec, pkg *model.IDorPkgInput, src *model.IDorSourceInput,
+	declaredLicenses []*model.IDorLicenseInput, discoveredLicenses []*model.IDorLicenseInput, seen map[string]bool) (*ent.CertifyLegalCreate, error) {
+
 	certifyLegalCreate := tx.CertifyLegal.Create().
 		SetDeclaredLicense(cl.DeclaredLicense).
 		SetDiscoveredLicense(cl.DiscoveredLicense).
@@ -296,6 +298,14 @@ func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.Certi
 		if err != nil {
 			return nil, fmt.Errorf("failed to create certifyLegal uuid with error: %w", err)
 		}
+
+		if _, exists := seen[certifyLegalID.String()]; !exists {
+			seen[certifyLegalID.String()] = true
+		} else {
+			// if duplicate entry is found, we will ignore it as it is exactly the same
+			return nil, nil
+		}
+
 		certifyLegalCreate.SetID(*certifyLegalID)
 	} else if src != nil {
 		var sourceID uuid.UUID
@@ -318,6 +328,14 @@ func generateCertifyLegalCreate(ctx context.Context, tx *ent.Tx, cl *model.Certi
 		if err != nil {
 			return nil, fmt.Errorf("failed to create certifyLegal uuid with error: %w", err)
 		}
+
+		if _, exists := seen[certifyLegalID.String()]; !exists {
+			seen[certifyLegalID.String()] = true
+		} else {
+			// if duplicate entry is found, we will ignore it as it is exactly the same
+			return nil, nil
+		}
+
 		certifyLegalCreate.SetID(*certifyLegalID)
 	}
 
@@ -351,20 +369,26 @@ func upsertBulkCertifyLegal(ctx context.Context, tx *ent.Tx, subjects model.Pack
 
 	index := 0
 	for _, cls := range batches {
-		creates := make([]*ent.CertifyLegalCreate, len(cls))
-		for i, cl := range cls {
+		var creates []*ent.CertifyLegalCreate
+		seen := make(map[string]bool)
+		for _, cl := range cls {
 			cl := cl
-			var err error
 			if len(subjects.Packages) > 0 {
-				creates[i], err = generateCertifyLegalCreate(ctx, tx, cl, subjects.Packages[index], nil, declaredLicensesList[index], discoveredLicensesList[index])
+				pkgCL, err := generateCertifyLegalCreate(ctx, tx, cl, subjects.Packages[index], nil, declaredLicensesList[index], discoveredLicensesList[index], seen)
 				if err != nil {
 					return nil, gqlerror.Errorf("generateCertifyLegalCreate :: %s", err)
 				}
+				if pkgCL != nil {
+					creates = append(creates, pkgCL)
+				}
 
 			} else if len(subjects.Sources) > 0 {
-				creates[i], err = generateCertifyLegalCreate(ctx, tx, cl, nil, subjects.Sources[index], declaredLicensesList[index], discoveredLicensesList[index])
+				srcCL, err := generateCertifyLegalCreate(ctx, tx, cl, nil, subjects.Sources[index], declaredLicensesList[index], discoveredLicensesList[index], seen)
 				if err != nil {
 					return nil, gqlerror.Errorf("generateCertifyLegalCreate :: %s", err)
+				}
+				if srcCL != nil {
+					creates = append(creates, srcCL)
 				}
 			} else {
 				return nil, gqlerror.Errorf("%v :: %s", "upsertBulkCertifyLegal", "subject must be either a package or source")
@@ -377,7 +401,7 @@ func upsertBulkCertifyLegal(ctx context.Context, tx *ent.Tx, subjects model.Pack
 				sql.ConflictColumns(certifyLegalConflictColumns...),
 				sql.ConflictWhere(conflictWhere),
 			).
-			DoNothing().
+			UpdateNewValues().
 			Exec(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "bulk upsert certifyLegal node")

--- a/pkg/assembler/backends/ent/backend/certifyVuln.go
+++ b/pkg/assembler/backends/ent/backend/certifyVuln.go
@@ -65,8 +65,6 @@ func certifyVulnConflictColumns() []string {
 		certifyvuln.FieldOrigin,
 		certifyvuln.FieldDbURI,
 		certifyvuln.FieldDbVersion,
-		certifyvuln.FieldTimeScanned,
-		certifyvuln.FieldDocumentRef,
 	}
 }
 
@@ -86,7 +84,7 @@ func (b *EntBackend) IngestCertifyVuln(ctx context.Context, pkg model.IDorPkgInp
 			OnConflict(
 				sql.ConflictColumns(conflictColumns...),
 			).
-			Ignore().
+			UpdateNewValues().
 			ID(ctx); err != nil {
 			return nil, errors.Wrap(err, "upsert certify Vuln statement node")
 		} else {
@@ -205,7 +203,7 @@ func upsertBulkCertifyVuln(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPk
 			OnConflict(
 				sql.ConflictColumns(conflictColumns...),
 			).
-			DoNothing().
+			UpdateNewValues().
 			Exec(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "bulk upsert certifyVuln node")

--- a/pkg/assembler/backends/ent/backend/certifyVuln.go
+++ b/pkg/assembler/backends/ent/backend/certifyVuln.go
@@ -74,8 +74,9 @@ func (b *EntBackend) IngestCertifyVuln(ctx context.Context, pkg model.IDorPkgInp
 		tx := ent.TxFromContext(ctx)
 
 		conflictColumns := certifyVulnConflictColumns()
+		seen := make(map[string]bool)
 
-		insert, err := generateCertifyVulnCreate(ctx, tx, &pkg, &vulnerability, &certifyVuln)
+		insert, err := generateCertifyVulnCreate(ctx, tx, &pkg, &vulnerability, &certifyVuln, seen)
 		if err != nil {
 			return nil, gqlerror.Errorf("generateCertifyVulnCreate :: %s", err)
 		}
@@ -115,7 +116,7 @@ func (b *EntBackend) IngestCertifyVulns(ctx context.Context, pkgs []*model.IDorP
 	return bulkCertifyVulnGlobalID(*ids), nil
 }
 
-func generateCertifyVulnCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgInput, vuln *model.IDorVulnerabilityInput, certifyVuln *model.ScanMetadataInput) (*ent.CertifyVulnCreate, error) {
+func generateCertifyVulnCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorPkgInput, vuln *model.IDorVulnerabilityInput, certifyVuln *model.ScanMetadataInput, seen map[string]bool) (*ent.CertifyVulnCreate, error) {
 
 	certifyVulnCreate := tx.CertifyVuln.Create()
 
@@ -166,6 +167,15 @@ func generateCertifyVulnCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorP
 	}
 	certifyVulnCreate.SetPackageID(pkgVersionID)
 
+	certifyVulnKey := guacCertifyVulnKey(pkgVersionID.String(), vulnID.String(), certifyVuln)
+
+	if _, exists := seen[certifyVulnKey.String()]; !exists {
+		seen[certifyVulnKey.String()] = true
+	} else {
+		// if duplicate entry is found, we will ignore it as it is exactly the same
+		return nil, nil
+	}
+
 	certifyVulnCreate.
 		SetCollector(certifyVuln.Collector).
 		SetDbURI(certifyVuln.DbURI).
@@ -179,6 +189,18 @@ func generateCertifyVulnCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorP
 	return certifyVulnCreate, nil
 }
 
+func canonicalCertifyVulnString(cv *model.ScanMetadataInput) string {
+	return fmt.Sprintf("%s::%s::%s::%s::%s::%s::%s:%s", cv.TimeScanned.UTC(), cv.DbURI, cv.DbVersion, cv.ScannerURI, cv.ScannerVersion, cv.Origin, cv.Collector, cv.DocumentRef)
+}
+
+// guacCertifyVulnKey generates an uuid based on the hash of the inputspec and inputs.
+// This is used to ensure that no duplicates are added into bulk ingestion causing a failure
+func guacCertifyVulnKey(pkgVersionID string, vulnID string, cvInput *model.ScanMetadataInput) uuid.UUID {
+	clIDString := fmt.Sprintf("%s::%s::%s?", pkgVersionID, vulnID, canonicalCertifyVulnString(cvInput))
+	clID := generateUUIDKey([]byte(clIDString))
+	return clID
+}
+
 func upsertBulkCertifyVuln(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPkgInput, vulnerabilities []*model.IDorVulnerabilityInput, certifyVulns []*model.ScanMetadataInput) (*[]string, error) {
 	ids := make([]string, 0)
 
@@ -188,13 +210,16 @@ func upsertBulkCertifyVuln(ctx context.Context, tx *ent.Tx, pkgs []*model.IDorPk
 
 	index := 0
 	for _, vulns := range batches {
-		creates := make([]*ent.CertifyVulnCreate, len(vulns))
-		for i, vuln := range vulns {
+		var creates []*ent.CertifyVulnCreate
+		seen := make(map[string]bool)
+		for _, vuln := range vulns {
 			vuln := vuln
-			var err error
-			creates[i], err = generateCertifyVulnCreate(ctx, tx, pkgs[index], vulnerabilities[index], vuln)
+			cv, err := generateCertifyVulnCreate(ctx, tx, pkgs[index], vulnerabilities[index], vuln, seen)
 			if err != nil {
 				return nil, gqlerror.Errorf("generateCertifyVulnCreate :: %s", err)
+			}
+			if cv != nil {
+				creates = append(creates, cv)
 			}
 			index++
 		}

--- a/pkg/assembler/backends/ent/backend/certifyVuln.go
+++ b/pkg/assembler/backends/ent/backend/certifyVuln.go
@@ -190,7 +190,7 @@ func generateCertifyVulnCreate(ctx context.Context, tx *ent.Tx, pkg *model.IDorP
 }
 
 func canonicalCertifyVulnString(cv *model.ScanMetadataInput) string {
-	return fmt.Sprintf("%s::%s::%s::%s::%s::%s::%s:%s", cv.TimeScanned.UTC(), cv.DbURI, cv.DbVersion, cv.ScannerURI, cv.ScannerVersion, cv.Origin, cv.Collector, cv.DocumentRef)
+	return fmt.Sprintf("%s::%s::%s::%s::%s::%s", cv.DbURI, cv.DbVersion, cv.ScannerURI, cv.ScannerVersion, cv.Origin, cv.Collector)
 }
 
 // guacCertifyVulnKey generates an uuid based on the hash of the inputspec and inputs.

--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -359,7 +359,6 @@ func (b *EntBackend) BatchQueryPkgIDCertifyLegal(ctx context.Context, pkgIDs []s
 	}
 
 	var aggPredicates []predicate.CertifyLegal
-	// aggregate to find the latest timescanned for certifyLegals for list of packages
 	aggPredicates = append(aggPredicates, certifylegal.PackageIDIn(queryList...), certifylegal.SourceIDIsNil())
 
 	var collectedCertLegal []*model.CertifyLegal

--- a/pkg/assembler/backends/ent/migrate/migrations/20250122170741_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20250122170741_ent_diff.sql
@@ -1,4 +1,18 @@
+-- Truncate all of the data and remove older certify legal entries
+TRUNCATE certify_legals RESTART IDENTITY CASCADE;
+-- Truncate all of the data and remove older certify vuln entries
+TRUNCATE certify_vulns RESTART IDENTITY CASCADE;
+-- Change ENT auto-migration index name from "certifylegal_package_id_declar_37fd118fe84f0a1eb9042a047d066a77" to "certifylegal_package_id_declared_license_discovered_license_att" from table: "certify_legals"
+ALTER INDEX IF EXISTS "certifyvuln_db_uri_db_version__21c35a4e5f38654fa77920fb7bbb325c" RENAME TO "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origi";
 -- Drop index "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origi" from table: "certify_vulns"
 DROP INDEX "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origi";
 -- Create index "certifyvuln_package_id_vulnerability_id_collector_scanner_uri_s" to table: "certify_vulns"
 CREATE UNIQUE INDEX "certifyvuln_package_id_vulnerability_id_collector_scanner_uri_s" ON "certify_vulns" ("package_id", "vulnerability_id", "collector", "scanner_uri", "scanner_version", "origin", "db_uri", "db_version");
+-- Drop index "certifylegal_package_id_declared_license_justification_time_sca" from table: "certify_legals"
+DROP INDEX "certifylegal_package_id_declared_license_justification_time_sca";
+-- Drop index "certifylegal_source_id_declared_license_justification_time_scan" from table: "certify_legals"
+DROP INDEX "certifylegal_source_id_declared_license_justification_time_scan";
+-- Create index "cl_pkg_id" to table: "certify_legals"
+CREATE UNIQUE INDEX "cl_pkg_id" ON "certify_legals" ("declared_license", "justification", "origin", "collector", "declared_licenses_hash", "discovered_licenses_hash", "package_id") WHERE ((package_id IS NOT NULL) AND (source_id IS NULL));
+-- Create index "cl_source_id" to table: "certify_legals"
+CREATE UNIQUE INDEX "cl_source_id" ON "certify_legals" ("declared_license", "justification", "origin", "collector", "declared_licenses_hash", "discovered_licenses_hash", "source_id") WHERE ((package_id IS NULL) AND (source_id IS NOT NULL));

--- a/pkg/assembler/backends/ent/migrate/migrations/20250122170741_ent_diff.sql
+++ b/pkg/assembler/backends/ent/migrate/migrations/20250122170741_ent_diff.sql
@@ -1,0 +1,4 @@
+-- Drop index "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origi" from table: "certify_vulns"
+DROP INDEX "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origi";
+-- Create index "certifyvuln_package_id_vulnerability_id_collector_scanner_uri_s" to table: "certify_vulns"
+CREATE UNIQUE INDEX "certifyvuln_package_id_vulnerability_id_collector_scanner_uri_s" ON "certify_vulns" ("package_id", "vulnerability_id", "collector", "scanner_uri", "scanner_version", "origin", "db_uri", "db_version");

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:KuaQHktgtdw7yZ1PEUPttDfzv0DWHUXkipkGpYggk3k=
+h1:zaZerGe9jmwxui76FN53UdhQN9CrD+reHOkSmA6ATxA=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -12,5 +12,5 @@ h1:KuaQHktgtdw7yZ1PEUPttDfzv0DWHUXkipkGpYggk3k=
 20241017140224_ent_diff.sql h1:BrrQdJnjtZJ9FYOXc5PgEafQ6N3ADdydFPevjdyTqnU=
 20241030212025_ent_diff.sql h1:IlCPmPKr+81472GhqF+hris+RX4zaKwBxVC1pCCi8vE=
 20241216154012_ent_diff.sql h1:RzLRAB0SIBcufd46h5eLApX3UCfl+ITHS+K/WLg+edI=
-20250122170741_ent_diff.sql h1:A88Ybp+J0KXpf9bpUA5Y3DrhvIRV/izi37oxXaIjl60=
-20250124141435_ent_diff.sql h1:1lIeyiwFEKOVZwxBbKCdchzVAY5WKdgZZsxPsAYPh1k=
+20250122170741_ent_diff.sql h1:x0nCamsbYknnW7QFtmFbKFD1OCnu8b/Et0ICvLF3tOY=
+20250124141435_ent_diff.sql h1:bjkujeoSKCtM/HSHeTqcF4mW9fpTYqADiEvMG/M3vFk=

--- a/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
+++ b/pkg/assembler/backends/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vZipb8UGFhkvjKFmLF3Cgp9SA3MfyKpL4AJX+XkbpPA=
+h1:KuaQHktgtdw7yZ1PEUPttDfzv0DWHUXkipkGpYggk3k=
 20240503123155_baseline.sql h1:oZtbKI8sJj3xQq7ibfvfhFoVl+Oa67CWP7DFrsVLVds=
 20240626153721_ent_diff.sql h1:FvV1xELikdPbtJk7kxIZn9MhvVVoFLF/2/iT/wM5RkA=
 20240702195630_ent_diff.sql h1:y8TgeUg35krYVORmC7cN4O96HqOc3mVO9IQ2lYzIzwg=
@@ -12,4 +12,5 @@ h1:vZipb8UGFhkvjKFmLF3Cgp9SA3MfyKpL4AJX+XkbpPA=
 20241017140224_ent_diff.sql h1:BrrQdJnjtZJ9FYOXc5PgEafQ6N3ADdydFPevjdyTqnU=
 20241030212025_ent_diff.sql h1:IlCPmPKr+81472GhqF+hris+RX4zaKwBxVC1pCCi8vE=
 20241216154012_ent_diff.sql h1:RzLRAB0SIBcufd46h5eLApX3UCfl+ITHS+K/WLg+edI=
-20250124141435_ent_diff.sql h1:DHf/iik/gyNGRE88C/6p3y/7OF/2ZxT4NquM878H6tk=
+20250122170741_ent_diff.sql h1:A88Ybp+J0KXpf9bpUA5Y3DrhvIRV/izi37oxXaIjl60=
+20250124141435_ent_diff.sql h1:1lIeyiwFEKOVZwxBbKCdchzVAY5WKdgZZsxPsAYPh1k=

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -235,17 +235,17 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifylegal_source_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "cl_source_id",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[9], CertifyLegalsColumns[10], CertifyLegalsColumns[12]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
 			},
 			{
-				Name:    "certifylegal_package_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "cl_pkg_id",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[9], CertifyLegalsColumns[10], CertifyLegalsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -397,9 +397,9 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_time_scanned_document_ref_vulnerability_id_package_id",
+				Name:    "certifyvuln_package_id_vulnerability_id_collector_scanner_uri_scanner_version_origin_db_uri_db_version",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[1], CertifyVulnsColumns[8], CertifyVulnsColumns[9], CertifyVulnsColumns[10]},
+				Columns: []*schema.Column{CertifyVulnsColumns[10], CertifyVulnsColumns[9], CertifyVulnsColumns[7], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[2], CertifyVulnsColumns[3]},
 			},
 			{
 				Name:    "certifyvuln_package_id",

--- a/pkg/assembler/backends/ent/schema/certifylegal.go
+++ b/pkg/assembler/backends/ent/schema/certifylegal.go
@@ -63,14 +63,14 @@ func (CertifyLegal) Edges() []ent.Edge {
 
 func (CertifyLegal) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("source_id", "declared_license", "justification", "time_scanned",
-			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
+		index.Fields("declared_license", "justification",
+			"origin", "collector", "declared_licenses_hash", "discovered_licenses_hash", "source_id").
 			Unique().
-			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")),
-		index.Fields("package_id", "declared_license", "justification", "time_scanned",
-			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
+			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")).StorageKey("cl_source_id"),
+		index.Fields("declared_license", "justification",
+			"origin", "collector", "declared_licenses_hash", "discovered_licenses_hash", "package_id").
 			Unique().
-			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),
+			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")).StorageKey("cl_pkg_id"),
 		index.Fields("package_id").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),                                                                       // query when subject is package ID
 		index.Fields("package_id", "declared_licenses_hash", "discovered_licenses_hash", "time_scanned").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")), // index on for batch query
 	}

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -60,7 +60,8 @@ func (CertifyVuln) Edges() []ent.Edge {
 // Indexes of the Vulnerability.
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned", "document_ref").Edges("vulnerability", "package").Unique(),
+		index.Fields("package_id", "vulnerability_id", "collector", "scanner_uri", "scanner_version", "origin", "db_uri", "db_version").
+			Unique(),
 		index.Fields("package_id"),                                     // speed up frequently run queries to check when CV nodes affect certain package IDs
 		index.Fields("vulnerability_id"),                               // speed up frequently run queries to check when CV nodes have a vulnerability
 		index.Fields("vulnerability_id", "package_id", "time_scanned"), // index on for batch query

--- a/pkg/assembler/backends/keyvalue/certifyLegal.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/guacsec/guac/pkg/assembler/kv"
@@ -59,10 +60,8 @@ func (n *certifyLegalStruct) Key() string {
 		fmt.Sprint(n.DiscoveredLicenses),
 		n.Attribution,
 		n.Justification,
-		timeKey(n.TimeScanned),
 		n.Origin,
 		n.Collector,
-		n.DocumentRef,
 	}, ":"))
 }
 
@@ -551,7 +550,7 @@ func (c *demoClient) CertifyLegal(ctx context.Context, filter *model.CertifyLega
 				if legal == nil {
 					continue
 				}
-				
+
 				out = append(out, legal)
 			}
 		}

--- a/pkg/assembler/backends/keyvalue/certifyLegal.go
+++ b/pkg/assembler/backends/keyvalue/certifyLegal.go
@@ -173,6 +173,10 @@ func (c *demoClient) ingestCertifyLegal(ctx context.Context, subject model.Packa
 
 	out, err := byKeykv[*certifyLegalStruct](ctx, clCol, in.Key(), c)
 	if err == nil {
+		in.ThisID = out.ThisID
+		if err := setkv(ctx, clCol, in, c); err != nil {
+			return "", err
+		}
 		return out.ThisID, nil
 	}
 	if !errors.Is(err, kv.NotFoundError) {
@@ -550,7 +554,6 @@ func (c *demoClient) CertifyLegal(ctx context.Context, filter *model.CertifyLega
 				if legal == nil {
 					continue
 				}
-
 				out = append(out, legal)
 			}
 		}

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -122,6 +122,10 @@ func (c *demoClient) ingestVulnerability(ctx context.Context, packageArg model.I
 
 	out, err := byKeykv[*certifyVulnerabilityLink](ctx, cVulnCol, in.Key(), c)
 	if err == nil {
+		in.ThisID = out.ThisID
+		if err := setkv(ctx, cVulnCol, in, c); err != nil {
+			return "", err
+		}
 		return out.ThisID, nil
 	}
 	if !errors.Is(err, kv.NotFoundError) {

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -50,14 +50,12 @@ func (n *certifyVulnerabilityLink) Key() string {
 	return hashKey(strings.Join([]string{
 		n.PackageID,
 		n.VulnerabilityID,
-		timeKey(n.TimeScanned),
 		n.DBURI,
 		n.DBVersion,
 		n.ScannerURI,
 		n.ScannerVersion,
 		n.Origin,
 		n.Collector,
-		n.DocumentRef,
 	}, ":"))
 }
 

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5209,7 +5209,7 @@ extend type Query {
   CertifyLegal(certifyLegalSpec: CertifyLegalSpec!): [CertifyLegal!]!
   "Returns a paginated results via CertifyLegalConnection"
   CertifyLegalList(certifyLegalSpec: CertifyLegalSpec!, after: ID, first: Int): CertifyLegalConnection
-  "Batch queries via pkgVersion IDs to find all CertifyLegal (latest timestamp)"
+  "Batch queries via pkgVersion IDs to find all CertifyLegal"
   BatchQueryPkgIDCertifyLegal(pkgIDs: [ID!]!): [CertifyLegal!]!
 }
 
@@ -5704,7 +5704,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp, including any ` + "`" + `novuln` + "`" + `)"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns (including any ` + "`" + `novuln` + "`" + `)"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -128,7 +128,7 @@ extend type Query {
   CertifyLegal(certifyLegalSpec: CertifyLegalSpec!): [CertifyLegal!]!
   "Returns a paginated results via CertifyLegalConnection"
   CertifyLegalList(certifyLegalSpec: CertifyLegalSpec!, after: ID, first: Int): CertifyLegalConnection
-  "Batch queries via pkgVersion IDs to find all CertifyLegal (latest timestamp)"
+  "Batch queries via pkgVersion IDs to find all CertifyLegal"
   BatchQueryPkgIDCertifyLegal(pkgIDs: [ID!]!): [CertifyLegal!]!
 }
 

--- a/pkg/assembler/graphql/schema/certifyVuln.graphql
+++ b/pkg/assembler/graphql/schema/certifyVuln.graphql
@@ -129,7 +129,7 @@ extend type Query {
   CertifyVuln(certifyVulnSpec: CertifyVulnSpec!): [CertifyVuln!]!
   "Returns a paginated results via CertifyVulnConnection"
   CertifyVulnList(certifyVulnSpec: CertifyVulnSpec!, after: ID, first: Int): CertifyVulnConnection
-  "Batch queries via pkgVersion IDs to find all CertifyVulns (latest timestamp, including any `novuln`)"
+  "Batch queries via pkgVersion IDs to find all CertifyVulns (including any `novuln`)"
   BatchQueryPkgIDCertifyVuln(pkgIDs: [ID!]!): [CertifyVuln!]!
 }
 


### PR DESCRIPTION
# Description of the PR

fixes https://github.com/guacsec/guac/issues/2451

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
