### PR TITLE
update ent to fix release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v3.2.1
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
@@ -75,7 +75,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v3.2.1
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
@@ -98,7 +98,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v3.2.1
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: Install formatter
@@ -118,7 +118,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v5.3.0
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: golangci-lint
@@ -244,7 +244,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v3.2.1
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # tag=v3.2.1
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -75,12 +75,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guaccsub
     id: guaccsub
     binary: guaccsub-{{ .Os }}-{{ .Arch }}
@@ -91,12 +88,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacgql
     id: guacgql
     binary: guacgql-{{ .Os }}-{{ .Arch }}
@@ -107,12 +101,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacingest
     id: guacingest
     binary: guacingest-{{ .Os }}-{{ .Arch }}
@@ -123,12 +114,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacone
     id: guacone
     binary: guacone-{{ .Os }}-{{ .Arch }}
@@ -139,12 +127,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
 
 universal_binaries:
   - replace: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,12 +71,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guaccsub
     id: guaccsub
     binary: guaccsub-{{ .Os }}-{{ .Arch }}
@@ -88,12 +85,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacgql
     id: guacgql
     binary: guacgql-{{ .Os }}-{{ .Arch }}
@@ -105,12 +99,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacingest
     id: guacingest
     binary: guacingest-{{ .Os }}-{{ .Arch }}
@@ -122,12 +113,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacone
     id: guacone
     binary: guacone-{{ .Os }}-{{ .Arch }}
@@ -139,12 +127,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: windows
-        goarch: arm
   - main: ./cmd/guacrest
     id: guacrest
     binary: guacrest-{{ .Os }}-{{ .Arch }}
@@ -156,12 +141,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
     - goos: windows
       goarch: arm64
-    - goos: windows
-      goarch: arm
 
 universal_binaries:
   - replace: true

--- a/go.mod
+++ b/go.mod
@@ -290,7 +290,7 @@ require (
 require (
 	deps.dev/api/v3 v3.0.0-20250121055735-18bf0292bfe2
 	entgo.io/contrib v0.6.0
-	entgo.io/ent v0.14.3
+	entgo.io/ent v0.14.4
 	github.com/99designs/gqlgen v0.17.64
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/Khan/genqlient v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ deps.dev/util/semver v0.0.0-20241010035105-b3ba03369df1 h1:t4P0dCCNIrV84B5d7kOIA
 deps.dev/util/semver v0.0.0-20241010035105-b3ba03369df1/go.mod h1:jkcH+k02gWHBiZ7G4OnUOkSZ6WDq54Pt5DrOA8FN8Uo=
 entgo.io/contrib v0.6.0 h1:xfo4TbJE7sJZWx7BV7YrpSz7IPFvS8MzL3fnfzZjKvQ=
 entgo.io/contrib v0.6.0/go.mod h1:3qWIseJ/9Wx2Hu5zVh15FDzv7d/UvKNcYKdViywWCQg=
-entgo.io/ent v0.14.3 h1:wokAV/kIlH9TeklJWGGS7AYJdVckr0DloWjIcO9iIIQ=
-entgo.io/ent v0.14.3/go.mod h1:aDPE/OziPEu8+OWbzy4UlvWmD2/kbRuWfK2A40hcxJM=
+entgo.io/ent v0.14.4 h1:/DhDraSLXIkBhyiVoJeSshr4ZYi7femzhj6/TckzZuI=
+entgo.io/ent v0.14.4/go.mod h1:aDPE/OziPEu8+OWbzy4UlvWmD2/kbRuWfK2A40hcxJM=
 github.com/99designs/gqlgen v0.17.64 h1:BzpqO5ofQXyy2XOa93Q6fP1BHLRjTOeU35ovTEsbYlw=
 github.com/99designs/gqlgen v0.17.64/go.mod h1:kaxLetFxPGeBBwiuKk75NxuI1fe9HRvob17In74v/Zc=
 github.com/Azure/azure-amqp-common-go/v3 v3.2.3 h1:uDF62mbd9bypXWi19V1bN5NZEO84JqgmI5G73ibAmrk=

--- a/pkg/assembler/backends/ent/runtime/runtime.go
+++ b/pkg/assembler/backends/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/guacsec/guac/pkg/assembler/backends/ent/runtime.go
 
 const (
-	Version = "v0.14.3"                                         // Version of ent codegen.
-	Sum     = "h1:wokAV/kIlH9TeklJWGGS7AYJdVckr0DloWjIcO9iIIQ=" // Sum of ent codegen.
+	Version = "v0.14.4"                                         // Version of ent codegen.
+	Sum     = "h1:/DhDraSLXIkBhyiVoJeSshr4ZYi7femzhj6/TckzZuI=" // Sum of ent codegen.
 )


### PR DESCRIPTION
# Description of the PR

update ent to fix release workflow. Also, remove build for 32-bit ARM architecture as it causes build issues with ent.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
