### PR TITLE
fix golang coordinate to ensure valid coordinate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/mod v0.23.0
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 	golang.org/x/vuln v1.0.4 // indirect

--- a/pkg/misc/coordinates/coordinates.go
+++ b/pkg/misc/coordinates/coordinates.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	purl "github.com/package-url/packageurl-go"
+	"golang.org/x/mod/semver"
 )
 
 type Coordinate struct {
@@ -238,7 +239,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 			Provider:       pkg.Type,
 			Namespace:      emptyToHyphen(strings.ReplaceAll(pkg.Namespace, "/", "%2f")),
 			Name:           pkg.Name,
-			Revision:       "v" + pkg.Version,
+			Revision:       ensureSemverPrefixGolang(pkg.Version),
 		}, nil
 	case "maven":
 		// maven is a unique case where it can have 3 Providers
@@ -306,4 +307,19 @@ func emptyToHyphen(namespace string) string {
 	} else {
 		return namespace
 	}
+}
+
+// ensureSemverPrefixGolang checks if the version string is valid SemVer and ensures it starts with "v" for golang version
+func ensureSemverPrefixGolang(version string) string {
+	if semver.IsValid(version) {
+		return version
+	}
+
+	vPrefixed := "v" + version
+	if semver.IsValid(vPrefixed) {
+		return vPrefixed
+	}
+
+	// If not a valid SemVer, return as-is
+	return version
 }

--- a/pkg/misc/coordinates/coordinates_test.go
+++ b/pkg/misc/coordinates/coordinates_test.go
@@ -160,7 +160,8 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				Revision:       "244fd47e07d1004",
 			},
 			wantErr: false,
-		}, {
+		},
+		{
 			Name:    "golang",
 			purlUri: "pkg:golang/cloud.google.com/go/compute@1.23.0",
 			want: &Coordinate{
@@ -174,13 +175,25 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 		},
 		{
 			Name:    "golang",
+			purlUri: "pkg:golang/github.com/aws/aws-lambda-go@v1.46.0",
+			want: &Coordinate{
+				CoordinateType: "go",
+				Provider:       "golang",
+				Namespace:      "github.com%2faws",
+				Name:           "aws-lambda-go",
+				Revision:       "v1.46.0",
+			},
+			wantErr: false,
+		},
+		{
+			Name:    "golang",
 			purlUri: "pkg:golang/context@234fd47e07d1004f0aed9c#api",
 			want: &Coordinate{
 				CoordinateType: "go",
 				Provider:       "golang",
 				Namespace:      "-",
 				Name:           "context",
-				Revision:       "v234fd47e07d1004f0aed9c",
+				Revision:       "234fd47e07d1004f0aed9c",
 			},
 			wantErr: false,
 		}, {


### PR DESCRIPTION
# Description of the PR

fix golang coordinate to ensure valid coordinate. Perviously we were adding "v" to every version which is not valid.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
