### PR TITLE
Increase ClearlyDefined rate limit interval

### DIFF
--- a/pkg/certifier/clearlydefined/clearlydefined.go
+++ b/pkg/certifier/clearlydefined/clearlydefined.go
@@ -44,8 +44,12 @@ import (
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
-var rateLimit = 250
-var rateLimitInterval = 30 * time.Second
+
+// Rate limits: https://docs.clearlydefined.io/docs/get-involved/using-data#production-instance-rate-limits
+var (
+	rateLimit         = 250
+	rateLimitInterval = time.Minute / time.Duration(rateLimit)
+)
 
 const (
 	PRODUCER_ID string = "guacsec/guac"


### PR DESCRIPTION
- The interval should be 1m (not 30s) per their API docs.
- Fixes #2603

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
