### PR TITLE
Group golang dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "golang.org/x/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
 
   # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
# Description of the PR

This should reduce some CI pressure, at the risk of increasing the PR size under review.

For PRs that update graphql/atlas/any library that then requires changing generated code, we would need to run `make generate` on top of the large diff. But, even this should be less frequent now, since instead of having to do this for 1 PR that changes gql and 1 PR that changes atlas we can do both in the same PR. If the diff size becomes too large we could exclude these, just like we do with the golang/x ones.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
