### PR TITLE
Use separate caches for separate jobs.

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: ci
+name: ci-integration
 
 on:
   workflow_dispatch: # testing only, trigger manually to test it works
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: test-integration-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: Setup the project
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: tilt-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Setup the project
         run: go mod download
       - name: Setup kind cluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: test-unit-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: Setup the project

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This workflow requires a GitHub App to be registered and installed at the 
+# This workflow requires a GitHub App to be registered and installed at the
 # GitHub Org or personal account level which provides the permissions needed
-# to trigger nightly releases. See details at 
+# to trigger nightly releases. See details at
 # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow.
 # Note that the GitHub App must grant read/write permissions on Contents.
 # This is needed because the inbuilt GITHUB_TOKEN will not trigger a new workflow
@@ -31,13 +31,13 @@ on:
 
 env:
   NIGHTLY_RELEASE_TAG: v0-nightly   #goreleaser enforces semver on tags
-  # Note that the container tag (per .goreleaser-nightly.yaml) 
+  # Note that the container tag (per .goreleaser-nightly.yaml)
   # is simply 'nightly' without semver prefix
 
 jobs:
   refresh-nightly-tag:
     runs-on: ubuntu-latest
-    name: trigger nightly build 
+    name: trigger nightly build
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v3
@@ -59,25 +59,25 @@ jobs:
 
             const { owner, repo } = context.repo
 
-            try { 
+            try {
               console.log('Deleting release')
-              const { data: { id } } = await github.rest.repos.getReleaseByTag({ 
-                owner, 
-                repo, 
+              const { data: { id } } = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
                 tag: "${{ env.NIGHTLY_RELEASE_TAG }}"
               })
-              const result = await github.rest.repos.deleteRelease({ 
-                owner, 
-                repo, 
-                release_id: id 
+              const result = await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: id
               })
               console.log(result)
-            } catch (error) { 
+            } catch (error) {
               // ignore error in case release doesn't exist
               console.log(error)
             }
 
-            try { 
+            try {
               console.log('Deleting tag')
               const result = github.rest.git.deleteRef({
                 owner: owner,
@@ -89,10 +89,10 @@ jobs:
               // ignore error in case tag doesn't exist
               console.log(error)
             }
- 
+
             // sleep to make sure the delete ops above are propagated in github
             await new Promise(r => setTimeout(r, 3000));
-        
+
             console.log('Creating tag to trigger build')
             const result = github.rest.git.createRef({
               owner: owner,

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: test-integration-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Setup the project
         run: go mod download
       - name: Install atlas

--- a/.github/workflows/reusable-local-build.yaml
+++ b/.github/workflows/reusable-local-build.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: reusable-local-build 
+name: reusable-local-build
 
 on:
   workflow_call:
@@ -47,11 +47,11 @@ jobs:
       - run: |
           #!/usr/bin/env bash
           set -euo pipefail
-  
+
           # a hack to workaround docker context show being not available
           sed -i -E '/--builder/d' .goreleaser.yaml
           sed -i -E '/DOCKER_CONTEXT/d' Makefile
-          
+
           make build
           make build_local_container
           docker tag ghcr.io/${{ github.repository }}:v0.0.0-local-organic-guac-amd64 local-organic-guac


### PR DESCRIPTION
One source of flakiness has been that two jobs were trying to write in parallel to the same cache. For example, see https://github.com/guacsec/guac/actions/runs/15494281276/job/43627077205

```
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/guac/guac --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key Linux-go-52c2abdfac9cab9cf65cce1386a80e24b4b2703023a2d12448df68fff9968079, another job may be creating this cache.
```

With this PR, we create separate cache keys for jobs that run in parallel. These should not attempt to use the same cache.

The only time a cache gets reused across jobs is for the integration tests. This is because we have integration tests on PR and then integration tests post merge.

I cleaned out some whitespace errors while here and also ensured workflows have different names so they can be differentiated in the GitHub UI.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
