### PR TITLE
Sync `go-version` in GHA to the one in `go.mod`

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.2.1
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
@@ -87,7 +87,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
-        go-version: '~1.21'
+        go-version: '1.24'
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: '3.10'
@@ -175,7 +175,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.2.1
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.2.1
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
@@ -65,7 +65,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.2.1
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: Install formatter
@@ -86,7 +86,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v5.5.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: golangci-lint

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.2.1
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.21"
+          go-version: '1.24'
       - name: Install cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # main
       - name: Install syft


### PR DESCRIPTION
We're still seeing some flakyness in some jobs when trying to cache the output of `setup-go` action. This PR brings all versions in sync and if this still fails then the next step is to look into https://github.com/actions/setup-go/issues/403.
