### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -4,6 +4,7 @@
 
 ---
 project_name: guac
+version: 2
 
 env:
   - CGO_ENABLED=0
@@ -181,7 +182,7 @@ signs:
     output: true
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: "{{ .Binary }}"
     allow_different_binary_count: true
 
@@ -189,7 +190,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{ .ShortCommit }}
+  version_template: SNAPSHOT-{{ .ShortCommit }}
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 ---
 project_name: guac
+version: 2
 
 env:
   - CGO_ENABLED=0
@@ -195,7 +196,7 @@ signs:
     output: true
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: "{{ .Binary }}"
     allow_different_binary_count: true
 
@@ -203,7 +204,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{ .ShortCommit }}
+  version_template: SNAPSHOT-{{ .ShortCommit }}
 
 changelog:
   sort: asc


### PR DESCRIPTION
# Description of the PR
This small PR updates the GoReleaser configuration to resolve the following warning which you can find in the [CI logs](https://github.com/guacsec/guac/actions/runs/15643671950/job/44076714468#step:10:77): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
