### PR TITLE
move deps.dev test to integration

### DIFF
--- a/internal/client/depsdevclient/deps_dev_client_test.go
+++ b/internal/client/depsdevclient/deps_dev_client_test.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
+
 package depsdevclient
 
 import (


### PR DESCRIPTION
# Description of the PR

Move deps.dev tests to be marked as integration tests since it calls out to external deps.dev api service.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
