### PR TITLE
feat: adds custom scorecard certifier

### DIFF
--- a/cmd/guaccollect/cmd/scorecard.go
+++ b/cmd/guaccollect/cmd/scorecard.go
@@ -50,19 +50,28 @@ type scorecardOptions struct {
 	addedLatency *time.Duration
 	// sets the batch size for pagination query for the certifier
 	batchSize int
+	// scorecard fetcher type: "local" (default) or "api"
+	fetcherType string
+	// API base URL for API-based fetcher
+	apiBase string
+	// domain prefix for API-based fetcher
+	domainPrefix string
+	// HTTP timeout for API-based fetcher
+	httpTimeout time.Duration
 }
 
 var scorecardCmd = &cobra.Command{
 	Use:   "scorecard [flags]",
 	Short: "runs the scorecard certifier",
 	Long: `
-guaccollect scorecard runs the scorecard certifier queries scorecard for sources that are collected in guac.
-Ingestion to GUAC happens via an event stream (NATS)
-to allow for decoupling of the collectors from the ingestion into GUAC. 
+guaccollect scorecard runs the scorecard certifier to query scorecard data for sources that are collected in GUAC.
+
+Ingestion to GUAC happens via an event stream (NATS) to allow for decoupling of the collectors
+from the ingestion into GUAC.
 
 Each collector collects the "document" and stores it in the blob store for further
-evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via 
-the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for 
+evaluation. The collector creates a CDEvent (https://cdevents.dev/) that is published via
+the event stream. The downstream guacingest subscribes to the stream and retrieves the "document" from the blob store for
 processing and ingestion.
 
 Various blob stores can be used (such as S3, Azure Blob, Google Cloud Bucket) as documented here: https://gocloud.dev/howto/blob/
@@ -81,6 +90,10 @@ you have access to read and write to the respective blob store.`,
 			viper.GetBool("publish-to-queue"),
 			viper.GetString("certifier-latency"),
 			viper.GetInt("certifier-batch-size"),
+			viper.GetString("scorecard-fetcher-type"),
+			viper.GetString("scorecard-api-base"),
+			viper.GetString("scorecard-domain-prefix"),
+			viper.GetString("scorecard-http-timeout"),
 		)
 		if err != nil {
 			fmt.Printf("unable to validate flags: %v\n", err)
@@ -91,10 +104,28 @@ you have access to read and write to the respective blob store.`,
 		ctx := logging.WithLogger(context.Background())
 		logger := logging.FromContext(ctx)
 
-		// scorecard runner is the scorecard library that runs the scorecard checks
-		scorecardRunner, err := scorecard.NewScorecardRunner(ctx)
-		if err != nil {
-			fmt.Printf("unable to create scorecard runner: %v\n", err)
+		var scorecardRunner scorecard.Scorecard
+
+		// Create scorecard runner based on fetcher type
+		switch opts.fetcherType {
+		case "api":
+			logger.Infof("Using API-based scorecard fetcher with base URL: %s", opts.apiBase)
+			scorecardRunner, err = scorecard.NewAPIScorecardRunner(ctx, opts.apiBase, opts.domainPrefix, opts.httpTimeout)
+			if err != nil {
+				fmt.Printf("unable to create API scorecard runner: %v\n", err)
+				_ = cmd.Help()
+				os.Exit(1)
+			}
+		case "local":
+			logger.Info("Using local scorecard library runner")
+			scorecardRunner, err = scorecard.NewScorecardRunner(ctx)
+			if err != nil {
+				fmt.Printf("unable to create local scorecard runner: %v\n", err)
+				_ = cmd.Help()
+				os.Exit(1)
+			}
+		default:
+			fmt.Printf("invalid scorecard-fetcher-type: %s. Must be 'local' or 'api'\n", opts.fetcherType)
 			_ = cmd.Help()
 			os.Exit(1)
 		}
@@ -136,7 +167,11 @@ func validateScorecardFlags(
 	poll bool,
 	pubToQueue bool,
 	certifierLatencyStr string,
-	batchSize int) (scorecardOptions, error) {
+	batchSize int,
+	fetcherType,
+	apiBase,
+	domainPrefix,
+	httpTimeoutStr string) (scorecardOptions, error) {
 
 	var opts scorecardOptions
 
@@ -146,6 +181,7 @@ func validateScorecardFlags(
 	opts.blobAddr = blobAddr
 	opts.poll = poll
 	opts.publishToQueue = pubToQueue
+	opts.batchSize = batchSize
 
 	i, err := time.ParseDuration(interval)
 	if err != nil {
@@ -163,7 +199,39 @@ func validateScorecardFlags(
 		opts.addedLatency = nil
 	}
 
-	opts.batchSize = batchSize
+	// Validate and set fetcher type
+	if fetcherType == "" {
+		fetcherType = "api" // default to api
+	}
+	if fetcherType != "local" && fetcherType != "api" {
+		return opts, fmt.Errorf("invalid scorecard-fetcher-type: %s. Must be 'local' or 'api'", fetcherType)
+	}
+	opts.fetcherType = fetcherType
+
+	// Set API-specific options
+	if apiBase == "" {
+		apiBase = "https://api.securityscorecards.dev"
+	}
+	opts.apiBase = apiBase
+
+	if domainPrefix == "" {
+		domainPrefix = "github.com"
+	}
+	opts.domainPrefix = domainPrefix
+
+	if httpTimeoutStr == "" {
+		httpTimeoutStr = "30s"
+	}
+	httpTimeout, err := time.ParseDuration(httpTimeoutStr)
+	if err != nil {
+		return opts, fmt.Errorf("failed to parse HTTP timeout duration with error: %w", err)
+	}
+	opts.httpTimeout = httpTimeout
+
+	// Validate API-specific requirements
+	if fetcherType == "api" && apiBase == "" {
+		return opts, fmt.Errorf("scorecard-api-base is required when using API fetcher")
+	}
 
 	return opts, nil
 }
@@ -177,7 +245,18 @@ func init() {
 		os.Exit(1)
 	}
 	scorecardCmd.PersistentFlags().AddFlagSet(set)
+
+	// Add scorecard-specific flags
+	scorecardCmd.Flags().String("scorecard-fetcher-type", "api", "Scorecard fetcher type: 'api' (default, uses REST API) or 'local' (uses scorecard library)")
+	scorecardCmd.Flags().String("scorecard-api-base", "https://api.securityscorecards.dev", "Base URL for scorecard API when using 'api' fetcher type")
+	scorecardCmd.Flags().String("scorecard-domain-prefix", "github.com", "Domain prefix for repository URLs when using 'api' fetcher type")
+	scorecardCmd.Flags().String("scorecard-http-timeout", "30s", "HTTP timeout for API requests when using 'api' fetcher type")
+
 	if err := viper.BindPFlags(scorecardCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlags(scorecardCmd.Flags()); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
 		os.Exit(1)
 	}

--- a/internal/testing/mocks/scorecard.go
+++ b/internal/testing/mocks/scorecard.go
@@ -54,3 +54,17 @@ func (mr *MockScorecardMockRecorder) GetScore(repoName, commitSHA, tag any) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScore", reflect.TypeOf((*MockScorecard)(nil).GetScore), repoName, commitSHA, tag)
 }
+
+// RequiresGitHubToken mocks base method.
+func (m *MockScorecard) RequiresGitHubToken() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequiresGitHubToken")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RequiresGitHubToken indicates an expected call of RequiresGitHubToken.
+func (mr *MockScorecardMockRecorder) RequiresGitHubToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiresGitHubToken", reflect.TypeOf((*MockScorecard)(nil).RequiresGitHubToken))
+}

--- a/pkg/certifier/scorecard/apiFetcher.go
+++ b/pkg/certifier/scorecard/apiFetcher.go
@@ -1,0 +1,215 @@
+//
+// Copyright the GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ossf/scorecard/v4/checker"
+	sc "github.com/ossf/scorecard/v4/pkg"
+)
+
+// apiScorecardRunner implements the Scorecard interface using REST API calls
+// instead of the local scorecard library
+type apiScorecardRunner struct {
+	ctx          context.Context
+	httpClient   *http.Client
+	apiBase      string
+	domainPrefix string
+}
+
+// ScorecardAPIResponse represents the structure returned by the OpenSSF Scorecard API
+type ScorecardAPIResponse struct {
+	Date  string  `json:"date"`
+	Score float64 `json:"score"`
+	Repo  *struct {
+		Name string `json:"name"`
+	} `json:"repo"`
+	Scorecard *struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	} `json:"scorecard"`
+	Checks []struct {
+		Name   string  `json:"name"`
+		Score  float64 `json:"score"`
+		Reason string  `json:"reason"`
+	} `json:"checks"`
+}
+
+// GetScore fetches scorecard data from the REST API instead of running scorecard locally
+func (a apiScorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error) {
+	// Normalize the repository name for API call
+	url := a.buildAPIURL(repoName)
+
+	resp, err := a.makeAPIRequest(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch scorecard from API: %w", err)
+	}
+
+	// Convert API response to ScorecardResult format
+	result, err := a.convertAPIResponseToScorecardResult(resp, repoName, commitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert API response: %w", err)
+	}
+
+	return result, nil
+}
+
+// RequiresGitHubToken returns false for API scorecard runner as it doesn't need GitHub authentication
+func (a apiScorecardRunner) RequiresGitHubToken() bool {
+	return false
+}
+
+// buildAPIURL constructs the OpenSSF Scorecard API URL for the given repository
+func (a apiScorecardRunner) buildAPIURL(repoName string) string {
+	// Handle different repository URL formats (e.g., github.com/owner/repo)
+	cleanRepo := strings.TrimPrefix(repoName, "https://")
+	cleanRepo = strings.TrimPrefix(cleanRepo, "http://")
+
+	// If the repo doesn't start with domain prefix, assume it's already in the right format
+	if !strings.HasPrefix(cleanRepo, a.domainPrefix+"/") {
+		cleanRepo = a.domainPrefix + "/" + cleanRepo
+	}
+
+	return fmt.Sprintf("%s/projects/%s", strings.TrimSuffix(a.apiBase, "/"), cleanRepo)
+}
+
+// makeAPIRequest performs the HTTP request to the Scorecard API with retries
+func (a apiScorecardRunner) makeAPIRequest(url string) (*ScorecardAPIResponse, error) {
+	var lastErr error
+
+	// Retry up to 3 times with exponential backoff
+	for attempt := 1; attempt <= 3; attempt++ {
+		req, err := http.NewRequestWithContext(a.ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := a.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt*attempt) * time.Second)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("repository not found in scorecard database")
+		}
+
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(resp.Body)
+			lastErr = fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+			if resp.StatusCode >= 500 {
+				time.Sleep(time.Duration(attempt*attempt) * time.Second)
+				continue
+			}
+			return nil, lastErr
+		}
+
+		var apiResp ScorecardAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			return nil, fmt.Errorf("failed to decode API response: %w", err)
+		}
+
+		return &apiResp, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown error after %d attempts", 3)
+	}
+	return nil, lastErr
+}
+
+// convertAPIResponseToScorecardResult converts the API response to the expected ScorecardResult format
+func (a apiScorecardRunner) convertAPIResponseToScorecardResult(apiResp *ScorecardAPIResponse, repoName, commitSHA string) (*sc.ScorecardResult, error) {
+	result := &sc.ScorecardResult{
+		Repo: sc.RepoInfo{
+			Name:      repoName,
+			CommitSHA: commitSHA,
+		},
+		Scorecard: sc.ScorecardInfo{
+			Version:   a.getVersionFromAPI(apiResp),
+			CommitSHA: a.getCommitFromAPI(apiResp),
+		},
+		Date:   a.parseDateFromAPI(apiResp),
+		Checks: make([]checker.CheckResult, len(apiResp.Checks)),
+	}
+
+	// Convert individual checks
+	for i, check := range apiResp.Checks {
+		result.Checks[i] = checker.CheckResult{
+			Name:   check.Name,
+			Score:  int(check.Score),
+			Reason: check.Reason,
+		}
+	}
+
+	return result, nil
+}
+
+func (a apiScorecardRunner) getVersionFromAPI(resp *ScorecardAPIResponse) string {
+	if resp.Scorecard != nil && resp.Scorecard.Version != "" {
+		return resp.Scorecard.Version
+	}
+	return ""
+}
+
+func (a apiScorecardRunner) getCommitFromAPI(resp *ScorecardAPIResponse) string {
+	if resp.Scorecard != nil && resp.Scorecard.Commit != "" {
+		return resp.Scorecard.Commit
+	}
+	return ""
+}
+
+func (a apiScorecardRunner) parseDateFromAPI(resp *ScorecardAPIResponse) time.Time {
+	if resp.Date != "" {
+		if t, err := time.Parse("2006-01-02", resp.Date); err == nil {
+			return t
+		}
+	}
+	return time.Now()
+}
+
+// NewAPIScorecardRunner creates a new API-based scorecard runner
+func NewAPIScorecardRunner(ctx context.Context, apiBase, domainPrefix string, timeout time.Duration) (Scorecard, error) {
+	if apiBase == "" {
+		apiBase = "https://api.securityscorecards.dev"
+	}
+	if domainPrefix == "" {
+		domainPrefix = "github.com"
+	}
+
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+
+	return &apiScorecardRunner{
+		ctx:          ctx,
+		httpClient:   httpClient,
+		apiBase:      apiBase,
+		domainPrefix: domainPrefix,
+	}, nil
+}

--- a/pkg/certifier/scorecard/apiFetcher_test.go
+++ b/pkg/certifier/scorecard/apiFetcher_test.go
@@ -1,0 +1,219 @@
+//
+// Copyright the GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIScorecardRunner_GetScore(t *testing.T) {
+	// Mock API response
+	mockResponse := ScorecardAPIResponse{
+		Date:  "2024-01-15",
+		Score: 7.5,
+		Repo: &struct {
+			Name string `json:"name"`
+		}{
+			Name: "kubernetes/kubernetes",
+		},
+		Scorecard: &struct {
+			Version string `json:"version"`
+			Commit  string `json:"commit"`
+		}{
+			Version: "v4.13.0",
+			Commit:  "abcd1234",
+		},
+		Checks: []struct {
+			Name   string  `json:"name"`
+			Score  float64 `json:"score"`
+			Reason string  `json:"reason"`
+		}{
+			{
+				Name:   "Binary-Artifacts",
+				Score:  10,
+				Reason: "no binaries found in the repo",
+			},
+			{
+				Name:   "Branch-Protection",
+				Score:  8,
+				Reason: "branch protection is enabled",
+			},
+		},
+	}
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/projects/github.com/kubernetes/kubernetes")
+		assert.Equal(t, "guac-scorecard-certifier/1.0", r.Header.Get("User-Agent"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(mockResponse)
+	}))
+	defer server.Close()
+
+	// Create API scorecard runner
+	ctx := context.Background()
+	runner, err := NewAPIScorecardRunner(ctx, server.URL, "github.com", 30*time.Second)
+	require.NoError(t, err)
+
+	// Test GetScore
+	result, err := runner.GetScore("kubernetes/kubernetes", "main", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify result
+	assert.Equal(t, "kubernetes/kubernetes", result.Repo.Name)
+	assert.Equal(t, "main", result.Repo.CommitSHA)
+	assert.Equal(t, "v4.13.0", result.Scorecard.Version)
+	assert.Equal(t, "abcd1234", result.Scorecard.CommitSHA)
+	assert.Len(t, result.Checks, 2)
+
+	// Verify individual checks
+	assert.Equal(t, "Binary-Artifacts", result.Checks[0].Name)
+	assert.Equal(t, 10, result.Checks[0].Score)
+	assert.Equal(t, "no binaries found in the repo", result.Checks[0].Reason)
+
+	assert.Equal(t, "Branch-Protection", result.Checks[1].Name)
+	assert.Equal(t, 8, result.Checks[1].Score)
+	assert.Equal(t, "branch protection is enabled", result.Checks[1].Reason)
+}
+
+func TestAPIScorecardRunner_HandleErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError string
+	}{
+		{
+			name:          "Not Found",
+			statusCode:    404,
+			responseBody:  `{"error": "repository not found"}`,
+			expectedError: "repository not found in scorecard database",
+		},
+		{
+			name:          "Bad Request",
+			statusCode:    400,
+			responseBody:  `{"error": "invalid request"}`,
+			expectedError: "API returned status 400",
+		},
+		{
+			name:          "Server Error",
+			statusCode:    500,
+			responseBody:  `{"error": "internal server error"}`,
+			expectedError: "API returned status 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			runner, err := NewAPIScorecardRunner(ctx, server.URL, "github.com", 30*time.Second)
+			require.NoError(t, err)
+
+			_, err = runner.GetScore("test/repo", "main", "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+func TestAPIScorecardRunner_URLBuilding(t *testing.T) {
+	tests := []struct {
+		name         string
+		repoName     string
+		apiBase      string
+		domainPrefix string
+		expectedPath string
+	}{
+		{
+			name:         "Standard repo",
+			repoName:     "kubernetes/kubernetes",
+			apiBase:      "https://api.example.com",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+		{
+			name:         "Repo with https prefix",
+			repoName:     "https://github.com/kubernetes/kubernetes",
+			apiBase:      "https://api.example.com",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+		{
+			name:         "Repo already prefixed",
+			repoName:     "github.com/kubernetes/kubernetes",
+			apiBase:      "https://api.example.com",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.expectedPath, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"date":"2024-01-01","score":5,"checks":[]}`))
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			runner, err := NewAPIScorecardRunner(ctx, server.URL, tt.domainPrefix, 30*time.Second)
+			require.NoError(t, err)
+
+			_, err = runner.GetScore(tt.repoName, "main", "")
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewAPIScorecardRunner_DefaultValues(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with empty values (should use defaults)
+	runner, err := NewAPIScorecardRunner(ctx, "", "", 0)
+	require.NoError(t, err)
+
+	apiRunner := runner.(*apiScorecardRunner)
+	assert.Equal(t, "https://api.securityscorecards.dev", apiRunner.apiBase)
+	assert.Equal(t, "github.com", apiRunner.domainPrefix)
+	assert.Equal(t, time.Duration(0), apiRunner.httpClient.Timeout)
+
+	// Test with custom values
+	runner, err = NewAPIScorecardRunner(ctx, "https://custom.api.com", "gitlab.com", 60*time.Second)
+	require.NoError(t, err)
+
+	apiRunner = runner.(*apiScorecardRunner)
+	assert.Equal(t, "https://custom.api.com", apiRunner.apiBase)
+	assert.Equal(t, "gitlab.com", apiRunner.domainPrefix)
+	assert.Equal(t, 60*time.Second, apiRunner.httpClient.Timeout)
+}

--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -100,21 +100,26 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 }
 
 // NewScorecardCertifier initializes the scorecard certifier.
-// It checks if the GITHUB_AUTH_TOKEN is set in the environment. If it is not, it returns an error.w
+// It checks if the GITHUB_AUTH_TOKEN is set in the environment only for local scorecard runners.
 // The token is used to access the GitHub API, https://github.com/ossf/scorecard#authentication.
 func NewScorecardCertifier(sc Scorecard) (certifier.Certifier, error) {
 	if sc == nil {
 		return nil, fmt.Errorf("scorecard cannot be nil")
 	}
 
-	// check if the GITHUB_AUTH_TOKEN is set
-	s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
-	if !ok || s == "" {
-		return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+	var ghToken string
+	
+	// Only check for GITHUB_AUTH_TOKEN if the scorecard implementation requires it
+	if sc.RequiresGitHubToken() {
+		s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
+		if !ok || s == "" {
+			return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+		}
+		ghToken = s
 	}
 
 	return &scorecard{
 		scorecard: sc,
-		ghToken:   s,
+		ghToken:   ghToken,
 	}, nil
 }

--- a/pkg/certifier/scorecard/scorecardRunner.go
+++ b/pkg/certifier/scorecard/scorecardRunner.go
@@ -90,6 +90,11 @@ func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.Scorecar
 	return &res, nil
 }
 
+// RequiresGitHubToken returns true for local scorecard runner as it needs GitHub authentication
+func (s scorecardRunner) RequiresGitHubToken() bool {
+	return true
+}
+
 func NewScorecardRunner(ctx context.Context) (Scorecard, error) {
 	return scorecardRunner{
 		ctx,

--- a/pkg/certifier/scorecard/types.go
+++ b/pkg/certifier/scorecard/types.go
@@ -22,4 +22,5 @@ import (
 // Scorecard is an interface for the scorecard library. This can also be mocked for testing.
 type Scorecard interface {
 	GetScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error)
+	RequiresGitHubToken() bool
 }


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
This PR adds an API-based scorecard fetcher as an alternative to local scorecard execution, solving GitHub rate limiting issues for large-scale GUAC deployments. New API fetcher uses OpenSSF Scorecard REST API instead of using the scorecard package. Added `--scorecard-fetcher-type` flag to choose between "api" (default) or "local". API fetcher requires no GitHub tokens, thus eliminating the GitHub rate limiting issues. 

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #2783 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
