### PR TITLE
fix: vulnerability is not getting ingested

### DIFF
--- a/pkg/ingestor/parser/vuln/score.go
+++ b/pkg/ingestor/parser/vuln/score.go
@@ -2,8 +2,8 @@ package vuln
 
 import (
 	"strconv"
+	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/clients/generated"
 	attestation_vuln "github.com/guacsec/guac/pkg/certifier/attestation/vuln"
 	gocvss20 "github.com/pandatix/go-cvss/20"
 	gocvss30 "github.com/pandatix/go-cvss/30"
@@ -13,27 +13,27 @@ import (
 
 func parseScoreBasedOnMethod(severity attestation_vuln.Severity) (float64, error) {
 	score := severity.Score
-	switch severity.Method {
+	switch {
 	// TODO: match for other score types
-	case string(generated.VulnerabilityScoreTypeCvssv2):
+	case strings.HasPrefix(score, "CVSS:2.0"):
 		vector, err := gocvss20.ParseVector(score)
 		if err != nil {
 			return 0, err
 		}
 		return vector.BaseScore(), nil
-	case string(generated.VulnerabilityScoreTypeCvssv3):
+	case strings.HasPrefix(score, "CVSS:3.0"):
 		vector, err := gocvss30.ParseVector(score)
 		if err != nil {
 			return 0, err
 		}
 		return vector.BaseScore(), nil
-	case string(generated.VulnerabilityScoreTypeCvssv31):
+	case strings.HasPrefix(score, "CVSS:3.1"):
 		vector, err := gocvss31.ParseVector(score)
 		if err != nil {
 			return 0, err
 		}
 		return vector.BaseScore(), nil
-	case string(generated.VulnerabilityScoreTypeCvssv4):
+	case strings.HasPrefix(score, "CVSS:4.0"):
 		vector, err := gocvss40.ParseVector(score)
 		if err != nil {
 			return 0, err

--- a/pkg/ingestor/parser/vuln/vuln.go
+++ b/pkg/ingestor/parser/vuln/vuln.go
@@ -32,7 +32,6 @@ package vuln
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -153,11 +152,11 @@ func parseVulns(_ context.Context, s *attestation_vuln.VulnerabilityStatement) (
 		}
 		ivs = append(ivs, iv)
 
-		var severityErrors error
 		for _, severity := range res.Severity {
 			score, err := parseScoreBasedOnMethod(severity)
 			if err != nil {
-				severityErrors = errors.Join(fmt.Errorf("parsing severity score failed for method %s: %w", severity.Method, err))
+				// TODO: log it as Ward/Info log which severity failed to parse and why
+				continue
 			}
 			vmi = append(vmi, assembler.VulnMetadataIngest{
 				Vulnerability: vuln,
@@ -166,9 +165,6 @@ func parseVulns(_ context.Context, s *attestation_vuln.VulnerabilityStatement) (
 					ScoreValue: score,
 				},
 			})
-		}
-		if severityErrors != nil {
-			return nil, nil, nil, severityErrors
 		}
 	}
 	return vs, ivs, vmi, nil


### PR DESCRIPTION
when you enable --add-vuln-metadata flag for osv certifier, it is encountering issues when parsing socre due to score menthod mismatch between the supplied value from OSV and the actual score in case of CVSS socres. Also there are unsupported socre types like "ubuntu". All these results in score parsing error which results in entire vulnerability being skipped from ingestion, instead more correct thing to do might be to ingest atleast the vulnerability id and whichever scores are successfully parsed and log the warning massages for unsupported scores. fixes #2751

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
