### PR TITLE
feat: adds query and compute modes to scorecard certifer

### DIFF
--- a/internal/testing/mocks/scorecard.go
+++ b/internal/testing/mocks/scorecard.go
@@ -54,3 +54,17 @@ func (mr *MockScorecardMockRecorder) GetScore(repoName, commitSHA, tag any) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScore", reflect.TypeOf((*MockScorecard)(nil).GetScore), repoName, commitSHA, tag)
 }
+
+// RequiresGitHubToken mocks base method.
+func (m *MockScorecard) RequiresGitHubToken() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequiresGitHubToken")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RequiresGitHubToken indicates an expected call of RequiresGitHubToken.
+func (mr *MockScorecardMockRecorder) RequiresGitHubToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiresGitHubToken", reflect.TypeOf((*MockScorecard)(nil).RequiresGitHubToken))
+}

--- a/pkg/certifier/scorecard/queryScorecardRunner.go
+++ b/pkg/certifier/scorecard/queryScorecardRunner.go
@@ -1,0 +1,235 @@
+//
+// Copyright the GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ossf/scorecard/v4/checker"
+	sc "github.com/ossf/scorecard/v4/pkg"
+
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+// queryScorecardRunner implements the Scorecard interface using REST API calls
+// for query mode (instead of computing scores locally)
+type queryScorecardRunner struct {
+	ctx          context.Context
+	httpClient   *http.Client
+	apiBase      string
+	domainPrefix string
+}
+
+// ScorecardAPIResponse represents the structure returned by the OpenSSF Scorecard API
+type ScorecardAPIResponse struct {
+	Date  string  `json:"date"`
+	Score float64 `json:"score"`
+	Repo  *struct {
+		Name string `json:"name"`
+	} `json:"repo"`
+	Scorecard *struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	} `json:"scorecard"`
+	Checks []struct {
+		Name   string  `json:"name"`
+		Score  float64 `json:"score"`
+		Reason string  `json:"reason"`
+	} `json:"checks"`
+}
+
+// GetScore fetches scorecard data from the REST API instead of running scorecard locally
+func (q queryScorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error) {
+	// Normalize the repository name for API call
+	url := q.buildAPIURL(repoName)
+
+	resp, err := q.makeAPIRequest(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch scorecard from API for the repo: %s: %w", repoName, err)
+	}
+
+	// Convert API response to ScorecardResult format
+	result, err := q.convertAPIResponseToScorecardResult(resp, repoName, commitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert API response: %w", err)
+	}
+
+	return result, nil
+}
+
+// RequiresGitHubToken returns false for query mode as it doesn't need GitHub authentication
+func (q queryScorecardRunner) RequiresGitHubToken() bool {
+	return false
+}
+
+// buildAPIURL constructs the OpenSSF Scorecard API URL for the given repository
+func (q queryScorecardRunner) buildAPIURL(repoName string) string {
+	// Handle different repository URL formats (e.g., github.com/owner/repo)
+	cleanRepo := strings.TrimPrefix(repoName, "https://")
+	cleanRepo = strings.TrimPrefix(cleanRepo, "http://")
+
+	// Decode URL encoding
+	if decoded, err := url.QueryUnescape(cleanRepo); err == nil {
+		cleanRepo = decoded
+	}
+
+	// Add domain prefix if not already present
+	if !strings.HasPrefix(cleanRepo, q.domainPrefix+"/") {
+		cleanRepo = q.domainPrefix + "/" + cleanRepo
+	}
+
+	return fmt.Sprintf("%s/projects/%s", strings.TrimSuffix(q.apiBase, "/"), cleanRepo)
+}
+
+// makeAPIRequest performs the HTTP request to the Scorecard API with retries
+func (q queryScorecardRunner) makeAPIRequest(url string) (*ScorecardAPIResponse, error) {
+	var lastErr error
+
+	// Retry up to 3 times with exponential backoff
+	for attempt := 1; attempt <= 3; attempt++ {
+		req, err := http.NewRequestWithContext(q.ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := q.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt*attempt) * time.Second)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			if err := resp.Body.Close(); err != nil {
+				logging.FromContext(q.ctx).Debugf("error closing response body: %v", err)
+			}
+			return nil, fmt.Errorf("repository not found in scorecard database")
+		}
+
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(resp.Body)
+			if err := resp.Body.Close(); err != nil {
+				logging.FromContext(q.ctx).Debugf("error closing response body: %v", err)
+			}
+			lastErr = fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+			if resp.StatusCode >= 500 {
+				time.Sleep(time.Duration(attempt*attempt) * time.Second)
+				continue
+			}
+			return nil, lastErr
+		}
+
+		var apiResp ScorecardAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			if err = resp.Body.Close(); err != nil {
+				logging.FromContext(q.ctx).Debugf("error closing response body after decode failure: %v", err)
+			}
+			return nil, fmt.Errorf("failed to decode API response: %w", err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			logging.FromContext(q.ctx).Debugf("error closing response body after success: %v", err)
+		}
+
+		return &apiResp, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown error after %d attempts", 3)
+	}
+	return nil, lastErr
+}
+
+// convertAPIResponseToScorecardResult converts the API response to the expected ScorecardResult format
+func (q queryScorecardRunner) convertAPIResponseToScorecardResult(apiResp *ScorecardAPIResponse, repoName, commitSHA string) (*sc.ScorecardResult, error) {
+	result := &sc.ScorecardResult{
+		Repo: sc.RepoInfo{
+			Name:      repoName,
+			CommitSHA: commitSHA,
+		},
+		Scorecard: sc.ScorecardInfo{
+			Version:   q.getVersionFromAPI(apiResp),
+			CommitSHA: q.getCommitFromAPI(apiResp),
+		},
+		Date:   q.parseDateFromAPI(apiResp),
+		Checks: make([]checker.CheckResult, len(apiResp.Checks)),
+	}
+
+	// Convert individual checks
+	for i, check := range apiResp.Checks {
+		result.Checks[i] = checker.CheckResult{
+			Name:   check.Name,
+			Score:  int(check.Score),
+			Reason: check.Reason,
+		}
+	}
+
+	return result, nil
+}
+
+func (q queryScorecardRunner) getVersionFromAPI(resp *ScorecardAPIResponse) string {
+	if resp.Scorecard != nil && resp.Scorecard.Version != "" {
+		return resp.Scorecard.Version
+	}
+	return ""
+}
+
+func (q queryScorecardRunner) getCommitFromAPI(resp *ScorecardAPIResponse) string {
+	if resp.Scorecard != nil && resp.Scorecard.Commit != "" {
+		return resp.Scorecard.Commit
+	}
+	return ""
+}
+
+func (q queryScorecardRunner) parseDateFromAPI(resp *ScorecardAPIResponse) time.Time {
+	if resp.Date != "" {
+		if t, err := time.Parse("2006-01-02", resp.Date); err == nil {
+			return t
+		}
+	}
+	return time.Now()
+}
+
+// NewQueryScorecardRunner creates a new query mode scorecard runner that uses the REST API
+func NewQueryScorecardRunner(ctx context.Context, apiBase, domainPrefix string, timeout time.Duration) (Scorecard, error) {
+	// Set default values if not provided
+	if apiBase == "" {
+		apiBase = "https://api.securityscorecards.dev"
+	}
+	if domainPrefix == "" {
+		domainPrefix = "github.com"
+	}
+
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+
+	return &queryScorecardRunner{
+		ctx:          ctx,
+		httpClient:   httpClient,
+		apiBase:      apiBase,
+		domainPrefix: domainPrefix,
+	}, nil
+}

--- a/pkg/certifier/scorecard/queryScorecardRunner_test.go
+++ b/pkg/certifier/scorecard/queryScorecardRunner_test.go
@@ -1,0 +1,225 @@
+//
+// Copyright the GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryScorecardRunner_GetScore(t *testing.T) {
+	// Mock API response
+	mockResponse := ScorecardAPIResponse{
+		Date:  "2024-01-15",
+		Score: 7.5,
+		Repo: &struct {
+			Name string `json:"name"`
+		}{
+			Name: "kubernetes/kubernetes",
+		},
+		Scorecard: &struct {
+			Version string `json:"version"`
+			Commit  string `json:"commit"`
+		}{
+			Version: "v4.13.0",
+			Commit:  "abcd1234",
+		},
+		Checks: []struct {
+			Name   string  `json:"name"`
+			Score  float64 `json:"score"`
+			Reason string  `json:"reason"`
+		}{
+			{
+				Name:   "Binary-Artifacts",
+				Score:  10,
+				Reason: "no binaries found in the repo",
+			},
+			{
+				Name:   "Branch-Protection",
+				Score:  8,
+				Reason: "branch protection is enabled",
+			},
+		},
+	}
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/projects/github.com/kubernetes/kubernetes")
+		assert.Equal(t, "guac-scorecard-certifier/1.0", r.Header.Get("User-Agent"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(mockResponse); err != nil {
+			t.Fatalf("failed to encode mock response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// Create query scorecard runner
+	ctx := context.Background()
+	runner, err := NewQueryScorecardRunner(ctx, server.URL, "github.com", 30*time.Second)
+	require.NoError(t, err)
+
+	// Test GetScore
+	result, err := runner.GetScore("kubernetes/kubernetes", "main", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify result
+	assert.Equal(t, "kubernetes/kubernetes", result.Repo.Name)
+	assert.Equal(t, "main", result.Repo.CommitSHA)
+	assert.Equal(t, "v4.13.0", result.Scorecard.Version)
+	assert.Equal(t, "abcd1234", result.Scorecard.CommitSHA)
+	assert.Len(t, result.Checks, 2)
+
+	// Verify individual checks
+	assert.Equal(t, "Binary-Artifacts", result.Checks[0].Name)
+	assert.Equal(t, 10, result.Checks[0].Score)
+	assert.Equal(t, "no binaries found in the repo", result.Checks[0].Reason)
+
+	assert.Equal(t, "Branch-Protection", result.Checks[1].Name)
+	assert.Equal(t, 8, result.Checks[1].Score)
+	assert.Equal(t, "branch protection is enabled", result.Checks[1].Reason)
+}
+
+func TestQueryScorecardRunner_HandleErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError string
+	}{
+		{
+			name:          "Not Found",
+			statusCode:    404,
+			responseBody:  `{"error": "repository not found"}`,
+			expectedError: "repository not found in scorecard database",
+		},
+		{
+			name:          "Bad Request",
+			statusCode:    400,
+			responseBody:  `{"error": "invalid request"}`,
+			expectedError: "API returned status 400",
+		},
+		{
+			name:          "Server Error",
+			statusCode:    500,
+			responseBody:  `{"error": "internal server error"}`,
+			expectedError: "API returned status 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if _, err := w.Write([]byte(tt.responseBody)); err != nil {
+					t.Fatalf("failed to write mock error response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			runner, err := NewQueryScorecardRunner(ctx, server.URL, "github.com", 30*time.Second)
+			require.NoError(t, err)
+
+			_, err = runner.GetScore("test/repo", "main", "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+func TestQueryScorecardRunner_URLBuilding(t *testing.T) {
+	tests := []struct {
+		name         string
+		repoName     string
+		apiBase      string
+		domainPrefix string
+		expectedPath string
+	}{
+		{
+			name:         "Standard repo",
+			repoName:     "kubernetes/kubernetes",
+			apiBase:      "https://api.securityscorecards.dev",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+		{
+			name:         "Repo with https prefix",
+			repoName:     "https://github.com/kubernetes/kubernetes",
+			apiBase:      "https://api.securityscorecards.dev",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+		{
+			name:         "Repo already prefixed",
+			repoName:     "github.com/kubernetes/kubernetes",
+			apiBase:      "https://api.securityscorecards.dev",
+			domainPrefix: "github.com",
+			expectedPath: "/projects/github.com/kubernetes/kubernetes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.expectedPath, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := w.Write([]byte(`{"date":"2024-01-01","score":5,"checks":[]}`)); err != nil {
+					t.Fatalf("failed to write mock url-building response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			runner, err := NewQueryScorecardRunner(ctx, server.URL, tt.domainPrefix, 30*time.Second)
+			require.NoError(t, err)
+
+			_, err = runner.GetScore(tt.repoName, "main", "")
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewQueryScorecardRunner_DefaultValues(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with empty values (should use defaults)
+	runner, err := NewQueryScorecardRunner(ctx, "", "", 0)
+	require.NoError(t, err)
+
+	queryRunner := runner.(*queryScorecardRunner)
+	assert.Equal(t, "https://api.securityscorecards.dev", queryRunner.apiBase)
+	assert.Equal(t, "github.com", queryRunner.domainPrefix)
+	assert.Equal(t, time.Duration(0), queryRunner.httpClient.Timeout)
+
+	// Test with custom values
+	runner, err = NewQueryScorecardRunner(ctx, "https://custom.api.com", "gitlab.com", 60*time.Second)
+	require.NoError(t, err)
+
+	queryRunner = runner.(*queryScorecardRunner)
+	assert.Equal(t, "https://custom.api.com", queryRunner.apiBase)
+	assert.Equal(t, "gitlab.com", queryRunner.domainPrefix)
+	assert.Equal(t, 60*time.Second, queryRunner.httpClient.Timeout)
+}

--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -100,21 +100,26 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 }
 
 // NewScorecardCertifier initializes the scorecard certifier.
-// It checks if the GITHUB_AUTH_TOKEN is set in the environment. If it is not, it returns an error.w
+// It checks if the GITHUB_AUTH_TOKEN is set in the environment only for compute scorecard runners.
 // The token is used to access the GitHub API, https://github.com/ossf/scorecard#authentication.
 func NewScorecardCertifier(sc Scorecard) (certifier.Certifier, error) {
 	if sc == nil {
 		return nil, fmt.Errorf("scorecard cannot be nil")
 	}
 
-	// check if the GITHUB_AUTH_TOKEN is set
-	s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
-	if !ok || s == "" {
-		return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+	var ghToken string
+
+	// Only check for GITHUB_AUTH_TOKEN if the scorecard implementation requires it
+	if sc.RequiresGitHubToken() {
+		s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
+		if !ok || s == "" {
+			return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+		}
+		ghToken = s
 	}
 
 	return &scorecard{
 		scorecard: sc,
-		ghToken:   s,
+		ghToken:   ghToken,
 	}, nil
 }

--- a/pkg/certifier/scorecard/scorecardRunner.go
+++ b/pkg/certifier/scorecard/scorecardRunner.go
@@ -90,6 +90,11 @@ func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.Scorecar
 	return &res, nil
 }
 
+// RequiresGitHubToken returns true for compute scorecard runner as it needs GitHub authentication
+func (s scorecardRunner) RequiresGitHubToken() bool {
+	return true
+}
+
 func NewScorecardRunner(ctx context.Context) (Scorecard, error) {
 	return scorecardRunner{
 		ctx,

--- a/pkg/certifier/scorecard/scorecard_test.go
+++ b/pkg/certifier/scorecard/scorecard_test.go
@@ -30,10 +30,16 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type mockScorecard struct{}
+type mockScorecard struct {
+	requiresGitHubToken bool
+}
 
 func (m mockScorecard) GetScore(repoName, commitSHA, tag string) (*pkg.ScorecardResult, error) {
 	return &pkg.ScorecardResult{}, nil
+}
+
+func (m mockScorecard) RequiresGitHubToken() bool {
+	return m.requiresGitHubToken
 }
 
 func TestNewScorecard(t *testing.T) {
@@ -50,18 +56,32 @@ func TestNewScorecard(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:          "Auth token is set",
-			sc:            mockScorecard{},
-			want:          &scorecard{scorecard: mockScorecard{}, ghToken: "test"},
+			name:          "Auth token is set and required",
+			sc:            mockScorecard{requiresGitHubToken: true},
+			want:          &scorecard{scorecard: mockScorecard{requiresGitHubToken: true}, ghToken: "test"},
 			authToken:     "test",
 			wantAuthToken: true,
 		},
 		{
-			name:          "Auth token is empty",
-			sc:            mockScorecard{},
+			name:          "Auth token is empty but required",
+			sc:            mockScorecard{requiresGitHubToken: true},
 			authToken:     "",
 			wantAuthToken: true,
 			wantErr:       true,
+		},
+		{
+			name:          "Auth token not required (query mode)",
+			sc:            mockScorecard{requiresGitHubToken: false},
+			want:          &scorecard{scorecard: mockScorecard{requiresGitHubToken: false}, ghToken: ""},
+			authToken:     "",
+			wantAuthToken: false,
+		},
+		{
+			name:          "Auth token not required but provided (query mode)",
+			sc:            mockScorecard{requiresGitHubToken: false},
+			want:          &scorecard{scorecard: mockScorecard{requiresGitHubToken: false}, ghToken: ""},
+			authToken:     "test",
+			wantAuthToken: false,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/certifier/scorecard/types.go
+++ b/pkg/certifier/scorecard/types.go
@@ -22,4 +22,5 @@ import (
 // Scorecard is an interface for the scorecard library. This can also be mocked for testing.
 type Scorecard interface {
 	GetScore(repoName, commitSHA, tag string) (*sc.ScorecardResult, error)
+	RequiresGitHubToken() bool
 }


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->
This PR adds an API-based scorecard fetcher as an alternative to local scorecard execution, solving GitHub rate limiting issues for large-scale GUAC deployments. New API fetcher uses OpenSSF Scorecard REST API instead of using the scorecard package. Added --scorecard-fetcher-type flag to choose between "api" (default) or "local". API fetcher requires no GitHub tokens, thus eliminating the GitHub rate limiting issues.

Fixes https://github.com/guacsec/guac/issues/2783

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
