### PR TITLE
Add a user to the Dockerfile for ent migrations.

### DIFF
--- a/pkg/assembler/backends/ent/migrate/Dockerfile
+++ b/pkg/assembler/backends/ent/migrate/Dockerfile
@@ -10,7 +10,7 @@ COPY atlas.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Create non-root user and switch to it
-RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
# Description of the PR

This should solve the periodic warning from Kusari Inspector that the Dockerfile runs as root. It's a good security practice to not run as root (as the warning says), so let's do that.

I just added the suggestion from the AI...

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
