### PR TITLE
feat: adds custom scorecard certifier

### DIFF
--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -24,6 +24,7 @@ import (
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/components/source"
 	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/ossf/scorecard/v5/docs/checks"
 	"github.com/ossf/scorecard/v5/log"
 	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
@@ -111,7 +112,10 @@ func NewScorecardCertifier(sc Scorecard) (certifier.Certifier, error) {
 	// check if the GITHUB_AUTH_TOKEN is set
 	s, ok := os.LookupEnv("GITHUB_AUTH_TOKEN")
 	if !ok || s == "" {
-		return nil, fmt.Errorf("GITHUB_AUTH_TOKEN is not set")
+		// Log warning but allow initialization without token
+		// The API path will still work, only local computation will fail
+		logger := logging.FromContext(context.Background())
+		logger.Warnf("GITHUB_AUTH_TOKEN not set - scorecard API will work, but local computation fallback will be disabled")
 	}
 
 	return &scorecard{

--- a/pkg/certifier/scorecard/scorecard.go
+++ b/pkg/certifier/scorecard/scorecard.go
@@ -102,7 +102,8 @@ func (s scorecard) CertifyComponent(_ context.Context, rootComponent interface{}
 }
 
 // NewScorecardCertifier initializes the scorecard certifier.
-// It checks if the GITHUB_AUTH_TOKEN is set in the environment. If it is not, it returns an error.w
+// It checks if the GITHUB_AUTH_TOKEN is set in the environment. If it is not,
+// a warning is logged; the scorecard API path still works without the token.
 // The token is used to access the GitHub API, https://github.com/ossf/scorecard#authentication.
 func NewScorecardCertifier(sc Scorecard) (certifier.Certifier, error) {
 	if sc == nil {

--- a/pkg/certifier/scorecard/scorecardRunner.go
+++ b/pkg/certifier/scorecard/scorecardRunner.go
@@ -18,19 +18,148 @@ package scorecard
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 
+	"github.com/guacsec/guac/pkg/logging"
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/checks"
 	"github.com/ossf/scorecard/v5/log"
 	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
 )
 
+const githubPrefix = "github.com/"
+
 // scorecardRunner is a struct that implements the Scorecard interface.
 type scorecardRunner struct {
 	ctx context.Context
 }
 
+// normalizeRepoName ensures the repo name has the github.com/ prefix required by the Scorecard API.
+// Adds the prefix if it is missing; otherwise returns the repo name unchanged.
+func normalizeRepoName(repoName string) string {
+	if strings.HasPrefix(repoName, githubPrefix) {
+		return repoName
+	}
+	return githubPrefix + repoName
+}
+
 func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.Result, error) {
+	logger := logging.FromContext(s.ctx)
+	repoName = normalizeRepoName(repoName)
+
+	// First try API approach
+	logger.Debugf("Attempting to fetch scorecard from API for repo: %s, commit: %s", repoName, commitSHA)
+	result, err := s.getScoreFromAPI(repoName, commitSHA, tag)
+	if err == nil {
+		logger.Infof("Successfully fetched scorecard from API for repo: %s", repoName)
+		return result, nil
+	}
+
+	// Log API failure and check if we can fallback to local computation
+	logger.Warnf("API fetch failed for repo %s: %v", repoName, err)
+
+	// Check if GitHub token is available for local computation
+	if _, ok := os.LookupEnv("GITHUB_AUTH_TOKEN"); !ok {
+		logger.Errorf("Cannot fall back to local computation - GITHUB_AUTH_TOKEN not set")
+		return nil, fmt.Errorf("scorecard API failed and GITHUB_AUTH_TOKEN not available for local computation: %w", err)
+	}
+
+	logger.Infof("Falling back to local computation for repo: %s", repoName)
+	result, err = s.computeScore(repoName, commitSHA, tag)
+	if err != nil {
+		logger.Errorf("Failed to compute scorecard locally for repo %s: %v", repoName, err)
+	}
+	return result, err
+}
+
+func (s scorecardRunner) getScoreFromAPI(repoName, commitSHA, tag string) (*sc.Result, error) {
+	logger := logging.FromContext(s.ctx)
+
+	// If tag is provided without a valid commitSHA, skip API and use local computation
+	// The API cannot resolve tags, but computeScore can look up the commit for a tag
+	if (commitSHA == "" || commitSHA == "HEAD") && tag != "" {
+		logger.Debugf("Tag %s provided without commit SHA - skipping API, will use local computation", tag)
+		return nil, fmt.Errorf("tag provided without commit SHA; falling back to local computation for tag %s", tag)
+	}
+
+	baseURL, err := url.JoinPath("https://api.securityscorecards.dev", "projects", repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	// If commitSHA is provided, try with it first
+	if commitSHA != "" && commitSHA != "HEAD" {
+		urlWithCommit := baseURL + "?commit=" + commitSHA
+		result, err := s.fetchFromAPI(urlWithCommit)
+		if err == nil {
+			return result, nil
+		}
+		logger.Debugf("API call with commit %s failed, retrying without commit: %v", commitSHA, err)
+	}
+
+	result, err := s.fetchFromAPI(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s scorecardRunner) fetchFromAPI(apiURL string) (*sc.Result, error) {
+	logger := logging.FromContext(s.ctx)
+	logger.Debugf("Making API request to: %s", apiURL)
+
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scorecard request failed: %w", err)
+	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	logger.Debugf("API response status code: %d", resp.StatusCode)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("scorecard not found in API")
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Use scorecard's built-in JSON parser, which is experimental
+	// but still better then rolling out your own type
+	result, _, err := sc.ExperimentalFromJSON2(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode API response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (s scorecardRunner) computeScore(repoName, commitSHA, tag string) (*sc.Result, error) {
+	logger := logging.FromContext(s.ctx)
+	logger.Infof("Starting local scorecard computation for repo: %s, commit: %s, tag: %s", repoName, commitSHA, tag)
+
 	// Can't use guacs standard logger because scorecard uses a different logger.
 	defaultLogger := log.NewLogger(log.DefaultLevel)
 	repo, repoClient, ossFuzzClient, ciiClient, vulnsClient, _, err := checker.GetClients(s.ctx, repoName, "", defaultLogger)
@@ -88,10 +217,12 @@ func (s scorecardRunner) GetScore(repoName, commitSHA, tag string) (*sc.Result, 
 		sc.WithVulnerabilitiesClient(vulnsClient),
 	}
 
+	logger.Debugf("Running %d scorecard checks locally", len(checkNames))
 	res, err := sc.Run(s.ctx, repo, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error, failed to run scorecard: %w", err)
 	}
+
 	if res.Repo.Name == "" {
 		// The commit SHA can be invalid or the repo can be private.
 		return nil, fmt.Errorf("error, failed to get scorecard data for repo %v, commit SHA %v", res.Repo.Name, commitSHA)

--- a/pkg/certifier/scorecard/scorecardRunner.go
+++ b/pkg/certifier/scorecard/scorecardRunner.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +33,17 @@ import (
 	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
 )
 
-const githubPrefix = "github.com/"
+const (
+	githubPrefix = "github.com/"
+	maxRetries   = 3
+)
+
+// Retry backoff for the scorecard API. The scorecard API is rate-limited,
+// so an exponential backoff retry is implemented on 429 and 5xx responses
+var (
+	initialRetryBackoff = 1 * time.Second
+	maxRetryBackoff     = 30 * time.Second
+)
 
 // scorecardRunner is a struct that implements the Scorecard interface.
 type scorecardRunner struct {
@@ -117,22 +128,12 @@ func (s scorecardRunner) fetchFromAPI(apiURL string) (*sc.Result, error) {
 		Timeout: 30 * time.Second,
 	}
 
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, apiURL, nil)
+	resp, err := s.requestWithRetry(httpClient, apiURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("scorecard request failed: %w", err)
+		return nil, err
 	}
 	defer func() {
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
+		_ = resp.Body.Close()
 	}()
 
 	logger.Debugf("API response status code: %d", resp.StatusCode)
@@ -156,6 +157,81 @@ func (s scorecardRunner) fetchFromAPI(apiURL string) (*sc.Result, error) {
 	return &result, nil
 }
 
+// requestWithRetry makes a GET against the scorecard API and retries on 429 and 5xx responses
+// with exponential backoff, honoring Retry-After when the server provides it.
+func (s scorecardRunner) requestWithRetry(client *http.Client, apiURL string) (*http.Response, error) {
+	logger := logging.FromContext(s.ctx)
+	backoff := initialRetryBackoff
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, apiURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("User-Agent", "guac-scorecard-certifier/1.0")
+		req.Header.Set("Accept", "application/json")
+
+		resp, requestError := client.Do(req)
+		if requestError == nil && !isRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+
+		wait := backoff
+		if requestError != nil {
+			lastErr = requestError
+		} else {
+			lastErr = fmt.Errorf("scorecard API returned retryable status %d", resp.StatusCode)
+			if ra, ok := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
+				wait = ra
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+
+		if attempt == maxRetries {
+			break
+		}
+
+		logger.Warnf("scorecard API request failed (attempt %d/%d), retrying in %s: %v",
+			attempt+1, maxRetries+1, wait, lastErr)
+
+		select {
+		case <-s.ctx.Done():
+			return nil, s.ctx.Err()
+		case <-time.After(wait):
+		}
+
+		backoff = min(backoff*2, maxRetryBackoff)
+	}
+
+	return nil, fmt.Errorf("scorecard request failed after %d attempts: %w", maxRetries+1, lastErr)
+}
+
+func isRetryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || (code >= 500 && code <= 599)
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value, which per RFC 7231
+// is either a delay in seconds or an HTTP-date.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		d := t.Sub(now)
+		if d <= 0 {
+			return 0, true
+		}
+		return d, true
+	}
+	return 0, false
+}
+
 func (s scorecardRunner) computeScore(repoName, commitSHA, tag string) (*sc.Result, error) {
 	logger := logging.FromContext(s.ctx)
 	logger.Infof("Starting local scorecard computation for repo: %s, commit: %s, tag: %s", repoName, commitSHA, tag)
@@ -163,7 +239,6 @@ func (s scorecardRunner) computeScore(repoName, commitSHA, tag string) (*sc.Resu
 	// Can't use guacs standard logger because scorecard uses a different logger.
 	defaultLogger := log.NewLogger(log.DefaultLevel)
 	repo, repoClient, ossFuzzClient, ciiClient, vulnsClient, _, err := checker.GetClients(s.ctx, repoName, "", defaultLogger)
-
 	if err != nil {
 		return nil, fmt.Errorf("error, failed to get clients: %w", err)
 	}
@@ -197,7 +272,6 @@ func (s scorecardRunner) computeScore(repoName, commitSHA, tag string) (*sc.Resu
 		releases, err := repoClient.ListReleases()
 		if err != nil {
 			return nil, fmt.Errorf("error, failed to run releases: %w", err)
-
 		}
 
 		for _, release := range releases {

--- a/pkg/certifier/scorecard/scorecardRunner_test.go
+++ b/pkg/certifier/scorecard/scorecardRunner_test.go
@@ -19,9 +19,14 @@ package scorecard
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func Test_scorecardRunner_GetScore(t *testing.T) {
@@ -144,5 +149,203 @@ func Test_scorecardRunner_getScoreFromAPI(t *testing.T) {
 				t.Logf("Successfully fetched scorecard for %s", got.Repo.Name)
 			}
 		})
+	}
+}
+
+func withShorterRetries(t *testing.T) {
+	t.Helper()
+	origInitial := initialRetryBackoff
+	origMax := maxRetryBackoff
+	initialRetryBackoff = 1 * time.Millisecond
+	maxRetryBackoff = 5 * time.Millisecond
+	t.Cleanup(func() {
+		initialRetryBackoff = origInitial
+		maxRetryBackoff = origMax
+	})
+}
+
+func TestRequestWithRetry_RetriesOn5xxThenSucceeds(t *testing.T) {
+	withShorterRetries(t)
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	runner := scorecardRunner{ctx: context.Background()}
+	resp, err := runner.requestWithRetry(srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("requestWithRetry returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got, want := calls.Load(), int32(3); got != want {
+		t.Errorf("call count = %d, want %d", got, want)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRequestWithRetry_RetriesOn429ThenSucceeds(t *testing.T) {
+	withShorterRetries(t)
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	runner := scorecardRunner{ctx: context.Background()}
+	resp, err := runner.requestWithRetry(srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("requestWithRetry returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d", got, want)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRequestWithRetry_ExhaustsAndReturnsError(t *testing.T) {
+	withShorterRetries(t)
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	runner := scorecardRunner{ctx: context.Background()}
+	resp, err := runner.requestWithRetry(srv.Client(), srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+
+	if got, want := calls.Load(), int32(maxRetries+1); got != want {
+		t.Errorf("call count = %d, want %d (one initial + maxRetries)", got, want)
+	}
+}
+
+func TestRequestWithRetry_DoesNotRetryOn4xx(t *testing.T) {
+	withShorterRetries(t)
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	runner := scorecardRunner{ctx: context.Background()}
+	resp, err := runner.requestWithRetry(srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("requestWithRetry returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("call count = %d, want 1 (no retry on 4xx)", got)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestRequestWithRetry_HonorsRetryAfterSeconds(t *testing.T) {
+	withShorterRetries(t)
+
+	const retryAfterSecs = 1
+	var calls atomic.Int32
+	var firstAt, secondAt time.Time
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			firstAt = time.Now()
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfterSecs))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		secondAt = time.Now()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	runner := scorecardRunner{ctx: context.Background()}
+	resp, err := runner.requestWithRetry(srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("requestWithRetry returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Gap between calls should be at least the Retry-After value. We subtract
+	// a small tolerance because timers aren't exact.
+	gap := secondAt.Sub(firstAt)
+	if gap < (retryAfterSecs*time.Second)-100*time.Millisecond {
+		t.Errorf("second call fired after %s, expected >= %ds (Retry-After)", gap, retryAfterSecs)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		value  string
+		want   time.Duration
+		wantOK bool
+	}{
+		{name: "empty", value: "", want: 0, wantOK: false},
+		{name: "seconds", value: "5", want: 5 * time.Second, wantOK: true},
+		{name: "zero seconds", value: "0", want: 0, wantOK: true},
+		{name: "negative rejected", value: "-1", want: 0, wantOK: false},
+		{name: "http-date future", value: now.Add(30 * time.Second).UTC().Format(http.TimeFormat), want: 30 * time.Second, wantOK: true},
+		{name: "http-date past", value: now.Add(-10 * time.Second).UTC().Format(http.TimeFormat), want: 0, wantOK: true},
+		{name: "garbage", value: "not-a-header", want: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tt.value, now)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("duration = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	retryable := []int{429, 500, 502, 503, 504, 599}
+	nonRetryable := []int{200, 301, 400, 401, 403, 404, 499}
+
+	for _, code := range retryable {
+		if !isRetryableStatus(code) {
+			t.Errorf("isRetryableStatus(%d) = false, want true", code)
+		}
+	}
+	for _, code := range nonRetryable {
+		if isRetryableStatus(code) {
+			t.Errorf("isRetryableStatus(%d) = true, want false", code)
+		}
 	}
 }

--- a/pkg/certifier/scorecard/scorecard_test.go
+++ b/pkg/certifier/scorecard/scorecard_test.go
@@ -61,7 +61,8 @@ func TestNewScorecard(t *testing.T) {
 			sc:            mockScorecard{},
 			authToken:     "",
 			wantAuthToken: true,
-			wantErr:       true,
+			wantErr:       false,
+			want:          &scorecard{scorecard: mockScorecard{}, ghToken: ""},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #2783

# Description of the PR

See comment https://github.com/guacsec/guac/pull/2815#issuecomment-3753670486

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
