### PR TITLE
Fix failing CI by removing the atlas lint step since Atlas lint command is no longer free

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,5 +98,3 @@ jobs:
         run: make format
       - name: Check that all linted text is up to date
         run: make generated_up_to_date
-      - name: Run atlas Lint
-        run: make atlas-lint

--- a/README.md
+++ b/README.md
@@ -144,6 +144,3 @@ GUAC-Maintainers@lists.openssf.org.
 
 Information about governance, including the project charter, can be found in the
 [guacsec/governance repo](https://github.com/guacsec/governance).
-
-
-...minor change to test CI


### PR DESCRIPTION
# Description of the PR

Fix failing CI by removing the atlas lint step since Atlas lint command is no longer free.

https://github.com/guacsec/guac/actions/runs/19710930044/job/56471042582?pr=2820

FYI @irenaliu18


# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] If GraphQL schema is changed, `make generate` has been run
- [x] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [x] If OpenAPI spec is changed, `make generate` has been run
- [x] If ent schema is changed, `make generate` has been run
- [x] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
