### PR TITLE
fix(ci): update unit testing for new findings

### DIFF
--- a/internal/testing/testdata/exampledata/certify-vuln.json
+++ b/internal/testing/testdata/exampledata/certify-vuln.json
@@ -25,6 +25,8 @@
         }, {
             "id": "GHSA-p6xc-xr62-6r2g"
         }, {
+            "id": "GHSA-vc5p-v9hr-52mj"
+        }, {
             "id": "GHSA-vwqq-5vrc-xw9h"
         }]
     },

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2269,6 +2269,9 @@ var (
 					"id":"GHSA-p6xc-xr62-6r2g"
 				 },
 				 {
+					"id":"GHSA-vc5p-v9hr-52mj"
+				 },
+				 {
 					"id":"GHSA-vwqq-5vrc-xw9h"
 				 }
 			  ]

--- a/pkg/ingestor/parser/common/scanner/scanner_test.go
+++ b/pkg/ingestor/parser/common/scanner/scanner_test.go
@@ -161,6 +161,27 @@ func TestPurlsToScan(t *testing.T) {
 				},
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "osv_certifier",
+					Collector:      "osv_certifier",
+					DocumentRef:    "sha256_daeea32fb48a532d48ce7a549b7e0cdf98eb6df80869c3b6d3ec21174b015d14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
 					VulnerabilityID: "ghsa-vwqq-5vrc-xw9h",
 				},
 				VulnData: &generated.ScanMetadataInput{
@@ -262,6 +283,22 @@ func TestPurlsToScan(t *testing.T) {
 				EqualVulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "ghsa",
 					VulnerabilityID: "ghsa-p6xc-xr62-6r2g",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+					Origin:        "osv_certifier",
+					Collector:     "osv_certifier",
+					DocumentRef:   "sha256_daeea32fb48a532d48ce7a549b7e0cdf98eb6df80869c3b6d3ec21174b015d14",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
 				},
 				VulnEqual: &generated.VulnEqualInputSpec{
 					Justification: "Decoded OSV data",

--- a/pkg/ingestor/parser/vuln/vuln_test.go
+++ b/pkg/ingestor/parser/vuln/vuln_test.go
@@ -155,6 +155,24 @@ func TestParser(t *testing.T) {
 				},
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
 					VulnerabilityID: "ghsa-vwqq-5vrc-xw9h",
 				},
 				VulnData: &generated.ScanMetadataInput{
@@ -238,6 +256,19 @@ func TestParser(t *testing.T) {
 				EqualVulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "ghsa",
 					VulnerabilityID: "ghsa-p6xc-xr62-6r2g",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
 				},
 				VulnEqual: &generated.VulnEqualInputSpec{
 					Justification: "Decoded OSV data",


### PR DESCRIPTION
# Description of the PR

This fixes unit tests failing on main. Currently a query is made to the live OSV.dev api which returns data. It looks like it is returning a new vulnerability since the tests were last updated - this is a quick fix for the new vulnerability. There is certainly merit in looking for another strategy that won't break in the future - this is targeted at restoring the baseline.

No associated issue but I can create one if interested

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
