### PR TITLE
fix: handle empty source_names gracefully in scorecard

### DIFF
--- a/pkg/certifier/components/source/source.go
+++ b/pkg/certifier/components/source/source.go
@@ -58,6 +58,12 @@ func (s sourceQuery) GetComponents(ctx context.Context, compChan chan<- interfac
 		if err != nil {
 			return fmt.Errorf("failed to query packages with error: %w", err)
 		}
+
+		// handle nil response or empty SourcesList when table is empty
+		if srcConn == nil || srcConn.SourcesList == nil {
+			break
+		}
+
 		srcEdges := srcConn.SourcesList.Edges
 
 		for _, srcNode := range srcEdges {


### PR DESCRIPTION
# Description of the PR

Fixes #2833 

Scorecard fails when the `source_names` table is empty. As a result of which, when a pod runs to execute the scorecard command, it errors out with a panic after the GUAC stack is deployed, since `source_names` table is empty during the startup. The pod also enters the `CrashLoopBackOff` error.

This change ensures that the scorecard doesn't panic when the `source_names` table is empty. This change is done in order to keep the behaviour of all the certifiers (cd, osv, scorecard) the same. (i.e, not panic when the commands are run on an empty DB)


# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
