### PR TITLE
fix: free up disk space in ubuntu runner to resolve no disk space issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,11 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # main
       - name: Install syft
         uses: anchore/sbom-action/download-syft@aa0e114b2e19480f157109b9922bda359bd98b90 # v0.20.8
-
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/boost
       - name: Run GoReleaser Snapshot
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: run-goreleaser-snapshot


### PR DESCRIPTION
# Description of the PR

Fixes #2832 

GitHub Actions’ ubuntu-latest runners come with a huge set of preinstalled languages and SDKs — and that’s by design to support many ecosystems.  Pure Go projects don’t use most of these preinstalled SDKs. 

Approximate Disk Space Freed by deleting the following preinstallations:
```
/usr/share/dotnet           ~1.2-2.0 GB
/usr/local/lib/android      ~8-12 GB
/usr/local/share/boost      ~1.5-2.5 GB
```

In the open source community, it is observed that the ubuntu runner upgrades break sometimes due to the `no diskspace issue` since the size of preinstalled languages and other dependencies varies from version to version. One popular approach to resolve this issue is to remove the bulky preinstallations which the project doesn't use. This PR would solve the `no diskspace issue` in the release pipeline.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
