### PR TITLE
fix: use bundle as signature in goreleaser to resolve cosign failure

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -168,16 +168,12 @@ sboms:
 signs:
   - id: guac-cosign-keyless
     artifacts: checksum
-    signature: "${artifact}-keyless.sig"
-    certificate: "${artifact}-keyless.pem"
+    signature: "${artifact}.bundle"
     cmd: cosign
     args:
       - "sign-blob"
+      - "--bundle=${signature}"
       - "--yes"
-      - "--output-signature"
-      - "${artifact}-keyless.sig"
-      - "--output-certificate"
-      - "${artifact}-keyless.pem"
       - "${artifact}"
     output: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -182,16 +182,12 @@ sboms:
 signs:
   - id: guac-cosign-keyless
     artifacts: checksum
-    signature: "${artifact}-keyless.sig"
-    certificate: "${artifact}-keyless.pem"
+    signature: "${artifact}.bundle"
     cmd: cosign
     args:
       - "sign-blob"
+      - "--bundle=${signature}"
       - "--yes"
-      - "--output-signature"
-      - "${artifact}-keyless.sig"
-      - "--output-certificate"
-      - "${artifact}-keyless.pem"
       - "${artifact}"
     output: true
 


### PR DESCRIPTION
# Description of the PR

Fixes #2831 

Recent versions of cosign require the use of a bundle when performing keyless signing. The existing code is no longer supported for keyless signing. Have updated the cosign signing configuration to use a bundle-based output, which is the recommended and supported approach for keyless signing.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
