### PR TITLE
fix: increase TiKV file descriptor limit to resolve failure in integration tests

### DIFF
--- a/internal/testing/backend/docker-compose.yaml
+++ b/internal/testing/backend/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       - --data-dir=/data
     restart: on-failure
     healthcheck:
-      test: [ "CMD", "curl", "-f", "127.0.0.1:2379/pd/api/v1/stores"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:2379/pd/api/v1/stores"]
       interval: 10s
       timeout: 10s
       retries: 3
@@ -74,6 +74,10 @@ services:
       - tikv_guac_data:/data
     ports:
       - "20160:20160"
+    ulimits:
+      nofile:
+        soft: 90000
+        hard: 90000
     command:
       - --addr=0.0.0.0:20160
       - --advertise-addr=127.0.0.1:20160


### PR DESCRIPTION
# Description of the PR

Fixes #2841 

TiKV requires atleast ~80000 file descriptors but was only getting the default 65,536, causing it to fail on startup with a FATAL error. This prevented the TiKV cluster from bootstrapping properly.

Currently the `ci-integration` workflow on this PR would fail because the test update in #2830 is not merged yet. Post merging that fix, we would get the error mentioned in #2841. Merging this PR would resolve that issue as well, and the test pipelines will run without any issues.

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
