### PR TITLE
fix: added content read permissions to the top level

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -29,6 +29,9 @@ on:
   # schedule:
   #   - cron: '44 4 * * *'   #UTC
 
+permissions:
+  contents: read
+
 env:
   NIGHTLY_RELEASE_TAG: v0-nightly   #goreleaser enforces semver on tags
   # Note that the container tag (per .goreleaser-nightly.yaml)


### PR DESCRIPTION
# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

Fixes #2845 

Adding this top level permission `content: read` will increase the score of the token permissions from 0 to 10. 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
