### PR TITLE
Update Go to 1.25.0 throughout the repository

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v3.2.1
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/go/pkg/mod
@@ -87,7 +87,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
       with:
-        go-version: '1.24'
+        go-version: '1.25.0'
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: '3.10'
@@ -175,7 +175,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v3.2.1
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v3.2.1
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/go/pkg/mod
@@ -65,7 +65,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v3.2.1
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: Install formatter
@@ -86,7 +86,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v6.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - name: Install atlas
         uses: ariga/setup-atlas@d52cd13fed38eca914fa57071155a4644fd6f820 # v0.2
       - name: golangci-lint

--- a/.github/workflows/postmerge.yaml
+++ b/.github/workflows/postmerge.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # tag=v3.2.1
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # main
       - name: Install syft

--- a/dockerfiles/Dockerfile.guac-cont
+++ b/dockerfiles/Dockerfile.guac-cont
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.19 as builder
+FROM docker.io/library/golang:1.25.0 as builder
 WORKDIR /go/src/github.com/guacsec/guac/
 ADD . /go/src/github.com/guacsec/guac/
 RUN --mount=type=cache,target=/go/pkg/mod make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/guacsec/guac
 
-go 1.24.1
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.57.0

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ mkShell {
     docker-compose
     jq  
     gcc
-    go_1_21
+    go_1_25
     golangci-lint
     gopls
     gotests


### PR DESCRIPTION
# Description of the PR

Generated by Jules

- Updated go.mod to use go 1.25.0
- Updated GitHub Actions workflows to use go-version 1.25.0
- Updated Dockerfile.guac-cont to use golang:1.25.0 builder
- Updated shell.nix to use go_1_25