### PR TITLE
fix: update predicateType to v0.2 in vulnerability attestations

### DIFF
--- a/internal/testing/testdata/exampledata/certify-novuln-v02.json
+++ b/internal/testing/testdata/exampledata/certify-novuln-v02.json
@@ -1,0 +1,20 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+      {
+        "uri": "pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1",
+        "digest": {"sha256": "3a2bd2c5cc4c978e8aefd8bd0ef335fb42ee31d1"}
+      }
+  ],
+  "predicateType": "https://in-toto.io/attestation/vulns/v0.2",
+  "predicate": {
+    "scanner": {
+      "uri": "osv.dev",
+      "version": "0.0.14"
+    },
+    "metadata": {
+      "scanStartedOn": "2022-11-21T17:45:50.52Z",
+      "scanFinishedOn": "2022-11-21T17:45:50.52Z"
+    }
+  }
+}

--- a/internal/testing/testdata/exampledata/certify-vuln-v02.json
+++ b/internal/testing/testdata/exampledata/certify-vuln-v02.json
@@ -1,0 +1,38 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "uri": "pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1"
+    }
+  ],
+  "predicateType": "https://in-toto.io/attestation/vulns/v0.2",
+  "predicate": {
+    "scanner": {
+      "uri": "osv.dev",
+      "version": "0.0.14",
+      "result": [{
+            "id": "GHSA-7rjr-3q55-vv33",
+            "severity": [{
+                "method": "CVSSv31",
+                "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+            }]
+        }, {
+            "id": "GHSA-8489-44mv-ggj8"
+        }, {
+            "id": "GHSA-fxph-q3j8-mv87"
+        }, {
+            "id": "GHSA-jfh8-c2jp-5v3q"
+        }, {
+            "id": "GHSA-p6xc-xr62-6r2g"
+        }, {
+            "id": "GHSA-vc5p-v9hr-52mj"
+        }, {
+            "id": "GHSA-vwqq-5vrc-xw9h"
+        }]
+    },
+    "metadata": {
+      "scanStartedOn": "2022-11-21T17:45:50.52Z",
+      "scanFinishedOn": "2022-11-21T17:45:50.52Z"
+    }
+  }
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -141,6 +141,9 @@ var (
 	//go:embed exampledata/certify-vuln.json
 	ITE6VulnExample []byte
 
+	//go:embed exampledata/certify-vuln-v02.json
+	ITE6VulnV02Example []byte
+
 	//go:embed exampledata/cd-log4j.json
 	ITE6CDLog4j []byte
 
@@ -155,6 +158,9 @@ var (
 
 	//go:embed exampledata/certify-novuln.json
 	ITE6NoVulnExample []byte
+
+	//go:embed exampledata/certify-novuln-v02.json
+	ITE6NoVulnV02Example []byte
 
 	//go:embed exampledata/oci-kubectl-linux-amd64-in-toto.json
 	OCIKubectlLinuxAMD64ITE6 []byte
@@ -2283,6 +2289,115 @@ var (
 		}
 	 }`
 
+	Text4ShellVulAttestationV02 = `{
+		"type":"https://in-toto.io/Statement/v1",
+		"subject":[
+		   {
+			  "uri":"pkg:maven/org.apache.commons/commons-text@1.9"
+		   }
+		],
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.2",
+		"predicate":{
+		   "scanner":{
+			  "uri":"osv.dev",
+			  "version":"0.0.14",
+			  "db":{
+			  },
+			  "result":[
+				 {
+					"id":"GHSA-599f-7c49-w659"
+				 }
+			  ]
+		   },
+		   "metadata":{
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+                          "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+		   }
+		}
+	 }`
+	SecondLevelVulAttestationV02 = `{
+		"type":"https://in-toto.io/Statement/v1",
+		"subject":[
+		   {
+			  "uri":"pkg:oci/vul-secondLevel-latest?repository_url=gcr.io"
+		   }
+		],
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.2",
+		"predicate":{
+		   "scanner": {
+			"uri": "osv.dev",
+			"version": "0.0.14"
+		   },
+		   "metadata":{
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+		   }
+		}
+	 }`
+	RootVulAttestationV02 = `{
+		"type":"https://in-toto.io/Statement/v1",
+		"subject":[
+		   {
+			  "uri":"pkg:oci/vul-image-latest?repository_url=gcr.io"
+		   }
+		],
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.2",
+		"predicate":{
+		   "scanner": {
+			"uri": "osv.dev",
+			"version": "0.0.14"
+		   },
+		   "metadata":{
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+		   }
+		}
+	 }`
+	Log4JVulAttestationV02 = `{
+		"type":"https://in-toto.io/Statement/v1",
+		"subject":[
+		   {
+			  "uri":"pkg:maven/org.apache.logging.log4j/log4j-core@2.8.1"
+		   }
+		],
+		"predicate_type":"https://in-toto.io/attestation/vulns/v0.2",
+		"predicate":{
+		   "scanner":{
+			  "uri":"osv.dev",
+			  "version":"0.0.14",
+			  "db":{
+			  },
+			  "result":[
+				 {
+					"id":"GHSA-7rjr-3q55-vv33"
+				 },
+				 {
+					"id":"GHSA-8489-44mv-ggj8"
+				 },
+				 {
+					"id":"GHSA-fxph-q3j8-mv87"
+				 },
+				 {
+					"id":"GHSA-jfh8-c2jp-5v3q"
+				 },
+				 {
+					"id":"GHSA-p6xc-xr62-6r2g"
+				 },
+				 {
+					"id":"GHSA-vc5p-v9hr-52mj"
+				 },
+				 {
+					"id":"GHSA-vwqq-5vrc-xw9h"
+				 }
+			  ]
+		   },
+		   "metadata":{
+			  "scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+			  "scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+		   }
+		}
+	 }`
+
 	RootPackage = root_package.PackageNode{
 		Purl: "pkg:oci/vul-image-latest?repository_url=gcr.io",
 	}
@@ -2413,6 +2528,126 @@ var (
 		    }
 		  ],
 		  "predicate_type": "https://in-toto.io/attestation/vulns/v0.1",
+		  "predicate": {
+		    "scanner": {
+		      "uri": "osv.dev",
+		      "version": "0.0.14",
+		      "db": {},
+		      "result": [
+			{
+			  "id": "GHSA-45p5-v273-3qqr"
+			},
+			{
+			  "id": "GHSA-53jx-vvf9-4x38"
+			},
+			{
+			  "id": "GHSA-h5fg-jpgr-rv9c"
+			}
+		      ]
+		    },
+		    "metadata": {
+		      "scanStartedOn": "2025-12-01T15:19:40.545851224Z",
+		      "scanFinishedOn": "2025-12-01T15:19:40.545851224Z"
+		    }
+		  }
+		}`
+
+	VertxWebCommonAttestationV02 = `{
+		"type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"uri": "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar"
+			}
+		],
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.2",
+		"predicate": {
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14"
+			},
+			"metadata": {
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+			}
+		}
+	}`
+
+	VertxAuthCommonAttestationV02 = `{
+		"type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"uri": "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar"
+			}
+		],
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.2",
+		"predicate": {
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14"
+			},
+			"metadata": {
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+			}
+		}
+	}`
+
+	VertxBridgeCommonAttestationV02 = `{
+		"type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"uri": "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar"
+			}
+		],
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.2",
+		"predicate": {
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14"
+			},
+			"metadata": {
+				"scanStartedOn":"2022-11-22T13:19:18.825699-05:00",
+				"scanFinishedOn":"2022-11-22T13:19:18.825699-05:00"
+			}
+		}
+	}`
+
+	VertxCoreCommonAttestationV02 = `{
+		"type": "https://in-toto.io/Statement/v1",
+		"subject": [
+			{
+				"uri": "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+			}
+		],
+		"predicate_type": "https://in-toto.io/attestation/vulns/v0.2",
+		"predicate": {
+			"scanner": {
+				"uri": "osv.dev",
+				"version": "0.0.14",
+				"result": [
+					{
+						"id": "GHSA-9ph3-v2vh-3qx7"
+					},
+					{
+						"id":"GHSA-cphf-4846-3xx9"
+					}
+				]
+			},
+			"metadata": {
+				"scanStartedOn":"2026-02-09T15:58:30.797127394Z",
+				"scanFinishedOn":"2026-02-09T15:58:30.797127394Z"
+			}
+		}
+	}`
+
+	VertxWebAttestationV02 = `{
+		  "type": "https://in-toto.io/Statement/v1",
+		  "subject": [
+		    {
+		      "uri": "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar"
+		    }
+		  ],
+		  "predicate_type": "https://in-toto.io/attestation/vulns/v0.2",
 		  "predicate": {
 		    "scanner": {
 		      "uri": "osv.dev",

--- a/pkg/certifier/attestation/vuln/attestation_vuln.go
+++ b/pkg/certifier/attestation/vuln/attestation_vuln.go
@@ -27,7 +27,8 @@ import (
 // Currently, the predicate is defined here but the intention is to upstream this to
 // https://github.com/in-toto/attestation in the near future once the quirks are worked out.
 const (
-	PredicateVuln = "https://in-toto.io/attestation/vulns/v0.1"
+	PredicateVuln   = "https://in-toto.io/attestation/vulns/v0.1"
+	PredicateVulnV2 = "https://in-toto.io/attestation/vulns/v0.2"
 )
 
 // VulnerabilityStatement defines the statement header and the vulnerability predicate

--- a/pkg/certifier/certify/certify_test.go
+++ b/pkg/certifier/certify/certify_test.go
@@ -82,7 +82,7 @@ func TestCertify(t *testing.T) {
 		query: newMockQuery(),
 		want: []*processor.Document{
 			{
-				Blob:   []byte(testdata.Text4ShellVulAttestation),
+				Blob:   []byte(testdata.Text4ShellVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -91,7 +91,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.SecondLevelVulAttestation),
+				Blob:   []byte(testdata.SecondLevelVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -100,7 +100,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.Log4JVulAttestation),
+				Blob:   []byte(testdata.Log4JVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -109,7 +109,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.RootVulAttestation),
+				Blob:   []byte(testdata.RootVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -125,7 +125,7 @@ func TestCertify(t *testing.T) {
 		query: newMockQuery(),
 		want: []*processor.Document{
 			{
-				Blob:   []byte(testdata.Text4ShellVulAttestation),
+				Blob:   []byte(testdata.Text4ShellVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -134,7 +134,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.SecondLevelVulAttestation),
+				Blob:   []byte(testdata.SecondLevelVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -143,7 +143,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.Log4JVulAttestation),
+				Blob:   []byte(testdata.Log4JVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -152,7 +152,7 @@ func TestCertify(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.RootVulAttestation),
+				Blob:   []byte(testdata.RootVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{

--- a/pkg/certifier/osv/osv.go
+++ b/pkg/certifier/osv/osv.go
@@ -181,7 +181,7 @@ func createAttestation(purl string, vulns []osv_models.Vulnerability, currentTim
 	attestation := &attestation_vuln.VulnerabilityStatement{
 		Statement: attestationv1.Statement{
 			Type:          attestationv1.StatementTypeUri,
-			PredicateType: attestation_vuln.PredicateVuln,
+			PredicateType: attestation_vuln.PredicateVulnV2,
 			Subject: []*attestationv1.ResourceDescriptor{
 				{
 					Uri: purl,

--- a/pkg/certifier/osv/osv_test.go
+++ b/pkg/certifier/osv/osv_test.go
@@ -57,7 +57,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 		rootComponent: []*root_package.PackageNode{&testdata.Text4ShellPackage, &testdata.SecondLevelPackage, &testdata.Log4JPackage, &testdata.RootPackage},
 		want: []*processor.Document{
 			{
-				Blob:   []byte(testdata.Text4ShellVulAttestation),
+				Blob:   []byte(testdata.Text4ShellVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -66,7 +66,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.SecondLevelVulAttestation),
+				Blob:   []byte(testdata.SecondLevelVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -75,7 +75,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.Log4JVulAttestation),
+				Blob:   []byte(testdata.Log4JVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -84,7 +84,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.RootVulAttestation),
+				Blob:   []byte(testdata.RootVulAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -104,7 +104,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 		rootComponent: []*root_package.PackageNode{&testdata.VertxWebCommonPackage, &testdata.VertxAuthCommonPackage, &testdata.VertxBridgeCommonPackage, &testdata.VertxCoreCommonPackage, &testdata.VertxWebPackage},
 		want: []*processor.Document{
 			{
-				Blob:   []byte(testdata.VertxWebCommonAttestation),
+				Blob:   []byte(testdata.VertxWebCommonAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -113,7 +113,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.VertxAuthCommonAttestation),
+				Blob:   []byte(testdata.VertxAuthCommonAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -122,7 +122,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.VertxBridgeCommonAttestation),
+				Blob:   []byte(testdata.VertxBridgeCommonAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -131,7 +131,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.VertxCoreCommonAttestation),
+				Blob:   []byte(testdata.VertxCoreCommonAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -140,7 +140,7 @@ func TestOSVCertifier_CertifyVulns(t *testing.T) {
 				},
 			},
 			{
-				Blob:   []byte(testdata.VertxWebAttestation),
+				Blob:   []byte(testdata.VertxWebAttestationV02),
 				Type:   processor.DocumentITE6Vul,
 				Format: processor.FormatJSON,
 				SourceInformation: processor.SourceInformation{
@@ -247,7 +247,7 @@ func Test_createAttestation(t *testing.T) {
 			want: &attestation_vuln.VulnerabilityStatement{
 				Statement: attestationv1.Statement{
 					Type:          attestationv1.StatementTypeUri,
-					PredicateType: attestation_vuln.PredicateVuln,
+					PredicateType: attestation_vuln.PredicateVulnV2,
 					Subject:       []*attestationv1.ResourceDescriptor{{Name: ""}},
 				},
 				Predicate: attestation_vuln.VulnerabilityPredicate{
@@ -281,7 +281,7 @@ func Test_createAttestation(t *testing.T) {
 			want: &attestation_vuln.VulnerabilityStatement{
 				Statement: attestationv1.Statement{
 					Type:          attestationv1.StatementTypeUri,
-					PredicateType: attestation_vuln.PredicateVuln,
+					PredicateType: attestation_vuln.PredicateVulnV2,
 					Subject:       []*attestationv1.ResourceDescriptor{{Name: ""}},
 				},
 				Predicate: attestation_vuln.VulnerabilityPredicate{

--- a/pkg/handler/processor/guesser/guesser_test.go
+++ b/pkg/handler/processor/guesser/guesser_test.go
@@ -190,6 +190,16 @@ func Test_GuessDocument(t *testing.T) {
 		expectedType:   processor.DocumentITE6Vul,
 		expectedFormat: processor.FormatJSON,
 	}, {
+		name: "valid Vuln v0.2 ITE6 Document",
+		document: &processor.Document{
+			Blob:              testdata.ITE6VulnV02Example,
+			Type:              processor.DocumentUnknown,
+			Format:            processor.FormatUnknown,
+			SourceInformation: processor.SourceInformation{},
+		},
+		expectedType:   processor.DocumentITE6Vul,
+		expectedFormat: processor.FormatJSON,
+	}, {
 		name: "valid clearly defined ITE6 Document",
 		document: &processor.Document{
 			Blob:              testdata.ITE6CDLog4j,

--- a/pkg/handler/processor/guesser/type_ite6.go
+++ b/pkg/handler/processor/guesser/type_ite6.go
@@ -39,7 +39,8 @@ func (_ *ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.Format
 				return processor.DocumentITE6Generic
 			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/certify/v0.1") {
 				return processor.DocumentITE6Generic
-			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.1") {
+			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.1") ||
+				strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.2") {
 				return processor.DocumentITE6Vul
 			} else if strings.HasPrefix(statement.PredicateType, "https://in-toto.io/attestation/clearlydefined/v0.1") {
 				return processor.DocumentITE6ClearlyDefined
@@ -50,7 +51,10 @@ func (_ *ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.Format
 	var attV1Statement attestationv1.Statement
 	if json.Unmarshal(blob, &attV1Statement) == nil && format == processor.FormatJSON {
 		if strings.HasPrefix(attV1Statement.Type, "https://in-toto.io/Statement") {
-			if strings.HasPrefix(attV1Statement.PredicateType, "https://in-toto.io/attestation/clearlydefined/v0.1") {
+			if strings.HasPrefix(attV1Statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.1") ||
+				strings.HasPrefix(attV1Statement.PredicateType, "https://in-toto.io/attestation/vulns/v0.2") {
+				return processor.DocumentITE6Vul
+			} else if strings.HasPrefix(attV1Statement.PredicateType, "https://in-toto.io/attestation/clearlydefined/v0.1") {
 				return processor.DocumentITE6ClearlyDefined
 			}
 			return processor.DocumentITE6Generic

--- a/pkg/handler/processor/guesser/type_ite6_test.go
+++ b/pkg/handler/processor/guesser/type_ite6_test.go
@@ -56,6 +56,10 @@ func Test_Ite6TypeGuesser(t *testing.T) {
 		blob:     testdata.ITE6VulnExample,
 		expected: processor.DocumentITE6Vul,
 	}, {
+		name:     "valid Vuln v0.2 ITE6 Document",
+		blob:     testdata.ITE6VulnV02Example,
+		expected: processor.DocumentITE6Vul,
+	}, {
 		name:     "valid clearly defined ITE6 Document",
 		blob:     testdata.ITE6CDLog4j,
 		expected: processor.DocumentITE6ClearlyDefined,

--- a/pkg/ingestor/parser/vuln/vuln.go
+++ b/pkg/ingestor/parser/vuln/vuln.go
@@ -15,8 +15,8 @@
 
 // Package vuln attestation parser parses the attestation defined by by
 // the certifier using the predicate type
-// "https://in-toto.io/attestation/vulns/v0.1" Three different types of ingest
-// predicates are created.
+// "https://in-toto.io/attestation/vulns/" (both v0.1 and v0.2). Three different
+// types of ingest predicates are created.
 //
 // - IsOccurences are created mapping between any package
 // purls found in the subject, and any digests found under those.

--- a/pkg/ingestor/parser/vuln/vuln_test.go
+++ b/pkg/ingestor/parser/vuln/vuln_test.go
@@ -316,6 +316,279 @@ func TestParser(t *testing.T) {
 		}},
 		wantIVs: []assembler.VulnEqualIngest{},
 		wantErr: false,
+	}, {
+		name: "valid v0.2 vulnerability certifier document",
+		doc: &processor.Document{
+			Blob:   testdata.ITE6VulnV02Example,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentITE6Vul,
+			SourceInformation: processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		},
+		wantCVs: []assembler.CertifyVulnIngest{
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-7rjr-3q55-vv33",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-8489-44mv-ggj8",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-fxph-q3j8-mv87",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-jfh8-c2jp-5v3q",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-p6xc-xr62-6r2g",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vwqq-5vrc-xw9h",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+		},
+		wantIVs: []assembler.VulnEqualIngest{
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vwqq-5vrc-xw9h",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-vwqq-5vrc-xw9h",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-7rjr-3q55-vv33",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-7rjr-3q55-vv33",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-8489-44mv-ggj8",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-8489-44mv-ggj8",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-fxph-q3j8-mv87",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-fxph-q3j8-mv87",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-jfh8-c2jp-5v3q",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-jfh8-c2jp-5v3q",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-p6xc-xr62-6r2g",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-p6xc-xr62-6r2g",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-vc5p-v9hr-52mj",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+		},
+		wantVMs: []assembler.VulnMetadataIngest{
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-7rjr-3q55-vv33",
+				},
+				VulnMetadata: &generated.VulnerabilityMetadataInputSpec{
+					ScoreType:  generated.VulnerabilityScoreTypeCvssv31,
+					ScoreValue: 9.0,
+				},
+			},
+		},
+		wantErr: false,
+	}, {
+		name: "no vulnerability v0.2 certifier document with package digest",
+		doc: &processor.Document{
+			Blob:   testdata.ITE6NoVulnV02Example,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentITE6Vul,
+			SourceInformation: processor.SourceInformation{
+				Collector: "TestCollector",
+				Source:    "TestSource",
+			},
+		},
+		wantCVs: []assembler.CertifyVulnIngest{{
+			Pkg: &generated.PkgInputSpec{
+				Type:      "maven",
+				Namespace: ptrfrom.String("org.apache.logging.log4j"),
+				Name:      "log4j-core",
+				Version:   ptrfrom.String("2.8.1"),
+				Subpath:   ptrfrom.String(""),
+			},
+			Vulnerability: &generated.VulnerabilityInputSpec{Type: "noVuln"},
+			VulnData: &generated.ScanMetadataInput{
+				TimeScanned:    tm,
+				ScannerUri:     "osv.dev",
+				ScannerVersion: "0.0.14",
+			},
+		}},
+		wantIVs: []assembler.VulnEqualIngest{},
+		wantErr: false,
 	}}
 	ivSortOpt := cmp.Transformer("Sort", func(in []assembler.VulnEqualIngest) []assembler.VulnEqualIngest {
 		out := append([]assembler.VulnEqualIngest(nil), in...)


### PR DESCRIPTION
# Description of the PR
Observed that the upstream PRs mentioned in the TODO were fixed. So went ahead to move the predicateType to v0.2. Hopefully this should also solve the issue #1242 completely. 

Fixes #1242 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
