### PR TITLE
feat: add release checklist issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,0 +1,40 @@
+---
+name: Release Checklist
+about: Checklist for performing a GUAC release
+title: "Release vX.Y.Z"
+labels: release
+assignees: ''
+---
+
+## Pre-release checklist
+
+- [ ] No open issues tagged [`block-release`](https://github.com/guacsec/guac/issues?q=is%3Aissue+is%3Aopen+label%3Ablock-release)
+- [ ] Locally tag a release candidate
+- [ ] Candidate builds successfully
+- [ ] Docs reviewed for areas needing updates
+- [ ] Demos run through and verified working
+- [ ] Release notes written (human-readable, not just commit list):
+  - [ ] New features
+  - [ ] Breaking changes
+  - [ ] API changes
+  - [ ] Other highlights (performance, etc.)
+  - [ ] List of contributors
+  - [ ] List of commits (use GitHub's generate release notes)
+- [ ] If GraphQL schema changed: opened issue against [guac-visualizer](https://github.com/guacsec/guac-visualizer)
+- [ ] [Helm chart](https://github.com/kusaridev/helm-charts/blob/main/charts/guac/Chart.yaml) updated
+
+## Making the release
+
+- [ ] Tag the new version: `git tag vX.Y.Z`
+  - Major: voted on by maintainers
+  - Minor: any API/CLI changes
+  - Patch: otherwise
+- [ ] Push the tag: `git push <remote> vX.Y.Z`
+- [ ] [Release workflow](https://github.com/guacsec/guac/blob/main/.github/workflows/release.yaml) runs successfully
+- [ ] Container images and binaries populated
+- [ ] Release notes updated on the GitHub release
+- [ ] One demo flow verified with new release tag
+
+## Post-release
+
+- [ ] Announce in relevant channels


### PR DESCRIPTION
## Summary

Adds a GitHub issue template for release checklists, based on the process documented in `RELEASES.md`.

## Why this matters

Per #1927, having a structured issue template helps the maintainer doing the release track all required steps. The checklist items come directly from the pre-release and release sections of `RELEASES.md`.

## Changes

- `.github/ISSUE_TEMPLATE/release_checklist.md`: New issue template with pre-release, release, and post-release checklists. Includes links to block-release label filter, guac-visualizer repo, Helm chart, and release workflow.

## Testing

Template follows the same markdown format as existing issue templates in `.github/ISSUE_TEMPLATE/`.

Fixes #1927

This contribution was developed with AI assistance (Claude Code).