### PR TITLE
fix: add vuln data to log4j-core test to resolve unit test failure

### DIFF
--- a/internal/testing/testdata/exampledata/certify-vuln-v02.json
+++ b/internal/testing/testdata/exampledata/certify-vuln-v02.json
@@ -11,6 +11,8 @@
       "uri": "osv.dev",
       "version": "0.0.14",
       "result": [{
+            "id": "GHSA-3pxv-7cmr-fjr4"
+        }, {
             "id": "GHSA-7rjr-3q55-vv33",
             "severity": [{
                 "method": "CVSSv31",

--- a/internal/testing/testdata/exampledata/certify-vuln.json
+++ b/internal/testing/testdata/exampledata/certify-vuln.json
@@ -11,6 +11,8 @@
       "uri": "osv.dev",
       "version": "0.0.14",
       "result": [{
+            "id": "GHSA-3pxv-7cmr-fjr4"
+        }, {
             "id": "GHSA-7rjr-3q55-vv33",
             "severity": [{
                 "method": "CVSSv31",

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2260,6 +2260,9 @@ var (
 			  },
 			  "result":[
 				 {
+					"id":"GHSA-3pxv-7cmr-fjr4"
+				 },
+				 {
 					"id":"GHSA-7rjr-3q55-vv33"
 				 },
 				 {
@@ -2368,6 +2371,9 @@ var (
 			  "db":{
 			  },
 			  "result":[
+				 {
+					"id":"GHSA-3pxv-7cmr-fjr4"
+				 },
 				 {
 					"id":"GHSA-7rjr-3q55-vv33"
 				 },

--- a/pkg/ingestor/parser/common/scanner/scanner_test.go
+++ b/pkg/ingestor/parser/common/scanner/scanner_test.go
@@ -56,6 +56,27 @@ func TestPurlsToScan(t *testing.T) {
 				},
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+					Origin:         "osv_certifier",
+					Collector:      "osv_certifier",
+					DocumentRef:    "sha256_daeea32fb48a532d48ce7a549b7e0cdf98eb6df80869c3b6d3ec21174b015d14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
 					VulnerabilityID: "ghsa-7rjr-3q55-vv33",
 				},
 				VulnData: &generated.ScanMetadataInput{
@@ -195,6 +216,22 @@ func TestPurlsToScan(t *testing.T) {
 			},
 		},
 		wantVEs: []assembler.VulnEqualIngest{
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+					Origin:        "osv_certifier",
+					Collector:     "osv_certifier",
+					DocumentRef:   "sha256_daeea32fb48a532d48ce7a549b7e0cdf98eb6df80869c3b6d3ec21174b015d14",
+				},
+			},
 			{
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",

--- a/pkg/ingestor/parser/vuln/vuln_test.go
+++ b/pkg/ingestor/parser/vuln/vuln_test.go
@@ -101,6 +101,24 @@ func TestParser(t *testing.T) {
 				},
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
 					VulnerabilityID: "ghsa-fxph-q3j8-mv87",
 				},
 				VulnData: &generated.ScanMetadataInput{
@@ -217,6 +235,19 @@ func TestParser(t *testing.T) {
 				EqualVulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "ghsa",
 					VulnerabilityID: "ghsa-8489-44mv-ggj8",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
 				},
 				VulnEqual: &generated.VulnEqualInputSpec{
 					Justification: "Decoded OSV data",
@@ -374,6 +405,24 @@ func TestParser(t *testing.T) {
 				},
 				Vulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				VulnData: &generated.ScanMetadataInput{
+					TimeScanned:    tm,
+					ScannerUri:     "osv.dev",
+					ScannerVersion: "0.0.14",
+				},
+			},
+			{
+				Pkg: &generated.PkgInputSpec{
+					Type:      "maven",
+					Namespace: ptrfrom.String("org.apache.logging.log4j"),
+					Name:      "log4j-core",
+					Version:   ptrfrom.String("2.8.1"),
+					Subpath:   ptrfrom.String(""),
+				},
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
 					VulnerabilityID: "ghsa-fxph-q3j8-mv87",
 				},
 				VulnData: &generated.ScanMetadataInput{
@@ -490,6 +539,19 @@ func TestParser(t *testing.T) {
 				EqualVulnerability: &generated.VulnerabilityInputSpec{
 					Type:            "ghsa",
 					VulnerabilityID: "ghsa-8489-44mv-ggj8",
+				},
+				VulnEqual: &generated.VulnEqualInputSpec{
+					Justification: "Decoded OSV data",
+				},
+			},
+			{
+				Vulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "osv",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
+				},
+				EqualVulnerability: &generated.VulnerabilityInputSpec{
+					Type:            "ghsa",
+					VulnerabilityID: "ghsa-3pxv-7cmr-fjr4",
 				},
 				VulnEqual: &generated.VulnEqualInputSpec{
 					Justification: "Decoded OSV data",


### PR DESCRIPTION
# Description of the PR

The OSV database added a new vulnerability (GHSA-3pxv-7cmr-fjr4) for log4j-core@2.8.1, causing tests that compare against hardcoded expected data to fail.

Fixes #2972 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
