### PR TITLE
feat: implements cloud-agnostic blob collector

### DIFF
--- a/cmd/guaccollect/cmd/blob.go
+++ b/cmd/guaccollect/cmd/blob.go
@@ -101,7 +101,7 @@ respective blob store.`,
 		if err != nil {
 			logger.Fatalf("unable to create blob collector: %v", err)
 		}
-		defer bc.Close()
+		defer func() { _ = bc.Close() }()
 
 		if err := collector.RegisterDocumentCollector(bc, blobCollector.CollectorBlob); err != nil {
 			logger.Fatalf("unable to register blob collector: %v", err)

--- a/cmd/guaccollect/cmd/blob.go
+++ b/cmd/guaccollect/cmd/blob.go
@@ -1,0 +1,140 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/guacsec/guac/pkg/handler/collector"
+	blobCollector "github.com/guacsec/guac/pkg/handler/collector/blob"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type blobOptions struct {
+	pubsubAddr     string
+	blobAddr       string
+	storeURL       string
+	poll           bool
+	pollInterval   time.Duration
+	publishToQueue bool
+}
+
+var blobCmd = &cobra.Command{
+	Use:   "blob [flags] store_url",
+	Short: "collect documents from any blob store (S3, GCS, Azure Blob, filesystem) using gocloud.dev",
+	Long: `
+guaccollect blob takes a gocloud.dev URL and collects all documents found
+in the blob store. This is a cloud-agnostic collector that supports any
+blob storage backed by gocloud.dev (S3, GCS, Azure Blob Storage, filesystem,
+etc).
+
+Store URL formats:
+  S3:    "s3://my-bucket?region=us-west-1"
+  GCS:   "gs://my-bucket"
+  Azure: "azblob://my-container"
+  File:  "file:///path/to/dir"
+
+Authentication is handled via environment variables per cloud provider.
+See https://gocloud.dev/howto/blob/ for full documentation.
+
+Specific authentication methods vary per cloud provider. Please follow the
+documentation per implementation to ensure you have access to read from the
+respective blob store.`,
+	Example: `  # Collect from an S3 bucket
+  guaccollect blob "s3://my-sbom-bucket?region=us-east-1"
+
+  # Collect from a GCS bucket
+  guaccollect blob "gs://my-sbom-bucket"
+
+  # Collect from Azure Blob Storage
+  guaccollect blob "azblob://my-container"
+
+  # Collect from local filesystem
+  guaccollect blob "file:///path/to/sboms"
+
+  # Collect with polling
+  guaccollect blob --service-poll --interval 5m "s3://my-sbom-bucket?region=us-east-1"`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		opts, err := validateBlobFlags(
+			viper.GetString("pubsub-addr"),
+			viper.GetString("blob-addr"),
+			viper.GetBool("service-poll"),
+			viper.GetString("interval"),
+			viper.GetBool("publish-to-queue"),
+			args,
+		)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		var collectorOpts []blobCollector.Opt
+		collectorOpts = append(collectorOpts, blobCollector.WithURL(opts.storeURL))
+		if opts.poll {
+			collectorOpts = append(collectorOpts, blobCollector.WithPolling(opts.pollInterval))
+		}
+
+		bc, err := blobCollector.NewBlobCollector(ctx, collectorOpts...)
+		if err != nil {
+			logger.Fatalf("unable to create blob collector: %v", err)
+		}
+		defer bc.Close()
+
+		if err := collector.RegisterDocumentCollector(bc, blobCollector.CollectorBlob); err != nil {
+			logger.Fatalf("unable to register blob collector: %v", err)
+		}
+
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+	},
+}
+
+func validateBlobFlags(pubsubAddr, blobAddr string, poll bool, interval string, pubToQueue bool, args []string) (blobOptions, error) {
+	var opts blobOptions
+
+	opts.pubsubAddr = pubsubAddr
+	opts.blobAddr = blobAddr
+	opts.poll = poll
+	opts.publishToQueue = pubToQueue
+
+	if len(args) != 1 {
+		return opts, fmt.Errorf("expected positional argument for store_url")
+	}
+	opts.storeURL = args[0]
+
+	if poll {
+		d, err := time.ParseDuration(interval)
+		if err != nil {
+			return opts, fmt.Errorf("failed to parse poll interval %q: %w", interval, err)
+		}
+		opts.pollInterval = d
+	}
+
+	return opts, nil
+}
+
+func init() {
+	rootCmd.AddCommand(blobCmd)
+}

--- a/cmd/guaccollect/cmd/blob.go
+++ b/cmd/guaccollect/cmd/blob.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/guaccollect/cmd/blob.go
+++ b/cmd/guaccollect/cmd/blob.go
@@ -32,10 +32,17 @@ type blobOptions struct {
 	pubsubAddr     string
 	blobAddr       string
 	storeURL       string
+	prefix         string
+	maxObjectSize  int64
 	poll           bool
 	pollInterval   time.Duration
 	publishToQueue bool
 }
+
+const (
+	blobPrefixFlag        = "blob-prefix"
+	blobMaxObjectSizeFlag = "blob-max-object-size"
+)
 
 var blobCmd = &cobra.Command{
 	Use:   "blob [flags] store_url",
@@ -57,7 +64,14 @@ See https://gocloud.dev/howto/blob/ for full documentation.
 
 Specific authentication methods vary per cloud provider. Please follow the
 documentation per implementation to ensure you have access to read from the
-respective blob store.`,
+respective blob store.
+
+By default every object in the bucket is fetched. Use --blob-prefix to
+scope collection to a subset of keys (e.g. only an sboms/ folder), and
+--blob-max-object-size to cap the per-object read (objects above the cap
+are logged and skipped instead of crashing the collector).
+
+NOTE: every in-scope object is ingested as-is; point this only at buckets (or --blob-prefix subsets) that contain documents GUAC can ingest.`,
 	Example: `  # Collect from an S3 bucket
   guaccollect blob "s3://my-sbom-bucket?region=us-east-1"
 
@@ -71,7 +85,10 @@ respective blob store.`,
   guaccollect blob "file:///path/to/sboms"
 
   # Collect with polling
-  guaccollect blob --service-poll --interval 5m "s3://my-sbom-bucket?region=us-east-1"`,
+  guaccollect blob --service-poll --interval 5m "s3://my-sbom-bucket?region=us-east-1"
+
+  # Scope to a prefix and cap per-object reads at 50 MiB
+  guaccollect blob --blob-prefix sboms/ --blob-max-object-size 52428800 "s3://my-sbom-bucket?region=us-east-1"`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())
@@ -83,6 +100,8 @@ respective blob store.`,
 			viper.GetBool("service-poll"),
 			viper.GetString("interval"),
 			viper.GetBool("publish-to-queue"),
+			viper.GetString(blobPrefixFlag),
+			viper.GetInt64(blobMaxObjectSizeFlag),
 			args,
 		)
 		if err != nil {
@@ -96,6 +115,12 @@ respective blob store.`,
 		if opts.poll {
 			collectorOpts = append(collectorOpts, blobCollector.WithPolling(opts.pollInterval))
 		}
+		if opts.prefix != "" {
+			collectorOpts = append(collectorOpts, blobCollector.WithPrefix(opts.prefix))
+		}
+		if opts.maxObjectSize > 0 {
+			collectorOpts = append(collectorOpts, blobCollector.WithMaxObjectSize(opts.maxObjectSize))
+		}
 
 		bc, err := blobCollector.NewBlobCollector(ctx, collectorOpts...)
 		if err != nil {
@@ -107,17 +132,23 @@ respective blob store.`,
 			logger.Fatalf("unable to register blob collector: %v", err)
 		}
 
-		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue)
+		labels, err := parseLabels(viper.GetStringSlice("label"))
+		if err != nil {
+			logger.Fatalf("unable to parse labels: %v", err)
+		}
+		initializeNATsandCollector(ctx, opts.pubsubAddr, opts.blobAddr, opts.publishToQueue, labels)
 	},
 }
 
-func validateBlobFlags(pubsubAddr, blobAddr string, poll bool, interval string, pubToQueue bool, args []string) (blobOptions, error) {
+func validateBlobFlags(pubsubAddr, blobAddr string, poll bool, interval string, pubToQueue bool, prefix string, maxObjectSize int64, args []string) (blobOptions, error) {
 	var opts blobOptions
 
 	opts.pubsubAddr = pubsubAddr
 	opts.blobAddr = blobAddr
 	opts.poll = poll
 	opts.publishToQueue = pubToQueue
+	opts.prefix = prefix
+	opts.maxObjectSize = maxObjectSize
 
 	if len(args) != 1 {
 		return opts, fmt.Errorf("expected positional argument for store_url")
@@ -132,9 +163,23 @@ func validateBlobFlags(pubsubAddr, blobAddr string, poll bool, interval string, 
 		opts.pollInterval = d
 	}
 
+	if maxObjectSize < 0 {
+		return opts, fmt.Errorf("--%s must be non-negative, got %d", blobMaxObjectSizeFlag, maxObjectSize)
+	}
+
 	return opts, nil
 }
 
 func init() {
+	blobCmd.PersistentFlags().String(blobPrefixFlag, "", "if set, only objects whose key begins with this prefix are collected")
+	blobCmd.PersistentFlags().Int64(blobMaxObjectSizeFlag, 0, "maximum object size in bytes to read; objects larger than this are logged and skipped (0 uses the built-in default)")
+	if err := viper.BindPFlag(blobPrefixFlag, blobCmd.PersistentFlags().Lookup(blobPrefixFlag)); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind %s flag: %v", blobPrefixFlag, err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlag(blobMaxObjectSizeFlag, blobCmd.PersistentFlags().Lookup(blobMaxObjectSizeFlag)); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind %s flag: %v", blobMaxObjectSizeFlag, err)
+		os.Exit(1)
+	}
 	rootCmd.AddCommand(blobCmd)
 }

--- a/pkg/handler/collector/blob/blob.go
+++ b/pkg/handler/collector/blob/blob.go
@@ -36,12 +36,22 @@ import (
 
 const CollectorBlob = "BlobCollector"
 
+// DefaultMaxObjectSize caps the per-object read in bytes when no explicit
+// limit is configured, defaults to 100 MiB.
+const DefaultMaxObjectSize int64 = 100 * 1024 * 1024
+
+// ErrObjectTooLarge is returned by getObject when the object's size
+// exceeds maxObjectSize. Callers log and skip; this is not a fatal error.
+var ErrObjectTooLarge = errors.New("object exceeds max object size")
+
 type blobCollector struct {
-	url          string
-	bucket       *blob.Bucket
-	lastDownload time.Time
-	poll         bool
-	interval     time.Duration
+	url           string
+	bucket        *blob.Bucket
+	lastDownload  time.Time
+	poll          bool
+	interval      time.Duration
+	prefix        string
+	maxObjectSize int64
 }
 
 type Opt func(*blobCollector)
@@ -65,6 +75,20 @@ func WithPolling(interval time.Duration) Opt {
 	}
 }
 
+// WithPrefix limits collection to objects whose key begins with prefix.
+func WithPrefix(prefix string) Opt {
+	return func(b *blobCollector) {
+		b.prefix = prefix
+	}
+}
+
+// WithMaxObjectSize caps the number of bytes read per object.
+func WithMaxObjectSize(n int64) Opt {
+	return func(b *blobCollector) {
+		b.maxObjectSize = n
+	}
+}
+
 // NewBlobCollector creates a cloud-agnostic collector that can collect
 // documents from any blob storage supported by gocloud.dev/blob (S3, GCS,
 // Azure Blob Storage, filesystem, etc).
@@ -76,6 +100,10 @@ func NewBlobCollector(ctx context.Context, opts ...Opt) (*blobCollector, error) 
 
 	for _, opt := range opts {
 		opt(bc)
+	}
+
+	if bc.maxObjectSize <= 0 {
+		bc.maxObjectSize = DefaultMaxObjectSize
 	}
 
 	if bc.bucket == nil {
@@ -129,7 +157,11 @@ func (b *blobCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<-
 
 func (b *blobCollector) getArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
 	logger := logging.FromContext(ctx)
-	iter := b.bucket.List(nil)
+	var listOpts *blob.ListOptions
+	if b.prefix != "" {
+		listOpts = &blob.ListOptions{Prefix: b.prefix}
+	}
+	iter := b.bucket.List(listOpts)
 
 	for {
 		obj, err := iter.Next(ctx)
@@ -150,7 +182,11 @@ func (b *blobCollector) getArtifacts(ctx context.Context, docChannel chan<- *pro
 
 		payload, err := b.getObject(ctx, obj.Key)
 		if err != nil {
-			logger.Warnf("failed to retrieve object %q: %v", obj.Key, err)
+			if errors.Is(err, ErrObjectTooLarge) {
+				logger.Warnf("skipping %q: %v (max %d bytes)", obj.Key, err, b.maxObjectSize)
+			} else {
+				logger.Warnf("failed to retrieve object %q: %v", obj.Key, err)
+			}
 			continue
 		}
 		if len(payload) == 0 {
@@ -180,9 +216,13 @@ func (b *blobCollector) getObject(ctx context.Context, key string) ([]byte, erro
 	}
 	defer func() { _ = reader.Close() }()
 
-	data, err := io.ReadAll(reader)
+	limited := io.LimitReader(reader, b.maxObjectSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %q: %w", key, err)
+	}
+	if int64(len(data)) > b.maxObjectSize {
+		return nil, ErrObjectTooLarge
 	}
 	return data, nil
 }

--- a/pkg/handler/collector/blob/blob.go
+++ b/pkg/handler/collector/blob/blob.go
@@ -1,0 +1,196 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/azureblob"
+	_ "gocloud.dev/blob/fileblob"
+	_ "gocloud.dev/blob/gcsblob"
+	_ "gocloud.dev/blob/memblob"
+	_ "gocloud.dev/blob/s3blob"
+
+	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+const CollectorBlob = "BlobCollector"
+
+type blobCollector struct {
+	url          string
+	bucket       *blob.Bucket
+	lastDownload time.Time
+	poll         bool
+	interval     time.Duration
+}
+
+type Opt func(*blobCollector)
+
+func WithURL(url string) Opt {
+	return func(b *blobCollector) {
+		b.url = url
+	}
+}
+
+func WithBucket(bucket *blob.Bucket) Opt {
+	return func(b *blobCollector) {
+		b.bucket = bucket
+	}
+}
+
+func WithPolling(interval time.Duration) Opt {
+	return func(b *blobCollector) {
+		b.poll = true
+		b.interval = interval
+	}
+}
+
+// NewBlobCollector creates a cloud-agnostic collector that can collect
+// documents from any blob storage supported by gocloud.dev/blob (S3, GCS,
+// Azure Blob Storage, filesystem, etc).
+
+// Authentication is handled via environment variables per cloud provider.
+// See https://gocloud.dev/howto/blob/ for details.
+func NewBlobCollector(ctx context.Context, opts ...Opt) (*blobCollector, error) {
+	bc := &blobCollector{}
+
+	for _, opt := range opts {
+		opt(bc)
+	}
+
+	if bc.bucket == nil {
+		if bc.url == "" {
+			return nil, errors.New("blob URL not specified")
+		}
+		bucket, err := blob.OpenBucket(ctx, bc.url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open bucket %q: %w", bc.url, err)
+		}
+		bc.bucket = bucket
+	}
+
+	return bc, nil
+}
+
+func (b *blobCollector) Type() string {
+	return CollectorBlob
+}
+
+// RetrieveArtifacts lists objects from the blob store and sends each as a
+// document through the channel. Supports one-shot and polling modes.
+func (b *blobCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	if b.bucket == nil {
+		return errors.New("blob collector not initialized")
+	}
+
+	getArtifacts := func() error {
+		if err := b.getArtifacts(ctx, docChannel); err != nil {
+			return fmt.Errorf("failed to get artifacts from blob store: %w", err)
+		}
+		b.lastDownload = time.Now()
+		return nil
+	}
+
+	if b.poll {
+		for {
+			if err := getArtifacts(); err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(b.interval):
+			}
+		}
+	}
+
+	return getArtifacts()
+}
+
+func (b *blobCollector) getArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
+	iter := b.bucket.List(nil)
+
+	for {
+		obj, err := iter.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to list objects: %w", err)
+		}
+
+		if obj.IsDir {
+			continue
+		}
+
+		if !b.lastDownload.IsZero() && !obj.ModTime.After(b.lastDownload) {
+			continue
+		}
+
+		payload, err := b.getObject(ctx, obj.Key)
+		if err != nil {
+			logger.Warnf("failed to retrieve object %q: %v", obj.Key, err)
+			continue
+		}
+		if len(payload) == 0 {
+			continue
+		}
+
+		doc := &processor.Document{
+			Blob:   payload,
+			Type:   processor.DocumentUnknown,
+			Format: processor.FormatUnknown,
+			SourceInformation: processor.SourceInformation{
+				Collector:   CollectorBlob,
+				Source:      b.url + "/" + obj.Key,
+				DocumentRef: events.GetDocRef(payload),
+			},
+		}
+		docChannel <- doc
+	}
+
+	return nil
+}
+
+func (b *blobCollector) getObject(ctx context.Context, key string) ([]byte, error) {
+	reader, err := b.bucket.NewReader(ctx, key, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reader for %q: %w", key, err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q: %w", key, err)
+	}
+	return data, nil
+}
+
+// Close closes the underlying bucket connection.
+func (b *blobCollector) Close() error {
+	if b.bucket != nil {
+		return b.bucket.Close()
+	}
+	return nil
+}

--- a/pkg/handler/collector/blob/blob.go
+++ b/pkg/handler/collector/blob/blob.go
@@ -178,7 +178,7 @@ func (b *blobCollector) getObject(ctx context.Context, key string) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reader for %q: %w", key, err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	data, err := io.ReadAll(reader)
 	if err != nil {

--- a/pkg/handler/collector/blob/blob.go
+++ b/pkg/handler/collector/blob/blob.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/handler/collector/blob/blob_test.go
+++ b/pkg/handler/collector/blob/blob_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/handler/collector/blob/blob_test.go
+++ b/pkg/handler/collector/blob/blob_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestNewBlobCollector(t *testing.T) {
 	bkt := memblob.OpenBucket(nil)
-	defer bkt.Close()
+	defer func() { _ = bkt.Close() }()
 
 	tests := []struct {
 		name    string
@@ -74,7 +74,7 @@ func TestBlobCollector_RetrieveArtifacts(t *testing.T) {
 	content := []byte("test document content")
 
 	bkt := memblob.OpenBucket(nil)
-	defer bkt.Close()
+	defer func() { _ = bkt.Close() }()
 
 	if err := bkt.WriteAll(ctx, "test/doc1.json", content, nil); err != nil {
 		t.Fatalf("failed to write test object: %v", err)
@@ -160,7 +160,7 @@ func TestBlobCollector_RetrieveArtifacts_Polling(t *testing.T) {
 	content := []byte("polling test content")
 
 	bkt := memblob.OpenBucket(nil)
-	defer bkt.Close()
+	defer func() { _ = bkt.Close() }()
 
 	if err := bkt.WriteAll(ctx, "poll-doc.json", content, nil); err != nil {
 		t.Fatalf("failed to write test object: %v", err)
@@ -193,7 +193,7 @@ func TestBlobCollector_MultipleObjects(t *testing.T) {
 	ctx := context.Background()
 
 	bkt := memblob.OpenBucket(nil)
-	defer bkt.Close()
+	defer func() { _ = bkt.Close() }()
 
 	files := map[string][]byte{
 		"sbom1.json":        []byte("sbom content 1"),

--- a/pkg/handler/collector/blob/blob_test.go
+++ b/pkg/handler/collector/blob/blob_test.go
@@ -234,6 +234,112 @@ func TestBlobCollector_MultipleObjects(t *testing.T) {
 	}
 }
 
+func TestBlobCollector_WithPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	bkt := memblob.OpenBucket(nil)
+	defer func() { _ = bkt.Close() }()
+
+	files := map[string][]byte{
+		"sboms/a.json":  []byte("a"),
+		"sboms/b.json":  []byte("b"),
+		"other/c.json":  []byte("c"),
+		"toplevel.json": []byte("d"),
+	}
+	for key, content := range files {
+		if err := bkt.WriteAll(ctx, key, content, nil); err != nil {
+			t.Fatalf("failed to write %s: %v", key, err)
+		}
+	}
+
+	bc, err := NewBlobCollector(ctx, WithBucket(bkt), WithPrefix("sboms/"))
+	if err != nil {
+		t.Fatalf("failed to create collector: %v", err)
+	}
+
+	docChan := make(chan *processor.Document, 10)
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- bc.RetrieveArtifacts(ctx, docChan)
+		close(docChan)
+	}()
+
+	var got []string
+	for doc := range docChan {
+		got = append(got, string(doc.Blob))
+	}
+	if err := <-errChan; err != nil {
+		t.Fatalf("RetrieveArtifacts() error = %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d documents, want 2 (only sboms/ prefix); got payloads: %v", len(got), got)
+	}
+	for _, payload := range got {
+		if payload != "a" && payload != "b" {
+			t.Errorf("unexpected document %q — prefix filter leaked", payload)
+		}
+	}
+}
+
+func TestBlobCollector_MaxObjectSize_SkipsOversized(t *testing.T) {
+	ctx := context.Background()
+
+	bkt := memblob.OpenBucket(nil)
+	defer func() { _ = bkt.Close() }()
+
+	small := []byte("tiny")
+	big := make([]byte, 4096)
+	for i := range big {
+		big[i] = 'x'
+	}
+	if err := bkt.WriteAll(ctx, "small.json", small, nil); err != nil {
+		t.Fatalf("write small: %v", err)
+	}
+	if err := bkt.WriteAll(ctx, "big.json", big, nil); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+
+	// Cap at 1024 bytes — big.json (4096 bytes) should be skipped.
+	bc, err := NewBlobCollector(ctx, WithBucket(bkt), WithMaxObjectSize(1024))
+	if err != nil {
+		t.Fatalf("failed to create collector: %v", err)
+	}
+
+	docChan := make(chan *processor.Document, 10)
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- bc.RetrieveArtifacts(ctx, docChan)
+		close(docChan)
+	}()
+
+	var got []string
+	for doc := range docChan {
+		got = append(got, string(doc.Blob))
+	}
+	if err := <-errChan; err != nil {
+		t.Fatalf("RetrieveArtifacts() error = %v", err)
+	}
+
+	if len(got) != 1 || got[0] != "tiny" {
+		t.Fatalf("expected only 'small.json' to pass the size cap; got %v", got)
+	}
+}
+
+func TestBlobCollector_DefaultMaxObjectSize(t *testing.T) {
+	ctx := context.Background()
+	bkt := memblob.OpenBucket(nil)
+	defer func() { _ = bkt.Close() }()
+
+	bc, err := NewBlobCollector(ctx, WithBucket(bkt))
+	if err != nil {
+		t.Fatalf("failed to create collector: %v", err)
+	}
+	if bc.maxObjectSize != DefaultMaxObjectSize {
+		t.Errorf("default maxObjectSize = %d, want %d", bc.maxObjectSize, DefaultMaxObjectSize)
+	}
+}
+
 // checkWhileIgnoringLogger compares documents ignoring the ChildLogger field.
 func checkWhileIgnoringLogger(collectedDoc, want []*processor.Document) bool {
 	if len(collectedDoc) != len(want) {

--- a/pkg/handler/collector/blob/blob_test.go
+++ b/pkg/handler/collector/blob/blob_test.go
@@ -1,0 +1,253 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"gocloud.dev/blob/memblob"
+
+	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+func TestNewBlobCollector(t *testing.T) {
+	bkt := memblob.OpenBucket(nil)
+	defer bkt.Close()
+
+	tests := []struct {
+		name    string
+		opts    []Opt
+		wantErr bool
+	}{
+		{
+			name:    "no url or bucket",
+			opts:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "with bucket",
+			opts:    []Opt{WithBucket(bkt)},
+			wantErr: false,
+		},
+		{
+			name:    "with invalid url",
+			opts:    []Opt{WithURL("invalid://bucket")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			bc, err := NewBlobCollector(ctx, tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewBlobCollector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if bc != nil && bc.Type() != CollectorBlob {
+				t.Errorf("Type() = %s, want %s", bc.Type(), CollectorBlob)
+			}
+		})
+	}
+}
+
+func TestBlobCollector_RetrieveArtifacts(t *testing.T) {
+	ctx := context.Background()
+	content := []byte("test document content")
+
+	bkt := memblob.OpenBucket(nil)
+	defer bkt.Close()
+
+	if err := bkt.WriteAll(ctx, "test/doc1.json", content, nil); err != nil {
+		t.Fatalf("failed to write test object: %v", err)
+	}
+
+	expectedDoc := &processor.Document{
+		Blob:   content,
+		Type:   processor.DocumentUnknown,
+		Format: processor.FormatUnknown,
+		SourceInformation: processor.SourceInformation{
+			Collector:   CollectorBlob,
+			Source:      "/" + "test/doc1.json",
+			DocumentRef: events.GetDocRef(content),
+		},
+	}
+
+	tests := []struct {
+		name     string
+		opts     []Opt
+		want     []*processor.Document
+		wantErr  bool
+		wantDone bool
+	}{
+		{
+			name:    "nil bucket",
+			opts:    nil,
+			wantErr: true,
+		},
+		{
+			name:     "get objects",
+			opts:     []Opt{WithBucket(bkt)},
+			want:     []*processor.Document{expectedDoc},
+			wantDone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bc *blobCollector
+			if tt.opts != nil {
+				var err error
+				bc, err = NewBlobCollector(ctx, tt.opts...)
+				if err != nil {
+					t.Fatalf("failed to create collector: %v", err)
+				}
+			} else {
+				bc = &blobCollector{}
+			}
+
+			collector.DeregisterDocumentCollector(CollectorBlob)
+			if err := collector.RegisterDocumentCollector(bc, CollectorBlob); err != nil &&
+				!errors.Is(err, collector.ErrCollectorOverwrite) {
+				t.Fatalf("could not register collector: %v", err)
+			}
+
+			var docs []*processor.Document
+			em := func(d *processor.Document) error {
+				docs = append(docs, d)
+				return nil
+			}
+			eh := func(err error) bool {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("RetrieveArtifacts() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return true
+			}
+
+			if err := collector.Collect(ctx, em, eh); err != nil {
+				t.Fatalf("Collect error: %v", err)
+			}
+
+			if !checkWhileIgnoringLogger(docs, tt.want) {
+				t.Errorf("RetrieveArtifacts() got = %v, want %v", docs, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlobCollector_RetrieveArtifacts_Polling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	content := []byte("polling test content")
+
+	bkt := memblob.OpenBucket(nil)
+	defer bkt.Close()
+
+	if err := bkt.WriteAll(ctx, "poll-doc.json", content, nil); err != nil {
+		t.Fatalf("failed to write test object: %v", err)
+	}
+
+	bc, err := NewBlobCollector(ctx, WithBucket(bkt), WithPolling(100*time.Millisecond))
+	if err != nil {
+		t.Fatalf("failed to create collector: %v", err)
+	}
+
+	docChan := make(chan *processor.Document, 10)
+
+	go func() {
+		_ = bc.RetrieveArtifacts(ctx, docChan)
+	}()
+
+	select {
+	case doc := <-docChan:
+		if !reflect.DeepEqual(doc.Blob, content) {
+			t.Errorf("got blob %s, want %s", doc.Blob, content)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for document")
+	}
+
+	cancel()
+}
+
+func TestBlobCollector_MultipleObjects(t *testing.T) {
+	ctx := context.Background()
+
+	bkt := memblob.OpenBucket(nil)
+	defer bkt.Close()
+
+	files := map[string][]byte{
+		"sbom1.json":        []byte("sbom content 1"),
+		"sbom2.json":        []byte("sbom content 2"),
+		"nested/sbom3.json": []byte("sbom content 3"),
+	}
+
+	for key, content := range files {
+		if err := bkt.WriteAll(ctx, key, content, nil); err != nil {
+			t.Fatalf("failed to write %s: %v", key, err)
+		}
+	}
+
+	bc, err := NewBlobCollector(ctx, WithBucket(bkt))
+	if err != nil {
+		t.Fatalf("failed to create collector: %v", err)
+	}
+
+	docChan := make(chan *processor.Document, 10)
+	errChan := make(chan error, 1)
+
+	go func() {
+		errChan <- bc.RetrieveArtifacts(ctx, docChan)
+		close(docChan)
+	}()
+
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatalf("RetrieveArtifacts() error = %v", err)
+	}
+
+	if len(docs) != 3 {
+		t.Errorf("got %d documents, want 3", len(docs))
+	}
+}
+
+// checkWhileIgnoringLogger compares documents ignoring the ChildLogger field.
+func checkWhileIgnoringLogger(collectedDoc, want []*processor.Document) bool {
+	if len(collectedDoc) != len(want) {
+		return false
+	}
+	for i := range len(collectedDoc) {
+		a, b := collectedDoc[i].ChildLogger, want[i].ChildLogger
+		collectedDoc[i].ChildLogger, want[i].ChildLogger = nil, nil
+
+		if !reflect.DeepEqual(collectedDoc[i], want[i]) {
+			return false
+		}
+
+		collectedDoc[i].ChildLogger, want[i].ChildLogger = a, b
+	}
+	return true
+}


### PR DESCRIPTION
# Description of the PR

This PR adds a cloud agnostic blob store collector

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
Fixes #1320 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
