### PR TITLE
feat(guacrest): implement GET /v0/package/{purl}

### DIFF
--- a/pkg/guacrest/server/retrievePackagePurls.go
+++ b/pkg/guacrest/server/retrievePackagePurls.go
@@ -1,0 +1,136 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Khan/genqlient/graphql"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	assembler_helpers "github.com/guacsec/guac/pkg/assembler/helpers"
+	"github.com/guacsec/guac/pkg/guacrest/helpers"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+// FindMatchingPurls returns the purls of every package version in the graph
+// whose purl is "associated with" the input purl, per the semantics of
+// GET /v0/package/{purl}.
+//
+// An input purl is treated as a template: components that it specifies act as
+// exact-match constraints, while omitted components act as wildcards.
+// Qualifiers are matched as a subset — a package qualifies if its qualifier
+// map contains every qualifier in the input, but may contain additional
+// qualifiers. For example, the input "pkg:foo/bar?a=b" matches both
+// "pkg:foo/bar?a=b" and "pkg:foo/bar?a=b&c=d".
+//
+// The graphql backend's qualifier filter is an exact-equality check, so the
+// superset semantics and the "omitted version is a wildcard" semantics are
+// applied on the client side here.
+func FindMatchingPurls(ctx context.Context, gqlClient graphql.Client, inputPurl string) ([]string, error) {
+	logger := logging.FromContext(ctx)
+
+	inputSpec, err := assembler_helpers.PurlToPkg(inputPurl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse purl %q: %w", inputPurl, err)
+	}
+
+	filter := pkgSpecForLooseMatch(inputSpec)
+
+	response, err := gql.Packages(ctx, gqlClient, filter)
+	if err != nil {
+		logger.Errorf("Packages query returned error: %v", err)
+		return nil, helpers.Err502
+	}
+	if response == nil {
+		logger.Errorf("Packages query returned a nil response")
+		return nil, helpers.Err500
+	}
+
+	wantVersion := strDeref(inputSpec.Version)
+	wantSubpath := strDeref(inputSpec.Subpath)
+	wantQualifiers := make(map[string]string, len(inputSpec.Qualifiers))
+	for _, q := range inputSpec.Qualifiers {
+		wantQualifiers[q.Key] = q.Value
+	}
+
+	seen := map[string]struct{}{}
+	purls := []string{}
+	for _, v := range helpers.GetVersionsOfPackagesResponse(response.GetPackages()) {
+		if wantVersion != "" && v.Version != wantVersion {
+			continue
+		}
+		if wantSubpath != "" && v.Subpath != wantSubpath {
+			continue
+		}
+		if !qualifiersContain(v.Qualifiers, wantQualifiers) {
+			continue
+		}
+		if _, dup := seen[v.Purl]; dup {
+			continue
+		}
+		seen[v.Purl] = struct{}{}
+		purls = append(purls, v.Purl)
+	}
+	return purls, nil
+}
+
+// pkgSpecForLooseMatch builds the GraphQL PkgSpec for the server-side portion
+// of the loose purl match: an exact match on type/namespace/name (all of which
+// are populated for any parseable purl) and on any non-empty version or
+// subpath. Qualifier matching is left entirely to the caller so we can
+// implement subset semantics on top of the backend's exact-equality filter.
+func pkgSpecForLooseMatch(inputSpec *gql.PkgInputSpec) gql.PkgSpec {
+	namespace := strDeref(inputSpec.Namespace)
+	filter := gql.PkgSpec{
+		Type:      &inputSpec.Type,
+		Namespace: &namespace,
+		Name:      &inputSpec.Name,
+	}
+	if version := strDeref(inputSpec.Version); version != "" {
+		filter.Version = &version
+	}
+	if subpath := strDeref(inputSpec.Subpath); subpath != "" {
+		filter.Subpath = &subpath
+	}
+	return filter
+}
+
+func qualifiersContain(
+	have []gql.AllPkgTreeNamespacesPackageNamespaceNamesPackageNameVersionsPackageVersionQualifiersPackageQualifier,
+	want map[string]string,
+) bool {
+	if len(want) == 0 {
+		return true
+	}
+	haveMap := make(map[string]string, len(have))
+	for _, q := range have {
+		haveMap[q.Key] = q.Value
+	}
+	for k, v := range want {
+		if hv, ok := haveMap[k]; !ok || hv != v {
+			return false
+		}
+	}
+	return true
+}
+
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/pkg/guacrest/server/retrievePackagePurls_test.go
+++ b/pkg/guacrest/server/retrievePackagePurls_test.go
@@ -1,0 +1,211 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	stdcmp "cmp"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	. "github.com/guacsec/guac/internal/testing/graphqlClients"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	gen "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/server"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+// Tests the purl-matching logic of GetPackagePurls.
+func Test_FindMatchingPurls(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	tests := []struct {
+		name     string
+		data     GuacData
+		purl     string
+		expected []string
+	}{
+		{
+			name: "Partial purl without version returns all versions of that name",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo", "pkg:guac/foo@v1", "pkg:guac/foo@v2"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"pkg:guac/foo", "pkg:guac/foo@v1", "pkg:guac/foo@v2"},
+		},
+		{
+			name: "Partial purl without version returns qualified packages too",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo", "pkg:guac/foo?a=b", "pkg:guac/foo?a=b&c=d"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"pkg:guac/foo", "pkg:guac/foo?a=b", "pkg:guac/foo?a=b&c=d"},
+		},
+		{
+			name: "Exact version selects only that version",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo", "pkg:guac/foo@v1", "pkg:guac/foo@v2"},
+			},
+			purl:     "pkg:guac/foo@v1",
+			expected: []string{"pkg:guac/foo@v1"},
+		},
+		{
+			name: "Qualifier input is matched as a subset",
+			data: GuacData{
+				Packages: []string{
+					"pkg:guac/foo",
+					"pkg:guac/foo?a=b",
+					"pkg:guac/foo?a=b&c=d",
+					"pkg:guac/foo?a=x",
+				},
+			},
+			purl:     "pkg:guac/foo?a=b",
+			expected: []string{"pkg:guac/foo?a=b", "pkg:guac/foo?a=b&c=d"},
+		},
+		{
+			name: "Input qualifier value must match exactly",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo?a=b", "pkg:guac/foo?a=x"},
+			},
+			purl:     "pkg:guac/foo?a=b",
+			expected: []string{"pkg:guac/foo?a=b"},
+		},
+		{
+			name: "Different name is not matched",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo", "pkg:guac/bar"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"pkg:guac/foo"},
+		},
+		{
+			name: "Different type is not matched",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo", "pkg:generic/foo"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"pkg:guac/foo"},
+		},
+		{
+			name: "Namespace is respected when input omits it",
+			data: GuacData{
+				Packages: []string{"pkg:golang/foo", "pkg:golang/ns/foo"},
+			},
+			purl:     "pkg:golang/foo",
+			expected: []string{"pkg:golang/foo"},
+		},
+		{
+			name: "Namespace is respected when input specifies it",
+			data: GuacData{
+				Packages: []string{"pkg:golang/foo", "pkg:golang/ns/foo"},
+			},
+			purl:     "pkg:golang/ns/foo",
+			expected: []string{"pkg:golang/ns/foo"},
+		},
+		{
+			name: "No matching packages returns empty list",
+			data: GuacData{
+				Packages: []string{"pkg:guac/bar"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{},
+		},
+		{
+			name:     "No packages ingested returns empty list",
+			purl:     "pkg:guac/foo",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gqlClient := SetupTest(t)
+			Ingest(ctx, t, gqlClient, tt.data)
+
+			got, err := server.FindMatchingPurls(ctx, gqlClient, tt.purl)
+			if err != nil {
+				t.Fatalf("FindMatchingPurls returned unexpected error: %v", err)
+			}
+			if !cmp.Equal(got, tt.expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(stdcmp.Less[string])) {
+				t.Errorf("FindMatchingPurls returned %v, but wanted %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// Tests the HTTP-level behavior of GetPackagePurls.
+func Test_GetPackagePurls(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+
+	t.Run("Returns 200 with PurlList and TotalCount", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		Ingest(ctx, t, gqlClient, GuacData{
+			Packages: []string{"pkg:guac/foo", "pkg:guac/foo@v1"},
+		})
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackagePurls(ctx, gen.GetPackagePurlsRequestObject{Purl: "pkg:guac/foo"})
+		if err != nil {
+			t.Fatalf("GetPackagePurls returned unexpected error: %v", err)
+		}
+		success, ok := res.(gen.GetPackagePurls200JSONResponse)
+		if !ok {
+			t.Fatalf("Expected 200 response, got %T: %v", res, res)
+		}
+
+		expected := []string{"pkg:guac/foo", "pkg:guac/foo@v1"}
+		if !cmp.Equal(success.PurlList, expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(stdcmp.Less[string])) {
+			t.Errorf("PurlList = %v, want %v", success.PurlList, expected)
+		}
+		if success.PaginationInfo.TotalCount == nil || *success.PaginationInfo.TotalCount != len(expected) {
+			t.Errorf("TotalCount = %v, want %d", success.PaginationInfo.TotalCount, len(expected))
+		}
+	})
+
+	t.Run("Returns 200 with empty list when nothing matches", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackagePurls(ctx, gen.GetPackagePurlsRequestObject{Purl: "pkg:guac/foo"})
+		if err != nil {
+			t.Fatalf("GetPackagePurls returned unexpected error: %v", err)
+		}
+		success, ok := res.(gen.GetPackagePurls200JSONResponse)
+		if !ok {
+			t.Fatalf("Expected 200 response, got %T: %v", res, res)
+		}
+		if len(success.PurlList) != 0 {
+			t.Errorf("Expected empty PurlList, got %v", success.PurlList)
+		}
+		if success.PaginationInfo.TotalCount == nil || *success.PaginationInfo.TotalCount != 0 {
+			t.Errorf("TotalCount = %v, want 0", success.PaginationInfo.TotalCount)
+		}
+	})
+
+	t.Run("Returns 400 for unparseable purl", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackagePurls(ctx, gen.GetPackagePurlsRequestObject{Purl: "not-a-purl"})
+		if err != nil {
+			t.Fatalf("GetPackagePurls returned unexpected error: %v", err)
+		}
+		if _, ok := res.(gen.GetPackagePurls400JSONResponse); !ok {
+			t.Fatalf("Expected 400 response, got %T: %v", res, res)
+		}
+	})
+}

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -102,9 +102,33 @@ func (s *DefaultServer) AnalyzeDependencies(ctx context.Context, request gen.Ana
 }
 
 func (s *DefaultServer) GetPackagePurls(ctx context.Context, request gen.GetPackagePurlsRequestObject) (gen.GetPackagePurlsResponseObject, error) {
-	return gen.GetPackagePurls500JSONResponse{
-		InternalServerErrorJSONResponse: gen.InternalServerErrorJSONResponse{
-			Message: "GetPackagePurls not implemented",
+	unescapedPurl, err := url.PathUnescape(request.Purl)
+	if err != nil {
+		return gen.GetPackagePurls400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: fmt.Sprintf("failed to unescape package url: %v", err),
+			},
+		}, nil
+	}
+
+	purls, err := FindMatchingPurls(ctx, s.gqlClient, unescapedPurl)
+	if err != nil {
+		errResp, ok := handleErr(ctx, err, GetPackagePurls).(gen.GetPackagePurlsResponseObject)
+		if ok {
+			return errResp, nil
+		}
+		return gen.GetPackagePurls400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: err.Error(),
+			},
+		}, nil
+	}
+
+	totalCount := len(purls)
+	return gen.GetPackagePurls200JSONResponse{
+		PurlListJSONResponse: gen.PurlListJSONResponse{
+			PaginationInfo: gen.PaginationInfo{TotalCount: &totalCount},
+			PurlList:       purls,
 		},
 	}, nil
 }


### PR DESCRIPTION
Replaces the 501 stub for getPackagePurls with a real handler that resolves partial purls against the graph.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

Fixes #2993

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
