### PR TITLE
feat(guacrest): implement GET /v0/package/{purl}/vulns

### DIFF
--- a/pkg/guacrest/server/retrieveVulns.go
+++ b/pkg/guacrest/server/retrieveVulns.go
@@ -1,0 +1,116 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Khan/genqlient/graphql"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	assembler_helpers "github.com/guacsec/guac/pkg/assembler/helpers"
+	gen "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/helpers"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+// GetVulnsForPackage returns the vulnerabilities certified against the
+// package identified by purl. When includeDependencies is true the returned
+// list also contains vulnerabilities certified against any transitive
+// dependency of that package.
+func GetVulnsForPackage(ctx context.Context, gqlClient graphql.Client, purl string, includeDependencies bool) ([]gen.Vulnerability, error) {
+	pkg, err := helpers.FindPackageWithPurl(ctx, gqlClient, purl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find package: %w", err)
+	}
+	pkgIDs := []string{pkg.Id}
+	if includeDependencies {
+		deps, err := GetDepsForPackage(ctx, gqlClient, purl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dependencies: %w", err)
+		}
+		for depID := range deps {
+			if depID == pkg.Id {
+				continue
+			}
+			pkgIDs = append(pkgIDs, depID)
+		}
+	}
+	return vulnsForPackageIDs(ctx, gqlClient, pkgIDs)
+}
+
+// vulnsForPackageIDs queries CertifyVuln for each package version ID and
+// flattens the results into the REST Vulnerability shape, deduplicating by
+// certification ID.
+func vulnsForPackageIDs(ctx context.Context, gqlClient graphql.Client, pkgIDs []string) ([]gen.Vulnerability, error) {
+	logger := logging.FromContext(ctx)
+	seen := map[string]struct{}{}
+	result := []gen.Vulnerability{}
+	for _, id := range pkgIDs {
+		pkgID := id
+		resp, err := gql.CertifyVuln(ctx, gqlClient, gql.CertifyVulnSpec{Package: &gql.PkgSpec{Id: &pkgID}})
+		if err != nil {
+			logger.Errorf("CertifyVuln query returned err: %v", err)
+			return nil, helpers.Err502
+		}
+		for _, cv := range resp.GetCertifyVuln() {
+			if _, dup := seen[cv.Id]; dup {
+				continue
+			}
+			seen[cv.Id] = struct{}{}
+			result = append(result, certifyVulnToREST(cv))
+		}
+	}
+	return result, nil
+}
+
+// certifyVulnToREST projects a gql CertifyVuln into the REST Vulnerability
+// shape defined by the OpenAPI spec.
+func certifyVulnToREST(cv gql.CertifyVulnCertifyVuln) gen.Vulnerability {
+	pkgTree := cv.Package.AllPkgTree
+	purl := assembler_helpers.AllPkgTreeToPurl(&pkgTree)
+
+	ids := make([]string, 0, len(cv.Vulnerability.VulnerabilityIDs))
+	for _, vid := range cv.Vulnerability.VulnerabilityIDs {
+		ids = append(ids, vid.VulnerabilityID)
+	}
+
+	vulnType := cv.Vulnerability.Type
+	dbURI := cv.Metadata.DbUri
+	dbVer := cv.Metadata.DbVersion
+	scannerURI := cv.Metadata.ScannerUri
+	scannerVer := cv.Metadata.ScannerVersion
+	origin := cv.Metadata.Origin
+	collector := cv.Metadata.Collector
+	timeScanned := cv.Metadata.TimeScanned
+
+	return gen.Vulnerability{
+		Package: purl,
+		Vulnerability: gen.VulnerabilityDetails{
+			Type:             &vulnType,
+			VulnerabilityIDs: ids,
+		},
+		Metadata: gen.ScanMetadata{
+			DbUri:          &dbURI,
+			DbVersion:      &dbVer,
+			ScannerUri:     &scannerURI,
+			ScannerVersion: &scannerVer,
+			Origin:         &origin,
+			Collector:      &collector,
+			TimeScanned:    &timeScanned,
+		},
+	}
+}

--- a/pkg/guacrest/server/retrieveVulns.go
+++ b/pkg/guacrest/server/retrieveVulns.go
@@ -41,6 +41,31 @@ func GetVulnsForArtifact(ctx context.Context, gqlClient graphql.Client, digest s
 	return vulnsForPackageIDs(ctx, gqlClient, pkgIDs)
 }
 
+// GetVulnsForPackage returns the vulnerabilities certified against the
+// package identified by purl. When includeDependencies is true the returned
+// list also contains vulnerabilities certified against any transitive
+// dependency of that package.
+func GetVulnsForPackage(ctx context.Context, gqlClient graphql.Client, purl string, includeDependencies bool) ([]gen.Vulnerability, error) {
+	pkg, err := helpers.FindPackageWithPurl(ctx, gqlClient, purl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find package: %w", err)
+	}
+	pkgIDs := []string{pkg.Id}
+	if includeDependencies {
+		deps, err := GetDepsForPackage(ctx, gqlClient, purl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dependencies: %w", err)
+		}
+		for depID := range deps {
+			if depID == pkg.Id {
+				continue
+			}
+			pkgIDs = append(pkgIDs, depID)
+		}
+	}
+	return vulnsForPackageIDs(ctx, gqlClient, pkgIDs)
+}
+
 // packageIDsForArtifact walks artifact -> IsOccurrence -> package and
 // returns the de-duplicated set of package version IDs.
 func packageIDsForArtifact(ctx context.Context, gqlClient graphql.Client, artID string) ([]string, error) {

--- a/pkg/guacrest/server/retrieveVulns_test.go
+++ b/pkg/guacrest/server/retrieveVulns_test.go
@@ -101,6 +101,103 @@ func Test_GetVulnsForArtifact(t *testing.T) {
 	}
 }
 
+func Test_GetVulnsForPackage(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	tests := []struct {
+		name                string
+		data                GuacData
+		purl                string
+		includeDependencies bool
+		expected            []string
+	}{
+		{
+			name: "Package with one vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo"},
+				Vulnerabilities: []string{"osv/CVE-2024-0001"},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"cve-2024-0001"},
+		},
+		{
+			name: "Package with no vuln returns empty",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{},
+		},
+		{
+			name: "includeDependencies=false does not walk deps",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: false,
+			expected:            []string{},
+		},
+		{
+			name: "includeDependencies=true returns dep vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: true,
+			expected:            []string{"cve-2024-0002"},
+		},
+		{
+			name: "includeDependencies=true still returns own vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0001", "osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: true,
+			expected:            []string{"cve-2024-0001", "cve-2024-0002"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gqlClient := SetupTest(t)
+			Ingest(ctx, t, gqlClient, tt.data)
+
+			got, err := server.GetVulnsForPackage(ctx, gqlClient, tt.purl, tt.includeDependencies)
+			if err != nil {
+				t.Fatalf("GetVulnsForPackage returned unexpected error: %v", err)
+			}
+			ids := vulnIDsFromResult(got)
+			if !cmp.Equal(ids, tt.expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(stdcmp.Less[string])) {
+				t.Errorf("vuln IDs = %v, want %v", ids, tt.expected)
+			}
+		})
+	}
+}
+
 func Test_GetArtifactVulns_HTTP(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 
@@ -137,6 +234,47 @@ func Test_GetArtifactVulns_HTTP(t *testing.T) {
 			t.Fatalf("GetArtifactVulns returned unexpected error: %v", err)
 		}
 		if _, ok := res.(gen.GetArtifactVulns400JSONResponse); !ok {
+			t.Fatalf("expected 400 response, got %T: %v", res, res)
+		}
+	})
+}
+
+func Test_GetPackageVulns_HTTP(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+
+	t.Run("Returns 200 with vuln list", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		Ingest(ctx, t, gqlClient, GuacData{
+			Packages:        []string{"pkg:guac/foo"},
+			Vulnerabilities: []string{"osv/CVE-2024-0001"},
+			CertifyVulns: []CertifyVuln{
+				{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+			},
+		})
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackageVulns(ctx, gen.GetPackageVulnsRequestObject{Purl: "pkg:guac/foo"})
+		if err != nil {
+			t.Fatalf("GetPackageVulns returned unexpected error: %v", err)
+		}
+		ok, success := res.(gen.GetPackageVulns200JSONResponse)
+		if !success {
+			t.Fatalf("expected 200 response, got %T: %v", res, res)
+		}
+		if len(ok.VulnerabilityListJSONResponse) == 0 {
+			t.Errorf("expected at least one vulnerability in response")
+		}
+	})
+
+	t.Run("Returns 400 for unknown purl", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackageVulns(ctx, gen.GetPackageVulnsRequestObject{Purl: "pkg:guac/missing"})
+		if err != nil {
+			t.Fatalf("GetPackageVulns returned unexpected error: %v", err)
+		}
+		if _, ok := res.(gen.GetPackageVulns400JSONResponse); !ok {
 			t.Fatalf("expected 400 response, got %T: %v", res, res)
 		}
 	})

--- a/pkg/guacrest/server/retrieveVulns_test.go
+++ b/pkg/guacrest/server/retrieveVulns_test.go
@@ -1,0 +1,183 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	stdcmp "cmp"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	. "github.com/guacsec/guac/internal/testing/graphqlClients"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	gen "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/server"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+func vulnScanMeta() *gql.ScanMetadataInput {
+	return &gql.ScanMetadataInput{TimeScanned: time.Now()}
+}
+
+func vulnIDsFromResult(vs []gen.Vulnerability) []string {
+	out := []string{}
+	for _, v := range vs {
+		out = append(out, v.Vulnerability.VulnerabilityIDs...)
+	}
+	return out
+}
+
+func Test_GetVulnsForPackage(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	tests := []struct {
+		name                string
+		data                GuacData
+		purl                string
+		includeDependencies bool
+		expected            []string
+	}{
+		{
+			name: "Package with one vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo"},
+				Vulnerabilities: []string{"osv/CVE-2024-0001"},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{"cve-2024-0001"},
+		},
+		{
+			name: "Package with no vuln returns empty",
+			data: GuacData{
+				Packages: []string{"pkg:guac/foo"},
+			},
+			purl:     "pkg:guac/foo",
+			expected: []string{},
+		},
+		{
+			name: "includeDependencies=false does not walk deps",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: false,
+			expected:            []string{},
+		},
+		{
+			name: "includeDependencies=true returns dep vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: true,
+			expected:            []string{"cve-2024-0002"},
+		},
+		{
+			name: "includeDependencies=true still returns own vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo", "pkg:guac/bar"},
+				Vulnerabilities: []string{"osv/CVE-2024-0001", "osv/CVE-2024-0002"},
+				HasSboms: []HasSbom{
+					{Subject: "pkg:guac/foo", IncludedSoftware: []string{"pkg:guac/bar"}},
+				},
+				CertifyVulns: []CertifyVuln{
+					{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+					{Package: "pkg:guac/bar", Vulnerability: "osv/CVE-2024-0002", Metadata: vulnScanMeta()},
+				},
+			},
+			purl:                "pkg:guac/foo",
+			includeDependencies: true,
+			expected:            []string{"cve-2024-0001", "cve-2024-0002"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gqlClient := SetupTest(t)
+			Ingest(ctx, t, gqlClient, tt.data)
+
+			got, err := server.GetVulnsForPackage(ctx, gqlClient, tt.purl, tt.includeDependencies)
+			if err != nil {
+				t.Fatalf("GetVulnsForPackage returned unexpected error: %v", err)
+			}
+			ids := vulnIDsFromResult(got)
+			if !cmp.Equal(ids, tt.expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(stdcmp.Less[string])) {
+				t.Errorf("vuln IDs = %v, want %v", ids, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_GetPackageVulns_HTTP(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+
+	t.Run("Returns 200 with vuln list", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		Ingest(ctx, t, gqlClient, GuacData{
+			Packages:        []string{"pkg:guac/foo"},
+			Vulnerabilities: []string{"osv/CVE-2024-0001"},
+			CertifyVulns: []CertifyVuln{
+				{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()},
+			},
+		})
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackageVulns(ctx, gen.GetPackageVulnsRequestObject{Purl: "pkg:guac/foo"})
+		if err != nil {
+			t.Fatalf("GetPackageVulns returned unexpected error: %v", err)
+		}
+		ok, success := res.(gen.GetPackageVulns200JSONResponse)
+		if !success {
+			t.Fatalf("expected 200 response, got %T: %v", res, res)
+		}
+		if len(ok.VulnerabilityListJSONResponse) == 0 {
+			t.Errorf("expected at least one vulnerability in response")
+		}
+	})
+
+	t.Run("Returns 400 for unknown purl", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetPackageVulns(ctx, gen.GetPackageVulnsRequestObject{Purl: "pkg:guac/missing"})
+		if err != nil {
+			t.Fatalf("GetPackageVulns returned unexpected error: %v", err)
+		}
+		if _, ok := res.(gen.GetPackageVulns400JSONResponse); !ok {
+			t.Fatalf("expected 400 response, got %T: %v", res, res)
+		}
+	})
+}

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -134,10 +134,35 @@ func (s *DefaultServer) GetPackagePurls(ctx context.Context, request gen.GetPack
 }
 
 func (s *DefaultServer) GetPackageVulns(ctx context.Context, request gen.GetPackageVulnsRequestObject) (gen.GetPackageVulnsResponseObject, error) {
-	return gen.GetPackageVulns500JSONResponse{
-		InternalServerErrorJSONResponse: gen.InternalServerErrorJSONResponse{
-			Message: "GetPackageVulns not implemented",
-		},
+	unescapedPurl, err := url.PathUnescape(request.Purl)
+	if err != nil {
+		return gen.GetPackageVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: fmt.Sprintf("failed to unescape package url: %v", err),
+			},
+		}, nil
+	}
+
+	includeDeps := false
+	if request.Params.IncludeDependencies != nil {
+		includeDeps = *request.Params.IncludeDependencies
+	}
+
+	vulns, err := GetVulnsForPackage(ctx, s.gqlClient, unescapedPurl, includeDeps)
+	if err != nil {
+		errResp, ok := handleErr(ctx, err, GetPackageVulns).(gen.GetPackageVulnsResponseObject)
+		if ok {
+			return errResp, nil
+		}
+		return gen.GetPackageVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: err.Error(),
+			},
+		}, nil
+	}
+
+	return gen.GetPackageVulns200JSONResponse{
+		VulnerabilityListJSONResponse: vulns,
 	}, nil
 }
 

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -110,10 +110,35 @@ func (s *DefaultServer) GetPackagePurls(ctx context.Context, request gen.GetPack
 }
 
 func (s *DefaultServer) GetPackageVulns(ctx context.Context, request gen.GetPackageVulnsRequestObject) (gen.GetPackageVulnsResponseObject, error) {
-	return gen.GetPackageVulns500JSONResponse{
-		InternalServerErrorJSONResponse: gen.InternalServerErrorJSONResponse{
-			Message: "GetPackageVulns not implemented",
-		},
+	unescapedPurl, err := url.PathUnescape(request.Purl)
+	if err != nil {
+		return gen.GetPackageVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: fmt.Sprintf("failed to unescape package url: %v", err),
+			},
+		}, nil
+	}
+
+	includeDeps := false
+	if request.Params.IncludeDependencies != nil {
+		includeDeps = *request.Params.IncludeDependencies
+	}
+
+	vulns, err := GetVulnsForPackage(ctx, s.gqlClient, unescapedPurl, includeDeps)
+	if err != nil {
+		errResp, ok := handleErr(ctx, err, GetPackageVulns).(gen.GetPackageVulnsResponseObject)
+		if ok {
+			return errResp, nil
+		}
+		return gen.GetPackageVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: err.Error(),
+			},
+		}, nil
+	}
+
+	return gen.GetPackageVulns200JSONResponse{
+		VulnerabilityListJSONResponse: vulns,
 	}, nil
 }
 


### PR DESCRIPTION
# Description of the PR

Returns CertifyVuln records for the package. When includeDependencies is set, transitive dependencies are walked via GetDepsForPackage and their vulns are included too.

Fixes #2998
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
