### PR TITLE
feat(guacrest): implement GET /v0/artifact/{digest}/vulns

### DIFF
--- a/pkg/guacrest/server/retrieveVulns.go
+++ b/pkg/guacrest/server/retrieveVulns.go
@@ -1,0 +1,144 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Khan/genqlient/graphql"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	assembler_helpers "github.com/guacsec/guac/pkg/assembler/helpers"
+	gen "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/helpers"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+// GetVulnsForArtifact returns the vulnerabilities certified against any
+// package that the artifact (identified by digest) is an occurrence of.
+func GetVulnsForArtifact(ctx context.Context, gqlClient graphql.Client, digest string) ([]gen.Vulnerability, error) {
+	art, err := helpers.FindArtifactWithDigest(ctx, gqlClient, digest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find artifact: %w", err)
+	}
+	pkgIDs, err := packageIDsForArtifact(ctx, gqlClient, art.Id)
+	if err != nil {
+		return nil, err
+	}
+	return vulnsForPackageIDs(ctx, gqlClient, pkgIDs)
+}
+
+// packageIDsForArtifact walks artifact -> IsOccurrence -> package and
+// returns the de-duplicated set of package version IDs.
+func packageIDsForArtifact(ctx context.Context, gqlClient graphql.Client, artID string) ([]string, error) {
+	logger := logging.FromContext(ctx)
+
+	occNeighbors, err := gql.Neighbors(ctx, gqlClient, artID, []gql.Edge{gql.EdgeArtifactIsOccurrence})
+	if err != nil {
+		logger.Errorf("Neighbors query returned err: %v", err)
+		return nil, helpers.Err502
+	}
+	seen := map[string]struct{}{}
+	var pkgIDs []string
+	for _, n := range occNeighbors.GetNeighbors() {
+		occ, ok := n.(*gql.NeighborsNeighborsIsOccurrence)
+		if !ok || occ == nil {
+			continue
+		}
+		pkgNeighbors, err := gql.Neighbors(ctx, gqlClient, occ.Id, []gql.Edge{gql.EdgeIsOccurrencePackage})
+		if err != nil {
+			logger.Errorf("Neighbors query returned err: %v", err)
+			return nil, helpers.Err502
+		}
+		for _, pn := range pkgNeighbors.GetNeighbors() {
+			pkg, ok := pn.(*gql.NeighborsNeighborsPackage)
+			if !ok || pkg == nil {
+				continue
+			}
+			for _, v := range helpers.GetVersionsOfAllPackageTree(pkg.AllPkgTree) {
+				if _, dup := seen[v.Id]; dup {
+					continue
+				}
+				seen[v.Id] = struct{}{}
+				pkgIDs = append(pkgIDs, v.Id)
+			}
+		}
+	}
+	return pkgIDs, nil
+}
+
+// vulnsForPackageIDs queries CertifyVuln for each package version ID and
+// flattens the results into the REST Vulnerability shape, deduplicating by
+// certification ID.
+func vulnsForPackageIDs(ctx context.Context, gqlClient graphql.Client, pkgIDs []string) ([]gen.Vulnerability, error) {
+	logger := logging.FromContext(ctx)
+	seen := map[string]struct{}{}
+	result := []gen.Vulnerability{}
+	for _, id := range pkgIDs {
+		pkgID := id
+		resp, err := gql.CertifyVuln(ctx, gqlClient, gql.CertifyVulnSpec{Package: &gql.PkgSpec{Id: &pkgID}})
+		if err != nil {
+			logger.Errorf("CertifyVuln query returned err: %v", err)
+			return nil, helpers.Err502
+		}
+		for _, cv := range resp.GetCertifyVuln() {
+			if _, dup := seen[cv.Id]; dup {
+				continue
+			}
+			seen[cv.Id] = struct{}{}
+			result = append(result, certifyVulnToREST(cv))
+		}
+	}
+	return result, nil
+}
+
+// certifyVulnToREST projects a gql CertifyVuln into the REST Vulnerability
+// shape defined by the OpenAPI spec.
+func certifyVulnToREST(cv gql.CertifyVulnCertifyVuln) gen.Vulnerability {
+	pkgTree := cv.Package.AllPkgTree
+	purl := assembler_helpers.AllPkgTreeToPurl(&pkgTree)
+
+	ids := make([]string, 0, len(cv.Vulnerability.VulnerabilityIDs))
+	for _, vid := range cv.Vulnerability.VulnerabilityIDs {
+		ids = append(ids, vid.VulnerabilityID)
+	}
+
+	vulnType := cv.Vulnerability.Type
+	dbURI := cv.Metadata.DbUri
+	dbVer := cv.Metadata.DbVersion
+	scannerURI := cv.Metadata.ScannerUri
+	scannerVer := cv.Metadata.ScannerVersion
+	origin := cv.Metadata.Origin
+	collector := cv.Metadata.Collector
+	timeScanned := cv.Metadata.TimeScanned
+
+	return gen.Vulnerability{
+		Package: purl,
+		Vulnerability: gen.VulnerabilityDetails{
+			Type:             &vulnType,
+			VulnerabilityIDs: ids,
+		},
+		Metadata: gen.ScanMetadata{
+			DbUri:          &dbURI,
+			DbVersion:      &dbVer,
+			ScannerUri:     &scannerURI,
+			ScannerVersion: &scannerVer,
+			Origin:         &origin,
+			Collector:      &collector,
+			TimeScanned:    &timeScanned,
+		},
+	}
+}

--- a/pkg/guacrest/server/retrieveVulns_test.go
+++ b/pkg/guacrest/server/retrieveVulns_test.go
@@ -1,0 +1,143 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	stdcmp "cmp"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	. "github.com/guacsec/guac/internal/testing/graphqlClients"
+	_ "github.com/guacsec/guac/pkg/assembler/backends/keyvalue"
+	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
+	gen "github.com/guacsec/guac/pkg/guacrest/generated"
+	"github.com/guacsec/guac/pkg/guacrest/server"
+	"github.com/guacsec/guac/pkg/logging"
+)
+
+func vulnScanMeta() *gql.ScanMetadataInput {
+	return &gql.ScanMetadataInput{TimeScanned: time.Now()}
+}
+
+func vulnIDsFromResult(vs []gen.Vulnerability) []string {
+	out := []string{}
+	for _, v := range vs {
+		out = append(out, v.Vulnerability.VulnerabilityIDs...)
+	}
+	return out
+}
+
+func Test_GetVulnsForArtifact(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	tests := []struct {
+		name     string
+		data     GuacData
+		digest   string
+		expected []string
+	}{
+		{
+			name: "Artifact -> IsOccurrence -> package with vuln",
+			data: GuacData{
+				Packages:        []string{"pkg:guac/foo"},
+				Artifacts:       []string{"sha-xyz"},
+				Vulnerabilities: []string{"osv/CVE-2024-0001"},
+				IsOccurrences:   []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
+				CertifyVulns:    []CertifyVuln{{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()}},
+			},
+			digest:   "sha-xyz",
+			expected: []string{"cve-2024-0001"},
+		},
+		{
+			name: "Artifact with no IsOccurrence returns empty",
+			data: GuacData{
+				Artifacts: []string{"sha-xyz"},
+			},
+			digest:   "sha-xyz",
+			expected: []string{},
+		},
+		{
+			name: "Artifact with package that has no vuln returns empty",
+			data: GuacData{
+				Packages:      []string{"pkg:guac/foo"},
+				Artifacts:     []string{"sha-xyz"},
+				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
+			},
+			digest:   "sha-xyz",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gqlClient := SetupTest(t)
+			Ingest(ctx, t, gqlClient, tt.data)
+
+			got, err := server.GetVulnsForArtifact(ctx, gqlClient, tt.digest)
+			if err != nil {
+				t.Fatalf("GetVulnsForArtifact returned unexpected error: %v", err)
+			}
+			ids := vulnIDsFromResult(got)
+			if !cmp.Equal(ids, tt.expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(stdcmp.Less[string])) {
+				t.Errorf("vuln IDs = %v, want %v", ids, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_GetArtifactVulns_HTTP(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+
+	t.Run("Returns 200 with vuln list", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		Ingest(ctx, t, gqlClient, GuacData{
+			Packages:        []string{"pkg:guac/foo"},
+			Artifacts:       []string{"sha-xyz"},
+			Vulnerabilities: []string{"osv/CVE-2024-0001"},
+			IsOccurrences:   []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
+			CertifyVulns:    []CertifyVuln{{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()}},
+		})
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetArtifactVulns(ctx, gen.GetArtifactVulnsRequestObject{Digest: "sha-xyz"})
+		if err != nil {
+			t.Fatalf("GetArtifactVulns returned unexpected error: %v", err)
+		}
+		ok, success := res.(gen.GetArtifactVulns200JSONResponse)
+		if !success {
+			t.Fatalf("expected 200 response, got %T: %v", res, res)
+		}
+		if len(ok.VulnerabilityListJSONResponse) == 0 {
+			t.Errorf("expected at least one vulnerability in response")
+		}
+	})
+
+	t.Run("Returns 400 for unknown digest", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetArtifactVulns(ctx, gen.GetArtifactVulnsRequestObject{Digest: "sha-missing"})
+		if err != nil {
+			t.Fatalf("GetArtifactVulns returned unexpected error: %v", err)
+		}
+		if _, ok := res.(gen.GetArtifactVulns400JSONResponse); !ok {
+			t.Fatalf("expected 400 response, got %T: %v", res, res)
+		}
+	})
+}

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -171,10 +171,30 @@ func (s *DefaultServer) GetPackageDeps(ctx context.Context, request gen.GetPacka
 }
 
 func (s *DefaultServer) GetArtifactVulns(ctx context.Context, request gen.GetArtifactVulnsRequestObject) (gen.GetArtifactVulnsResponseObject, error) {
-	return gen.GetArtifactVulns500JSONResponse{
-		InternalServerErrorJSONResponse: gen.InternalServerErrorJSONResponse{
-			Message: "GetArtifactVulns not implemented",
-		},
+	unescapedDigest, err := url.PathUnescape(request.Digest)
+	if err != nil {
+		return gen.GetArtifactVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: fmt.Sprintf("failed to unescape digest: %v", err),
+			},
+		}, nil
+	}
+
+	vulns, err := GetVulnsForArtifact(ctx, s.gqlClient, unescapedDigest)
+	if err != nil {
+		errResp, ok := handleErr(ctx, err, GetArtifactVulns).(gen.GetArtifactVulnsResponseObject)
+		if ok {
+			return errResp, nil
+		}
+		return gen.GetArtifactVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: err.Error(),
+			},
+		}, nil
+	}
+
+	return gen.GetArtifactVulns200JSONResponse{
+		VulnerabilityListJSONResponse: vulns,
 	}, nil
 }
 

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -147,10 +147,30 @@ func (s *DefaultServer) GetPackageDeps(ctx context.Context, request gen.GetPacka
 }
 
 func (s *DefaultServer) GetArtifactVulns(ctx context.Context, request gen.GetArtifactVulnsRequestObject) (gen.GetArtifactVulnsResponseObject, error) {
-	return gen.GetArtifactVulns500JSONResponse{
-		InternalServerErrorJSONResponse: gen.InternalServerErrorJSONResponse{
-			Message: "GetArtifactVulns not implemented",
-		},
+	unescapedDigest, err := url.PathUnescape(request.Digest)
+	if err != nil {
+		return gen.GetArtifactVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: fmt.Sprintf("failed to unescape digest: %v", err),
+			},
+		}, nil
+	}
+
+	vulns, err := GetVulnsForArtifact(ctx, s.gqlClient, unescapedDigest)
+	if err != nil {
+		errResp, ok := handleErr(ctx, err, GetArtifactVulns).(gen.GetArtifactVulnsResponseObject)
+		if ok {
+			return errResp, nil
+		}
+		return gen.GetArtifactVulns400JSONResponse{
+			BadRequestJSONResponse: gen.BadRequestJSONResponse{
+				Message: err.Error(),
+			},
+		}, nil
+	}
+
+	return gen.GetArtifactVulns200JSONResponse{
+		VulnerabilityListJSONResponse: vulns,
 	}, nil
 }
 


### PR DESCRIPTION
# Description of the PR
Walks artifact -> IsOccurrence -> package -> CertifyVuln and returns the vulnerabilities in the OpenAPI VulnerabilityList shape.

Fixes #3000 

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
