### PR TITLE
fix(guacrest): populate PaginationInfo.TotalCount in getPackageDeps

### DIFF
--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -142,6 +142,8 @@ func (s *DefaultServer) GetPackageDeps(ctx context.Context, request gen.GetPacka
 	for _, depPurl := range purls {
 		result.PurlList = append(result.PurlList, depPurl)
 	}
+	totalCount := len(result.PurlList)
+	result.PaginationInfo = gen.PaginationInfo{TotalCount: &totalCount}
 
 	return result, nil
 }

--- a/pkg/guacrest/server/server.go
+++ b/pkg/guacrest/server/server.go
@@ -166,6 +166,8 @@ func (s *DefaultServer) GetPackageDeps(ctx context.Context, request gen.GetPacka
 	for _, depPurl := range purls {
 		result.PurlList = append(result.PurlList, depPurl)
 	}
+	totalCount := len(result.PurlList)
+	result.PaginationInfo = gen.PaginationInfo{TotalCount: &totalCount}
 
 	return result, nil
 }


### PR DESCRIPTION
# Description of the PR
The PurlList schema requires PaginationInfo, and the handler was returning a zero value.

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
