### PR TITLE
fix(e2e): update PURL version encoding in expect fixtures of E2E

### DIFF
--- a/internal/testing/e2e/expectIsDependencyQ2.json
+++ b/internal/testing/e2e/expectIsDependencyQ2.json
@@ -12,7 +12,7 @@
                 "name": "consul",
                 "versions": [
                   {
-                    "purl": "pkg:guac/cdx/docker.io/library/consul@sha256%3A22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c?tag=latest",
+                    "purl": "pkg:guac/cdx/docker.io/library/consul@sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c?tag=latest",
                     "version": "sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c",
                     "qualifiers": [
                       {

--- a/internal/testing/e2e/expectPathPy.json
+++ b/internal/testing/e2e/expectPathPy.json
@@ -25,7 +25,7 @@
             "name": "python",
             "versions": [
               {
-                "purl": "pkg:guac/cdx/docker.io/library/python@sha256%3Ae9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d?tag=latest",
+                "purl": "pkg:guac/cdx/docker.io/library/python@sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d?tag=latest",
                 "version": "sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d",
                 "subpath": ""
               }
@@ -48,7 +48,7 @@
               "name": "python",
               "versions": [
                 {
-                  "purl": "pkg:guac/cdx/docker.io/library/python@sha256%3Ae9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d?tag=latest",
+                  "purl": "pkg:guac/cdx/docker.io/library/python@sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d?tag=latest",
                   "version": "sha256:e9ebb760d74df0c28447c2f67050800c3392a3987ed77ce493545c7d3ad24c9d",
                   "subpath": ""
                 }

--- a/internal/testing/e2e/expectPkgQ4.json
+++ b/internal/testing/e2e/expectPkgQ4.json
@@ -10,7 +10,7 @@
               "name": "consul",
               "versions": [
                 {
-                  "purl": "pkg:guac/cdx/docker.io/library/consul@sha256%3A22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c?tag=latest",
+                  "purl": "pkg:guac/cdx/docker.io/library/consul@sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c?tag=latest",
                   "version": "sha256:22ab19cf1326abbfaafec6a14eb68f96e899e88ffe9ce26fa36affcf8ffb582c",
                   "qualifiers": [
                     {

--- a/internal/testing/e2e/expectPkgQ9.json
+++ b/internal/testing/e2e/expectPkgQ9.json
@@ -10,7 +10,7 @@
               "name": "libaudit-common",
               "versions": [
                 {
-                  "purl": "pkg:deb/debian/libaudit-common@1%3A3.0-2?arch=all&distro=debian-11&upstream=audit",
+                  "purl": "pkg:deb/debian/libaudit-common@1:3.0-2?arch=all&distro=debian-11&upstream=audit",
                   "version": "1:3.0-2",
                   "qualifiers": [
                     {
@@ -39,7 +39,7 @@
               "name": "libaudit-common",
               "versions": [
                 {
-                  "purl": "pkg:deb/ubuntu/libaudit-common@1%3A2.8.5-2ubuntu6?arch=all&distro=ubuntu-20.04&upstream=audit",
+                  "purl": "pkg:deb/ubuntu/libaudit-common@1:2.8.5-2ubuntu6?arch=all&distro=ubuntu-20.04&upstream=audit",
                   "version": "1:2.8.5-2ubuntu6",
                   "qualifiers": [
                     {
@@ -58,7 +58,7 @@
                   "subpath": ""
                 },
                 {
-                  "purl": "pkg:deb/ubuntu/libaudit-common@1%3A3.0.7-1build1?arch=all&distro=ubuntu-22.04&upstream=audit",
+                  "purl": "pkg:deb/ubuntu/libaudit-common@1:3.0.7-1build1?arch=all&distro=ubuntu-22.04&upstream=audit",
                   "version": "1:3.0.7-1build1",
                   "qualifiers": [
                     {


### PR DESCRIPTION
package-url-go v0.1.5 (adopted in #2988) emits ':' raw instead of URL-encoded '%3A'. So they all have to be replaced in E2E as well.

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
