### PR TITLE
feat:  adds devcontainer configurations to bring up GUAC components

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,74 @@
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Dev Container configuration for trialing GUAC.
+//
+// Works with GitHub Codespaces (cloud), the VS Code Dev Containers
+// extension (local), JetBrains Gateway, and DevPod. On container
+// create it pulls the published GUAC release image; on every start
+// it brings up the full service stack with the in-memory GraphQL
+// backend via docker compose. The GraphQL playground previews
+// automatically on port 8080 and the REST API is on 8081.
+//
+// To use the persistent ent/PostgreSQL backend instead, swap
+// container_files/mem.yaml for container_files/ent.yaml in the
+// postStartCommand below.
+//
+// See https://docs.guac.sh/ for ingestion and query examples.
+{
+  "name": "GUAC",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
+
+  "containerEnv": {
+    "GUAC_IMAGE": "ghcr.io/guacsec/guac:v1.1.0",
+    "GUAC_API_PORT": "8080"
+  },
+
+  "onCreateCommand": "docker pull ghcr.io/guacsec/guac:v1.1.0",
+
+  "postStartCommand": "docker compose -f docker-compose.yml -f container_files/mem.yaml up -d && bash -c 'c=0; until curl --silent --head --fail http://localhost:8080 >/dev/null; do if [ $c -ge 60 ]; then echo \"GUAC did not become ready in time\"; docker compose logs --tail=100; exit 1; fi; sleep 2; c=$((c+1)); done; echo; echo \"GUAC is ready.\"; echo \"  - GraphQL playground: port 8080 (auto-previewed)\"; echo \"  - REST API:           port 8081 (e.g. /healthz)\"; echo \"  - Tail logs:          docker compose logs -f\"; echo \"  - Stop:               docker compose down\"'",
+
+  "forwardPorts": [8080, 8081],
+
+  "portsAttributes": {
+    "8080": {
+      "label": "GUAC GraphQL",
+      "onAutoForward": "openPreview"
+    },
+    "8081": {
+      "label": "GUAC REST API",
+      "onAutoForward": "notify"
+    }
+  },
+
+  "otherPortsAttributes": {
+    "onAutoForward": "silent"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "graphql.vscode-graphql",
+        "graphql.vscode-graphql-syntax",
+        "ms-azuretools.vscode-docker",
+        "golang.go"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ can take a look.
 Starting the GUAC services with our
 [docker compose quickstart](https://docs.guac.sh/setup/).
 
+### Try in a Dev Container
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/guacsec/guac)
+
+The repo ships a [`.devcontainer`](./.devcontainer/devcontainer.json)
+config that brings up a full GUAC stack (GraphQL, REST, collectsub,
+ingestor, NATS, and the deps_dev / osv / ClearlyDefined collectors)
+backed by the published GUAC release image -- no local setup required.
+The GraphQL playground auto-previews on port 8080 and the REST API is
+on 8081. The same config also works with the VS Code Dev Containers
+extension (local, fully offline), JetBrains Gateway, and DevPod.
+
 ## Docs
 
 All documentation for GUAC lives on [docs.guac.sh](https://docs.guac.sh), backed

--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ Starting the GUAC services with our
 
 ### Try in a Dev Container
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/guacsec/guac)
-
 The repo ships a [`.devcontainer`](./.devcontainer/devcontainer.json)
-config that brings up a full GUAC stack (GraphQL, REST, collectsub,
+config that brings up the full GUAC stack (GraphQL, REST, collectsub,
 ingestor, NATS, and the deps_dev / osv / ClearlyDefined collectors)
-backed by the published GUAC release image -- no local setup required.
-The GraphQL playground auto-previews on port 8080 and the REST API is
-on 8081. The same config also works with the VS Code Dev Containers
-extension (local, fully offline), JetBrains Gateway, and DevPod.
+locally on Docker, backed by the published GUAC release image. Open
+the repo in VS Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+and select "Reopen in Container" -- the GraphQL playground forwards
+to port 8080 and the REST API to 8081. Also works with JetBrains
+Gateway and [DevPod](https://devpod.sh).
 
 ## Docs
 


### PR DESCRIPTION
# Description of the PR
Once this PR gets merged, GUAC Stack can be brought up with just a click using the devcontainers. Helpful for people who just want to try out GUAC for the first time. 

Fixes #2123

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
