### PR TITLE
feat: add VEX Hub certifier

### DIFF
--- a/cmd/guaccollect/cmd/vexhub.go
+++ b/cmd/guaccollect/cmd/vexhub.go
@@ -1,0 +1,197 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/certifier/vexhub"
+	"github.com/guacsec/guac/pkg/cli"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/metrics"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	vexHubQuerySize = 1000
+)
+
+type vexHubOptions struct {
+	graphqlEndpoint string
+	headerFile      string
+	pubsubAddr      string
+	blobAddr        string
+	poll            bool
+	interval        time.Duration
+	publishToQueue  bool
+	addedLatency    *time.Duration
+	batchSize       int
+	lastScan        *int
+	enableOtel      bool
+	manifestURL     string
+}
+
+var vexHubCmd = &cobra.Command{
+	Use:   "vexhub [flags]",
+	Short: "runs the VEX Hub certifier",
+	Long: `
+guaccollect vexhub runs the VEX Hub certifier that queries VEX repositories
+(conforming to the VEX Repo Spec) for VEX statements affecting packages in GUAC.
+Ingestion to GUAC happens via an event stream (NATS) to allow for decoupling of
+the collectors from the ingestion into GUAC.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		opts, err := validateVEXHubFlags(
+			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
+			viper.GetString("pubsub-addr"),
+			viper.GetString("blob-addr"),
+			viper.GetString("interval"),
+			viper.GetBool("service-poll"),
+			viper.GetBool("publish-to-queue"),
+			viper.GetString("certifier-latency"),
+			viper.GetInt("certifier-batch-size"),
+			viper.GetInt("last-scan"),
+			viper.GetBool("enable-otel"),
+			viper.GetString("vexhub-manifest-url"),
+		)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+
+		if opts.enableOtel {
+			shutdown, err := metrics.SetupOTelSDK(ctx)
+			if err != nil {
+				logger.Fatalf("Error setting up Otel: %v", err)
+			}
+			defer func() {
+				if err := shutdown(ctx); err != nil {
+					logger.Errorf("Error on Otel shutdown: %v", err)
+				}
+			}()
+		}
+
+		vexHubCertifierFunc := func() certifier.Certifier {
+			return vexhub.NewVEXHubCertifier(opts.manifestURL)
+		}
+		if err := certify.RegisterCertifier(vexHubCertifierFunc, certifier.CertifierVEXHub); err != nil {
+			logger.Fatalf("unable to register certifier: %v", err)
+		}
+
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
+		httpClient := http.Client{Transport: transport}
+		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
+
+		packageQueryFunc, err := getVEXHubPackageQuery(gqlclient, opts.batchSize, opts.addedLatency, opts.lastScan)
+		if err != nil {
+			logger.Errorf("error: %v", err)
+			os.Exit(1)
+		}
+
+		initializeNATsandCertifier(ctx, opts.blobAddr, opts.pubsubAddr, opts.poll, opts.publishToQueue, opts.interval, packageQueryFunc())
+	},
+}
+
+func getVEXHubPackageQuery(client graphql.Client, batchSize int, addedLatency *time.Duration, lastScan *int) (func() certifier.QueryComponents, error) {
+	return func() certifier.QueryComponents {
+		packageQuery := root_package.NewPackageQuery(client, generated.QueryTypeVulnerability, batchSize, vexHubQuerySize, addedLatency, lastScan)
+		return packageQuery
+	}, nil
+}
+
+func validateVEXHubFlags(
+	graphqlEndpoint,
+	headerFile,
+	pubsubAddr,
+	blobAddr,
+	interval string,
+	poll bool,
+	pubToQueue bool,
+	certifierLatencyStr string,
+	batchSize int,
+	lastScan int,
+	enableOtel bool,
+	manifestURL string,
+) (vexHubOptions, error) {
+	var opts vexHubOptions
+
+	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
+	opts.pubsubAddr = pubsubAddr
+	opts.blobAddr = blobAddr
+	opts.poll = poll
+	opts.publishToQueue = pubToQueue
+	opts.enableOtel = enableOtel
+	opts.manifestURL = manifestURL
+
+	i, err := time.ParseDuration(interval)
+	if err != nil {
+		return opts, fmt.Errorf("failed to parser duration with error: %w", err)
+	}
+	opts.interval = i
+
+	if certifierLatencyStr != "" {
+		addedLatency, err := time.ParseDuration(certifierLatencyStr)
+		if err != nil {
+			return opts, fmt.Errorf("failed to parser duration with error: %w", err)
+		}
+		opts.addedLatency = &addedLatency
+	} else {
+		opts.addedLatency = nil
+	}
+
+	opts.batchSize = batchSize
+	if lastScan != 0 {
+		opts.lastScan = &lastScan
+	}
+	return opts, nil
+}
+
+func init() {
+	set, err := cli.BuildFlags([]string{"interval",
+		"header-file", "certifier-latency",
+		"certifier-batch-size", "last-scan"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	vexHubCmd.Flags().String("vexhub-manifest-url", vexhub.DefaultManifestURL,
+		"URL of the VEX repository manifest (vex-repository.json)")
+	vexHubCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(vexHubCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlags(vexHubCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+	rootCmd.AddCommand(vexHubCmd)
+}

--- a/cmd/guaccollect/cmd/vexhub.go
+++ b/cmd/guaccollect/cmd/vexhub.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/guaccollect/cmd/vexhub.go
+++ b/cmd/guaccollect/cmd/vexhub.go
@@ -98,8 +98,14 @@ the collectors from the ingestion into GUAC.`,
 			}()
 		}
 
+		// certify.generateDocuments calls this factory once per component batch.
+		// The certifier caches the indexed archive and tracks which documents it
+		// has already emitted on itself, so hand back a single shared instance --
+		// returning a new one per batch would drop that state and re-download the
+		// archive on every batch.
+		vexHubCertifier := vexhub.NewVEXHubCertifier(opts.manifestURL)
 		vexHubCertifierFunc := func() certifier.Certifier {
-			return vexhub.NewVEXHubCertifier(opts.manifestURL)
+			return vexHubCertifier
 		}
 		if err := certify.RegisterCertifier(vexHubCertifierFunc, certifier.CertifierVEXHub); err != nil {
 			logger.Fatalf("unable to register certifier: %v", err)

--- a/cmd/guacone/cmd/vexhub.go
+++ b/cmd/guacone/cmd/vexhub.go
@@ -1,0 +1,357 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/certify"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/certifier/vexhub"
+	"github.com/guacsec/guac/pkg/cli"
+	csub_client "github.com/guacsec/guac/pkg/collectsub/client"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/ingestor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/metrics"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	vexHubQuerySize = 1000
+)
+
+type vexHubOptions struct {
+	graphqlEndpoint         string
+	headerFile              string
+	poll                    bool
+	csubClientOptions       csub_client.CsubClientOptions
+	interval                time.Duration
+	queryVulnOnIngestion    bool
+	queryLicenseOnIngestion bool
+	queryEOLOnIngestion     bool
+	queryDepsDevOnIngestion bool
+	addedLatency            *time.Duration
+	batchSize               int
+	lastScan                *int
+	enableOtel              bool
+	manifestURL             string
+}
+
+var vexHubCmd = &cobra.Command{
+	Use:   "vexhub [flags]",
+	Short: "runs the VEX Hub certifier",
+	Long:  "Queries VEX repositories (conforming to the VEX Repo Spec) for VEX statements affecting packages in GUAC",
+	Run: func(cmd *cobra.Command, args []string) {
+		opts, err := validateVEXHubFlags(
+			viper.GetString("gql-addr"),
+			viper.GetString("header-file"),
+			viper.GetString("interval"),
+			viper.GetString("csub-addr"),
+			viper.GetBool("poll"),
+			viper.GetBool("csub-tls"),
+			viper.GetBool("csub-tls-skip-verify"),
+			viper.GetBool("add-vuln-on-ingest"),
+			viper.GetBool("add-license-on-ingest"),
+			viper.GetBool("add-eol-on-ingest"),
+			viper.GetBool("add-depsdev-on-ingest"),
+			viper.GetString("certifier-latency"),
+			viper.GetInt("certifier-batch-size"),
+			viper.GetInt("last-scan"),
+			viper.GetBool("enable-otel"),
+			viper.GetString("vexhub-manifest-url"),
+		)
+		if err != nil {
+			fmt.Printf("unable to validate flags: %v\n", err)
+			_ = cmd.Help()
+			os.Exit(1)
+		}
+
+		ctx := logging.WithLogger(context.Background())
+		logger := logging.FromContext(ctx)
+		transport := cli.HTTPHeaderTransport(ctx, opts.headerFile, http.DefaultTransport)
+
+		if opts.enableOtel {
+			shutdown, err := metrics.SetupOTelSDK(ctx)
+			if err != nil {
+				logger.Fatalf("Error setting up Otel: %v", err)
+			}
+			defer func() {
+				if err := shutdown(ctx); err != nil {
+					logger.Errorf("Error on Otel shutdown: %v", err)
+				}
+			}()
+		}
+
+		vexHubCertifierFunc := func() certifier.Certifier {
+			return vexhub.NewVEXHubCertifier(opts.manifestURL)
+		}
+		if err := certify.RegisterCertifier(vexHubCertifierFunc, certifier.CertifierVEXHub); err != nil {
+			logger.Fatalf("unable to register certifier: %v", err)
+		}
+
+		csubClient, err := csub_client.NewClient(opts.csubClientOptions)
+		if err != nil {
+			logger.Infof("collectsub client initialization failed, this ingestion will not pull in any additional data through the collectsub service: %v", err)
+			csubClient = nil
+		} else {
+			defer csubClient.Close()
+		}
+
+		httpClient := http.Client{Transport: transport}
+		gqlclient := graphql.NewClient(opts.graphqlEndpoint, &httpClient)
+		packageQuery := root_package.NewPackageQuery(gqlclient, generated.QueryTypeVulnerability, opts.batchSize, vexHubQuerySize, opts.addedLatency, opts.lastScan)
+
+		totalNum := 0
+		docChan := make(chan *processor.Document)
+		ingestionStop := make(chan bool, 1)
+		tickInterval := 30 * time.Second
+		ticker := time.NewTicker(tickInterval)
+		ctx, cf := context.WithCancel(ctx)
+
+		var gotErr int32
+		var wg sync.WaitGroup
+		ingestion := func() {
+			defer wg.Done()
+			var totalDocs []*processor.Document
+			const threshold = 1000
+			stop := false
+			for !stop {
+				select {
+				case <-ticker.C:
+					if len(totalDocs) > 0 {
+						err = ingestor.MergedIngest(ctx,
+							totalDocs,
+							opts.graphqlEndpoint,
+							transport,
+							csubClient,
+							opts.queryVulnOnIngestion,
+							opts.queryLicenseOnIngestion,
+							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
+						)
+						if err != nil {
+							stop = true
+							atomic.StoreInt32(&gotErr, 1)
+							logger.Errorf("unable to ingest documents: %v", err)
+						}
+						totalDocs = []*processor.Document{}
+					}
+					ticker.Reset(tickInterval)
+				case d := <-docChan:
+					totalNum += 1
+					totalDocs = append(totalDocs, d)
+					if len(totalDocs) >= threshold {
+						err = ingestor.MergedIngest(ctx,
+							totalDocs,
+							opts.graphqlEndpoint,
+							transport,
+							csubClient,
+							opts.queryVulnOnIngestion,
+							opts.queryLicenseOnIngestion,
+							opts.queryEOLOnIngestion,
+							opts.queryDepsDevOnIngestion,
+						)
+						if err != nil {
+							stop = true
+							atomic.StoreInt32(&gotErr, 1)
+							logger.Errorf("unable to ingest documents: %v", err)
+						}
+						totalDocs = []*processor.Document{}
+						ticker.Reset(tickInterval)
+					}
+				case <-ingestionStop:
+					stop = true
+				case <-ctx.Done():
+					return
+				}
+			}
+			for len(docChan) > 0 {
+				totalNum += 1
+				totalDocs = append(totalDocs, <-docChan)
+				if len(totalDocs) >= threshold {
+					err = ingestor.MergedIngest(
+						ctx,
+						totalDocs,
+						opts.graphqlEndpoint,
+						transport,
+						csubClient,
+						opts.queryVulnOnIngestion,
+						opts.queryLicenseOnIngestion,
+						opts.queryEOLOnIngestion,
+						opts.queryDepsDevOnIngestion,
+					)
+					if err != nil {
+						atomic.StoreInt32(&gotErr, 1)
+						logger.Errorf("unable to ingest documents: %v", err)
+					}
+					totalDocs = []*processor.Document{}
+				}
+			}
+			if len(totalDocs) > 0 {
+				err = ingestor.MergedIngest(
+					ctx,
+					totalDocs,
+					opts.graphqlEndpoint,
+					transport,
+					csubClient,
+					opts.queryVulnOnIngestion,
+					opts.queryLicenseOnIngestion,
+					opts.queryEOLOnIngestion,
+					opts.queryDepsDevOnIngestion,
+				)
+				if err != nil {
+					atomic.StoreInt32(&gotErr, 1)
+					logger.Errorf("unable to ingest documents: %v", err)
+				}
+			}
+		}
+		wg.Add(1)
+		go ingestion()
+
+		emit := func(d *processor.Document) error {
+			docChan <- d
+			return nil
+		}
+
+		errHandler := func(err error) bool {
+			if err != nil {
+				logger.Errorf("certifier ended with error: %v", err)
+				atomic.StoreInt32(&gotErr, 1)
+			}
+			return true
+		}
+
+		done := make(chan bool, 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := certify.Certify(ctx, packageQuery, emit, errHandler, opts.poll, opts.interval); err != nil {
+				logger.Errorf("Unhandled error in the certifier: %s", err)
+			}
+			done <- true
+		}()
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case s := <-sigs:
+			logger.Infof("Signal received: %s, shutting down gracefully\n", s.String())
+			cf()
+		case <-done:
+			logger.Infof("All certifiers completed")
+		}
+		ingestionStop <- true
+		wg.Wait()
+		cf()
+
+		if atomic.LoadInt32(&gotErr) == 1 {
+			logger.Errorf("completed ingestion with errors")
+		} else {
+			logger.Infof("completed ingesting %v documents", totalNum)
+		}
+	},
+}
+
+func validateVEXHubFlags(
+	graphqlEndpoint,
+	headerFile,
+	interval,
+	csubAddr string,
+	poll,
+	csubTls,
+	csubTlsSkipVerify bool,
+	queryVulnIngestion bool,
+	queryLicenseIngestion bool,
+	queryEOLIngestion bool,
+	queryDepsDevIngestion bool,
+	certifierLatencyStr string,
+	batchSize int, lastScan int,
+	enableOtel bool,
+	manifestURL string,
+) (vexHubOptions, error) {
+	var opts vexHubOptions
+	opts.graphqlEndpoint = graphqlEndpoint
+	opts.headerFile = headerFile
+	opts.poll = poll
+	i, err := time.ParseDuration(interval)
+	if err != nil {
+		return opts, err
+	}
+	opts.interval = i
+	opts.enableOtel = enableOtel
+	opts.manifestURL = manifestURL
+
+	if certifierLatencyStr != "" {
+		addedLatency, err := time.ParseDuration(certifierLatencyStr)
+		if err != nil {
+			return opts, fmt.Errorf("failed to parser duration with error: %w", err)
+		}
+		opts.addedLatency = &addedLatency
+	} else {
+		opts.addedLatency = nil
+	}
+
+	opts.batchSize = batchSize
+
+	if lastScan != 0 {
+		opts.lastScan = &lastScan
+	}
+
+	csubOpts, err := csub_client.ValidateCsubClientFlags(csubAddr, csubTls, csubTlsSkipVerify)
+	if err != nil {
+		return opts, fmt.Errorf("unable to validate csub client flags: %w", err)
+	}
+	opts.csubClientOptions = csubOpts
+	opts.queryVulnOnIngestion = queryVulnIngestion
+	opts.queryLicenseOnIngestion = queryLicenseIngestion
+	opts.queryEOLOnIngestion = queryEOLIngestion
+	opts.queryDepsDevOnIngestion = queryDepsDevIngestion
+
+	return opts, nil
+}
+
+func init() {
+	set, err := cli.BuildFlags([]string{"certifier-latency",
+		"certifier-batch-size", "last-scan"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup flag: %v", err)
+		os.Exit(1)
+	}
+	vexHubCmd.Flags().String("vexhub-manifest-url", vexhub.DefaultManifestURL,
+		"URL of the VEX repository manifest (vex-repository.json)")
+	vexHubCmd.PersistentFlags().AddFlagSet(set)
+	if err := viper.BindPFlags(vexHubCmd.PersistentFlags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlags(vexHubCmd.Flags()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to bind flags: %v", err)
+		os.Exit(1)
+	}
+	certifierCmd.AddCommand(vexHubCmd)
+}

--- a/cmd/guacone/cmd/vexhub.go
+++ b/cmd/guacone/cmd/vexhub.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/guacone/cmd/vexhub.go
+++ b/cmd/guacone/cmd/vexhub.go
@@ -108,8 +108,14 @@ var vexHubCmd = &cobra.Command{
 			}()
 		}
 
+		// certify.generateDocuments calls this factory once per component batch.
+		// The certifier caches the indexed archive and tracks which documents it
+		// has already emitted on itself, so hand back a single shared instance --
+		// returning a new one per batch would drop that state and re-download the
+		// archive on every batch.
+		vexHubCertifier := vexhub.NewVEXHubCertifier(opts.manifestURL)
 		vexHubCertifierFunc := func() certifier.Certifier {
-			return vexhub.NewVEXHubCertifier(opts.manifestURL)
+			return vexHubCertifier
 		}
 		if err := certify.RegisterCertifier(vexHubCertifierFunc, certifier.CertifierVEXHub); err != nil {
 			logger.Fatalf("unable to register certifier: %v", err)

--- a/docs/vexhub_certifier.md
+++ b/docs/vexhub_certifier.md
@@ -1,42 +1,75 @@
 # VEX Hub Certifier
 
-The VEX Hub certifier queries VEX (Vulnerability Exploitability eXchange) repositories conforming to the [VEX Repository Specification](https://github.com/openvex/vex-repo-spec) to discover VEX statements affecting software packages ingested into GUAC.
+The VEX Hub certifier queries VEX (Vulnerability Exploitability eXchange)
+repositories conforming to the
+[VEX Repository Specification](https://github.com/openvex/vex-repo-spec) to
+discover VEX statements affecting software packages ingested into GUAC.
 
 ## Overview
 
-The certifier downloads and indexes VEX repositories to match package URLs (PURLs) against known VEX statements, outputting OpenVEX documents to GUAC processors.
+The certifier downloads and indexes VEX repositories to match package URLs
+(PURLs) against known VEX statements, outputting OpenVEX documents to GUAC
+processors.
 
 ## Configuration & Flags
 
 The certifier can be configured via CLI flags or configuration files:
 
-- `--vexhub-manifest-url`: URL of the VEX repository manifest (defaults to `https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json`).
-- `--certifier-batch-size`: Number of package nodes certified per batch query (defaults to 1000).
+- `--vexhub-manifest-url`: URL of the VEX repository manifest (defaults to
+  `https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json`).
+- `--certifier-batch-size`: Number of package nodes certified per batch query
+  (defaults to 1000).
 - `--interval`: Duration between polling runs when polling is enabled.
-- `--poll` / `--service-poll`: Enables continuous polling mode for periodic VEX synchronization.
+- `--poll` / `--service-poll`: Enables continuous polling mode for periodic VEX
+  synchronization.
 
 ## Manifest and Repository Layout
 
 A VEX repository follows the VEX Repo Spec layout:
 
-1. **Repository Manifest (`vex-repository.json`)**:
-   Contains metadata about the repository, supported specification versions (`spec_version: "0.1"`), archive mirror locations, and an optional `update_interval` (e.g., `"1h"`, `"24h"`).
-   Subdirectory paths within an archive may be denoted using a `//` delimiter in the location URL (e.g., `https://example.com/archive.tar.gz//subdir-name`).
+1. **Repository Manifest (`vex-repository.json`)**: Contains metadata about the
+   repository, supported specification versions (`spec_version: "0.1"`), archive
+   mirror locations, and an optional `update_interval` (e.g., `"1h"`, `"24h"`).
+   Subdirectory paths within an archive may be denoted using a `//` delimiter in
+   the location URL (e.g., `https://example.com/archive.tar.gz//subdir-name`).
 
-2. **Index (`index.json`)**:
-   Located inside the archive root or specified subdirectory. Maps PURL identifiers to the relative path of their corresponding VEX document and specifies document format.
+2. **Index (`index.json`)**: Located inside the archive root or specified
+   subdirectory. Maps PURL identifiers to the relative path of their
+   corresponding VEX document and specifies document format.
 
-3. **VEX Documents**:
-   Individual VEX files stored at paths designated in `index.json`.
+3. **VEX Documents**: Individual VEX files stored at paths designated in
+   `index.json`.
 
 ## Supported Formats
 
-- **OpenVEX**: Fully supported (`format: "openvex"` or unspecified/empty format for backward compatibility).
-- Non-OpenVEX formats (such as CSAF) listed in `index.json` are skipped by the certifier.
+- **OpenVEX**: Fully supported (`format: "openvex"` or unspecified/empty format
+  for backward compatibility).
+- Non-OpenVEX formats (such as CSAF) listed in `index.json` are skipped by the
+  certifier.
 
 ## Caching and Performance
 
-- **Manifest & Document Caching**: The certifier caches parsed manifests and VEX document maps in-memory, keyed by the manifest URL.
-- **Cache TTL**: The cache TTL is dynamically derived from the manifest's `update_interval` field (defaulting to 1 hour if not specified).
-- **Two-Pass Extraction**: Archives are buffered to temporary files and read using two streaming passes to extract only referenced documents, protecting against unbounded memory consumption and tar-bombs.
-- **Cross-Batch Deduplication**: Documents that have already been emitted are tracked across batch queries to prevent redundant ingestions.
+- **Shared Instance**: The certifier is constructed once and reused for every
+  component batch. The cache and deduplication state live on that instance, so
+  registering a factory that builds a new certifier per batch would discard both
+  and re-download the archive on every batch.
+- **Document Caching**: The indexed archive is held in memory as a
+  canonical-PURL to document map.
+- **Cache TTL**: The cache TTL is derived from the manifest's `update_interval`
+  field (defaulting to 1 hour when absent or unparseable).
+- **Two-Pass Extraction**: Archives are buffered to temporary files and read
+  using two streaming passes to extract only referenced documents, protecting
+  against unbounded memory consumption and tar-bombs. Individual entries larger
+  than 32 MiB are rejected rather than truncated.
+- **Deduplication**: Emitted documents are tracked by document digest rather
+  than by PURL, so an unchanged document is never re-sent, while a statement
+  revised upstream is picked up on the next refresh.
+
+## Error Handling
+
+- A manifest that declares no locations for the supported spec version, or whose
+  every location fails the reachability probe, returns an error. An unreachable
+  hub is therefore distinguishable from a hub with nothing to report.
+- The reachability probe uses HEAD but treats only a transport error or a
+  definitive `404`/`410` as disqualifying, since many object stores and CDNs
+  answer `403`/`405` to HEAD while serving the same URL over GET.

--- a/docs/vexhub_certifier.md
+++ b/docs/vexhub_certifier.md
@@ -1,0 +1,42 @@
+# VEX Hub Certifier
+
+The VEX Hub certifier queries VEX (Vulnerability Exploitability eXchange) repositories conforming to the [VEX Repository Specification](https://github.com/openvex/vex-repo-spec) to discover VEX statements affecting software packages ingested into GUAC.
+
+## Overview
+
+The certifier downloads and indexes VEX repositories to match package URLs (PURLs) against known VEX statements, outputting OpenVEX documents to GUAC processors.
+
+## Configuration & Flags
+
+The certifier can be configured via CLI flags or configuration files:
+
+- `--vexhub-manifest-url`: URL of the VEX repository manifest (defaults to `https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json`).
+- `--certifier-batch-size`: Number of package nodes certified per batch query (defaults to 1000).
+- `--interval`: Duration between polling runs when polling is enabled.
+- `--poll` / `--service-poll`: Enables continuous polling mode for periodic VEX synchronization.
+
+## Manifest and Repository Layout
+
+A VEX repository follows the VEX Repo Spec layout:
+
+1. **Repository Manifest (`vex-repository.json`)**:
+   Contains metadata about the repository, supported specification versions (`spec_version: "0.1"`), archive mirror locations, and an optional `update_interval` (e.g., `"1h"`, `"24h"`).
+   Subdirectory paths within an archive may be denoted using a `//` delimiter in the location URL (e.g., `https://example.com/archive.tar.gz//subdir-name`).
+
+2. **Index (`index.json`)**:
+   Located inside the archive root or specified subdirectory. Maps PURL identifiers to the relative path of their corresponding VEX document and specifies document format.
+
+3. **VEX Documents**:
+   Individual VEX files stored at paths designated in `index.json`.
+
+## Supported Formats
+
+- **OpenVEX**: Fully supported (`format: "openvex"` or unspecified/empty format for backward compatibility).
+- Non-OpenVEX formats (such as CSAF) listed in `index.json` are skipped by the certifier.
+
+## Caching and Performance
+
+- **Manifest & Document Caching**: The certifier caches parsed manifests and VEX document maps in-memory, keyed by the manifest URL.
+- **Cache TTL**: The cache TTL is dynamically derived from the manifest's `update_interval` field (defaulting to 1 hour if not specified).
+- **Two-Pass Extraction**: Archives are buffered to temporary files and read using two streaming passes to extract only referenced documents, protecting against unbounded memory consumption and tar-bombs.
+- **Cross-Batch Deduplication**: Documents that have already been emitted are tracked across batch queries to prevent redundant ingestions.

--- a/pkg/certifier/certifier.go
+++ b/pkg/certifier/certifier.go
@@ -51,4 +51,5 @@ const (
 	CertifierClearlyDefined CertifierType = "CD"
 	CertifierScorecard      CertifierType = "scorecard"
 	CertifierEOL            CertifierType = "EOL"
+	CertifierVEXHub         CertifierType = "vexhub"
 )

--- a/pkg/certifier/certifier.go
+++ b/pkg/certifier/certifier.go
@@ -52,4 +52,5 @@ const (
 	CertifierScorecard      CertifierType = "scorecard"
 	CertifierEOL            CertifierType = "EOL"
 	CertifierDatadogMalware CertifierType = "DATADOG_MALWARE"
+	CertifierVEXHub         CertifierType = "vexhub"
 )

--- a/pkg/certifier/vexhub/vexhub.go
+++ b/pkg/certifier/vexhub/vexhub.go
@@ -1,0 +1,359 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vexhub
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/guacsec/guac/pkg/certifier"
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/clients"
+	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
+
+	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/time/rate"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+const (
+	DefaultManifestURL = "https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json"
+	VEXHubCollector    = "vexhub_certifier"
+	rateLimit          = 100
+)
+
+var rateLimitInterval = time.Second
+
+var ErrComponentTypeMismatch = errors.New("rootComponent type is not []*root_package.PackageNode")
+
+// Manifest represents a vex-repository.json file.
+type Manifest struct {
+	Name     string            `json:"name"`
+	Versions []ManifestVersion `json:"versions"`
+}
+
+// ManifestVersion holds the spec version and locations of a VEX repo.
+type ManifestVersion struct {
+	SpecVersion    string             `json:"spec_version"`
+	Locations      []ManifestLocation `json:"locations"`
+	UpdateInterval string             `json:"update_interval"`
+}
+
+// ManifestLocation holds the URL for a VEX repo archive.
+type ManifestLocation struct {
+	URL string `json:"url"`
+}
+
+// Index represents the index.json file inside the VEX repo archive.
+type Index struct {
+	UpdatedAt string         `json:"updated_at"`
+	Packages  []IndexPackage `json:"packages"`
+}
+
+// IndexPackage maps a PURL to its VEX document location.
+type IndexPackage struct {
+	ID       string `json:"id"`
+	Location string `json:"location"`
+	Format   string `json:"format,omitempty"`
+}
+
+// vexHubCertifier queries VEX repositories for VEX statements.
+type vexHubCertifier struct {
+	httpClient  *http.Client
+	manifestURL string
+}
+
+// NewVEXHubCertifier creates a new VEX Hub certifier.
+func NewVEXHubCertifier(manifestURL string) certifier.Certifier {
+	limiter := rate.NewLimiter(rate.Every(rateLimitInterval), rateLimit)
+	transport := clients.NewRateLimitedTransport(version.UATransport, limiter)
+	client := &http.Client{Transport: transport}
+	if manifestURL == "" {
+		manifestURL = DefaultManifestURL
+	}
+	return &vexHubCertifier{
+		httpClient:  client,
+		manifestURL: manifestURL,
+	}
+}
+
+// CertifyComponent fetches VEX documents from the VEX Hub for the given packages.
+func (v *vexHubCertifier) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
+
+	packageNodes, ok := rootComponent.([]*root_package.PackageNode)
+	if !ok {
+		return ErrComponentTypeMismatch
+	}
+
+	var purls []string
+	for _, node := range packageNodes {
+		purls = append(purls, node.Purl)
+	}
+
+	if len(purls) == 0 {
+		return nil
+	}
+
+	// Fetch the manifest to get the archive URL.
+	manifest, err := fetchManifest(ctx, v.httpClient, v.manifestURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
+	}
+
+	archiveURL, subdir := getArchiveURL(manifest)
+	if archiveURL == "" {
+		logger.Infof("no archive location found in VEX Hub manifest")
+		return nil
+	}
+
+	// Download and extract the archive, building a PURL→VEX doc map.
+	vexDocs, err := downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
+	if err != nil {
+		return fmt.Errorf("failed to download VEX Hub archive: %w", err)
+	}
+
+	logger.Infof("VEX Hub: indexed %d packages from archive", len(vexDocs))
+
+	// Look up each PURL and emit matching VEX documents.
+	if _, err := emitVEXDocuments(purls, vexDocs, docChannel); err != nil {
+		return fmt.Errorf("failed to emit VEX documents: %w", err)
+	}
+
+	return nil
+}
+
+// fetchManifest downloads and parses the vex-repository.json manifest.
+func fetchManifest(ctx context.Context, client *http.Client, url string) (*Manifest, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("manifest fetch returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest body: %w", err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+	return &manifest, nil
+}
+
+// getArchiveURL extracts the archive URL and optional subdirectory from the manifest.
+// The subdirectory is specified after "//" in the URL (per VEX Repo Spec).
+// Example: "https://example.com/archive.tar.gz//vexhub-main" → URL + subdir "vexhub-main"
+func getArchiveURL(manifest *Manifest) (archiveURL, subdir string) {
+	if len(manifest.Versions) == 0 {
+		return "", ""
+	}
+	// Use the first version with a location.
+	for _, v := range manifest.Versions {
+		if len(v.Locations) > 0 {
+			rawURL := v.Locations[0].URL
+			// Look for "//" that is NOT part of the scheme (e.g., "https://").
+			// The subdirectory separator always appears after the host/path portion.
+			schemeEnd := strings.Index(rawURL, "://")
+			searchStart := 0
+			if schemeEnd >= 0 {
+				searchStart = schemeEnd + 3
+			}
+			rest := rawURL[searchStart:]
+			if idx := strings.Index(rest, "//"); idx >= 0 {
+				archiveURL = rawURL[:searchStart+idx]
+				subdir = rest[idx+2:]
+			} else {
+				archiveURL = rawURL
+			}
+			return archiveURL, subdir
+		}
+	}
+	return "", ""
+}
+
+// downloadAndIndex downloads a tar.gz archive, extracts it, parses index.json,
+// and returns a map of PURL→VEX document bytes.
+func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subdir string) (map[string][]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating archive request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("downloading archive: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("archive download returned status %d", resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+
+	// First pass: extract all files into memory.
+	files := make(map[string][]byte)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar entry: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("reading file %s: %w", header.Name, err)
+		}
+
+		// Normalize path: strip the subdir prefix if present.
+		name := header.Name
+		if subdir != "" {
+			if after, found := strings.CutPrefix(name, subdir+"/"); found {
+				name = after
+			} else if after, found := strings.CutPrefix(name, subdir); found {
+				name = after
+			}
+		}
+		// Also strip leading directory component from tar (e.g., "vexhub-main/")
+		if idx := strings.Index(name, "/"); idx >= 0 {
+			// Keep the path after the first directory component only if subdir wasn't already stripped.
+			if subdir == "" {
+				name = name[idx+1:]
+			}
+		}
+		if name != "" {
+			files[name] = data
+		}
+	}
+
+	// Parse index.json.
+	indexData, ok := files["index.json"]
+	if !ok {
+		return nil, fmt.Errorf("index.json not found in archive")
+	}
+
+	var index Index
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil, fmt.Errorf("parsing index.json: %w", err)
+	}
+
+	// Build PURL→VEX doc map.
+	vexDocs := make(map[string][]byte, len(index.Packages))
+	for _, pkg := range index.Packages {
+		docData, ok := files[pkg.Location]
+		if !ok {
+			continue
+		}
+		vexDocs[pkg.ID] = docData
+	}
+
+	return vexDocs, nil
+}
+
+// emitVEXDocuments looks up each PURL in the VEX index and emits matching documents.
+func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan<- *processor.Document) ([]*processor.Document, error) {
+	var emitted []*processor.Document
+	seen := make(map[string]bool)
+
+	for _, purl := range purls {
+		if strings.Contains(purl, "pkg:guac") {
+			continue
+		}
+
+		// Try exact PURL match first, then strip version for lookup.
+		lookupKey := purl
+		if _, ok := vexDocs[lookupKey]; !ok {
+			lookupKey = stripPurlVersion(purl)
+		}
+
+		docData, ok := vexDocs[lookupKey]
+		if !ok {
+			continue
+		}
+
+		if seen[lookupKey] {
+			continue
+		}
+		seen[lookupKey] = true
+
+		doc := &processor.Document{
+			Blob:   docData,
+			Type:   processor.DocumentOpenVEX,
+			Format: processor.FormatJSON,
+			SourceInformation: processor.SourceInformation{
+				Collector:   VEXHubCollector,
+				Source:      VEXHubCollector,
+				DocumentRef: events.GetDocRef(docData),
+			},
+		}
+		if docChannel != nil {
+			docChannel <- doc
+		}
+		emitted = append(emitted, doc)
+	}
+
+	return emitted, nil
+}
+
+// stripPurlVersion removes the version, qualifiers, and subpath from a PURL.
+// e.g. "pkg:npm/lodash@4.17.21" → "pkg:npm/lodash"
+func stripPurlVersion(purl string) string {
+	// Remove subpath (after last #)
+	if idx := strings.Index(purl, "#"); idx >= 0 {
+		purl = purl[:idx]
+	}
+	// Remove qualifiers (after ?)
+	if idx := strings.Index(purl, "?"); idx >= 0 {
+		purl = purl[:idx]
+	}
+	// Remove version (after @)
+	if idx := strings.LastIndex(purl, "@"); idx >= 0 {
+		purl = purl[:idx]
+	}
+	return purl
+}

--- a/pkg/certifier/vexhub/vexhub.go
+++ b/pkg/certifier/vexhub/vexhub.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package vexhub
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -35,6 +36,7 @@ import (
 	"github.com/guacsec/guac/pkg/version"
 
 	jsoniter "github.com/json-iterator/go"
+	packageurl "github.com/package-url/packageurl-go"
 	"golang.org/x/time/rate"
 )
 
@@ -44,6 +46,21 @@ const (
 	DefaultManifestURL = "https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json"
 	VEXHubCollector    = "vexhub_certifier"
 	rateLimit          = 100
+
+	// httpTimeout is the deadline for any single HTTP request made by the certifier.
+	// This prevents goroutine pinning when the archive endpoint stalls.
+	httpTimeout = 5 * time.Minute
+
+	// maxArchiveBytes is the total cumulative bytes we will buffer from the archive.
+	// Prevents OOM when the hub grows large (tar-bomb protection).
+	maxArchiveBytes = 512 * 1024 * 1024 // 512 MiB
+
+	// maxEntryBytes is the per-file byte limit applied via io.LimitReader.
+	maxEntryBytes = 32 * 1024 * 1024 // 32 MiB
+
+	// supportedSpecVersion is the only spec version we know how to parse.
+	// Forward-incompatible versions are logged and skipped.
+	supportedSpecVersion = "0.1"
 )
 
 var rateLimitInterval = time.Second
@@ -91,7 +108,12 @@ type vexHubCertifier struct {
 func NewVEXHubCertifier(manifestURL string) certifier.Certifier {
 	limiter := rate.NewLimiter(rate.Every(rateLimitInterval), rateLimit)
 	transport := clients.NewRateLimitedTransport(version.UATransport, limiter)
-	client := &http.Client{Transport: transport}
+	// Set an explicit Timeout so a stalled archive endpoint cannot pin the
+	// certifier goroutine indefinitely (P0 fix #2).
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   httpTimeout,
+	}
 	if manifestURL == "" {
 		manifestURL = DefaultManifestURL
 	}
@@ -125,13 +147,13 @@ func (v *vexHubCertifier) CertifyComponent(ctx context.Context, rootComponent in
 		return fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
 	}
 
-	archiveURL, subdir := getArchiveURL(manifest)
+	archiveURL, subdir := getArchiveURL(logger, manifest)
 	if archiveURL == "" {
-		logger.Infof("no archive location found in VEX Hub manifest")
+		logger.Infof("no compatible archive location found in VEX Hub manifest")
 		return nil
 	}
 
-	// Download and extract the archive, building a PURL→VEX doc map.
+	// Download and extract the archive, building a canonical-PURL→VEX doc map.
 	vexDocs, err := downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
 	if err != nil {
 		return fmt.Errorf("failed to download VEX Hub archive: %w", err)
@@ -175,39 +197,68 @@ func fetchManifest(ctx context.Context, client *http.Client, url string) (*Manif
 	return &manifest, nil
 }
 
-// getArchiveURL extracts the archive URL and optional subdirectory from the manifest.
+// getArchiveURL extracts the archive URL and optional subdirectory from the manifest,
+// selecting only entries whose spec_version matches supportedSpecVersion.
 // The subdirectory is specified after "//" in the URL (per VEX Repo Spec).
 // Example: "https://example.com/archive.tar.gz//vexhub-main" → URL + subdir "vexhub-main"
-func getArchiveURL(manifest *Manifest) (archiveURL, subdir string) {
+//
+// Forward-incompatible spec versions are logged and skipped to avoid silently
+// downloading archives that this parser cannot handle (P1 fix #2).
+func getArchiveURL(logger interface{ Infof(string, ...interface{}) }, manifest *Manifest) (archiveURL, subdir string) {
 	if len(manifest.Versions) == 0 {
 		return "", ""
 	}
-	// Use the first version with a location.
 	for _, v := range manifest.Versions {
-		if len(v.Locations) > 0 {
-			rawURL := v.Locations[0].URL
-			// Look for "//" that is NOT part of the scheme (e.g., "https://").
-			// The subdirectory separator always appears after the host/path portion.
-			schemeEnd := strings.Index(rawURL, "://")
-			searchStart := 0
-			if schemeEnd >= 0 {
-				searchStart = schemeEnd + 3
-			}
-			rest := rawURL[searchStart:]
-			if idx := strings.Index(rest, "//"); idx >= 0 {
-				archiveURL = rawURL[:searchStart+idx]
-				subdir = rest[idx+2:]
-			} else {
-				archiveURL = rawURL
-			}
-			return archiveURL, subdir
+		if v.SpecVersion != supportedSpecVersion {
+			logger.Infof("VEX Hub: skipping unsupported spec_version %q (supported: %q)", v.SpecVersion, supportedSpecVersion)
+			continue
 		}
+		if len(v.Locations) == 0 {
+			continue
+		}
+		rawURL := v.Locations[0].URL
+		// Look for "//" that is NOT part of the scheme (e.g., "https://").
+		// The subdirectory separator always appears after the host/path portion.
+		schemeEnd := strings.Index(rawURL, "://")
+		searchStart := 0
+		if schemeEnd >= 0 {
+			searchStart = schemeEnd + 3
+		}
+		rest := rawURL[searchStart:]
+		if idx := strings.Index(rest, "//"); idx >= 0 {
+			archiveURL = rawURL[:searchStart+idx]
+			subdir = rest[idx+2:]
+		} else {
+			archiveURL = rawURL
+		}
+		return archiveURL, subdir
 	}
 	return "", ""
 }
 
-// downloadAndIndex downloads a tar.gz archive, extracts it, parses index.json,
-// and returns a map of PURL→VEX document bytes.
+// canonicalizePURL parses a PURL with packageurl-go and re-stringifies it so
+// that qualifier ordering, namespace casing, and percent-encoding are all
+// normalised before map keying (P1 fix #1).
+// Returns the original string unchanged if parsing fails.
+func canonicalizePURL(purl string) string {
+	p, err := packageurl.FromString(purl)
+	if err != nil {
+		return purl
+	}
+	return p.ToString()
+}
+
+// downloadAndIndex downloads a tar.gz archive, uses a two-pass approach to
+// safely extract only the files referenced in index.json, and returns a map
+// of canonical-PURL → VEX document bytes.
+//
+// Two-pass design (P0 fix #1):
+//  1. Stream the archive once, buffering only index.json and recording the
+//     names of files referenced by index.Packages.
+//  2. Stream the archive a second time (from the in-memory copy), reading
+//     only those referenced files, each wrapped in io.LimitReader.
+//
+// This prevents unbounded memory growth (tar-bomb / OOM) as the hub scales.
 func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subdir string) (map[string][]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
@@ -223,35 +274,20 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		return nil, fmt.Errorf("archive download returned status %d", resp.StatusCode)
 	}
 
-	gz, err := gzip.NewReader(resp.Body)
+	// Buffer the entire compressed archive so we can make two passes over it.
+	// We cap the raw download at maxArchiveBytes to avoid OOM from a huge tarball.
+	limitedBody := io.LimitReader(resp.Body, maxArchiveBytes+1)
+	archiveData, err := io.ReadAll(limitedBody)
 	if err != nil {
-		return nil, fmt.Errorf("creating gzip reader: %w", err)
+		return nil, fmt.Errorf("buffering archive: %w", err)
 	}
-	defer func() { _ = gz.Close() }()
+	if int64(len(archiveData)) > maxArchiveBytes {
+		return nil, fmt.Errorf("archive exceeds maximum allowed size of %d bytes", maxArchiveBytes)
+	}
 
-	tr := tar.NewReader(gz)
-
-	// First pass: extract all files into memory.
-	files := make(map[string][]byte)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("reading tar entry: %w", err)
-		}
-		if header.Typeflag != tar.TypeReg {
-			continue
-		}
-
-		data, err := io.ReadAll(tr)
-		if err != nil {
-			return nil, fmt.Errorf("reading file %s: %w", header.Name, err)
-		}
-
-		// Normalize path: strip the subdir prefix if present.
-		name := header.Name
+	// normalizeName strips the subdir prefix and the leading top-level directory
+	// component (e.g. "vexhub-main/") from a tar entry name.
+	normalizeName := func(name string) string {
 		if subdir != "" {
 			if after, found := strings.CutPrefix(name, subdir+"/"); found {
 				name = after
@@ -259,21 +295,49 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 				name = after
 			}
 		}
-		// Also strip leading directory component from tar (e.g., "vexhub-main/")
-		if idx := strings.Index(name, "/"); idx >= 0 {
-			// Keep the path after the first directory component only if subdir wasn't already stripped.
-			if subdir == "" {
+		if subdir == "" {
+			if idx := strings.Index(name, "/"); idx >= 0 {
 				name = name[idx+1:]
 			}
 		}
-		if name != "" {
-			files[name] = data
-		}
+		return name
 	}
 
-	// Parse index.json.
-	indexData, ok := files["index.json"]
-	if !ok {
+	// openTar returns a fresh *tar.Reader over the buffered archive bytes.
+	openTar := func() (*tar.Reader, error) {
+		gz, err := gzip.NewReader(bytes.NewReader(archiveData))
+		if err != nil {
+			return nil, fmt.Errorf("creating gzip reader: %w", err)
+		}
+		return tar.NewReader(gz), nil
+	}
+
+	// ── Pass 1: find and parse index.json only ────────────────────────────────
+	tr1, err := openTar()
+	if err != nil {
+		return nil, err
+	}
+	var indexData []byte
+	for {
+		header, err := tr1.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar entry (pass 1): %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if normalizeName(header.Name) == "index.json" {
+			indexData, err = io.ReadAll(io.LimitReader(tr1, maxEntryBytes))
+			if err != nil {
+				return nil, fmt.Errorf("reading index.json: %w", err)
+			}
+			break
+		}
+	}
+	if indexData == nil {
 		return nil, fmt.Errorf("index.json not found in archive")
 	}
 
@@ -282,20 +346,62 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		return nil, fmt.Errorf("parsing index.json: %w", err)
 	}
 
-	// Build PURL→VEX doc map.
+	// Build the set of file paths we actually need.
+	needed := make(map[string]bool, len(index.Packages))
+	for _, pkg := range index.Packages {
+		needed[pkg.Location] = true
+	}
+
+	// ── Pass 2: read only the referenced files ────────────────────────────────
+	tr2, err := openTar()
+	if err != nil {
+		return nil, err
+	}
+	fileContents := make(map[string][]byte, len(needed))
+	var cumulativeBytes int64
+	for {
+		header, err := tr2.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar entry (pass 2): %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := normalizeName(header.Name)
+		if !needed[name] {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(tr2, maxEntryBytes))
+		if err != nil {
+			return nil, fmt.Errorf("reading file %s: %w", header.Name, err)
+		}
+		cumulativeBytes += int64(len(data))
+		if cumulativeBytes > maxArchiveBytes {
+			return nil, fmt.Errorf("extracted content exceeds maximum allowed size of %d bytes", maxArchiveBytes)
+		}
+		fileContents[name] = data
+	}
+
+	// Build canonical-PURL → VEX doc map.
 	vexDocs := make(map[string][]byte, len(index.Packages))
 	for _, pkg := range index.Packages {
-		docData, ok := files[pkg.Location]
+		docData, ok := fileContents[pkg.Location]
 		if !ok {
 			continue
 		}
-		vexDocs[pkg.ID] = docData
+		// Canonicalize the PURL from the index so lookups are consistent.
+		vexDocs[canonicalizePURL(pkg.ID)] = docData
 	}
 
 	return vexDocs, nil
 }
 
 // emitVEXDocuments looks up each PURL in the VEX index and emits matching documents.
+// Both the query PURLs and the index keys are canonicalized via packageurl-go
+// before comparison so that PURL spelling variants do not cause misses (P1 fix #1).
 func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan<- *processor.Document) ([]*processor.Document, error) {
 	var emitted []*processor.Document
 	seen := make(map[string]bool)
@@ -305,13 +411,25 @@ func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan
 			continue
 		}
 
-		// Try exact PURL match first, then strip version for lookup.
-		lookupKey := purl
-		if _, ok := vexDocs[lookupKey]; !ok {
-			lookupKey = stripPurlVersion(purl)
-		}
+		// Canonicalize the query PURL so qualifier order, namespace casing, and
+		// percent-encoding all match the canonicalized index keys built in
+		// downloadAndIndex.
+		lookupKey := canonicalizePURL(purl)
 
 		docData, ok := vexDocs[lookupKey]
+		if !ok {
+			// If an exact (canonicalized) match is not found, try without version
+			// by zeroing the Version field and re-stringifying.
+			p, err := packageurl.FromString(purl)
+			if err == nil {
+				p.Version = ""
+				p.Qualifiers = packageurl.Qualifiers{}
+				p.Subpath = ""
+				lookupKey = p.ToString()
+				docData, ok = vexDocs[lookupKey]
+			}
+		}
+
 		if !ok {
 			continue
 		}
@@ -338,22 +456,4 @@ func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan
 	}
 
 	return emitted, nil
-}
-
-// stripPurlVersion removes the version, qualifiers, and subpath from a PURL.
-// e.g. "pkg:npm/lodash@4.17.21" → "pkg:npm/lodash"
-func stripPurlVersion(purl string) string {
-	// Remove subpath (after last #)
-	if idx := strings.Index(purl, "#"); idx >= 0 {
-		purl = purl[:idx]
-	}
-	// Remove qualifiers (after ?)
-	if idx := strings.Index(purl, "?"); idx >= 0 {
-		purl = purl[:idx]
-	}
-	// Remove version (after @)
-	if idx := strings.LastIndex(purl, "@"); idx >= 0 {
-		purl = purl[:idx]
-	}
-	return purl
 }

--- a/pkg/certifier/vexhub/vexhub.go
+++ b/pkg/certifier/vexhub/vexhub.go
@@ -17,27 +17,25 @@ package vexhub
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
-	"github.com/guacsec/guac/pkg/clients"
 	"github.com/guacsec/guac/pkg/events"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
-	"github.com/guacsec/guac/pkg/version"
 
 	jsoniter "github.com/json-iterator/go"
 	packageurl "github.com/package-url/packageurl-go"
-	"golang.org/x/time/rate"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -45,10 +43,8 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 const (
 	DefaultManifestURL = "https://raw.githubusercontent.com/aquasecurity/vexhub/main/vex-repository.json"
 	VEXHubCollector    = "vexhub_certifier"
-	rateLimit          = 100
 
 	// httpTimeout is the deadline for any single HTTP request made by the certifier.
-	// This prevents goroutine pinning when the archive endpoint stalls.
 	httpTimeout = 5 * time.Minute
 
 	// maxArchiveBytes is the total cumulative bytes we will buffer from the archive.
@@ -62,8 +58,6 @@ const (
 	// Forward-incompatible versions are logged and skipped.
 	supportedSpecVersion = "0.1"
 )
-
-var rateLimitInterval = time.Second
 
 var ErrComponentTypeMismatch = errors.New("rootComponent type is not []*root_package.PackageNode")
 
@@ -98,28 +92,37 @@ type IndexPackage struct {
 	Format   string `json:"format,omitempty"`
 }
 
-// vexHubCertifier queries VEX repositories for VEX statements.
 type vexHubCertifier struct {
 	httpClient  *http.Client
 	manifestURL string
+
+	// cache stores parsed manifest + vexDocs keyed by manifest URL, with TTL
+	// derived from the manifest's update_interval field.
+	cache   map[string]*manifestCacheEntry
+	cacheMu sync.RWMutex
+
+	// seen tracks which canonical PURLs have already been emitted so that
+	// duplicate documents are not sent across subsequent CertifyComponent batches.
+	seen   map[string]struct{}
+	seenMu sync.Mutex
+}
+
+type manifestCacheEntry struct {
+	manifest *Manifest
+	vexDocs  map[string][]byte
+	expiry   time.Time
 }
 
 // NewVEXHubCertifier creates a new VEX Hub certifier.
 func NewVEXHubCertifier(manifestURL string) certifier.Certifier {
-	limiter := rate.NewLimiter(rate.Every(rateLimitInterval), rateLimit)
-	transport := clients.NewRateLimitedTransport(version.UATransport, limiter)
-	// Set an explicit Timeout so a stalled archive endpoint cannot pin the
-	// certifier goroutine indefinitely (P0 fix #2).
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   httpTimeout,
-	}
 	if manifestURL == "" {
 		manifestURL = DefaultManifestURL
 	}
 	return &vexHubCertifier{
-		httpClient:  client,
+		httpClient:  &http.Client{Timeout: httpTimeout},
 		manifestURL: manifestURL,
+		cache:       make(map[string]*manifestCacheEntry),
+		seen:        make(map[string]struct{}),
 	}
 }
 
@@ -141,28 +144,54 @@ func (v *vexHubCertifier) CertifyComponent(ctx context.Context, rootComponent in
 		return nil
 	}
 
-	// Fetch the manifest to get the archive URL.
-	manifest, err := fetchManifest(ctx, v.httpClient, v.manifestURL)
-	if err != nil {
-		return fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
-	}
+	// Return cached vexDocs if they are still fresh.
+	var vexDocs map[string][]byte
+	v.cacheMu.RLock()
+	entry, cached := v.cache[v.manifestURL]
+	v.cacheMu.RUnlock()
+	if cached && time.Now().Before(entry.expiry) {
+		vexDocs = entry.vexDocs
+	} else {
+		// Fetch the manifest to discover archive locations.
+		manifest, err := fetchManifest(ctx, v.httpClient, v.manifestURL)
+		if err != nil {
+			return fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
+		}
 
-	archiveURL, subdir := getArchiveURL(logger, manifest)
-	if archiveURL == "" {
-		logger.Infof("no compatible archive location found in VEX Hub manifest")
-		return nil
-	}
+		archiveURL, subdir := getArchiveURL(ctx, v.httpClient, manifest)
+		if archiveURL == "" {
+			logger.Infof("no compatible archive location found in VEX Hub manifest")
+			return nil
+		}
 
-	// Download and extract the archive, building a canonical-PURL→VEX doc map.
-	vexDocs, err := downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
-	if err != nil {
-		return fmt.Errorf("failed to download VEX Hub archive: %w", err)
+		vexDocs, err = downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
+		if err != nil {
+			return err
+		}
+
+		// Use update_interval from the matching manifest version as the TTL.
+		ttl := time.Hour // safe default when update_interval is absent or unparseable
+		for _, ver := range manifest.Versions {
+			if ver.SpecVersion == supportedSpecVersion && ver.UpdateInterval != "" {
+				if d, perr := time.ParseDuration(ver.UpdateInterval); perr == nil {
+					ttl = d
+				}
+				break
+			}
+		}
+
+		v.cacheMu.Lock()
+		v.cache[v.manifestURL] = &manifestCacheEntry{
+			manifest: manifest,
+			vexDocs:  vexDocs,
+			expiry:   time.Now().Add(ttl),
+		}
+		v.cacheMu.Unlock()
 	}
 
 	logger.Infof("VEX Hub: indexed %d packages from archive", len(vexDocs))
 
-	// Look up each PURL and emit matching VEX documents.
-	if _, err := emitVEXDocuments(purls, vexDocs, docChannel); err != nil {
+	if _, err := v.emitVEXDocuments(ctx, purls, vexDocs, docChannel); err != nil {
 		return fmt.Errorf("failed to emit VEX documents: %w", err)
 	}
 
@@ -197,17 +226,19 @@ func fetchManifest(ctx context.Context, client *http.Client, url string) (*Manif
 	return &manifest, nil
 }
 
-// getArchiveURL extracts the archive URL and optional subdirectory from the manifest,
-// selecting only entries whose spec_version matches supportedSpecVersion.
-// The subdirectory is specified after "//" in the URL (per VEX Repo Spec).
-// Example: "https://example.com/archive.tar.gz//vexhub-main" → URL + subdir "vexhub-main"
+// getArchiveURL iterates over every version and every location in the manifest,
+// selecting the first URL whose spec_version matches supportedSpecVersion and
+// that responds to a HEAD request with HTTP 200.
 //
-// Forward-incompatible spec versions are logged and skipped to avoid silently
-// downloading archives that this parser cannot handle (P1 fix #2).
-func getArchiveURL(logger interface{ Infof(string, ...interface{}) }, manifest *Manifest) (archiveURL, subdir string) {
+// The subdirectory is specified after "//" in the URL (per VEX Repo Spec).
+// Example: "https://example.com/archive.tar.gz//vexhub-main" -> archiveURL + subdir "vexhub-main"
+//
+// Versions with unsupported spec_version values are logged and skipped.
+func getArchiveURL(ctx context.Context, client *http.Client, manifest *Manifest) (archiveURL, subdir string) {
 	if len(manifest.Versions) == 0 {
 		return "", ""
 	}
+	logger := logging.FromContext(ctx)
 	for _, v := range manifest.Versions {
 		if v.SpecVersion != supportedSpecVersion {
 			logger.Infof("VEX Hub: skipping unsupported spec_version %q (supported: %q)", v.SpecVersion, supportedSpecVersion)
@@ -216,29 +247,50 @@ func getArchiveURL(logger interface{ Infof(string, ...interface{}) }, manifest *
 		if len(v.Locations) == 0 {
 			continue
 		}
-		rawURL := v.Locations[0].URL
-		// Look for "//" that is NOT part of the scheme (e.g., "https://").
-		// The subdirectory separator always appears after the host/path portion.
-		schemeEnd := strings.Index(rawURL, "://")
-		searchStart := 0
-		if schemeEnd >= 0 {
-			searchStart = schemeEnd + 3
+		for _, loc := range v.Locations {
+			rawURL := loc.URL
+			if rawURL == "" {
+				continue
+			}
+
+			// Parse out optional subdir after "//".
+			var targetURL, sub string
+			schemeEnd := strings.Index(rawURL, "://")
+			searchStart := 0
+			if schemeEnd >= 0 {
+				searchStart = schemeEnd + 3
+			}
+			rest := rawURL[searchStart:]
+			if idx := strings.Index(rest, "//"); idx >= 0 {
+				targetURL = rawURL[:searchStart+idx]
+				sub = rest[idx+2:]
+			} else {
+				targetURL = rawURL
+			}
+
+			// Probe reachability with a HEAD request against the actual archive URL.
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, targetURL, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := client.Do(req)
+			if err != nil || resp.StatusCode != http.StatusOK {
+				if resp != nil {
+					_ = resp.Body.Close()
+				}
+				continue
+			}
+			_ = resp.Body.Close()
+
+			return targetURL, sub
 		}
-		rest := rawURL[searchStart:]
-		if idx := strings.Index(rest, "//"); idx >= 0 {
-			archiveURL = rawURL[:searchStart+idx]
-			subdir = rest[idx+2:]
-		} else {
-			archiveURL = rawURL
-		}
-		return archiveURL, subdir
 	}
 	return "", ""
 }
 
 // canonicalizePURL parses a PURL with packageurl-go and re-stringifies it so
 // that qualifier ordering, namespace casing, and percent-encoding are all
-// normalised before map keying (P1 fix #1).
+// normalised before map keying.
 // Returns the original string unchanged if parsing fails.
 func canonicalizePURL(purl string) string {
 	p, err := packageurl.FromString(purl)
@@ -248,17 +300,18 @@ func canonicalizePURL(purl string) string {
 	return p.ToString()
 }
 
-// downloadAndIndex downloads a tar.gz archive, uses a two-pass approach to
+// downloadAndIndex downloads a tar.gz archive using a two-pass approach to
 // safely extract only the files referenced in index.json, and returns a map
-// of canonical-PURL → VEX document bytes.
+// of canonical-PURL -> VEX document bytes.
 //
-// Two-pass design (P0 fix #1):
-//  1. Stream the archive once, buffering only index.json and recording the
-//     names of files referenced by index.Packages.
-//  2. Stream the archive a second time (from the in-memory copy), reading
-//     only those referenced files, each wrapped in io.LimitReader.
+// Two-pass design:
+//  1. Stream the archive into a temp file; parse only index.json to learn
+//     which files are referenced.
+//  2. Seek back to the start; stream again, reading only referenced files,
+//     each capped by maxEntryBytes.
 //
-// This prevents unbounded memory growth (tar-bomb / OOM) as the hub scales.
+// Using os.CreateTemp keeps the compressed archive off the heap and allows
+// two sequential seeks without holding the whole payload in memory.
 func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subdir string) (map[string][]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
@@ -274,20 +327,32 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		return nil, fmt.Errorf("archive download returned status %d", resp.StatusCode)
 	}
 
-	// Buffer the entire compressed archive so we can make two passes over it.
-	// We cap the raw download at maxArchiveBytes to avoid OOM from a huge tarball.
-	limitedBody := io.LimitReader(resp.Body, maxArchiveBytes+1)
-	archiveData, err := io.ReadAll(limitedBody)
+	// Buffer the compressed archive to a temp file for two-pass reading.
+	tmpFile, err := os.CreateTemp("", "vexhub-*.tar.gz")
 	if err != nil {
-		return nil, fmt.Errorf("buffering archive: %w", err)
+		return nil, fmt.Errorf("creating temp file: %w", err)
 	}
-	if int64(len(archiveData)) > maxArchiveBytes {
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	written, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxArchiveBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("buffering archive to temp file: %w", err)
+	}
+	if written > maxArchiveBytes {
 		return nil, fmt.Errorf("archive exceeds maximum allowed size of %d bytes", maxArchiveBytes)
 	}
 
-	// normalizeName strips the subdir prefix and the leading top-level directory
-	// component (e.g. "vexhub-main/") from a tar entry name.
+	// normalizeName strips the leading top-level directory component (e.g. "vexhub-main/")
+	// from a tar entry name first, then optionally strips the subdir prefix.
 	normalizeName := func(name string) string {
+		// Always strip the leading top-level directory component.
+		if idx := strings.Index(name, "/"); idx >= 0 {
+			name = name[idx+1:]
+		}
+		// Then strip the subdir prefix if one was specified in the manifest URL.
 		if subdir != "" {
 			if after, found := strings.CutPrefix(name, subdir+"/"); found {
 				name = after
@@ -295,24 +360,22 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 				name = after
 			}
 		}
-		if subdir == "" {
-			if idx := strings.Index(name, "/"); idx >= 0 {
-				name = name[idx+1:]
-			}
-		}
 		return name
 	}
 
-	// openTar returns a fresh *tar.Reader over the buffered archive bytes.
+	// openTar returns a fresh *tar.Reader positioned at the beginning of the archive.
 	openTar := func() (*tar.Reader, error) {
-		gz, err := gzip.NewReader(bytes.NewReader(archiveData))
+		if _, err := tmpFile.Seek(0, 0); err != nil {
+			return nil, fmt.Errorf("seeking temp file for pass: %w", err)
+		}
+		gz, err := gzip.NewReader(tmpFile)
 		if err != nil {
 			return nil, fmt.Errorf("creating gzip reader: %w", err)
 		}
 		return tar.NewReader(gz), nil
 	}
 
-	// ── Pass 1: find and parse index.json only ────────────────────────────────
+	// Pass 1: locate and parse index.json.
 	tr1, err := openTar()
 	if err != nil {
 		return nil, err
@@ -352,7 +415,7 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		needed[pkg.Location] = true
 	}
 
-	// ── Pass 2: read only the referenced files ────────────────────────────────
+	// Pass 2: read only the referenced files.
 	tr2, err := openTar()
 	if err != nil {
 		return nil, err
@@ -385,14 +448,17 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		fileContents[name] = data
 	}
 
-	// Build canonical-PURL → VEX doc map.
+	// Build canonical-PURL -> VEX doc map; skip unsupported formats.
+	// Empty format is treated as openvex (backward-compatible default).
 	vexDocs := make(map[string][]byte, len(index.Packages))
 	for _, pkg := range index.Packages {
+		if pkg.Format != "" && pkg.Format != "openvex" {
+			continue
+		}
 		docData, ok := fileContents[pkg.Location]
 		if !ok {
 			continue
 		}
-		// Canonicalize the PURL from the index so lookups are consistent.
 		vexDocs[canonicalizePURL(pkg.ID)] = docData
 	}
 
@@ -401,25 +467,25 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 
 // emitVEXDocuments looks up each PURL in the VEX index and emits matching documents.
 // Both the query PURLs and the index keys are canonicalized via packageurl-go
-// before comparison so that PURL spelling variants do not cause misses (P1 fix #1).
-func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan<- *processor.Document) ([]*processor.Document, error) {
+// before comparison so that PURL spelling variants do not cause misses.
+// Documents already emitted in a previous batch are deduplicated via v.seen.
+// The channel send is wrapped in a select so that context cancellation
+// (e.g. graceful shutdown) is respected and the call never hangs.
+func (v *vexHubCertifier) emitVEXDocuments(ctx context.Context, purls []string, vexDocs map[string][]byte, docChannel chan<- *processor.Document) ([]*processor.Document, error) {
 	var emitted []*processor.Document
-	seen := make(map[string]bool)
+	v.seenMu.Lock()
+	defer v.seenMu.Unlock()
 
 	for _, purl := range purls {
 		if strings.Contains(purl, "pkg:guac") {
 			continue
 		}
 
-		// Canonicalize the query PURL so qualifier order, namespace casing, and
-		// percent-encoding all match the canonicalized index keys built in
-		// downloadAndIndex.
 		lookupKey := canonicalizePURL(purl)
 
 		docData, ok := vexDocs[lookupKey]
 		if !ok {
-			// If an exact (canonicalized) match is not found, try without version
-			// by zeroing the Version field and re-stringifying.
+			// Try again with version, qualifiers, and subpath stripped.
 			p, err := packageurl.FromString(purl)
 			if err == nil {
 				p.Version = ""
@@ -434,10 +500,10 @@ func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan
 			continue
 		}
 
-		if seen[lookupKey] {
+		if _, seen := v.seen[lookupKey]; seen {
 			continue
 		}
-		seen[lookupKey] = true
+		v.seen[lookupKey] = struct{}{}
 
 		doc := &processor.Document{
 			Blob:   docData,
@@ -449,8 +515,13 @@ func emitVEXDocuments(purls []string, vexDocs map[string][]byte, docChannel chan
 				DocumentRef: events.GetDocRef(docData),
 			},
 		}
+
 		if docChannel != nil {
-			docChannel <- doc
+			select {
+			case <-ctx.Done():
+				return emitted, ctx.Err()
+			case docChannel <- doc:
+			}
 		}
 		emitted = append(emitted, doc)
 	}

--- a/pkg/certifier/vexhub/vexhub.go
+++ b/pkg/certifier/vexhub/vexhub.go
@@ -57,6 +57,10 @@ const (
 	// supportedSpecVersion is the only spec version we know how to parse.
 	// Forward-incompatible versions are logged and skipped.
 	supportedSpecVersion = "0.1"
+
+	// defaultCacheTTL applies when the manifest omits update_interval or the
+	// value it carries cannot be parsed.
+	defaultCacheTTL = time.Hour
 )
 
 var ErrComponentTypeMismatch = errors.New("rootComponent type is not []*root_package.PackageNode")
@@ -92,28 +96,40 @@ type IndexPackage struct {
 	Format   string `json:"format,omitempty"`
 }
 
+// vexHubCertifier holds the state that has to outlive a single CertifyComponent
+// call: the indexed archive and the documents already emitted.
+//
+// certify.generateDocuments invokes the registered factory once per component
+// batch, so a factory that constructs a fresh certifier each time would reset
+// this state on every batch and re-download the archive just as often. Callers
+// must build one instance and have the factory hand back that same pointer; the
+// mutexes below guard the concurrent CertifyComponent calls that sharing implies.
 type vexHubCertifier struct {
 	httpClient  *http.Client
 	manifestURL string
 
-	// cache stores parsed manifest + vexDocs keyed by manifest URL, with TTL
-	// derived from the manifest's update_interval field.
-	cache   map[string]*manifestCacheEntry
+	// cacheMu guards cache, which holds the indexed archive until its TTL
+	// (the manifest's update_interval) expires.
 	cacheMu sync.RWMutex
+	cache   *archiveCache
 
-	// seen tracks which canonical PURLs have already been emitted so that
-	// duplicate documents are not sent across subsequent CertifyComponent batches.
-	seen   map[string]struct{}
+	// seenMu guards seen, which holds the DocumentRef of every VEX document
+	// already pushed downstream.
 	seenMu sync.Mutex
+	seen   map[string]struct{}
 }
 
-type manifestCacheEntry struct {
-	manifest *Manifest
-	vexDocs  map[string][]byte
-	expiry   time.Time
+// archiveCache is one indexed VEX archive: canonical PURL -> document bytes.
+type archiveCache struct {
+	vexDocs map[string][]byte
+	expiry  time.Time
 }
 
 // NewVEXHubCertifier creates a new VEX Hub certifier.
+//
+// The returned certifier caches the indexed archive and tracks emitted documents
+// on itself, so construct it once and reuse it for the lifetime of the process
+// rather than building one inside the certify.RegisterCertifier factory.
 func NewVEXHubCertifier(manifestURL string) certifier.Certifier {
 	if manifestURL == "" {
 		manifestURL = DefaultManifestURL
@@ -121,15 +137,12 @@ func NewVEXHubCertifier(manifestURL string) certifier.Certifier {
 	return &vexHubCertifier{
 		httpClient:  &http.Client{Timeout: httpTimeout},
 		manifestURL: manifestURL,
-		cache:       make(map[string]*manifestCacheEntry),
 		seen:        make(map[string]struct{}),
 	}
 }
 
 // CertifyComponent fetches VEX documents from the VEX Hub for the given packages.
 func (v *vexHubCertifier) CertifyComponent(ctx context.Context, rootComponent interface{}, docChannel chan<- *processor.Document) error {
-	logger := logging.FromContext(ctx)
-
 	packageNodes, ok := rootComponent.([]*root_package.PackageNode)
 	if !ok {
 		return ErrComponentTypeMismatch
@@ -144,58 +157,67 @@ func (v *vexHubCertifier) CertifyComponent(ctx context.Context, rootComponent in
 		return nil
 	}
 
-	// Return cached vexDocs if they are still fresh.
-	var vexDocs map[string][]byte
-	v.cacheMu.RLock()
-	entry, cached := v.cache[v.manifestURL]
-	v.cacheMu.RUnlock()
-	if cached && time.Now().Before(entry.expiry) {
-		vexDocs = entry.vexDocs
-	} else {
-		// Fetch the manifest to discover archive locations.
-		manifest, err := fetchManifest(ctx, v.httpClient, v.manifestURL)
-		if err != nil {
-			return fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
-		}
-
-		archiveURL, subdir := getArchiveURL(ctx, v.httpClient, manifest)
-		if archiveURL == "" {
-			logger.Infof("no compatible archive location found in VEX Hub manifest")
-			return nil
-		}
-
-		vexDocs, err = downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
-		if err != nil {
-			return err
-		}
-
-		// Use update_interval from the matching manifest version as the TTL.
-		ttl := time.Hour // safe default when update_interval is absent or unparseable
-		for _, ver := range manifest.Versions {
-			if ver.SpecVersion == supportedSpecVersion && ver.UpdateInterval != "" {
-				if d, perr := time.ParseDuration(ver.UpdateInterval); perr == nil {
-					ttl = d
-				}
-				break
-			}
-		}
-
-		v.cacheMu.Lock()
-		v.cache[v.manifestURL] = &manifestCacheEntry{
-			manifest: manifest,
-			vexDocs:  vexDocs,
-			expiry:   time.Now().Add(ttl),
-		}
-		v.cacheMu.Unlock()
+	vexDocs, err := v.indexedDocs(ctx)
+	if err != nil {
+		return err
 	}
-
-	logger.Infof("VEX Hub: indexed %d packages from archive", len(vexDocs))
 
 	if _, err := v.emitVEXDocuments(ctx, purls, vexDocs, docChannel); err != nil {
 		return fmt.Errorf("failed to emit VEX documents: %w", err)
 	}
 
 	return nil
+}
+
+// indexedDocs returns the indexed archive, refreshing it from the hub when the
+// cached copy is absent or past its TTL.
+func (v *vexHubCertifier) indexedDocs(ctx context.Context) (map[string][]byte, error) {
+	v.cacheMu.RLock()
+	cache := v.cache
+	v.cacheMu.RUnlock()
+	if cache != nil && time.Now().Before(cache.expiry) {
+		return cache.vexDocs, nil
+	}
+
+	manifest, err := fetchManifest(ctx, v.httpClient, v.manifestURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch VEX Hub manifest: %w", err)
+	}
+
+	archiveURL, subdir, err := getArchiveURL(ctx, v.httpClient, manifest)
+	if err != nil {
+		return nil, fmt.Errorf("no usable archive location in VEX Hub manifest %s: %w", v.manifestURL, err)
+	}
+
+	vexDocs, err := downloadAndIndex(ctx, v.httpClient, archiveURL, subdir)
+	if err != nil {
+		return nil, err
+	}
+
+	v.cacheMu.Lock()
+	v.cache = &archiveCache{vexDocs: vexDocs, expiry: time.Now().Add(cacheTTL(manifest))}
+	v.cacheMu.Unlock()
+
+	// Logged on refresh rather than per batch: with the certifier shared across
+	// batches this fires once per update_interval.
+	logging.FromContext(ctx).Infof("VEX Hub: indexed %d packages from %s", len(vexDocs), archiveURL)
+
+	return vexDocs, nil
+}
+
+// cacheTTL reads update_interval off the supported manifest version, falling
+// back to defaultCacheTTL when it is absent or unparseable.
+func cacheTTL(manifest *Manifest) time.Duration {
+	for _, ver := range manifest.Versions {
+		if ver.SpecVersion != supportedSpecVersion {
+			continue
+		}
+		if d, err := time.ParseDuration(ver.UpdateInterval); err == nil && d > 0 {
+			return d
+		}
+		break
+	}
+	return defaultCacheTTL
 }
 
 // fetchManifest downloads and parses the vex-repository.json manifest.
@@ -227,65 +249,84 @@ func fetchManifest(ctx context.Context, client *http.Client, url string) (*Manif
 }
 
 // getArchiveURL iterates over every version and every location in the manifest,
-// selecting the first URL whose spec_version matches supportedSpecVersion and
-// that responds to a HEAD request with HTTP 200.
+// returning the first URL whose spec_version matches supportedSpecVersion and
+// that a HEAD probe does not positively rule out.
 //
 // The subdirectory is specified after "//" in the URL (per VEX Repo Spec).
 // Example: "https://example.com/archive.tar.gz//vexhub-main" -> archiveURL + subdir "vexhub-main"
 //
-// Versions with unsupported spec_version values are logged and skipped.
-func getArchiveURL(ctx context.Context, client *http.Client, manifest *Manifest) (archiveURL, subdir string) {
-	if len(manifest.Versions) == 0 {
-		return "", ""
-	}
+// Versions with unsupported spec_version values are logged and skipped. When no
+// location survives, an error is returned rather than an empty URL, so that an
+// unreachable or misconfigured hub is distinguishable from a hub that simply has
+// nothing to report.
+func getArchiveURL(ctx context.Context, client *http.Client, manifest *Manifest) (archiveURL, subdir string, err error) {
 	logger := logging.FromContext(ctx)
+
+	probed := 0
 	for _, v := range manifest.Versions {
 		if v.SpecVersion != supportedSpecVersion {
 			logger.Infof("VEX Hub: skipping unsupported spec_version %q (supported: %q)", v.SpecVersion, supportedSpecVersion)
 			continue
 		}
-		if len(v.Locations) == 0 {
-			continue
-		}
 		for _, loc := range v.Locations {
-			rawURL := loc.URL
-			if rawURL == "" {
+			if loc.URL == "" {
 				continue
 			}
-
-			// Parse out optional subdir after "//".
-			var targetURL, sub string
-			schemeEnd := strings.Index(rawURL, "://")
-			searchStart := 0
-			if schemeEnd >= 0 {
-				searchStart = schemeEnd + 3
+			targetURL, sub := splitSubdir(loc.URL)
+			probed++
+			if reachable(ctx, client, targetURL) {
+				return targetURL, sub, nil
 			}
-			rest := rawURL[searchStart:]
-			if idx := strings.Index(rest, "//"); idx >= 0 {
-				targetURL = rawURL[:searchStart+idx]
-				sub = rest[idx+2:]
-			} else {
-				targetURL = rawURL
-			}
-
-			// Probe reachability with a HEAD request against the actual archive URL.
-			req, err := http.NewRequestWithContext(ctx, http.MethodHead, targetURL, nil)
-			if err != nil {
-				continue
-			}
-			resp, err := client.Do(req)
-			if err != nil || resp.StatusCode != http.StatusOK {
-				if resp != nil {
-					_ = resp.Body.Close()
-				}
-				continue
-			}
-			_ = resp.Body.Close()
-
-			return targetURL, sub
 		}
 	}
-	return "", ""
+
+	if probed == 0 {
+		return "", "", fmt.Errorf("manifest declares no locations for spec_version %s", supportedSpecVersion)
+	}
+	return "", "", fmt.Errorf("all %d declared location(s) failed the reachability probe", probed)
+}
+
+// splitSubdir separates the archive URL from the optional "//"-delimited
+// subdirectory the VEX Repo Spec allows after the host.
+func splitSubdir(rawURL string) (targetURL, subdir string) {
+	searchStart := 0
+	if schemeEnd := strings.Index(rawURL, "://"); schemeEnd >= 0 {
+		searchStart = schemeEnd + 3
+	}
+	rest := rawURL[searchStart:]
+	idx := strings.Index(rest, "//")
+	if idx < 0 {
+		return rawURL, ""
+	}
+	return rawURL[:searchStart+idx], rest[idx+2:]
+}
+
+// reachable probes a candidate archive location with HEAD.
+//
+// The check is deliberately lenient: plenty of object stores and CDNs answer
+// 403/405/501 to HEAD while serving the very same URL over GET, so demanding a
+// 200 here would discard locations that work fine. Only a transport error or a
+// definitive 404/410 rules a location out.
+func reachable(ctx context.Context, client *http.Client, url string) bool {
+	logger := logging.FromContext(ctx)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		logger.Warnf("VEX Hub: skipping malformed location %s: %v", url, err)
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Warnf("VEX Hub: location %s is unreachable: %v", url, err)
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		logger.Warnf("VEX Hub: location %s returned %d, skipping", url, resp.StatusCode)
+		return false
+	}
+	return true
 }
 
 // canonicalizePURL parses a PURL with packageurl-go and re-stringifies it so
@@ -298,6 +339,57 @@ func canonicalizePURL(purl string) string {
 		return purl
 	}
 	return p.ToString()
+}
+
+// archivePrefix reports the archive-internal prefix that turns tar entry names
+// into paths relative to the VEX repository root, given the entry expected to
+// hold index.json.
+//
+// Hubs publish archives both with a single top-level wrapper directory (what a
+// GitHub tarball produces) and without one, so the prefix is discovered rather
+// than assumed. Only a single leading component is accepted, so an unrelated
+// index.json nested deeper in the tree cannot hijack the match.
+func archivePrefix(entryName, indexPath string) (string, bool) {
+	if entryName == indexPath {
+		return "", true
+	}
+	wrapper, found := strings.CutSuffix(entryName, "/"+indexPath)
+	if !found || wrapper == "" || strings.Contains(wrapper, "/") {
+		return "", false
+	}
+	return wrapper + "/", true
+}
+
+// repoRelativeName strips the discovered wrapper prefix and the manifest subdir
+// from a tar entry name, yielding the path as index.json spells it. Entries
+// outside the repository root are reported with ok == false.
+func repoRelativeName(entryName, prefix, subdir string) (string, bool) {
+	name, ok := strings.CutPrefix(entryName, prefix)
+	if !ok {
+		return "", false
+	}
+	if sub := strings.Trim(subdir, "/"); sub != "" {
+		if name, ok = strings.CutPrefix(name, sub+"/"); !ok {
+			return "", false
+		}
+	}
+	return name, true
+}
+
+// readEntry reads a single tar entry, refusing anything over maxEntryBytes.
+//
+// Reading one byte past the limit is what separates "this file is too big" from
+// a file that lands exactly on it; a plain io.LimitReader would hand back a
+// truncated document that only fails later as a baffling JSON parse error.
+func readEntry(r io.Reader, name string) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxEntryBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", name, err)
+	}
+	if int64(len(data)) > maxEntryBytes {
+		return nil, fmt.Errorf("%s exceeds maximum entry size of %d bytes", name, maxEntryBytes)
+	}
+	return data, nil
 }
 
 // downloadAndIndex downloads a tar.gz archive using a two-pass approach to
@@ -345,22 +437,14 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		return nil, fmt.Errorf("archive exceeds maximum allowed size of %d bytes", maxArchiveBytes)
 	}
 
-	// normalizeName strips the leading top-level directory component (e.g. "vexhub-main/")
-	// from a tar entry name first, then optionally strips the subdir prefix.
-	normalizeName := func(name string) string {
-		// Always strip the leading top-level directory component.
-		if idx := strings.Index(name, "/"); idx >= 0 {
-			name = name[idx+1:]
-		}
-		// Then strip the subdir prefix if one was specified in the manifest URL.
-		if subdir != "" {
-			if after, found := strings.CutPrefix(name, subdir+"/"); found {
-				name = after
-			} else if after, found := strings.CutPrefix(name, subdir); found {
-				name = after
-			}
-		}
-		return name
+	// Locations inside index.json are relative to the repository root, which sits
+	// under the manifest's subdir (when it declares one) and under whatever
+	// top-level wrapper directory the archive happens to use. Rather than assume
+	// a wrapper exists, pass 1 discovers the prefix from wherever index.json
+	// actually turns up and pass 2 reuses it verbatim.
+	indexPath := "index.json"
+	if sub := strings.Trim(subdir, "/"); sub != "" {
+		indexPath = sub + "/index.json"
 	}
 
 	// openTar returns a fresh *tar.Reader positioned at the beginning of the archive.
@@ -380,7 +464,11 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 	if err != nil {
 		return nil, err
 	}
-	var indexData []byte
+	var (
+		indexData []byte
+		prefix    string
+		found     bool
+	)
 	for {
 		header, err := tr1.Next()
 		if err == io.EOF {
@@ -392,16 +480,18 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
-		if normalizeName(header.Name) == "index.json" {
-			indexData, err = io.ReadAll(io.LimitReader(tr1, maxEntryBytes))
-			if err != nil {
-				return nil, fmt.Errorf("reading index.json: %w", err)
-			}
-			break
+		p, ok := archivePrefix(header.Name, indexPath)
+		if !ok {
+			continue
 		}
+		if indexData, err = readEntry(tr1, header.Name); err != nil {
+			return nil, err
+		}
+		prefix, found = p, true
+		break
 	}
-	if indexData == nil {
-		return nil, fmt.Errorf("index.json not found in archive")
+	if !found {
+		return nil, fmt.Errorf("%s not found in archive", indexPath)
 	}
 
 	var index Index
@@ -433,13 +523,13 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
-		name := normalizeName(header.Name)
-		if !needed[name] {
+		name, ok := repoRelativeName(header.Name, prefix, subdir)
+		if !ok || !needed[name] {
 			continue
 		}
-		data, err := io.ReadAll(io.LimitReader(tr2, maxEntryBytes))
+		data, err := readEntry(tr2, header.Name)
 		if err != nil {
-			return nil, fmt.Errorf("reading file %s: %w", header.Name, err)
+			return nil, err
 		}
 		cumulativeBytes += int64(len(data))
 		if cumulativeBytes > maxArchiveBytes {
@@ -465,45 +555,33 @@ func downloadAndIndex(ctx context.Context, client *http.Client, archiveURL, subd
 	return vexDocs, nil
 }
 
-// emitVEXDocuments looks up each PURL in the VEX index and emits matching documents.
-// Both the query PURLs and the index keys are canonicalized via packageurl-go
-// before comparison so that PURL spelling variants do not cause misses.
-// Documents already emitted in a previous batch are deduplicated via v.seen.
-// The channel send is wrapped in a select so that context cancellation
+// emitVEXDocuments looks up each PURL in the VEX index and emits matching
+// documents. Both the query PURLs and the index keys are canonicalized via
+// packageurl-go before comparison so that PURL spelling variants do not cause
+// misses. The channel send is wrapped in a select so that context cancellation
 // (e.g. graceful shutdown) is respected and the call never hangs.
 func (v *vexHubCertifier) emitVEXDocuments(ctx context.Context, purls []string, vexDocs map[string][]byte, docChannel chan<- *processor.Document) ([]*processor.Document, error) {
 	var emitted []*processor.Document
-	v.seenMu.Lock()
-	defer v.seenMu.Unlock()
 
 	for _, purl := range purls {
 		if strings.Contains(purl, "pkg:guac") {
 			continue
 		}
 
-		lookupKey := canonicalizePURL(purl)
-
-		docData, ok := vexDocs[lookupKey]
-		if !ok {
-			// Try again with version, qualifiers, and subpath stripped.
-			p, err := packageurl.FromString(purl)
-			if err == nil {
-				p.Version = ""
-				p.Qualifiers = packageurl.Qualifiers{}
-				p.Subpath = ""
-				lookupKey = p.ToString()
-				docData, ok = vexDocs[lookupKey]
-			}
-		}
-
+		docData, ok := lookupVEXDoc(vexDocs, purl)
 		if !ok {
 			continue
 		}
 
-		if _, seen := v.seen[lookupKey]; seen {
+		// Dedup on the document digest rather than the PURL. Keying on the PURL
+		// would permanently suppress a package once seen, so a statement revised
+		// upstream would never reach the pipeline again after a cache refresh --
+		// defeating the point of polling on update_interval. The digest lets
+		// changed content through while still swallowing unchanged repeats.
+		docRef := events.GetDocRef(docData)
+		if v.markEmitted(docRef) {
 			continue
 		}
-		v.seen[lookupKey] = struct{}{}
 
 		doc := &processor.Document{
 			Blob:   docData,
@@ -512,7 +590,7 @@ func (v *vexHubCertifier) emitVEXDocuments(ctx context.Context, purls []string, 
 			SourceInformation: processor.SourceInformation{
 				Collector:   VEXHubCollector,
 				Source:      VEXHubCollector,
-				DocumentRef: events.GetDocRef(docData),
+				DocumentRef: docRef,
 			},
 		}
 
@@ -527,4 +605,34 @@ func (v *vexHubCertifier) emitVEXDocuments(ctx context.Context, purls []string, 
 	}
 
 	return emitted, nil
+}
+
+// lookupVEXDoc resolves a PURL against the index, retrying with version,
+// qualifiers and subpath stripped since hubs commonly key on the bare package.
+func lookupVEXDoc(vexDocs map[string][]byte, purl string) ([]byte, bool) {
+	if docData, ok := vexDocs[canonicalizePURL(purl)]; ok {
+		return docData, true
+	}
+	p, err := packageurl.FromString(purl)
+	if err != nil {
+		return nil, false
+	}
+	p.Version = ""
+	p.Qualifiers = packageurl.Qualifiers{}
+	p.Subpath = ""
+	docData, ok := vexDocs[p.ToString()]
+	return docData, ok
+}
+
+// markEmitted records docRef and reports whether it had already been emitted.
+// The lock is scoped to the map access alone so that it is never held across the
+// blocking channel send in emitVEXDocuments.
+func (v *vexHubCertifier) markEmitted(docRef string) bool {
+	v.seenMu.Lock()
+	defer v.seenMu.Unlock()
+	if _, seen := v.seen[docRef]; seen {
+		return true
+	}
+	v.seen[docRef] = struct{}{}
+	return false
 }

--- a/pkg/certifier/vexhub/vexhub_test.go
+++ b/pkg/certifier/vexhub/vexhub_test.go
@@ -1,0 +1,263 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vexhub
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/guacsec/guac/pkg/certifier/components/root_package"
+	"github.com/guacsec/guac/pkg/handler/processor"
+)
+
+// buildTestArchive creates a tar.gz archive with index.json and a VEX document.
+func buildTestArchive(t *testing.T, indexJSON string, vexFiles map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Write index.json under a root dir prefix (simulating GitHub archive).
+	writeFile := func(name, content string) {
+		hdr := &tar.Header{
+			Name: "vexhub-main/" + name,
+			Mode: 0644,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile("index.json", indexJSON)
+	for path, content := range vexFiles {
+		writeFile(path, content)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestStripPurlVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"pkg:npm/lodash@4.17.21", "pkg:npm/lodash"},
+		{"pkg:maven/org.apache/log4j@2.0?type=jar", "pkg:maven/org.apache/log4j"},
+		{"pkg:npm/lodash@4.17.21#sub/path", "pkg:npm/lodash"},
+		{"pkg:deb/debian/curl", "pkg:deb/debian/curl"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripPurlVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("stripPurlVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetArchiveURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  Manifest
+		wantURL   string
+		wantSubdir string
+	}{
+		{
+			name: "simple URL",
+			manifest: Manifest{
+				Versions: []ManifestVersion{{
+					Locations: []ManifestLocation{{URL: "https://example.com/vex.tar.gz"}},
+				}},
+			},
+			wantURL:    "https://example.com/vex.tar.gz",
+			wantSubdir: "",
+		},
+		{
+			name:      "empty manifest",
+			manifest:  Manifest{},
+			wantURL:   "",
+			wantSubdir: "",
+		},
+		{
+			name: "URL with subdirectory",
+			manifest: Manifest{
+				Versions: []ManifestVersion{{
+					Locations: []ManifestLocation{{URL: "https://github.com/org/repo/archive/refs/heads/main.tar.gz//vexhub-main"}},
+				}},
+			},
+			wantURL:    "https://github.com/org/repo/archive/refs/heads/main.tar.gz",
+			wantSubdir: "vexhub-main",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotSubdir := getArchiveURL(&tt.manifest)
+			if gotURL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
+			}
+			if gotSubdir != tt.wantSubdir {
+				t.Errorf("subdir = %q, want %q", gotSubdir, tt.wantSubdir)
+			}
+		})
+	}
+}
+
+func TestEmitVEXDocuments(t *testing.T) {
+	vexDoc := []byte(`{"@context": "https://openvex.dev/ns/v0.2.0", "@id": "test"}`)
+	vexDocs := map[string][]byte{
+		"pkg:npm/lodash": vexDoc,
+	}
+
+	t.Run("matching purl emits document", func(t *testing.T) {
+		docChan := make(chan *processor.Document, 10)
+		docs, err := emitVEXDocuments(
+			[]string{"pkg:npm/lodash@4.17.21"},
+			vexDocs,
+			docChan,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("expected 1 doc, got %d", len(docs))
+		}
+		if docs[0].Type != processor.DocumentOpenVEX {
+			t.Errorf("expected type %v, got %v", processor.DocumentOpenVEX, docs[0].Type)
+		}
+	})
+
+	t.Run("no match emits nothing", func(t *testing.T) {
+		docs, err := emitVEXDocuments(
+			[]string{"pkg:npm/express@1.0.0"},
+			vexDocs,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs) != 0 {
+			t.Fatalf("expected 0 docs, got %d", len(docs))
+		}
+	})
+
+	t.Run("guac purls are skipped", func(t *testing.T) {
+		docs, err := emitVEXDocuments(
+			[]string{"pkg:guac/test@1.0"},
+			vexDocs,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs) != 0 {
+			t.Fatalf("expected 0 docs for guac purl, got %d", len(docs))
+		}
+	})
+
+	t.Run("duplicate purls only emit once", func(t *testing.T) {
+		docChan := make(chan *processor.Document, 10)
+		docs, err := emitVEXDocuments(
+			[]string{"pkg:npm/lodash@4.17.21", "pkg:npm/lodash@4.17.20"},
+			vexDocs,
+			docChan,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("expected 1 doc for duplicate purls, got %d", len(docs))
+		}
+	})
+}
+
+func TestCertifyComponentTypeMismatch(t *testing.T) {
+	c := &vexHubCertifier{httpClient: http.DefaultClient, manifestURL: "http://example.com"}
+	err := c.CertifyComponent(context.Background(), "wrong type", nil)
+	if err == nil || err != ErrComponentTypeMismatch {
+		t.Errorf("expected ErrComponentTypeMismatch, got %v", err)
+	}
+}
+
+func TestCertifyComponentEndToEnd(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"test-vex","statements":[{"vulnerability":{"name":"CVE-2021-44228"},"products":[{"@id":"pkg:npm/lodash"}],"status":"not_affected"}]}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+
+	archive := buildTestArchive(t, indexJSON, map[string]string{
+		"pkg/npm/lodash/vex.json": vexDoc,
+	})
+
+	// Serve the manifest and archive.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	certifier := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+
+	docChan := make(chan *processor.Document, 10)
+	nodes := []*root_package.PackageNode{
+		{Purl: "pkg:npm/lodash@4.17.21"},
+		{Purl: "pkg:npm/express@1.0.0"},
+	}
+
+	err := certifier.CertifyComponent(context.Background(), nodes, docChan)
+	if err != nil {
+		t.Fatalf("CertifyComponent failed: %v", err)
+	}
+
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+	if docs[0].Type != processor.DocumentOpenVEX {
+		t.Errorf("expected type %v, got %v", processor.DocumentOpenVEX, docs[0].Type)
+	}
+	if docs[0].SourceInformation.Collector != VEXHubCollector {
+		t.Errorf("expected collector %q, got %q", VEXHubCollector, docs[0].SourceInformation.Collector)
+	}
+}

--- a/pkg/certifier/vexhub/vexhub_test.go
+++ b/pkg/certifier/vexhub/vexhub_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The GUAC Authors.
+// Copyright 2026 The GUAC Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,20 +23,27 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
-// buildTestArchive creates a tar.gz archive with index.json and a VEX document.
+// noopLogger satisfies the logger interface used by getArchiveURL in tests.
+type noopLogger struct{}
+
+func (n noopLogger) Infof(_ string, _ ...interface{}) {}
+
+// buildTestArchive creates a tar.gz archive with index.json and optional VEX files.
+// All entries are nested under a "vexhub-main/" top-level directory (simulating a
+// GitHub archive download).
 func buildTestArchive(t *testing.T, indexJSON string, vexFiles map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 
-	// Write index.json under a root dir prefix (simulating GitHub archive).
 	writeFile := func(name, content string) {
 		hdr := &tar.Header{
 			Name: "vexhub-main/" + name,
@@ -65,63 +72,102 @@ func buildTestArchive(t *testing.T, indexJSON string, vexFiles map[string]string
 	return buf.Bytes()
 }
 
-func TestStripPurlVersion(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"pkg:npm/lodash@4.17.21", "pkg:npm/lodash"},
-		{"pkg:maven/org.apache/log4j@2.0?type=jar", "pkg:maven/org.apache/log4j"},
-		{"pkg:npm/lodash@4.17.21#sub/path", "pkg:npm/lodash"},
-		{"pkg:deb/debian/curl", "pkg:deb/debian/curl"},
+// buildArchiveWithoutIndex creates a tar.gz that intentionally omits index.json.
+func buildArchiveWithoutIndex(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	hdr := &tar.Header{Name: "vexhub-main/other.json", Mode: 0644, Size: 2}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := stripPurlVersion(tt.input)
-			if got != tt.want {
-				t.Errorf("stripPurlVersion(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
+	if _, err := tw.Write([]byte("{}")); err != nil {
+		t.Fatal(err)
 	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }
 
+// TestGetArchiveURL verifies that getArchiveURL correctly filters spec versions
+// and parses the // subdirectory separator.
 func TestGetArchiveURL(t *testing.T) {
+	logger := noopLogger{}
 	tests := []struct {
-		name      string
-		manifest  Manifest
-		wantURL   string
+		name       string
+		manifest   Manifest
+		wantURL    string
 		wantSubdir string
 	}{
 		{
-			name: "simple URL",
+			name: "supported spec version simple URL",
 			manifest: Manifest{
 				Versions: []ManifestVersion{{
-					Locations: []ManifestLocation{{URL: "https://example.com/vex.tar.gz"}},
+					SpecVersion: "0.1",
+					Locations:   []ManifestLocation{{URL: "https://example.com/vex.tar.gz"}},
 				}},
 			},
 			wantURL:    "https://example.com/vex.tar.gz",
 			wantSubdir: "",
 		},
 		{
-			name:      "empty manifest",
-			manifest:  Manifest{},
-			wantURL:   "",
+			name:       "empty manifest",
+			manifest:   Manifest{},
+			wantURL:    "",
 			wantSubdir: "",
 		},
 		{
 			name: "URL with subdirectory",
 			manifest: Manifest{
 				Versions: []ManifestVersion{{
-					Locations: []ManifestLocation{{URL: "https://github.com/org/repo/archive/refs/heads/main.tar.gz//vexhub-main"}},
+					SpecVersion: "0.1",
+					Locations:   []ManifestLocation{{URL: "https://github.com/org/repo/archive/refs/heads/main.tar.gz//vexhub-main"}},
 				}},
 			},
 			wantURL:    "https://github.com/org/repo/archive/refs/heads/main.tar.gz",
 			wantSubdir: "vexhub-main",
 		},
+		{
+			// P1 fix: unknown spec version must be skipped; no URL returned.
+			name: "unsupported spec version is skipped",
+			manifest: Manifest{
+				Versions: []ManifestVersion{
+					{
+						SpecVersion: "99.0",
+						Locations:   []ManifestLocation{{URL: "https://example.com/new.tar.gz"}},
+					},
+				},
+			},
+			wantURL:    "",
+			wantSubdir: "",
+		},
+		{
+			// First entry is unsupported, second entry is supported — should pick the second.
+			name: "multi-version manifest picks first compatible",
+			manifest: Manifest{
+				Versions: []ManifestVersion{
+					{
+						SpecVersion: "99.0",
+						Locations:   []ManifestLocation{{URL: "https://example.com/new.tar.gz"}},
+					},
+					{
+						SpecVersion: "0.1",
+						Locations:   []ManifestLocation{{URL: "https://example.com/old.tar.gz"}},
+					},
+				},
+			},
+			wantURL:    "https://example.com/old.tar.gz",
+			wantSubdir: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotSubdir := getArchiveURL(&tt.manifest)
+			gotURL, gotSubdir := getArchiveURL(logger, &tt.manifest)
 			if gotURL != tt.wantURL {
 				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
 			}
@@ -132,13 +178,17 @@ func TestGetArchiveURL(t *testing.T) {
 	}
 }
 
+// TestEmitVEXDocuments exercises PURL canonicalization, deduplication, guac
+// skipping, and the version-stripped fallback.
 func TestEmitVEXDocuments(t *testing.T) {
 	vexDoc := []byte(`{"@context": "https://openvex.dev/ns/v0.2.0", "@id": "test"}`)
+
+	// Index keyed with canonical PURL (no version).
 	vexDocs := map[string][]byte{
-		"pkg:npm/lodash": vexDoc,
+		canonicalizePURL("pkg:npm/lodash"): vexDoc,
 	}
 
-	t.Run("matching purl emits document", func(t *testing.T) {
+	t.Run("exact versioned purl matches via version-stripped fallback", func(t *testing.T) {
 		docChan := make(chan *processor.Document, 10)
 		docs, err := emitVEXDocuments(
 			[]string{"pkg:npm/lodash@4.17.21"},
@@ -198,8 +248,25 @@ func TestEmitVEXDocuments(t *testing.T) {
 			t.Fatalf("expected 1 doc for duplicate purls, got %d", len(docs))
 		}
 	})
+
+	t.Run("stripped-version-still-misses for unknown package", func(t *testing.T) {
+		// A versioned PURL that, even after stripping, has no index entry.
+		docs, err := emitVEXDocuments(
+			[]string{"pkg:npm/totally-unknown@1.2.3"},
+			vexDocs,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs) != 0 {
+			t.Fatalf("expected 0 docs for unknown package, got %d", len(docs))
+		}
+	})
 }
 
+// TestCertifyComponentTypeMismatch checks that a wrong component type returns
+// the expected sentinel error.
 func TestCertifyComponentTypeMismatch(t *testing.T) {
 	c := &vexHubCertifier{httpClient: http.DefaultClient, manifestURL: "http://example.com"}
 	err := c.CertifyComponent(context.Background(), "wrong type", nil)
@@ -208,6 +275,8 @@ func TestCertifyComponentTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestCertifyComponentEndToEnd runs the full certifier pipeline against an
+// in-process httptest server serving a manifest and archive.
 func TestCertifyComponentEndToEnd(t *testing.T) {
 	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"test-vex","statements":[{"vulnerability":{"name":"CVE-2021-44228"},"products":[{"@id":"pkg:npm/lodash"}],"status":"not_affected"}]}`
 	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
@@ -216,7 +285,6 @@ func TestCertifyComponentEndToEnd(t *testing.T) {
 		"pkg/npm/lodash/vex.json": vexDoc,
 	})
 
-	// Serve the manifest and archive.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -259,5 +327,148 @@ func TestCertifyComponentEndToEnd(t *testing.T) {
 	}
 	if docs[0].SourceInformation.Collector != VEXHubCollector {
 		t.Errorf("expected collector %q, got %q", VEXHubCollector, docs[0].SourceInformation.Collector)
+	}
+}
+
+// TestMalformedManifest verifies that a non-JSON manifest body returns an error.
+func TestMalformedManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not valid json {{{{"))
+	}))
+	defer server.Close()
+
+	c := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed manifest, got nil")
+	}
+}
+
+// TestMissingIndexJSON verifies that an archive without index.json returns an error.
+func TestMissingIndexJSON(t *testing.T) {
+	archive := buildArchiveWithoutIndex(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "index.json") {
+		t.Fatalf("expected index.json error, got: %v", err)
+	}
+}
+
+// TestOversizedArchive verifies that an archive exceeding maxArchiveBytes is rejected.
+func TestOversizedArchive(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		// Send more than maxArchiveBytes of zeros (uncompressed, but enough to trigger the limit check).
+		chunk := make([]byte, 1024*1024) // 1 MiB chunk
+		for i := 0; i <= int(maxArchiveBytes/int64(len(chunk)))+1; i++ {
+			_, _ = w.Write(chunk)
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
+	if err == nil {
+		t.Fatal("expected error for oversized archive, got nil")
+	}
+}
+
+// TestNetworkError verifies that a network failure during archive download
+// is surfaced as an error from CertifyComponent.
+func TestNetworkError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		// Hijack the connection to force a network error mid-response.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		_ = conn.Close()
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
+	if err == nil {
+		t.Fatal("expected error for network failure, got nil")
+	}
+}
+
+// TestMultiVersionManifest checks that when the manifest has multiple versions
+// the certifier picks the first one with the supported spec_version.
+func TestMultiVersionManifest(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"multi-test"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{
+		"pkg/npm/lodash/vex.json": vexDoc,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		// Serve an unsupported version first; the certifier should skip it.
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[
+			{"spec_version":"99.0","locations":[{"url":"%s/should-not-be-used.tar.gz"}]},
+			{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}
+		]}`, "http://"+r.Host, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	// Crash if the wrong archive is requested.
+	mux.HandleFunc("/should-not-be-used.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "wrong version selected", http.StatusBadRequest)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &vexHubCertifier{
+		httpClient:  server.Client(),
+		manifestURL: server.URL + "/vex-repository.json",
+	}
+	docChan := make(chan *processor.Document, 10)
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}, docChan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
 	}
 }

--- a/pkg/certifier/vexhub/vexhub_test.go
+++ b/pkg/certifier/vexhub/vexhub_test.go
@@ -24,21 +24,35 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
-// noopLogger satisfies the logger interface used by getArchiveURL in tests.
-type noopLogger struct{}
-
-func (n noopLogger) Infof(_ string, _ ...interface{}) {}
+// newTestCertifier returns a vexHubCertifier with all maps initialised,
+// suitable for direct use in white-box tests.
+func newTestCertifier(client *http.Client, manifestURL string) *vexHubCertifier {
+	return &vexHubCertifier{
+		httpClient:  client,
+		manifestURL: manifestURL,
+		cache:       make(map[string]*manifestCacheEntry),
+		seen:        make(map[string]struct{}),
+	}
+}
 
 // buildTestArchive creates a tar.gz archive with index.json and optional VEX files.
 // All entries are nested under a "vexhub-main/" top-level directory (simulating a
 // GitHub archive download).
 func buildTestArchive(t *testing.T, indexJSON string, vexFiles map[string]string) []byte {
+	t.Helper()
+	return buildTestArchiveWithPrefix(t, "vexhub-main/", indexJSON, vexFiles)
+}
+
+// buildTestArchiveWithPrefix creates a tar.gz archive with index.json and optional VEX files
+// prefixed by prefix.
+func buildTestArchiveWithPrefix(t *testing.T, prefix string, indexJSON string, vexFiles map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
@@ -46,7 +60,7 @@ func buildTestArchive(t *testing.T, indexJSON string, vexFiles map[string]string
 
 	writeFile := func(name, content string) {
 		hdr := &tar.Header{
-			Name: "vexhub-main/" + name,
+			Name: prefix + name,
 			Mode: 0644,
 			Size: int64(len(content)),
 		}
@@ -97,7 +111,13 @@ func buildArchiveWithoutIndex(t *testing.T) []byte {
 // TestGetArchiveURL verifies that getArchiveURL correctly filters spec versions
 // and parses the // subdirectory separator.
 func TestGetArchiveURL(t *testing.T) {
-	logger := noopLogger{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
 	tests := []struct {
 		name       string
 		manifest   Manifest
@@ -109,10 +129,10 @@ func TestGetArchiveURL(t *testing.T) {
 			manifest: Manifest{
 				Versions: []ManifestVersion{{
 					SpecVersion: "0.1",
-					Locations:   []ManifestLocation{{URL: "https://example.com/vex.tar.gz"}},
+					Locations:   []ManifestLocation{{URL: srv.URL + "/vex.tar.gz"}},
 				}},
 			},
-			wantURL:    "https://example.com/vex.tar.gz",
+			wantURL:    srv.URL + "/vex.tar.gz",
 			wantSubdir: "",
 		},
 		{
@@ -126,48 +146,47 @@ func TestGetArchiveURL(t *testing.T) {
 			manifest: Manifest{
 				Versions: []ManifestVersion{{
 					SpecVersion: "0.1",
-					Locations:   []ManifestLocation{{URL: "https://github.com/org/repo/archive/refs/heads/main.tar.gz//vexhub-main"}},
+					Locations:   []ManifestLocation{{URL: srv.URL + "/archive.tar.gz//vexhub-main"}},
 				}},
 			},
-			wantURL:    "https://github.com/org/repo/archive/refs/heads/main.tar.gz",
+			wantURL:    srv.URL + "/archive.tar.gz",
 			wantSubdir: "vexhub-main",
 		},
 		{
-			// P1 fix: unknown spec version must be skipped; no URL returned.
 			name: "unsupported spec version is skipped",
 			manifest: Manifest{
-				Versions: []ManifestVersion{
-					{
-						SpecVersion: "99.0",
-						Locations:   []ManifestLocation{{URL: "https://example.com/new.tar.gz"}},
-					},
-				},
+				Versions: []ManifestVersion{{
+					SpecVersion: "99.0",
+					Locations:   []ManifestLocation{{URL: srv.URL + "/new.tar.gz"}},
+				}},
 			},
 			wantURL:    "",
 			wantSubdir: "",
 		},
 		{
-			// First entry is unsupported, second entry is supported — should pick the second.
 			name: "multi-version manifest picks first compatible",
 			manifest: Manifest{
 				Versions: []ManifestVersion{
 					{
 						SpecVersion: "99.0",
-						Locations:   []ManifestLocation{{URL: "https://example.com/new.tar.gz"}},
+						Locations:   []ManifestLocation{{URL: srv.URL + "/new.tar.gz"}},
 					},
 					{
 						SpecVersion: "0.1",
-						Locations:   []ManifestLocation{{URL: "https://example.com/old.tar.gz"}},
+						Locations:   []ManifestLocation{{URL: srv.URL + "/old.tar.gz"}},
 					},
 				},
 			},
-			wantURL:    "https://example.com/old.tar.gz",
+			wantURL:    srv.URL + "/old.tar.gz",
 			wantSubdir: "",
 		},
 	}
+
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotSubdir := getArchiveURL(logger, &tt.manifest)
+			gotURL, gotSubdir := getArchiveURL(ctx, srv.Client(), &tt.manifest)
 			if gotURL != tt.wantURL {
 				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
 			}
@@ -189,12 +208,9 @@ func TestEmitVEXDocuments(t *testing.T) {
 	}
 
 	t.Run("exact versioned purl matches via version-stripped fallback", func(t *testing.T) {
+		c := newTestCertifier(http.DefaultClient, "")
 		docChan := make(chan *processor.Document, 10)
-		docs, err := emitVEXDocuments(
-			[]string{"pkg:npm/lodash@4.17.21"},
-			vexDocs,
-			docChan,
-		)
+		docs, err := c.emitVEXDocuments(context.Background(), []string{"pkg:npm/lodash@4.17.21"}, vexDocs, docChan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,11 +223,8 @@ func TestEmitVEXDocuments(t *testing.T) {
 	})
 
 	t.Run("no match emits nothing", func(t *testing.T) {
-		docs, err := emitVEXDocuments(
-			[]string{"pkg:npm/express@1.0.0"},
-			vexDocs,
-			nil,
-		)
+		c := newTestCertifier(http.DefaultClient, "")
+		docs, err := c.emitVEXDocuments(context.Background(), []string{"pkg:npm/express@1.0.0"}, vexDocs, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,11 +234,8 @@ func TestEmitVEXDocuments(t *testing.T) {
 	})
 
 	t.Run("guac purls are skipped", func(t *testing.T) {
-		docs, err := emitVEXDocuments(
-			[]string{"pkg:guac/test@1.0"},
-			vexDocs,
-			nil,
-		)
+		c := newTestCertifier(http.DefaultClient, "")
+		docs, err := c.emitVEXDocuments(context.Background(), []string{"pkg:guac/test@1.0"}, vexDocs, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -235,8 +245,10 @@ func TestEmitVEXDocuments(t *testing.T) {
 	})
 
 	t.Run("duplicate purls only emit once", func(t *testing.T) {
+		c := newTestCertifier(http.DefaultClient, "")
 		docChan := make(chan *processor.Document, 10)
-		docs, err := emitVEXDocuments(
+		docs, err := c.emitVEXDocuments(
+			context.Background(),
 			[]string{"pkg:npm/lodash@4.17.21", "pkg:npm/lodash@4.17.20"},
 			vexDocs,
 			docChan,
@@ -249,13 +261,30 @@ func TestEmitVEXDocuments(t *testing.T) {
 		}
 	})
 
+	t.Run("cross-batch deduplication via struct-level seen map", func(t *testing.T) {
+		c := newTestCertifier(http.DefaultClient, "")
+		docChan := make(chan *processor.Document, 10)
+		// First batch emits one doc.
+		docs1, err := c.emitVEXDocuments(context.Background(), []string{"pkg:npm/lodash@4.17.21"}, vexDocs, docChan)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs1) != 1 {
+			t.Fatalf("batch 1: expected 1 doc, got %d", len(docs1))
+		}
+		// Second batch with same PURL should emit nothing.
+		docs2, err := c.emitVEXDocuments(context.Background(), []string{"pkg:npm/lodash@4.17.20"}, vexDocs, docChan)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(docs2) != 0 {
+			t.Fatalf("batch 2: expected 0 docs (dedup across batches), got %d", len(docs2))
+		}
+	})
+
 	t.Run("stripped-version-still-misses for unknown package", func(t *testing.T) {
-		// A versioned PURL that, even after stripping, has no index entry.
-		docs, err := emitVEXDocuments(
-			[]string{"pkg:npm/totally-unknown@1.2.3"},
-			vexDocs,
-			nil,
-		)
+		c := newTestCertifier(http.DefaultClient, "")
+		docs, err := c.emitVEXDocuments(context.Background(), []string{"pkg:npm/totally-unknown@1.2.3"}, vexDocs, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -263,12 +292,23 @@ func TestEmitVEXDocuments(t *testing.T) {
 			t.Fatalf("expected 0 docs for unknown package, got %d", len(docs))
 		}
 	})
+
+	t.Run("context cancellation aborts emission", func(t *testing.T) {
+		c := newTestCertifier(http.DefaultClient, "")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+		unbufferedChan := make(chan *processor.Document)
+		_, err := c.emitVEXDocuments(ctx, []string{"pkg:npm/lodash@4.17.21"}, vexDocs, unbufferedChan)
+		if err == nil {
+			t.Fatal("expected error on cancelled context, got nil")
+		}
+	})
 }
 
 // TestCertifyComponentTypeMismatch checks that a wrong component type returns
 // the expected sentinel error.
 func TestCertifyComponentTypeMismatch(t *testing.T) {
-	c := &vexHubCertifier{httpClient: http.DefaultClient, manifestURL: "http://example.com"}
+	c := newTestCertifier(http.DefaultClient, "http://example.com")
 	err := c.CertifyComponent(context.Background(), "wrong type", nil)
 	if err == nil || err != ErrComponentTypeMismatch {
 		t.Errorf("expected ErrComponentTypeMismatch, got %v", err)
@@ -291,16 +331,17 @@ func TestCertifyComponentEndToEnd(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
 	})
 	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	certifier := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 
 	docChan := make(chan *processor.Document, 10)
 	nodes := []*root_package.PackageNode{
@@ -308,7 +349,7 @@ func TestCertifyComponentEndToEnd(t *testing.T) {
 		{Purl: "pkg:npm/express@1.0.0"},
 	}
 
-	err := certifier.CertifyComponent(context.Background(), nodes, docChan)
+	err := c.CertifyComponent(context.Background(), nodes, docChan)
 	if err != nil {
 		t.Fatalf("CertifyComponent failed: %v", err)
 	}
@@ -337,10 +378,7 @@ func TestMalformedManifest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
 	if err == nil {
 		t.Fatal("expected error for malformed manifest, got nil")
@@ -356,15 +394,16 @@ func TestMissingIndexJSON(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
 	})
 	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		_, _ = w.Write(archive)
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "index.json") {
 		t.Fatalf("expected index.json error, got: %v", err)
@@ -378,8 +417,11 @@ func TestOversizedArchive(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
 	})
 	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
-		// Send more than maxArchiveBytes of zeros (uncompressed, but enough to trigger the limit check).
-		chunk := make([]byte, 1024*1024) // 1 MiB chunk
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		chunk := make([]byte, 1024*1024) // 1 MiB chunks
 		for i := 0; i <= int(maxArchiveBytes/int64(len(chunk)))+1; i++ {
 			_, _ = w.Write(chunk)
 		}
@@ -387,10 +429,7 @@ func TestOversizedArchive(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
 	if err == nil {
 		t.Fatal("expected error for oversized archive, got nil")
@@ -405,7 +444,11 @@ func TestNetworkError(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
 	})
 	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
-		// Hijack the connection to force a network error mid-response.
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Hijack the connection on GET to force a network error.
 		hj, ok := w.(http.Hijacker)
 		if !ok {
 			http.Error(w, "no hijack", http.StatusInternalServerError)
@@ -417,10 +460,7 @@ func TestNetworkError(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
 	if err == nil {
 		t.Fatal("expected error for network failure, got nil")
@@ -438,26 +478,25 @@ func TestMultiVersionManifest(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
-		// Serve an unsupported version first; the certifier should skip it.
 		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[
 			{"spec_version":"99.0","locations":[{"url":"%s/should-not-be-used.tar.gz"}]},
 			{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}
 		]}`, "http://"+r.Host, "http://"+r.Host)
 	})
 	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		_, _ = w.Write(archive)
 	})
-	// Crash if the wrong archive is requested.
 	mux.HandleFunc("/should-not-be-used.tar.gz", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "wrong version selected", http.StatusBadRequest)
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &vexHubCertifier{
-		httpClient:  server.Client(),
-		manifestURL: server.URL + "/vex-repository.json",
-	}
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
 	docChan := make(chan *processor.Document, 10)
 	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}, docChan)
 	if err != nil {
@@ -470,5 +509,141 @@ func TestMultiVersionManifest(t *testing.T) {
 	}
 	if len(docs) != 1 {
 		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+}
+
+// TestSubdirVsTopLevelDirMismatch tests archives where the top-level directory
+// inside the tarball does not match the subdir specified after "//" in the URL.
+func TestSubdirVsTopLevelDirMismatch(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"subdir-test"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	// The tar archive has a top-level dir "github-release-1.0.0/", and inside it "custom-subdir/pkg/npm/lodash/vex.json".
+	archive := buildTestArchiveWithPrefix(t, "github-release-1.0.0/custom-subdir/", indexJSON, map[string]string{
+		"pkg/npm/lodash/vex.json": vexDoc,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		// URL specifies subdirectory "custom-subdir" after "//"
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz//custom-subdir"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	docChan := make(chan *processor.Document, 10)
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}, docChan)
+	if err != nil {
+		t.Fatalf("CertifyComponent failed: %v", err)
+	}
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document with custom subdir, got %d", len(docs))
+	}
+}
+
+// TestFormatFiltering verifies that non-openvex format entries are skipped.
+func TestFormatFiltering(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"format-test"}`
+	// Index with one openvex entry and one csaf entry.
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[
+		{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json","format":"openvex"},
+		{"id":"pkg:npm/express","location":"pkg/npm/express/csaf.json","format":"csaf"}
+	]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{
+		"pkg/npm/lodash/vex.json":   vexDoc,
+		"pkg/npm/express/csaf.json": `{"document":{}}`,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	docChan := make(chan *processor.Document, 10)
+	nodes := []*root_package.PackageNode{
+		{Purl: "pkg:npm/lodash@1.0"},
+		{Purl: "pkg:npm/express@4.0"},
+	}
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+	// Only lodash (openvex) should be emitted; express (csaf) must be skipped.
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc (openvex only), got %d", len(docs))
+	}
+}
+
+// TestCachingAndTTL verifies that the certifier reuses cached manifest and vexDocs
+// without re-downloading until the TTL expires.
+func TestCachingAndTTL(t *testing.T) {
+	var downloadCount int32
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"cache-test"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{
+		"pkg/npm/lodash/vex.json": vexDoc,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","update_interval":"1h","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&downloadCount, 1)
+		}
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := NewVEXHubCertifier(server.URL + "/vex-repository.json")
+	nodes := []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}
+
+	// First call downloads the archive.
+	docChan := make(chan *processor.Document, 10)
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if atomic.LoadInt32(&downloadCount) != 1 {
+		t.Fatalf("expected 1 download, got %d", atomic.LoadInt32(&downloadCount))
+	}
+
+	// Second call should use cache (no new download).
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if atomic.LoadInt32(&downloadCount) != 1 {
+		t.Fatalf("expected 1 download (cached), got %d", atomic.LoadInt32(&downloadCount))
 	}
 }

--- a/pkg/certifier/vexhub/vexhub_test.go
+++ b/pkg/certifier/vexhub/vexhub_test.go
@@ -21,12 +21,15 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/guacsec/guac/pkg/certifier"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
@@ -37,7 +40,6 @@ func newTestCertifier(client *http.Client, manifestURL string) *vexHubCertifier 
 	return &vexHubCertifier{
 		httpClient:  client,
 		manifestURL: manifestURL,
-		cache:       make(map[string]*manifestCacheEntry),
 		seen:        make(map[string]struct{}),
 	}
 }
@@ -123,6 +125,7 @@ func TestGetArchiveURL(t *testing.T) {
 		manifest   Manifest
 		wantURL    string
 		wantSubdir string
+		wantErr    bool
 	}{
 		{
 			name: "supported spec version simple URL",
@@ -140,6 +143,7 @@ func TestGetArchiveURL(t *testing.T) {
 			manifest:   Manifest{},
 			wantURL:    "",
 			wantSubdir: "",
+			wantErr:    true,
 		},
 		{
 			name: "URL with subdirectory",
@@ -162,6 +166,7 @@ func TestGetArchiveURL(t *testing.T) {
 			},
 			wantURL:    "",
 			wantSubdir: "",
+			wantErr:    true,
 		},
 		{
 			name: "multi-version manifest picks first compatible",
@@ -186,7 +191,10 @@ func TestGetArchiveURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotSubdir := getArchiveURL(ctx, srv.Client(), &tt.manifest)
+			gotURL, gotSubdir, err := getArchiveURL(ctx, srv.Client(), &tt.manifest)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
 			if gotURL != tt.wantURL {
 				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
 			}
@@ -645,5 +653,277 @@ func TestCachingAndTTL(t *testing.T) {
 	}
 	if atomic.LoadInt32(&downloadCount) != 1 {
 		t.Fatalf("expected 1 download (cached), got %d", atomic.LoadInt32(&downloadCount))
+	}
+}
+
+// TestRevisedDocumentReEmitsAfterRefresh is the regression test for dedup being
+// keyed on the document digest rather than the PURL. A hub that publishes an
+// updated VEX statement for a package we have already reported must get that
+// statement through on the next refresh; keying on the PURL would suppress it
+// for the lifetime of the process and make polling on update_interval pointless.
+func TestRevisedDocumentReEmitsAfterRefresh(t *testing.T) {
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	revisions := []string{
+		`{"@context":"https://openvex.dev/ns/v0.2.0","@id":"rev-1"}`,
+		`{"@context":"https://openvex.dev/ns/v0.2.0","@id":"rev-2"}`,
+	}
+	var gets int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		// A zero-length TTL forces a refresh on every call, standing in for a
+		// hub whose update_interval has elapsed.
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","update_interval":"1ns","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		n := int(atomic.AddInt32(&gets, 1)) - 1
+		if n >= len(revisions) {
+			n = len(revisions) - 1
+		}
+		_, _ = w.Write(buildTestArchive(t, indexJSON, map[string]string{"pkg/npm/lodash/vex.json": revisions[n]}))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	nodes := []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}
+	docChan := make(chan *processor.Document, 10)
+
+	// First pass: the original statement is emitted.
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	// Second pass: the hub now serves a revised statement, which must get through.
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	// Third pass: content is unchanged from the second, so nothing new is emitted.
+	if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+		t.Fatalf("third call failed: %v", err)
+	}
+
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 docs (original + revision, unchanged repeat suppressed), got %d", len(docs))
+	}
+	if string(docs[0].Blob) == string(docs[1].Blob) {
+		t.Fatal("expected the second document to be the revised statement")
+	}
+}
+
+// TestSharedCertifierKeepsStateAcrossBatches guards the contract that
+// certify.generateDocuments calls the registered factory once per component
+// batch: the factory must return one shared instance, otherwise the cache and
+// the dedup set are reallocated per batch.
+func TestSharedCertifierKeepsStateAcrossBatches(t *testing.T) {
+	var downloads int32
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"shared"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{"pkg/npm/lodash/vex.json": vexDoc})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","update_interval":"1h","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		atomic.AddInt32(&downloads, 1)
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Mirrors how the cobra commands register the certifier.
+	shared := NewVEXHubCertifier(server.URL + "/vex-repository.json")
+	factory := func() certifier.Certifier { return shared }
+
+	docChan := make(chan *processor.Document, 10)
+	for batch := 0; batch < 3; batch++ {
+		nodes := []*root_package.PackageNode{{Purl: fmt.Sprintf("pkg:npm/lodash@4.17.%d", batch)}}
+		if err := factory().CertifyComponent(context.Background(), nodes, docChan); err != nil {
+			t.Fatalf("batch %d failed: %v", batch, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&downloads); got != 1 {
+		t.Fatalf("expected 1 archive download across 3 batches, got %d", got)
+	}
+	close(docChan)
+	var docs []*processor.Document
+	for doc := range docChan {
+		docs = append(docs, doc)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc across 3 batches (dedup holds), got %d", len(docs))
+	}
+}
+
+// TestNoUsableLocationReturnsError verifies that a hub whose locations are all
+// unreachable surfaces as an error rather than a silent success, so that a
+// broken hub is distinguishable from a hub with nothing to report.
+func TestNoUsableLocationReturnsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/missing.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/missing.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@1.0"}}, nil)
+	if err == nil {
+		t.Fatal("expected an error when no archive location is usable, got nil")
+	}
+	if !strings.Contains(err.Error(), "no usable archive location") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestHeadMethodNotAllowedStillUsable covers object stores and CDNs that answer
+// 403/405 to HEAD while serving the same URL over GET perfectly well. Demanding
+// a 200 from the probe would discard a location that works.
+func TestHeadMethodNotAllowedStillUsable(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"head-405"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{"pkg/npm/lodash/vex.json": vexDoc})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	docChan := make(chan *processor.Document, 10)
+	if err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}, docChan); err != nil {
+		t.Fatalf("CertifyComponent failed for a location answering 405 to HEAD: %v", err)
+	}
+	close(docChan)
+	if len(docChan) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docChan))
+	}
+}
+
+// TestArchiveWithoutTopLevelDirectory covers archives that place index.json at
+// the root instead of under a wrapper directory. Unconditionally stripping the
+// leading path component would eat a real directory here.
+func TestArchiveWithoutTopLevelDirectory(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"no-wrapper"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchiveWithPrefix(t, "", indexJSON, map[string]string{"pkg/npm/lodash/vex.json": vexDoc})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestCertifier(server.Client(), server.URL+"/vex-repository.json")
+	docChan := make(chan *processor.Document, 10)
+	if err := c.CertifyComponent(context.Background(), []*root_package.PackageNode{{Purl: "pkg:npm/lodash@4.17.21"}}, docChan); err != nil {
+		t.Fatalf("CertifyComponent failed: %v", err)
+	}
+	close(docChan)
+	if len(docChan) != 1 {
+		t.Fatalf("expected 1 document from a wrapper-less archive, got %d", len(docChan))
+	}
+}
+
+// TestReadEntryRejectsOversizedFile verifies that an entry over maxEntryBytes
+// errors out instead of being silently truncated into unparseable JSON.
+func TestReadEntryRejectsOversizedFile(t *testing.T) {
+	oversized := io.LimitReader(zeroReader{}, maxEntryBytes+1)
+	if _, err := readEntry(oversized, "huge.json"); err == nil {
+		t.Fatal("expected an error for an entry over maxEntryBytes, got nil")
+	} else if !strings.Contains(err.Error(), "exceeds maximum entry size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	atLimit := io.LimitReader(zeroReader{}, maxEntryBytes)
+	data, err := readEntry(atLimit, "exact.json")
+	if err != nil {
+		t.Fatalf("entry exactly at the limit should be accepted, got: %v", err)
+	}
+	if int64(len(data)) != maxEntryBytes {
+		t.Fatalf("expected %d bytes, got %d", int64(maxEntryBytes), len(data))
+	}
+}
+
+// zeroReader is an endless stream of zero bytes, bounded by the caller.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) { return len(p), nil }
+
+// TestConcurrentBatchesShareStateSafely drives one shared certifier from several
+// goroutines, the way certify.generateDocuments does now that the factory hands
+// back a singleton. This is what makes the cache and dedup mutexes load-bearing.
+func TestConcurrentBatchesShareStateSafely(t *testing.T) {
+	vexDoc := `{"@context":"https://openvex.dev/ns/v0.2.0","@id":"concurrent"}`
+	indexJSON := `{"updated_at":"2024-01-01T00:00:00Z","packages":[{"id":"pkg:npm/lodash","location":"pkg/npm/lodash/vex.json"}]}`
+	archive := buildTestArchive(t, indexJSON, map[string]string{"pkg/npm/lodash/vex.json": vexDoc})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vex-repository.json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":"test","versions":[{"spec_version":"0.1","update_interval":"1h","locations":[{"url":"%s/archive.tar.gz"}]}]}`, "http://"+r.Host)
+	})
+	mux.HandleFunc("/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := NewVEXHubCertifier(server.URL + "/vex-repository.json")
+	docChan := make(chan *processor.Document, 100)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			nodes := []*root_package.PackageNode{{Purl: fmt.Sprintf("pkg:npm/lodash@4.17.%d", i)}}
+			if err := c.CertifyComponent(context.Background(), nodes, docChan); err != nil {
+				t.Errorf("batch %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	close(docChan)
+	if n := len(docChan); n != 1 {
+		t.Fatalf("expected exactly 1 doc across concurrent batches, got %d", n)
 	}
 }


### PR DESCRIPTION
# Description of the PR
This PR adds a new certifier to support VEX Hub integration, as discussed in the linked issue. 

The `vexhub` certifier queries repositories conforming to the VEX Repo Spec. It fetches the manifest (`vex-repository.json`), downloads the tar.gz archive, and uses `index.json` to map package PURLs to their corresponding OpenVEX documents. The manifest URL is configurable via the `--vexhub-manifest-url` flag (defaults to the Aqua Security VEX Hub). 

Both `guacone` and `guaccollect` CLI commands have been added.

Fixes #2296

# PR Checklist
- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [x] All CI checks are passing (tests and formatting)
