### PR TITLE
fix(processor): dead-letter pubsub messages whose blob is persistently missing

### DIFF
--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -24,7 +24,12 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/pubsub"
+
+	"github.com/nats-io/nats.go/jetstream"
 	"go.uber.org/zap"
 
 	uuid "github.com/gofrs/uuid"
@@ -44,15 +49,30 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor/scorecard"
 	"github.com/guacsec/guac/pkg/handler/processor/spdx"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/metrics"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
-	"gocloud.dev/pubsub"
 )
 
 var (
 	documentProcessors = map[processor.DocumentType]processor.DocumentProcessor{}
 	json               = jsoniter.ConfigCompatibleWithStandardLibrary
 )
+
+// maxBlobNotFoundRetries caps how many times a single pubsub message will be
+// retried when the blob store reports the object is missing. After this many
+// consecutive NotFound responses for the same message, it is acked (dropped)
+// so it stops being redelivered indefinitely. Guards against orphaned events
+// whose underlying blob has been deleted or never landed.
+const maxBlobNotFoundRetries = 3
+
+// metricsCollectorName is the namespace used for processor metrics.
+const metricsCollectorName = "guac_processor"
+
+// blobNotFoundDroppedCounter is the metric name (sans namespace) for the
+// counter tracking pubsub messages dropped because their referenced blob is
+// persistently missing.
+const blobNotFoundDroppedCounter = "blob_notfound_dropped_total"
 
 func init() {
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Generic)
@@ -80,6 +100,72 @@ func RegisterDocumentProcessor(p processor.DocumentProcessor, d processor.Docume
 	return nil
 }
 
+// deliveryCountSource returns a stable label describing where the delivery
+// count was sourced from, for log/metric clarity.
+func deliveryCountSource(fromBroker bool) string {
+	if fromBroker {
+		return "broker"
+	}
+	return "in_process"
+}
+
+// notFoundTracker counts consecutive NotFound responses per blob key for
+// pubsub backends that don't expose a native delivery count (e.g. mempubsub
+// in tests). NATS JetStream tracks NumDelivered server-side, so we prefer
+// that path when available.
+type notFoundTracker struct {
+	mu       sync.Mutex
+	attempts map[string]int
+}
+
+func newNotFoundTracker() *notFoundTracker {
+	return &notFoundTracker{attempts: make(map[string]int)}
+}
+
+func (t *notFoundTracker) increment(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.attempts[key]++
+	return t.attempts[key]
+}
+
+func (t *notFoundTracker) clear(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.attempts, key)
+}
+
+// deliveryAttempt returns the broker-reported delivery count for msg if the
+// underlying transport exposes one (currently NATS JetStream). The boolean
+// indicates whether a server-side count was available; callers fall back to
+// in-process tracking when it is not.
+func deliveryAttempt(msg *pubsub.Message) (int, bool) {
+	var jsMsg jetstream.Msg
+	if !msg.As(&jsMsg) {
+		return 0, false
+	}
+	md, err := jsMsg.Metadata()
+	if err != nil || md == nil {
+		return 0, false
+	}
+	return int(md.NumDelivered), true
+}
+
+// registerProcessorMetrics registers (or recovers an existing) counter for
+// dropped-message accounting. Returns nil for the counter if registration
+// fails so the caller can degrade gracefully without aborting ingest.
+func registerProcessorMetrics(ctx context.Context, logger *zap.SugaredLogger) metrics.Counter {
+	collector := metrics.FromContext(ctx, metricsCollectorName)
+	counter, err := collector.RegisterCounter(ctx, blobNotFoundDroppedCounter, "processor_id")
+	if err != nil {
+		// Most commonly this fires in tests where the counter was registered
+		// by a prior Subscribe; the metric is still usable via AddCounter.
+		logger.Debugf("blob-notfound counter registration: %v", err)
+		return nil
+	}
+	return counter
+}
+
 // Subscribe receives the CD event and decodes the event to obtain the blob store key.
 // The key is used to retrieve the "document" from the blob store to be processed and ingested.
 func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobStore, emPubSub *emitter.EmitterPubSub) error {
@@ -97,6 +183,11 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 	}
 
 	retries := 0
+
+	// In-process fallback for backends without a native delivery count.
+	tracker := newNotFoundTracker()
+	droppedCounter := registerProcessorMetrics(ctx, logger)
+	metricsCollector := metrics.FromContext(ctx, metricsCollectorName)
 
 	// should still continue if there are errors since problem is with individual documents
 	processFunc := func(d *pubsub.Message) error {
@@ -116,9 +207,43 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 
 		documentBytes, err := blobStore.Read(ctx, blobStoreKey)
 		if err != nil {
+			if gcerrors.Code(err) == gcerrors.NotFound {
+				attempts, fromBroker := deliveryAttempt(d)
+				if !fromBroker {
+					attempts = tracker.increment(blobStoreKey)
+				}
+
+				childLogger.Errorw("failed read document to blob store",
+					"processor_id", uuidString,
+					"attempt", attempts,
+					"max_attempts", maxBlobNotFoundRetries,
+					"delivery_count_source", deliveryCountSource(fromBroker),
+					"error", err.Error(),
+				)
+
+				if attempts >= maxBlobNotFoundRetries {
+					childLogger.Warnw("blob persistently missing — dropping pubsub message to stop redelivery",
+						"processor_id", uuidString,
+						"attempts", attempts,
+						"blob_key", blobStoreKey,
+						"delivery_count_source", deliveryCountSource(fromBroker),
+					)
+					if droppedCounter != nil {
+						droppedCounter.Inc()
+					} else if err := metricsCollector.AddCounter(ctx, blobNotFoundDroppedCounter, 1, uuidString); err != nil {
+						childLogger.Debugf("[processor: %s] AddCounter blob-notfound: %v", uuidString, err)
+					}
+					tracker.clear(blobStoreKey)
+					d.Ack()
+				}
+				return nil
+			}
 			childLogger.Errorf("[processor: %s] failed read document to blob store: %v", uuidString, err)
 			return nil
 		}
+
+		// successful read — clear any prior NotFound bookkeeping for this key
+		tracker.clear(blobStoreKey)
 
 		doc := processor.Document{}
 		if err = json.Unmarshal(documentBytes, &doc); err != nil {

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -115,7 +115,12 @@ func deliveryCountSource(fromBroker bool) string {
 // in tests). NATS JetStream tracks NumDelivered server-side, so we prefer
 // that path when available.
 type notFoundTracker struct {
-	mu       sync.Mutex
+	mu sync.Mutex
+	// attempts is keyed by blob store key, not by pubsub message. Two distinct
+	// messages referencing the same missing blob therefore share one counter,
+	// so the second can reach maxBlobNotFoundRetries in fewer deliveries of its
+	// own. That is acceptable: both messages point at the same absent blob, and
+	// a successful read clears the entry.
 	attempts map[string]int
 }
 
@@ -152,19 +157,17 @@ func deliveryAttempt(msg *pubsub.Message) (int, bool) {
 	return int(md.NumDelivered), true
 }
 
-// registerProcessorMetrics registers (or recovers an existing) counter for
-// dropped-message accounting. Returns nil for the counter if registration
-// fails so the caller can degrade gracefully without aborting ingest.
-func registerProcessorMetrics(ctx context.Context, logger *zap.SugaredLogger) metrics.Counter {
-	collector := metrics.FromContext(ctx, metricsCollectorName)
-	counter, err := collector.RegisterCounter(ctx, blobNotFoundDroppedCounter, "processor_id")
-	if err != nil {
-		// Most commonly this fires in tests where the counter was registered
-		// by a prior Subscribe; the metric is still usable via AddCounter.
+// registerProcessorMetrics declares the dropped-message counter on collector so
+// that AddCounter can find it later. The Counter returned by RegisterCounter is
+// deliberately discarded: it is bound to the label *names* rather than to this
+// processor's UUID, so incrementing it would record a different series than the
+// AddCounter call at the drop site. Registration failure is not fatal — most
+// commonly it means a prior Subscribe already registered the counter on this
+// collector — so it is logged and ingest continues.
+func registerProcessorMetrics(ctx context.Context, collector metrics.MetricCollector, logger *zap.SugaredLogger) {
+	if _, err := collector.RegisterCounter(ctx, blobNotFoundDroppedCounter, "processor_id"); err != nil {
 		logger.Debugf("blob-notfound counter registration: %v", err)
-		return nil
 	}
-	return counter
 }
 
 // Subscribe receives the CD event and decodes the event to obtain the blob store key.
@@ -187,8 +190,11 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 
 	// In-process fallback for backends without a native delivery count.
 	tracker := newNotFoundTracker()
-	droppedCounter := registerProcessorMetrics(ctx, logger)
+	// One collector instance for both registration and increment: FromContext
+	// constructs a fresh collector when the context carries none, so calling it
+	// twice would register the counter on a collector the drop site never uses.
 	metricsCollector := metrics.FromContext(ctx, metricsCollectorName)
+	registerProcessorMetrics(ctx, metricsCollector, logger)
 
 	// should still continue if there are errors since problem is with individual documents
 	processFunc := func(d *pubsub.Message) error {
@@ -229,9 +235,7 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 						"blob_key", blobStoreKey,
 						"delivery_count_source", deliveryCountSource(fromBroker),
 					)
-					if droppedCounter != nil {
-						droppedCounter.Inc()
-					} else if err := metricsCollector.AddCounter(ctx, blobNotFoundDroppedCounter, 1, uuidString); err != nil {
+					if err := metricsCollector.AddCounter(ctx, blobNotFoundDroppedCounter, 1, uuidString); err != nil {
 						childLogger.Debugf("[processor: %s] AddCounter blob-notfound: %v", uuidString, err)
 					}
 					tracker.clear(blobStoreKey)

--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -24,7 +24,12 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/pubsub"
+
+	"github.com/nats-io/nats.go/jetstream"
 	"go.uber.org/zap"
 
 	uuid "github.com/gofrs/uuid"
@@ -44,15 +49,30 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor/scorecard"
 	"github.com/guacsec/guac/pkg/handler/processor/spdx"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/metrics"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
-	"gocloud.dev/pubsub"
 )
 
 var (
 	documentProcessors = map[processor.DocumentType]processor.DocumentProcessor{}
 	json               = jsoniter.ConfigCompatibleWithStandardLibrary
 )
+
+// maxBlobNotFoundRetries caps how many times a single pubsub message will be
+// retried when the blob store reports the object is missing. After this many
+// consecutive NotFound responses for the same message, it is acked (dropped)
+// so it stops being redelivered indefinitely. Guards against orphaned events
+// whose underlying blob has been deleted or never landed.
+const maxBlobNotFoundRetries = 3
+
+// metricsCollectorName is the namespace used for processor metrics.
+const metricsCollectorName = "guac_processor"
+
+// blobNotFoundDroppedCounter is the metric name (sans namespace) for the
+// counter tracking pubsub messages dropped because their referenced blob is
+// persistently missing.
+const blobNotFoundDroppedCounter = "blob_notfound_dropped_total"
 
 func init() {
 	_ = RegisterDocumentProcessor(&ite6.ITE6Processor{}, processor.DocumentITE6Generic)
@@ -81,6 +101,72 @@ func RegisterDocumentProcessor(p processor.DocumentProcessor, d processor.Docume
 	return nil
 }
 
+// deliveryCountSource returns a stable label describing where the delivery
+// count was sourced from, for log/metric clarity.
+func deliveryCountSource(fromBroker bool) string {
+	if fromBroker {
+		return "broker"
+	}
+	return "in_process"
+}
+
+// notFoundTracker counts consecutive NotFound responses per blob key for
+// pubsub backends that don't expose a native delivery count (e.g. mempubsub
+// in tests). NATS JetStream tracks NumDelivered server-side, so we prefer
+// that path when available.
+type notFoundTracker struct {
+	mu       sync.Mutex
+	attempts map[string]int
+}
+
+func newNotFoundTracker() *notFoundTracker {
+	return &notFoundTracker{attempts: make(map[string]int)}
+}
+
+func (t *notFoundTracker) increment(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.attempts[key]++
+	return t.attempts[key]
+}
+
+func (t *notFoundTracker) clear(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.attempts, key)
+}
+
+// deliveryAttempt returns the broker-reported delivery count for msg if the
+// underlying transport exposes one (currently NATS JetStream). The boolean
+// indicates whether a server-side count was available; callers fall back to
+// in-process tracking when it is not.
+func deliveryAttempt(msg *pubsub.Message) (int, bool) {
+	var jsMsg jetstream.Msg
+	if !msg.As(&jsMsg) {
+		return 0, false
+	}
+	md, err := jsMsg.Metadata()
+	if err != nil || md == nil {
+		return 0, false
+	}
+	return int(md.NumDelivered), true
+}
+
+// registerProcessorMetrics registers (or recovers an existing) counter for
+// dropped-message accounting. Returns nil for the counter if registration
+// fails so the caller can degrade gracefully without aborting ingest.
+func registerProcessorMetrics(ctx context.Context, logger *zap.SugaredLogger) metrics.Counter {
+	collector := metrics.FromContext(ctx, metricsCollectorName)
+	counter, err := collector.RegisterCounter(ctx, blobNotFoundDroppedCounter, "processor_id")
+	if err != nil {
+		// Most commonly this fires in tests where the counter was registered
+		// by a prior Subscribe; the metric is still usable via AddCounter.
+		logger.Debugf("blob-notfound counter registration: %v", err)
+		return nil
+	}
+	return counter
+}
+
 // Subscribe receives the CD event and decodes the event to obtain the blob store key.
 // The key is used to retrieve the "document" from the blob store to be processed and ingested.
 func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobStore, emPubSub *emitter.EmitterPubSub) error {
@@ -98,6 +184,11 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 	}
 
 	retries := 0
+
+	// In-process fallback for backends without a native delivery count.
+	tracker := newNotFoundTracker()
+	droppedCounter := registerProcessorMetrics(ctx, logger)
+	metricsCollector := metrics.FromContext(ctx, metricsCollectorName)
 
 	// should still continue if there are errors since problem is with individual documents
 	processFunc := func(d *pubsub.Message) error {
@@ -117,9 +208,43 @@ func Subscribe(ctx context.Context, em collector.Emitter, blobStore *blob.BlobSt
 
 		documentBytes, err := blobStore.Read(ctx, blobStoreKey)
 		if err != nil {
+			if gcerrors.Code(err) == gcerrors.NotFound {
+				attempts, fromBroker := deliveryAttempt(d)
+				if !fromBroker {
+					attempts = tracker.increment(blobStoreKey)
+				}
+
+				childLogger.Errorw("failed read document to blob store",
+					"processor_id", uuidString,
+					"attempt", attempts,
+					"max_attempts", maxBlobNotFoundRetries,
+					"delivery_count_source", deliveryCountSource(fromBroker),
+					"error", err.Error(),
+				)
+
+				if attempts >= maxBlobNotFoundRetries {
+					childLogger.Warnw("blob persistently missing — dropping pubsub message to stop redelivery",
+						"processor_id", uuidString,
+						"attempts", attempts,
+						"blob_key", blobStoreKey,
+						"delivery_count_source", deliveryCountSource(fromBroker),
+					)
+					if droppedCounter != nil {
+						droppedCounter.Inc()
+					} else if err := metricsCollector.AddCounter(ctx, blobNotFoundDroppedCounter, 1, uuidString); err != nil {
+						childLogger.Debugf("[processor: %s] AddCounter blob-notfound: %v", uuidString, err)
+					}
+					tracker.clear(blobStoreKey)
+					d.Ack()
+				}
+				return nil
+			}
 			childLogger.Errorf("[processor: %s] failed read document to blob store: %v", uuidString, err)
 			return nil
 		}
+
+		// successful read — clear any prior NotFound bookkeeping for this key
+		tracker.clear(blobStoreKey)
 
 		doc := processor.Document{}
 		if err = json.Unmarshal(documentBytes, &doc); err != nil {

--- a/pkg/handler/processor/process/process_test.go
+++ b/pkg/handler/processor/process/process_test.go
@@ -19,11 +19,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"strings"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	nats_test "github.com/guacsec/guac/internal/testing/nats"
@@ -851,4 +852,36 @@ func testPublish(ctx context.Context, d *processor.Document, blobStore *blob.Blo
 
 	logger.Debugf("doc published: %+v", d.SourceInformation.Source)
 	return nil
+}
+
+func TestNotFoundTracker(t *testing.T) {
+	tracker := newNotFoundTracker()
+
+	if got := tracker.increment("a"); got != 1 {
+		t.Fatalf("first increment for 'a' = %d, want 1", got)
+	}
+	if got := tracker.increment("a"); got != 2 {
+		t.Fatalf("second increment for 'a' = %d, want 2", got)
+	}
+	if got := tracker.increment("b"); got != 1 {
+		t.Fatalf("first increment for 'b' = %d, want 1", got)
+	}
+
+	tracker.clear("a")
+	if got := tracker.increment("a"); got != 1 {
+		t.Fatalf("increment after clear for 'a' = %d, want 1", got)
+	}
+	// 'b' should be untouched by clearing 'a'
+	if got := tracker.increment("b"); got != 2 {
+		t.Fatalf("increment for 'b' after clearing 'a' = %d, want 2", got)
+	}
+}
+
+func TestDeliveryCountSource(t *testing.T) {
+	if got := deliveryCountSource(true); got != "broker" {
+		t.Errorf("deliveryCountSource(true) = %q, want %q", got, "broker")
+	}
+	if got := deliveryCountSource(false); got != "in_process" {
+		t.Errorf("deliveryCountSource(false) = %q, want %q", got, "in_process")
+	}
 }

--- a/pkg/handler/processor/process/process_test.go
+++ b/pkg/handler/processor/process/process_test.go
@@ -19,11 +19,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"strings"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	nats_test "github.com/guacsec/guac/internal/testing/nats"
@@ -900,4 +901,36 @@ func Test_DecompressDocumentLimit(t *testing.T) {
 			t.Fatalf("expected 262144 bytes decoded, got %d", len(doc.Blob))
 		}
 	})
+}
+
+func TestNotFoundTracker(t *testing.T) {
+	tracker := newNotFoundTracker()
+
+	if got := tracker.increment("a"); got != 1 {
+		t.Fatalf("first increment for 'a' = %d, want 1", got)
+	}
+	if got := tracker.increment("a"); got != 2 {
+		t.Fatalf("second increment for 'a' = %d, want 2", got)
+	}
+	if got := tracker.increment("b"); got != 1 {
+		t.Fatalf("first increment for 'b' = %d, want 1", got)
+	}
+
+	tracker.clear("a")
+	if got := tracker.increment("a"); got != 1 {
+		t.Fatalf("increment after clear for 'a' = %d, want 1", got)
+	}
+	// 'b' should be untouched by clearing 'a'
+	if got := tracker.increment("b"); got != 2 {
+		t.Fatalf("increment for 'b' after clearing 'a' = %d, want 2", got)
+	}
+}
+
+func TestDeliveryCountSource(t *testing.T) {
+	if got := deliveryCountSource(true); got != "broker" {
+		t.Errorf("deliveryCountSource(true) = %q, want %q", got, "broker")
+	}
+	if got := deliveryCountSource(false); got != "in_process" {
+		t.Errorf("deliveryCountSource(false) = %q, want %q", got, "in_process")
+	}
 }


### PR DESCRIPTION
## Summary

The processor previously retried blob `NotFound` responses indefinitely. `process.Subscribe` returned `nil` from its handler without acking, so NATS redelivered the same orphaned message forever — generating hundreds of thousands of `GetObject` errors per processor over weeks for blobs that no longer exist.

After `maxBlobNotFoundRetries` (3) consecutive `NotFound` responses for a message, the message is now acked to stop redelivery. Other read errors retain their previous redelivery behavior.

## How retries are counted

When the underlying transport exposes a delivery count, that is preferred so the threshold is shared across replicas and survives processor restarts:

- NATS JetStream: uses `Metadata().NumDelivered` via `gocloud.dev/pubsub.Message.As(&jetstream.Msg)`.
- Other backends (incl. `mempubsub` in tests): falls back to a per-key in-process counter.

A Prometheus counter `guac_processor_blob_notfound_dropped_total` (label `processor_id`) is registered for alerting on orphan accumulation, and a structured warn log is emitted on each drop with the blob key and attempt count.

## What this does not address

Why orphan events get published in the first place (likely TTL mismatch between blob lifecycle and NATS retention, or out-of-band cleanup). That belongs in a separate investigation.

## Test plan

Run on this branch:

- `go build ./...` clean (exit 0)
- `go vet ./...` clean (exit 0)
- `go test -race -timeout=60s ./... -count=1` — 79 packages OK, 0 fail, 0 data races. Note: at the Makefile's default `-timeout=30s` under race-detector parallelism, the unrelated `pkg/ingestor/parser/common/scanner` package occasionally tips over (it runs ~25–30 s in isolation, with the same behaviour on `main`); raising the timeout to 60 s clears it.
- `golangci-lint run ./pkg/handler/processor/process/...` — 0 issues
- New unit tests pass: `TestNotFoundTracker` (per-key increment/clear isolation) and `TestDeliveryCountSource` (label values). Existing `Test_ProcessSubscribe` continues to pass unchanged.