### PR TITLE
test(osv): refresh vertx-core@4.3.7 fixture with new GHSA

### DIFF
--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -2512,6 +2512,9 @@ var (
 				"version": "0.0.14",
 				"result": [
 					{
+						"id": "GHSA-3g76-f9xq-8vp6"
+					},
+					{
 						"id": "GHSA-9ph3-v2vh-3qx7"
 					},
 					{
@@ -2631,6 +2634,9 @@ var (
 				"uri": "osv.dev",
 				"version": "0.0.14",
 				"result": [
+					{
+						"id": "GHSA-3g76-f9xq-8vp6"
+					},
 					{
 						"id": "GHSA-9ph3-v2vh-3qx7"
 					},


### PR DESCRIPTION
# Description of the PR

Tests are failing due to outdated OSV data. Have updated the test data. 

# PR Checklist

- [X] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [X] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [X] All CI checks are passing (tests and formatting)
- [X] All dependent PRs have already been merged
