### PR TITLE
fix(processor): bound decompressed document size to prevent decompression bombs

### DIFF
--- a/pkg/handler/processor/process/process.go
+++ b/pkg/handler/processor/process/process.go
@@ -308,10 +308,17 @@ func decodeDocument(ctx context.Context, i *processor.Document) error {
 	return nil
 }
 
+// maxDecompressedSize caps how many bytes a document may decompress to, so a
+// small blob cannot expand without bound (a decompression bomb).
+var maxDecompressedSize int64 = 1 << 30 // 1 GiB
+
 func decompressDocument(i *processor.Document, reader io.Reader) error {
-	uncompressed, err := io.ReadAll(reader)
+	uncompressed, err := io.ReadAll(io.LimitReader(reader, maxDecompressedSize+1))
 	if err != nil {
 		return fmt.Errorf("unable to decompress document: %w", err)
+	}
+	if int64(len(uncompressed)) > maxDecompressedSize {
+		return fmt.Errorf("decompressed document exceeds the %d byte limit", maxDecompressedSize)
 	}
 	i.Blob = uncompressed
 	return nil

--- a/pkg/handler/processor/process/process_test.go
+++ b/pkg/handler/processor/process/process_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/handler/processor/guesser"
 	"github.com/guacsec/guac/pkg/logging"
+	"github.com/klauspost/compress/zstd"
 )
 
 func Test_SimpleDocProcessTest(t *testing.T) {
@@ -851,4 +852,52 @@ func testPublish(ctx context.Context, d *processor.Document, blobStore *blob.Blo
 
 	logger.Debugf("doc published: %+v", d.SourceInformation.Source)
 	return nil
+}
+
+func zstdOfZeros(t *testing.T, size int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk := make([]byte, 1<<16)
+	for written := 0; written < size; written += len(chunk) {
+		if _, err := enc.Write(chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func Test_DecompressDocumentLimit(t *testing.T) {
+	orig := maxDecompressedSize
+	maxDecompressedSize = 1 << 20 // 1 MiB for the test
+	defer func() { maxDecompressedSize = orig }()
+
+	t.Run("decompression bomb is rejected", func(t *testing.T) {
+		bomb := zstdOfZeros(t, 5<<20)
+		doc := &processor.Document{Blob: bomb, Encoding: processor.EncodingZstd}
+		err := decodeDocument(context.Background(), doc)
+		if err == nil {
+			t.Fatalf("expected error for over-limit decompression, got nil (blob=%d bytes)", len(doc.Blob))
+		}
+		if !strings.Contains(err.Error(), "limit") {
+			t.Fatalf("expected limit error, got: %v", err)
+		}
+	})
+
+	t.Run("document under the limit still decodes", func(t *testing.T) {
+		small := zstdOfZeros(t, 256<<10)
+		doc := &processor.Document{Blob: small, Encoding: processor.EncodingZstd}
+		if err := decodeDocument(context.Background(), doc); err != nil {
+			t.Fatalf("unexpected error for under-limit document: %v", err)
+		}
+		if len(doc.Blob) != 256<<10 {
+			t.Fatalf("expected 262144 bytes decoded, got %d", len(doc.Blob))
+		}
+	})
 }


### PR DESCRIPTION
# Description of the PR

`decompressDocument` read the bzip2/zstd stream with `io.ReadAll` and no size limit, so a small compressed document could expand to an arbitrary size and exhaust the processor's memory. The encoding is auto-detected from the blob's magic bytes, so any ingested artifact can reach this path.

This bounds the decompressed size with `io.LimitReader` and rejects documents that exceed the limit, matching the object-size handling already used by the blob collector (`pkg/handler/collector/blob/blob.go`). A 56 KB zstd input previously materialized 500 MiB in memory; it is now rejected once it passes the limit.

Fixes #3075

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
