### PR TITLE
fix(keyvalue): skip nil results in CertifyBad and CertifyGood full-scan queries

### DIFF
--- a/pkg/assembler/backends/keyvalue/certifyBad.go
+++ b/pkg/assembler/backends/keyvalue/certifyBad.go
@@ -451,6 +451,10 @@ func (c *demoClient) CertifyBad(ctx context.Context, filter *model.CertifyBadSpe
 					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 				}
 
+				if cb == nil {
+					continue
+				}
+
 				out = append(out, cb)
 			}
 		}

--- a/pkg/assembler/backends/keyvalue/certifyGood.go
+++ b/pkg/assembler/backends/keyvalue/certifyGood.go
@@ -450,6 +450,10 @@ func (c *demoClient) CertifyGood(ctx context.Context, filter *model.CertifyGoodS
 					return nil, gqlerror.Errorf("%v :: %v", funcName, err)
 				}
 
+				if cg == nil {
+					continue
+				}
+
 				out = append(out, cg)
 			}
 		}


### PR DESCRIPTION

# Description of the PR
  - Fix nil elements being appended to query results in the keyvalue backend's `CertifyBad()` and `CertifyGood()` functions
  - The bug is in the full-scan path (the `else` branch) — when no artifact or source filter matches, the code scans all entries and appends results from `CBIfMatch`/`CGIfMatch` without checking for nil
  - The `foundOne` path (the `if` branch) already has the nil guard — this PR adds the same guard to the `else` branch in both files

  ## Problem

When you query `CertifyBad` or `CertifyGood` with a **package filter** (not artifact or source), the backend can't do a targeted lookup — the comment in the code says "Cant really search for an exact Pkg, as these can be linked to either names or versions, and version could be empty." So it falls through to a full scan of all entries.

During that scan, `CBIfMatch`/`CGIfMatch` returns `(nil, nil)` for entries that don't match the filter. But the code appends these nil values to the output slice anyway. The GraphQL layer then tries to serialize an array containing nil elements, which violates the schema (`[CertifyBad!]!` — the `!` inside the brackets means elements must be non-null), and the client gets:
```
the requested element is null which the schema does not allow
```
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
