### PR TITLE
docs: add Gagan as maintainer to the security insights file

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -19,6 +19,7 @@ project-lifecycle:
   - github:pxp928
   - github:SantiagoTorres
   - github:jeffmendoza
+  - github:gaganhr94
 contribution-policy:
   accepts-pull-requests: true
   accepts-automated-pull-requests: true


### PR DESCRIPTION
# Description of the PR

As per the decision taken in https://github.com/guacsec/governance/issues/105, adding myself to the list of maintainers

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
