### PR TITLE
feat: sync devcontainer image tag on release 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     "GUAC_API_PORT": "8080"
   },
 
-  "onCreateCommand": "docker pull ghcr.io/guacsec/guac:v1.1.0",
+  "onCreateCommand": "docker pull $GUAC_IMAGE",
 
   "postStartCommand": "docker compose -f docker-compose.yml -f container_files/mem.yaml up -d && bash -c 'c=0; until curl --silent --head --fail http://localhost:8080 >/dev/null; do if [ $c -ge 60 ]; then echo \"GUAC did not become ready in time\"; docker compose logs --tail=100; exit 1; fi; sleep 2; c=$((c+1)); done; echo; echo \"GUAC is ready.\"; echo \"  - GraphQL playground: port 8080 (auto-previewed)\"; echo \"  - REST API:           port 8081 (e.g. /healthz)\"; echo \"  - Tail logs:          docker compose logs -f\"; echo \"  - Stop:               docker compose down\"'",
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -261,3 +261,49 @@ jobs:
           gh release upload ${{ github.ref_name }} guac-postgres-compose.yaml
           rm guac-postgres-compose.yaml
         shell: bash
+
+  bump-devcontainer:
+    runs-on: ubuntu-latest
+    name: bump devcontainer GUAC_IMAGE
+    needs: [goreleaser]
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'nightly')
+    permissions:
+      contents: write # To push the bump branch
+      pull-requests: write # To open the bump PR
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Open PR bumping the devcontainer image pin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY}:${TAG}"
+          sed -i -E "s#(\"GUAC_IMAGE\": \")[^\"]*#\1${image}#" .devcontainer/devcontainer.json
+          if git diff --quiet; then
+            echo "devcontainer already pins ${image}"
+            exit 0
+          fi
+          branch="chore/devcontainer-guac-image-${TAG}"
+          existing=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number')
+          if [ -n "${existing}" ]; then
+            echo "PR #${existing} already open for ${branch}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git commit -a -s -m "chore(devcontainer): bump GUAC_IMAGE to ${TAG}"
+          # --force is safe: this branch name is unique per tag and only ever
+          # written by this job, so the only thing it can overwrite is a stale
+          # branch left behind by a closed bump PR.
+          git push --force "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${branch}"
+          gh pr create --base main --head "${branch}" \
+            --title "chore(devcontainer): bump GUAC_IMAGE to ${TAG}" \
+            --body "Automated by the release workflow so the devcontainer trial pulls the newest release. Refs #3006."
+        shell: bash


### PR DESCRIPTION
# Description of the PR

Fixes #3006 

## Fix

Implements option (2) from the issue — wiring the bump into the release process.

**1. One source of truth in the devcontainer file**

```diff
-  "onCreateCommand": "docker pull ghcr.io/guacsec/guac:v1.1.0",
+  "onCreateCommand": "docker pull $GUAC_IMAGE",
```
containerEnv values are available to lifecycle commands, so this line now follows the
pin instead of repeating it. The version now exists in exactly one place.

2. New bump-devcontainer job in release.yaml

On each v* tag, after goreleaser publishes the image, it rewrites the pin to the new
tag and opens a PR against main for a maintainer to merge.

- Skips nightly tags, which are also v* tags
- needs: [goreleaser] so it never pins an image that isn't published yet
- Builds the image name from ${GITHUB_REPOSITORY} + tag, matching goreleaser's own
template, so the two can't drift
- Exits early if nothing changed or a bump PR is already open — safe to re-run

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
