### PR TITLE
fix: resolve unused findings and first errcheck batch

### DIFF
--- a/internal/testing/mockRegistry/mock_registry.go
+++ b/internal/testing/mockRegistry/mock_registry.go
@@ -415,7 +415,7 @@ func readAllBody(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return nil, nil
 	}
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 	return io.ReadAll(r.Body)
 }
 

--- a/internal/testing/mockRegistry/mock_registry_test.go
+++ b/internal/testing/mockRegistry/mock_registry_test.go
@@ -37,7 +37,7 @@ func TestMockRegistry_APIVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get API version: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -61,7 +61,7 @@ func TestMockRegistry_Catalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get catalog: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -118,7 +118,7 @@ func TestMockRegistry_Tags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to get tags: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != tt.expectedCode {
 				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
@@ -238,7 +238,7 @@ func TestMockRegistry_Manifests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to do request: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != tt.expectedCode {
 				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
@@ -320,7 +320,7 @@ func TestMockRegistry_Blobs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to do request: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != tt.expectedCode {
 				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
@@ -358,7 +358,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to start upload: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusAccepted {
 			body, _ := io.ReadAll(resp.Body)
@@ -379,7 +379,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get upload state: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusNoContent {
 			t.Errorf("Expected status 204, got %d", resp.StatusCode)
 		}
@@ -408,7 +408,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to upload chunk %d: %v", i, err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != http.StatusAccepted {
 				body, _ := io.ReadAll(resp.Body)
@@ -430,7 +430,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to complete upload: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusCreated {
 			body, _ := io.ReadAll(resp.Body)
@@ -442,7 +442,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get blob: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -475,7 +475,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to do request: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusCreated {
 			body, _ := io.ReadAll(resp.Body)
@@ -487,7 +487,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get blob: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -529,7 +529,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to do request: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusCreated {
 			t.Fatalf("Failed to upload blob to source repo: %d", resp.StatusCode)
@@ -546,7 +546,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to do request: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("Expected status 201, got %d", resp.StatusCode)
@@ -557,7 +557,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get blob: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -579,7 +579,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to do request: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("Expected status 400, got %d", resp.StatusCode)
@@ -592,7 +592,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to start upload: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		location := resp.Header.Get("Location")
 		if location == "" {
@@ -612,7 +612,7 @@ func TestMockRegistry_BlobUpload(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to upload chunk: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
 			t.Errorf("Expected status 416, got %d", resp.StatusCode)
@@ -848,7 +848,7 @@ func TestMockRegistry_Referrers(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to send request: %v", err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != tt.expectedCode {
 				t.Errorf("Expected status %d, got %d", tt.expectedCode, resp.StatusCode)
@@ -878,7 +878,7 @@ func TestMockRegistry_Referrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get referrers: %v", err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("Failed to get initial referrers: %d", resp.StatusCode)
 		}
@@ -893,7 +893,7 @@ func TestMockRegistry_Referrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to delete manifest: %v", err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusAccepted {
 			t.Fatalf("Failed to delete manifest: %d", resp.StatusCode)
 		}
@@ -904,7 +904,7 @@ func TestMockRegistry_Referrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get referrers after delete: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		var index v1.Index
 		if err := json.NewDecoder(resp.Body).Decode(&index); err != nil {

--- a/pkg/handler/collector/deps_dev/deps_dev.go
+++ b/pkg/handler/collector/deps_dev/deps_dev.go
@@ -28,8 +28,6 @@ import (
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/guacsec/guac/pkg/metrics"
 
-	pb "deps.dev/api/v3"
-
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -44,8 +42,6 @@ const (
 	GetProjectDurationHistogram = "http_deps_dev_project_duration"
 	GetVersionErrorsCounter     = "http_deps_dev_version_errors"
 	prometheusPrefix            = "deps_dev"
-	// RPS = rate per second
-	rateLimit = 150
 )
 
 type IsDepPackage struct {
@@ -59,7 +55,6 @@ type depsCollector struct {
 
 	dc                   *ddc.DepsClient
 	collectDataSource    datasource.CollectSource
-	client               pb.InsightsClient
 	poll                 bool
 	retrieveDependencies bool
 	interval             time.Duration


### PR DESCRIPTION
Part of #2971

Phase 1 of the phased lint cleanup discussed in the issue:

- **unused (2/2, all cleared)**: removed a dead rateLimit const and an unused InsightsClient field (plus its orphaned import) in pkg/handler/collector/deps_dev.
- **errcheck (23)**: cleared the whole internal/testing/mockRegistry package, the largest coherent single-package cluster under the batch size. All were unchecked Body.Close(); fixed following the existing convention in the codebase (explicit `_ =` assignment for best-effort closes), no nolint suppressions.

Verified with a full before/after lint diff: exactly the 25 targeted findings are gone, zero new findings. go build and the touched packages' tests pass.

Remaining for later phases: errcheck 217 (the arangodb backend holds ~150 of these and is the natural phase 2), staticcheck 177, govet 4.