### PR TITLE
fix(e2e): wait for ingestion to settle instead of sleeping for a fixed time

### DIFF
--- a/internal/testing/e2e/e2e
+++ b/internal/testing/e2e/e2e
@@ -147,6 +147,60 @@ queryOrder=(
 
 queries="${GUAC_DIR}/demo/graphql/queries.gql"
 
+# Ingestion is asynchronous and how long it takes varies, so waiting a fixed amount of
+# time and hoping the data landed is what makes this job flaky. Wait for the expected
+# content instead: poll the queries until they match their expect files, then let the
+# normal validation below report anything still outstanding.
+#
+# Note this deliberately does not wait for the graph to stop changing. A polling
+# deps_dev collector runs in the background for the whole job, so the data is never
+# static and a stability check would either never fire or fire while a freshly wiped
+# database was still empty.
+#
+# PathQ1 is skipped because it needs ids that are only looked up after ingestion.
+wait_for_expected_data() {
+  local max_wait=${INGESTION_MAX_WAIT:-900}
+  local interval=15
+  local elapsed=0
+  local pending=0
+  local scratch
+  scratch=$(mktemp)
+
+  echo -n "@@@@ Waiting for ingested data to match the expected results"
+  set +e
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    pending=0
+    for query in "${queryOrder[@]}"; do
+      [ "$query" == "PathQ1" ] && continue
+      gql-cli http://localhost:8080/query -o "$query" < "$queries" 2>/dev/null \
+        | jq "${queryValues[$query]}" > "$scratch" 2>/dev/null
+      if ! diff -q "${SCRIPT_DIR}/expect${query}.json" "$scratch" >/dev/null 2>&1; then
+        pending=$((pending + 1))
+      fi
+    done
+
+    if [ "$pending" -eq 0 ]; then
+      set -e
+      rm -f "$scratch"
+      echo
+      echo "@@@@ Ingested data matched after ${elapsed}s" | tee -a "$LOG_FILE"
+      return 0
+    fi
+
+    echo -n "."
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  set -e
+  rm -f "$scratch"
+  echo
+
+  # Out of time. Carry on so the validation below prints the actual diffs and fails
+  # there, rather than timing out with no explanation of what was missing.
+  echo "@@@@ ${pending} quer(y/ies) still not matching after ${max_wait}s, validating anyway" | tee -a "$LOG_FILE"
+  return 0
+}
+
 duplicate_schema
 
 # Loop through ingestion commands
@@ -154,13 +208,7 @@ for command in "${ingestion_commands[@]}"; do
   echo @@@@ Running ingestion command: "$command" | tee -a "$LOG_FILE"
   eval "$command"
 
-  echo @@@@ Waiting for 5 minutes
-  sleep 300
-
-  if [ $? -ne 0 ]; then
-    echo "Error: Command '$command' failed" | tee -a "$LOG_FILE"
-    exit 1
-  fi
+  wait_for_expected_data
 
   echo @@@@ Running queries and validating output
 


### PR DESCRIPTION
# Description of the PR

Fixes #3154

The E2E job starts ingestion asynchronously and then waits with `sleep 300` before running the queries and diffing them against the expect\*.json files. How long ingestion actually takes varies a lot, so when it's still in flight the queries return less than the fixtures contain and the diffs fail on missing entries. That's why the job fails on main far more often than it passes.

The fixed wait also has very little to do with the real work. In one recent run the first ingestion command took 34 minutes before it was done, then waited its 5 minutes and passed. The failure was on the second command, `guaccollect files --service-poll=false`, which goes through collectsub and NATS and gets ingested in the background by guacingest, and got the same fixed 5 minutes.

This replaces the sleep with `wait_for_expected_data`, which polls each query through its existing filter until the output matches its expect file, then hands over to the normal validation. There's a ceiling, 900s by default and overridable with `INGESTION_MAX_WAIT`, and once it's hit validation runs anyway so a genuinely broken run prints real diffs instead of a bare timeout. A run where the data is simply wrong still fails, it just fails on content rather than on timing.

Worth saying why it waits for content rather than for the graph to go quiet, since that's the more obvious approach and it doesn't work here. `guacone collect deps_dev -p` runs in the background for the whole job so the data is never static, and right after `wipe_data` an empty database looks perfectly stable. A settle check either never fires or fires while nothing has been ingested yet. I tried that first and CI showed both failure modes in a single run.

PathQ1 is left out of the polling because it needs ids that are only looked up after ingestion.

This also drops the error check that sat after the sleep. It read `if [ $? -ne 0 ]` but ran after `sleep 300`, so it was testing sleep's exit status rather than the ingestion command's, and always saw 0. The script runs with `set -euf -o pipefail` so a failing ingest already aborts before that point.

## Testing

The full pipeline only runs in CI, so locally I drove the helper directly with stubbed `gql-cli` output:

- Returns as soon as the sampled queries match their expect files, without waiting out the window.
- On the timeout path it returns 0 and execution carries on into validation rather than aborting under `set -e`.
- Leaves no scratch files behind. The script sets `-f`, so globs don't expand and the scratch file has to be cleaned by name rather than with a wildcard.

`bash -n` is clean.

Happy to adjust the ceiling or the poll interval, or to have it poll a cheaper signal than the full query set if you'd rather.

No codegen touched, this is only the e2e shell script.
