### PR TITLE
feat: add PyPI package metadata collector

### DIFF
--- a/pkg/handler/collector/pypi/pypi.go
+++ b/pkg/handler/collector/pypi/pypi.go
@@ -1,0 +1,171 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pypi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/guacsec/guac/pkg/logging"
+	"github.com/guacsec/guac/pkg/version"
+	"github.com/package-url/packageurl-go"
+)
+
+const (
+	PypiCollector = "pypi"
+	// defaultBaseURL is the PyPI JSON API. A package's metadata is served at
+	// <baseURL>/<name>/json.
+	defaultBaseURL = "https://pypi.org/pypi"
+)
+
+type pypiCollector struct {
+	collectDataSource datasource.CollectSource
+	client            *http.Client
+	baseURL           string
+	poll              bool
+	interval          time.Duration
+	// checkedNames dedupes packages already fetched across poll cycles.
+	checkedNames map[string]bool
+}
+
+// NewPypiCollector returns a collector that fetches package metadata from the
+// PyPI JSON API for each pypi purl provided by the data source. When poll is
+// set it keeps re-reading the data source on interval and picks up newly added
+// packages.
+func NewPypiCollector(collectDataSource datasource.CollectSource, poll bool, interval time.Duration) *pypiCollector {
+	return &pypiCollector{
+		collectDataSource: collectDataSource,
+		client:            &http.Client{Transport: version.UATransport},
+		baseURL:           defaultBaseURL,
+		poll:              poll,
+		interval:          interval,
+		checkedNames:      map[string]bool{},
+	}
+}
+
+// RetrieveArtifacts fetches PyPI metadata for the packages in the data source
+// and emits a document per package. When polling it blocks and re-reads the
+// data source until the context is cancelled.
+func (p *pypiCollector) RetrieveArtifacts(ctx context.Context, docChannel chan<- *processor.Document) error {
+	if p.poll {
+		for {
+			if err := p.populatePackages(ctx, docChannel); err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err() // nolint:wrapcheck
+			case <-time.After(p.interval):
+			}
+		}
+	}
+	return p.populatePackages(ctx, docChannel)
+}
+
+func (p *pypiCollector) populatePackages(ctx context.Context, docChannel chan<- *processor.Document) error {
+	logger := logging.FromContext(ctx)
+
+	ds, err := p.collectDataSource.GetDataSources(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve datasource: %w", err)
+	}
+
+	for _, src := range ds.PurlDataSources {
+		name, err := pypiNameFromPurl(src.Value)
+		if err != nil {
+			logger.Warnf("skipping non-pypi source %q: %v", src.Value, err)
+			continue
+		}
+		if p.checkedNames[name] {
+			continue
+		}
+		p.checkedNames[name] = true
+
+		doc, err := p.fetchPackage(ctx, name)
+		if err != nil {
+			logger.Errorf("failed to fetch pypi metadata for %q: %v", name, err)
+			// leave it unchecked so a later poll can retry
+			delete(p.checkedNames, name)
+			continue
+		}
+		docChannel <- doc
+	}
+	return nil
+}
+
+func (p *pypiCollector) fetchPackage(ctx context.Context, name string) (*processor.Document, error) {
+	target := fmt.Sprintf("%s/%s/json", strings.TrimRight(p.baseURL, "/"), url.PathEscape(name))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", target, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, target)
+	}
+
+	blob, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return &processor.Document{
+		Blob:   blob,
+		Type:   processor.DocumentPyPI,
+		Format: processor.FormatJSON,
+		SourceInformation: processor.SourceInformation{
+			Collector:   PypiCollector,
+			Source:      target,
+			DocumentRef: events.GetDocRef(blob),
+		},
+	}, nil
+}
+
+// pypiNameFromPurl extracts the package name from a pypi purl. It accepts a
+// bare name as well so callers can hand in plain package names.
+func pypiNameFromPurl(value string) (string, error) {
+	if !strings.HasPrefix(value, "pkg:") {
+		return value, nil
+	}
+	instance, err := packageurl.FromString(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid purl: %w", err)
+	}
+	if instance.Type != packageurl.TypePyPi {
+		return "", fmt.Errorf("purl type %q is not pypi", instance.Type)
+	}
+	return instance.Name, nil
+}
+
+// Type returns the collector type
+func (p *pypiCollector) Type() string {
+	return PypiCollector
+}

--- a/pkg/handler/collector/pypi/pypi_test.go
+++ b/pkg/handler/collector/pypi/pypi_test.go
@@ -1,0 +1,169 @@
+//
+// Copyright 2024 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pypi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/guacsec/guac/internal/testing/dochelper"
+	"github.com/guacsec/guac/pkg/collectsub/datasource"
+	"github.com/guacsec/guac/pkg/collectsub/datasource/inmemsource"
+	"github.com/guacsec/guac/pkg/events"
+	"github.com/guacsec/guac/pkg/handler/collector"
+	"github.com/guacsec/guac/pkg/handler/processor"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// pypiTestServer serves testdata files at /<name>/json, mirroring the PyPI
+// JSON API. Unknown names get a 404 the way PyPI would return one.
+func pypiTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), "/json")
+		body, err := os.ReadFile(filepath.Join("testdata", name+".json"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	return httptest.NewServer(mux)
+}
+
+func wantDoc(t *testing.T, name, source string) *processor.Document {
+	t.Helper()
+	blob, err := os.ReadFile(filepath.Join("testdata", name+".json"))
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	return &processor.Document{
+		Blob:   blob,
+		Type:   processor.DocumentPyPI,
+		Format: processor.FormatJSON,
+		SourceInformation: processor.SourceInformation{
+			Collector:   PypiCollector,
+			Source:      source,
+			DocumentRef: events.GetDocRef(blob),
+		},
+	}
+}
+
+func Test_pypiCollector_RetrieveArtifacts(t *testing.T) {
+	server := pypiTestServer(t)
+	defer server.Close()
+
+	tests := []struct {
+		name     string
+		packages []string
+		want     []string // testdata basenames expected, in order
+	}{
+		{
+			name:     "no packages",
+			packages: []string{},
+			want:     nil,
+		},
+		{
+			name:     "single pypi purl",
+			packages: []string{"pkg:pypi/requests@2.31.0"},
+			want:     []string{"requests"},
+		},
+		{
+			name:     "bare package name",
+			packages: []string{"requests"},
+			want:     []string{"requests"},
+		},
+		{
+			name:     "duplicate purl is fetched once",
+			packages: []string{"pkg:pypi/requests@2.31.0", "pkg:pypi/requests@2.30.0"},
+			want:     []string{"requests"},
+		},
+		{
+			name:     "non-pypi purl is skipped",
+			packages: []string{"pkg:npm/left-pad@1.0.0", "pkg:pypi/requests@2.31.0"},
+			want:     []string{"requests"},
+		},
+		{
+			name:     "missing package emits nothing",
+			packages: []string{"pkg:pypi/does-not-exist@0.0.0"},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewPypiCollector(toPurlSource(tt.packages), false, time.Second)
+			c.baseURL = server.URL
+
+			collector.DeregisterDocumentCollector(PypiCollector)
+			if err := collector.RegisterDocumentCollector(c, PypiCollector); err != nil {
+				t.Fatalf("could not register collector: %v", err)
+			}
+
+			var got []*processor.Document
+			em := func(d *processor.Document) error {
+				got = append(got, d)
+				return nil
+			}
+			eh := func(err error) bool {
+				if err != nil {
+					t.Errorf("RetrieveArtifacts() error = %v", err)
+				}
+				return true
+			}
+			if err := collector.Collect(context.Background(), em, eh); err != nil {
+				t.Fatalf("Collect error: %v", err)
+			}
+
+			if c.Type() != PypiCollector {
+				t.Errorf("Type() = %s, want %s", c.Type(), PypiCollector)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d docs, want %d", len(got), len(tt.want))
+			}
+			for i, name := range tt.want {
+				source := server.URL + "/" + name + "/json"
+				want := wantDoc(t, name, source)
+				if !dochelper.DocTreeEqual(dochelper.DocNode(got[i]), dochelper.DocNode(want)) {
+					t.Errorf("doc %d mismatch: %s", i, cmp.Diff(dochelper.DocNode(want), dochelper.DocNode(got[i])))
+				}
+			}
+		})
+	}
+}
+
+func toPurlSource(purlValues []string) datasource.CollectSource {
+	values := []datasource.Source{}
+	for _, v := range purlValues {
+		values = append(values, datasource.Source{Value: v})
+	}
+	ds, err := inmemsource.NewInmemDataSources(&datasource.DataSources{
+		PurlDataSources: values,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return ds
+}

--- a/pkg/handler/collector/pypi/testdata/requests.json
+++ b/pkg/handler/collector/pypi/testdata/requests.json
@@ -1,0 +1,29 @@
+{
+  "info": {
+    "name": "requests",
+    "version": "2.31.0",
+    "summary": "Python HTTP for Humans.",
+    "home_page": "https://requests.readthedocs.io",
+    "author": "Kenneth Reitz",
+    "license": "Apache 2.0",
+    "requires_dist": [
+      "charset-normalizer (<4,>=2)",
+      "idna (<4,>=2.5)",
+      "urllib3 (<3,>=1.21.1)",
+      "certifi (>=2017.4.17)"
+    ],
+    "project_urls": {
+      "Source": "https://github.com/psf/requests"
+    }
+  },
+  "urls": [
+    {
+      "filename": "requests-2.31.0-py3-none-any.whl",
+      "packagetype": "bdist_wheel",
+      "url": "https://files.pythonhosted.org/packages/70/8e/requests-2.31.0-py3-none-any.whl",
+      "digests": {
+        "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+      }
+    }
+  ]
+}

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -70,6 +70,7 @@ const (
 	DocumentScorecard          DocumentType = "SCORECARD"
 	DocumentCycloneDX          DocumentType = "CycloneDX"
 	DocumentDepsDev            DocumentType = "DEPS_DEV"
+	DocumentPyPI               DocumentType = "PYPI"
 	DocumentCsaf               DocumentType = "CSAF"
 	DocumentOpenVEX            DocumentType = "OPEN_VEX"
 	DocumentIngestPredicates   DocumentType = "INGEST_PREDICATES"


### PR DESCRIPTION
Adds a PyPI collector so GUAC can pull package metadata from the PyPI JSON API and feed it into the supply-chain graph, closing the gap for pypi purls that the deps.dev collector only covers indirectly.

It reads pypi purls from a collect data source and fetches each package's metadata from `https://pypi.org/pypi/<name>/json`, emitting one `processor.Document` per package. I modeled it on the deps.dev collector: `RetrieveArtifacts` runs once or loops on an interval when `poll` is set, packages already fetched are deduped across poll cycles, and non-pypi sources are skipped with a warning. Bare package names work too, not just purls. A new `DocumentPyPI` document type tags the emitted docs.

Scope here is the collector only. The processor/parser side (registering a document parser + guesser for `DocumentPyPI`) is a natural follow-up and I'm happy to send that separately.

Tests spin up an `httptest` server standing in for the PyPI API and serve fixtures from `testdata/`, so they run without network. Cases cover a single purl, a bare name, dedupe of a repeated package, a non-pypi purl getting skipped, and a missing package emitting nothing. `go build ./...`, `go vet`, and `go test ./pkg/handler/collector/pypi/...` all pass.

Refs #208
