### PR TITLE
fix(emitter): give the processor consumer an ack wait it can meet

### DIFF
--- a/pkg/emitter/emitter.go
+++ b/pkg/emitter/emitter.go
@@ -71,7 +71,7 @@ func buildTopicURL(serviceURL string) string {
 // If using NATS, additional parameters are needed for jetstream
 func buildSubscriptionURL(serviceURL string) string {
 	if strings.HasPrefix(serviceURL, "nats://") {
-		return fmt.Sprintf("%s?%s&subject=%s&consumer_durable_name=%s&stream_name=%s&stream_subjects=%s", serviceURL, "jetstream", subjectNameDocCollected, durableProcessor, streamName, streamSubjects)
+		return fmt.Sprintf("%s?%s&subject=%s&consumer_durable_name=%s&consumer_ack_wait=%s&stream_name=%s&stream_subjects=%s", serviceURL, "jetstream", subjectNameDocCollected, durableProcessor, consumerAckWait, streamName, streamSubjects)
 	} else {
 		return serviceURL
 	}

--- a/pkg/emitter/emitter_test.go
+++ b/pkg/emitter/emitter_test.go
@@ -18,6 +18,7 @@ package emitter
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,5 +79,20 @@ func TestEmitter_PublishOnEmit(t *testing.T) {
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("nats emitter Subscribe test errored = %v", err)
 		}
+	}
+}
+
+func TestBuildSubscriptionURLSetsAckWait(t *testing.T) {
+	// The default ack wait is 30s, which is shorter than a large SBOM takes to
+	// ingest, so the server redelivers documents that are still being processed.
+	got := buildSubscriptionURL("nats://127.0.0.1:4222")
+	if !strings.Contains(got, "consumer_ack_wait="+consumerAckWait.String()) {
+		t.Errorf("subscription url is missing the consumer ack wait: %s", got)
+	}
+
+	// Anything that isn't NATS is passed through untouched.
+	const other = "mem://topicA"
+	if got := buildSubscriptionURL(other); got != other {
+		t.Errorf("buildSubscriptionURL(%q) = %q, want it unchanged", other, got)
 	}
 }

--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -33,6 +33,11 @@ const (
 	durableProcessor        string        = "processor"
 	bufferChannelSize       int           = 1000
 	backOffTimer            time.Duration = 1 * time.Second
+	// How long JetStream waits for an ack before redelivering. Ingesting one
+	// document can take minutes for a large SBOM with enrichment, and the default
+	// is 30s, so without this the server redelivers documents that are still being
+	// processed and the consumer spends its time re-fetching work already in flight.
+	consumerAckWait time.Duration = 10 * time.Minute
 )
 
 type jetStream struct {


### PR DESCRIPTION
Fixes #2930 and 
Fixes #3154


The processor's durable consumer is created with only a durable name, so `AckWait` falls through to the JetStream default of 30 seconds. Ingesting one document regularly takes longer than that, a 1.5MB SPDX with vuln, license and EOL enrichment takes minutes, so the server keeps redelivering documents that are still being processed. `MaxDeliver` is unbounded so nothing stops it, and the consumer ends up spending its time re-fetching work it already has in flight.

I checked the consumer against a local NATS using the same subscription URL the code builds:

```
consumer       : processor
  AckWait      : 30s
  MaxDeliver   : -1
  MaxAckPending: 1000
```

This sets ack wait to 10 minutes, comfortably longer than a document takes.

**How it shows up.** It's what's behind the E2E flakiness. Across 12 ci-integration runs on main, guaccollect always publishes all 67 documents with no errors, but guacingest only gets through some of them, and the count lines up with whether E2E passed:

```
pass: 67, 61, 60, 56
fail: 44, 37, 35, 15, 14, 10, 9, 9
```

In one failing run the acks arrive in bursts with five and eleven minute gaps between them, no errors anywhere, and the same processor still alive at the end. That's the consumer chasing redeliveries rather than anything actually failing.

This isn't only a CI problem either. Anyone running guac as services rather than the one-shot CLI is on the same path.

**Testing.** Unit test on the URL builder, and I confirmed against a local NATS that the parameter really does change the consumer, ack wait came back as 10m0s instead of 30s. I couldn't run the full E2E locally, so it's worth letting this one go through CI a few times.

One thing I left out: `MaxDeliver` being unbounded means a document that genuinely can't be processed is retried forever with nowhere to land. A cap plus a dead letter target seems worth having, but it's a separate change.
