### PR TITLE
fix(guacrest): require <algorithm>:<digest> for artifact REST endpoints

### DIFF
--- a/pkg/guacrest/helpers/artifact.go
+++ b/pkg/guacrest/helpers/artifact.go
@@ -18,18 +18,25 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Khan/genqlient/graphql"
 	gql "github.com/guacsec/guac/pkg/assembler/clients/generated"
 	"github.com/guacsec/guac/pkg/logging"
 )
 
-// Queries for an artifact by digest and returns its id. The digest must uniquely
-// identify an artifact, otherwise an error is returned.
+// Queries for an artifact by its <algorithm>:<digest> identifier and returns its
+// id. The identifier must uniquely identify an artifact, otherwise an error is
+// returned.
 func FindArtifactWithDigest(ctx context.Context, gqlClient graphql.Client,
-	digest string) (gql.AllArtifactTree, error) {
+	algorithmDigest string) (gql.AllArtifactTree, error) {
 	logger := logging.FromContext(ctx)
-	filter := gql.ArtifactSpec{Digest: &digest}
+
+	algorithm, digest, found := strings.Cut(algorithmDigest, ":")
+	if !found || algorithm == "" || digest == "" {
+		return gql.AllArtifactTree{}, fmt.Errorf("artifact digest must be in the form <algorithm>:<digest>, got %q", algorithmDigest)
+	}
+	filter := gql.ArtifactSpec{Algorithm: &algorithm, Digest: &digest}
 
 	artifacts, err := gql.Artifacts(ctx, gqlClient, filter)
 	if err != nil {
@@ -40,7 +47,7 @@ func FindArtifactWithDigest(ctx context.Context, gqlClient graphql.Client,
 		return gql.AllArtifactTree{}, fmt.Errorf("no artifacts matched the digest")
 	}
 	if len(artifacts.GetArtifacts()) > 1 {
-		logger.Errorf("More than one artifact was found with digest %s", digest)
+		logger.Errorf("More than one artifact was found with digest %s", algorithmDigest)
 		return gql.AllArtifactTree{}, Err500
 	}
 	return artifacts.GetArtifacts()[0].AllArtifactTree, nil

--- a/pkg/guacrest/helpers/artifact_test.go
+++ b/pkg/guacrest/helpers/artifact_test.go
@@ -30,7 +30,7 @@ func Test_FindArtifactWithDigest_ArtifactNotFound(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())
 	gqlClient := test_helpers.SetupTest(t)
 
-	_, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "xyz")
+	_, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "sha256:xyz")
 	assert.ErrorContains(t, err, "no artifacts matched the digest")
 }
 
@@ -47,8 +47,48 @@ func Test_FindArtifactWithDigest_ArtifactFound(t *testing.T) {
 		t.Fatalf("Error ingesting test data")
 	}
 
-	res, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "abc")
+	res, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "sha256:abc")
 	assert.NoError(t, err)
 	assert.Equal(t, res.Algorithm, "sha256")
 	assert.Equal(t, res.Digest, "abc")
+}
+
+func Test_FindArtifactWithDigest_DisambiguatesSameDigestDifferentAlgorithm(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	gqlClient := test_helpers.SetupTest(t)
+
+	for _, algorithm := range []string{"sha256", "sha1"} {
+		idOrArtifactSpec := gql.IDorArtifactInput{ArtifactInput: &gql.ArtifactInputSpec{
+			Algorithm: algorithm,
+			Digest:    "abc",
+		}}
+		_, err := gql.IngestArtifact(ctx, gqlClient, idOrArtifactSpec)
+		if err != nil {
+			t.Fatalf("Error ingesting test data")
+		}
+	}
+
+	res, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "sha1:abc")
+	assert.NoError(t, err)
+	assert.Equal(t, res.Algorithm, "sha1")
+	assert.Equal(t, res.Digest, "abc")
+}
+
+func Test_FindArtifactWithDigest_MissingAlgorithmPrefix(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	gqlClient := test_helpers.SetupTest(t)
+
+	_, err := helpers.FindArtifactWithDigest(ctx, gqlClient, "abc")
+	assert.ErrorContains(t, err, "must be in the form <algorithm>:<digest>")
+}
+
+func Test_FindArtifactWithDigest_EmptyAlgorithmOrDigest(t *testing.T) {
+	ctx := logging.WithLogger(context.Background())
+	gqlClient := test_helpers.SetupTest(t)
+
+	_, err := helpers.FindArtifactWithDigest(ctx, gqlClient, ":abc")
+	assert.ErrorContains(t, err, "must be in the form <algorithm>:<digest>")
+
+	_, err = helpers.FindArtifactWithDigest(ctx, gqlClient, "sha256:")
+	assert.ErrorContains(t, err, "must be in the form <algorithm>:<digest>")
 }

--- a/pkg/guacrest/server/retrieveDependencies_test.go
+++ b/pkg/guacrest/server/retrieveDependencies_test.go
@@ -248,7 +248,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 					{Subject: "sha-xyz", IncludedSoftware: []string{"pkg:guac/bar"}},
 				},
 			},
-			digest:           "sha-xyz",
+			digest:           "sha256:sha-xyz",
 			expectedByDigest: []string{"pkg:guac/bar"},
 		},
 		{
@@ -261,7 +261,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 					{Subject: "sha-123", IncludedSoftware: []string{"pkg:guac/foo"}},
 				},
 			},
-			digest:           "sha-xyz",
+			digest:           "sha256:sha-xyz",
 			expectedByDigest: []string{"pkg:guac/foo"},
 		},
 		{
@@ -274,7 +274,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 					{Subject: "pkg:guac/bar", IncludedSoftware: []string{"pkg:guac/foo"}},
 				},
 			},
-			digest:           "sha-xyz",
+			digest:           "sha256:sha-xyz",
 			expectedByDigest: []string{"pkg:guac/bar"},
 		},
 		{
@@ -285,7 +285,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				HasSboms:      []HasSbom{{Subject: "sha-xyz", IncludedSoftware: []string{"sha-123"}}},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/bar", Artifact: "sha-123"}},
 			},
-			digest:           "sha-xyz",
+			digest:           "sha256:sha-xyz",
 			expectedByDigest: []string{"pkg:guac/bar"},
 		},
 		{
@@ -296,7 +296,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				HasSboms:   []HasSbom{{Subject: "sha-456", IncludedSoftware: []string{"pkg:guac/foo"}}},
 				HashEquals: []HashEqual{{ArtifactA: "sha-123", ArtifactB: "sha-456"}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo"},
 		},
 		{
@@ -313,7 +313,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 					{ArtifactA: "sha-123", ArtifactB: "sha-789"},
 				},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo", "pkg:guac/bar"},
 		},
 		{
@@ -325,7 +325,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
 				HasSlsas:      []HasSlsa{{Subject: "sha-123", BuiltBy: "GHA", BuiltFrom: []string{"sha-xyz"}}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo"},
 		},
 		{
@@ -340,7 +340,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				},
 				HasSlsas: []HasSlsa{{Subject: "sha-123", BuiltBy: "GHA", BuiltFrom: []string{"sha-xyz", "sha-abc"}}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo", "pkg:guac/bar"},
 		},
 		{
@@ -354,7 +354,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 					IncludedIsOccurrences: []IsOccurrence{{Subject: "pkg:guac/bar", Artifact: "sha-123"}},
 				}},
 			},
-			digest:           "sha-xyz",
+			digest:           "sha256:sha-xyz",
 			expectedByDigest: []string{"pkg:guac/bar"},
 		},
 		{
@@ -365,7 +365,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				HashEquals:    []HashEqual{{ArtifactA: "sha-123", ArtifactB: "sha-456"}},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-456"}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{},
 		},
 		{
@@ -380,7 +380,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-789"}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{},
 		},
 		{
@@ -395,7 +395,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-789"}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo"},
 		},
 		{
@@ -410,7 +410,7 @@ func Test_RetrieveDependencies_ByDigest(t *testing.T) {
 				},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-789"}},
 			},
-			digest:           "sha-123",
+			digest:           "sha256:sha-123",
 			expectedByDigest: []string{"pkg:guac/foo"},
 		},
 	}
@@ -490,7 +490,7 @@ func Test_ClientErrorsForArtifact(t *testing.T) {
 		digest string
 	}{{
 		name:   "Artifact not found because version was not specified",
-		digest: "sha-abc",
+		digest: "sha256:sha-abc",
 	}, {
 		name: "Neither Purl nor Digest provided",
 	}, {

--- a/pkg/guacrest/server/retrieveVulns_test.go
+++ b/pkg/guacrest/server/retrieveVulns_test.go
@@ -61,7 +61,7 @@ func Test_GetVulnsForArtifact(t *testing.T) {
 				IsOccurrences:   []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
 				CertifyVulns:    []CertifyVuln{{Package: "pkg:guac/foo", Vulnerability: "osv/CVE-2024-0001", Metadata: vulnScanMeta()}},
 			},
-			digest:   "sha-xyz",
+			digest:   "sha256:sha-xyz",
 			expected: []string{"cve-2024-0001"},
 		},
 		{
@@ -69,7 +69,7 @@ func Test_GetVulnsForArtifact(t *testing.T) {
 			data: GuacData{
 				Artifacts: []string{"sha-xyz"},
 			},
-			digest:   "sha-xyz",
+			digest:   "sha256:sha-xyz",
 			expected: []string{},
 		},
 		{
@@ -79,7 +79,7 @@ func Test_GetVulnsForArtifact(t *testing.T) {
 				Artifacts:     []string{"sha-xyz"},
 				IsOccurrences: []IsOccurrence{{Subject: "pkg:guac/foo", Artifact: "sha-xyz"}},
 			},
-			digest:   "sha-xyz",
+			digest:   "sha256:sha-xyz",
 			expected: []string{},
 		},
 	}
@@ -212,7 +212,7 @@ func Test_GetArtifactVulns_HTTP(t *testing.T) {
 		})
 		restApi := server.NewDefaultServer(gqlClient)
 
-		res, err := restApi.GetArtifactVulns(ctx, gen.GetArtifactVulnsRequestObject{Digest: "sha-xyz"})
+		res, err := restApi.GetArtifactVulns(ctx, gen.GetArtifactVulnsRequestObject{Digest: "sha256:sha-xyz"})
 		if err != nil {
 			t.Fatalf("GetArtifactVulns returned unexpected error: %v", err)
 		}
@@ -226,6 +226,19 @@ func Test_GetArtifactVulns_HTTP(t *testing.T) {
 	})
 
 	t.Run("Returns 400 for unknown digest", func(t *testing.T) {
+		gqlClient := SetupTest(t)
+		restApi := server.NewDefaultServer(gqlClient)
+
+		res, err := restApi.GetArtifactVulns(ctx, gen.GetArtifactVulnsRequestObject{Digest: "sha256:sha-missing"})
+		if err != nil {
+			t.Fatalf("GetArtifactVulns returned unexpected error: %v", err)
+		}
+		if _, ok := res.(gen.GetArtifactVulns400JSONResponse); !ok {
+			t.Fatalf("expected 400 response, got %T: %v", res, res)
+		}
+	})
+
+	t.Run("Returns 400 for digest missing algorithm prefix", func(t *testing.T) {
 		gqlClient := SetupTest(t)
 		restApi := server.NewDefaultServer(gqlClient)
 


### PR DESCRIPTION
# Description of the PR

The REST artifact endpoints (`GET /v0/artifact/{digest}/vulns` and
`GET /v0/artifact/{digest}/dependencies`) documented their path parameter as
`<algorithm>:<digest>` in the OpenAPI spec, but `FindArtifactWithDigest`
only ever set the `Digest` field on the `ArtifactSpec` filter, never
`Algorithm`. Since ent stores algorithm and digest in separate columns, a
correctly-formed `sha256:abc...` identifier never matched anything (only the
bare hex `abc...` worked), and if the same hex digest existed under two
different algorithms, the filter matched both rows and returned a 500.

This fixes `FindArtifactWithDigest` to parse the `<algorithm>:<digest>`
prefix, set both `Algorithm` and `Digest` on the filter, and return a 400
when the prefix is missing or malformed (empty algorithm or digest half).

This is a breaking change for any caller currently passing a bare digest,
which is what the endpoints accepted before this fix (and what the
documented API contract never actually supported).

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

Fixes #3171