### PR TITLE
chore: add GUAC maintainers to kodiakhq auto-approve list

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -13,4 +13,13 @@ always = false
 require_automerge_label = false
 
 [approve]
-auto_approve_usernames = ["dependabot"]
+auto_approve_usernames = [
+  "dependabot",
+  "mlieberman85",
+  "mihaimaruseac",
+  "lumjjb",
+  "pxp928",
+  "SantiagoTorres",
+  "jeffmendoza",
+  "gaganhr94",
+]


### PR DESCRIPTION
# Description of the PR

Adds the GUAC maintainers to `auto_approve_usernames` in `.github/.kodiak.toml`, alongside the existing `dependabot` entry. The list matches `MAINTAINERS.guac` in guacsec/governance. `main` requires two approving reviews to merge. Today a maintainer's own PR needs two other people to sign off before it can land. When a maintainer opens a PR, the code has already had a maintainer's eyes on it. Letting kodiakhq supply one of the two approvals recognises that, while the second approval still has to come from another maintainer — so no change lands without a second human reviewing it. Net effect: maintainer contributions land faster, with the same two-reviewer floor.
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
