### PR TITLE
fix(emitter): pin the processor consumer's max waiting to 100

### DIFF
--- a/pkg/emitter/emitter.go
+++ b/pkg/emitter/emitter.go
@@ -71,7 +71,7 @@ func buildTopicURL(serviceURL string) string {
 // If using NATS, additional parameters are needed for jetstream
 func buildSubscriptionURL(serviceURL string) string {
 	if strings.HasPrefix(serviceURL, "nats://") {
-		return fmt.Sprintf("%s?%s&subject=%s&consumer_durable_name=%s&consumer_ack_wait=%s&stream_name=%s&stream_subjects=%s", serviceURL, "jetstream", subjectNameDocCollected, durableProcessor, consumerAckWait, streamName, streamSubjects)
+		return fmt.Sprintf("%s?%s&subject=%s&consumer_durable_name=%s&consumer_ack_wait=%s&consumer_max_waiting=%d&stream_name=%s&stream_subjects=%s", serviceURL, "jetstream", subjectNameDocCollected, durableProcessor, consumerAckWait, consumerMaxWaiting, streamName, streamSubjects)
 	} else {
 		return serviceURL
 	}

--- a/pkg/emitter/emitter_test.go
+++ b/pkg/emitter/emitter_test.go
@@ -18,6 +18,7 @@ package emitter
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -79,6 +80,13 @@ func TestEmitter_PublishOnEmit(t *testing.T) {
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("nats emitter Subscribe test errored = %v", err)
 		}
+	}
+}
+
+func TestBuildSubscriptionURLSetsMaxWaiting(t *testing.T) {
+	got := buildSubscriptionURL("nats://127.0.0.1:4222")
+	if !strings.Contains(got, "consumer_max_waiting="+strconv.Itoa(consumerMaxWaiting)) {
+		t.Errorf("subscription url is missing the consumer max waiting: %s", got)
 	}
 }
 

--- a/pkg/emitter/nats_emitter.go
+++ b/pkg/emitter/nats_emitter.go
@@ -33,11 +33,8 @@ const (
 	durableProcessor        string        = "processor"
 	bufferChannelSize       int           = 1000
 	backOffTimer            time.Duration = 1 * time.Second
-	// How long JetStream waits for an ack before redelivering. Ingesting one
-	// document can take minutes for a large SBOM with enrichment, and the default
-	// is 30s, so without this the server redelivers documents that are still being
-	// processed and the consumer spends its time re-fetching work already in flight.
 	consumerAckWait time.Duration = 10 * time.Minute
+	consumerMaxWaiting int = 100
 )
 
 type jetStream struct {


### PR DESCRIPTION
# Description of the PR

Fixes #3184 

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged
