### PR TITLE
fix(clearlydefined): normalize git source identity

### DIFF
--- a/pkg/certifier/clearlydefined/clearlydefined.go
+++ b/pkg/certifier/clearlydefined/clearlydefined.go
@@ -213,18 +213,19 @@ func evaluateDefinitionForSource(ctx context.Context, client *http.Client, defin
 	var sourceInputs []string
 	for _, definition := range definitionMap {
 		if definition.Described.SourceLocation != nil {
-			srcInput := helpers.SourceToSourceInput(definition.Described.SourceLocation.Type, definition.Described.SourceLocation.Namespace,
-				definition.Described.SourceLocation.Name, &definition.Described.SourceLocation.Revision)
+			sourceLocation := definition.Described.SourceLocation
+			srcType, namespace, name := normalizedSourceLocation(sourceLocation)
+			srcInput := helpers.SourceToSourceInput(srcType, namespace, name, &sourceLocation.Revision)
 
 			nameID := helpers.SrcClientKey(srcInput).NameId
 
 			if _, ok := sourceMap[nameID]; !ok {
 				coordinate := &coordinates.Coordinate{
-					CoordinateType: definition.Described.SourceLocation.Type,
-					Provider:       definition.Described.SourceLocation.Provider,
-					Namespace:      definition.Described.SourceLocation.Namespace,
-					Name:           definition.Described.SourceLocation.Name,
-					Revision:       definition.Described.SourceLocation.Revision,
+					CoordinateType: sourceLocation.Type,
+					Provider:       sourceLocation.Provider,
+					Namespace:      sourceLocation.Namespace,
+					Name:           sourceLocation.Name,
+					Revision:       sourceLocation.Revision,
 				}
 				sourceMap[nameID] = true
 				sourceInputs = append(sourceInputs, nameID)
@@ -241,6 +242,43 @@ func evaluateDefinitionForSource(ctx context.Context, client *http.Client, defin
 		return generateDocument(definitionMap, docChannel)
 	}
 	return nil, nil
+}
+
+// normalizedSourceLocation returns the canonical GUAC source identity for a
+// ClearlyDefined source location. ClearlyDefined namespaces omit the VCS host
+// (for example "facebook"), while other GUAC data sources use VcsToSrc and
+// produce namespaces such as "github.com/facebook".
+//
+// Prefer the source URL for git sources so all ingestion paths reuse GUAC's
+// existing VCS normalization. ClearlyDefined source URLs may point at a
+// revision-specific browser path, so strip known revision suffixes first.
+// If the URL cannot be normalized, preserve the existing ClearlyDefined fields.
+func normalizedSourceLocation(sourceLocation *attestation_license.SourceLocation) (string, string, string) {
+	srcType := sourceLocation.Type
+	namespace := sourceLocation.Namespace
+	name := sourceLocation.Name
+
+	if sourceLocation.Type != "git" || sourceLocation.URL == "" {
+		return srcType, namespace, name
+	}
+
+	repositoryURL := strings.TrimSuffix(sourceLocation.URL, "/")
+	if sourceLocation.Revision != "" {
+		for _, suffix := range []string{
+			"/-/tree/" + sourceLocation.Revision,
+			"/tree/" + sourceLocation.Revision,
+			"/src/" + sourceLocation.Revision,
+		} {
+			repositoryURL = strings.TrimSuffix(repositoryURL, suffix)
+		}
+	}
+
+	normalized, err := helpers.VcsToSrc(repositoryURL)
+	if err != nil {
+		return srcType, namespace, name
+	}
+
+	return normalized.Type, normalized.Namespace, normalized.Name
 }
 
 // generateDocument generates the processor document for ingestion

--- a/pkg/certifier/clearlydefined/clearlydefined_test.go
+++ b/pkg/certifier/clearlydefined/clearlydefined_test.go
@@ -33,10 +33,102 @@ import (
 	"github.com/guacsec/guac/internal/testing/dochelper"
 	mockclearlydefined "github.com/guacsec/guac/internal/testing/mockClearlyDefined"
 	"github.com/guacsec/guac/internal/testing/testdata"
+	attestation_license "github.com/guacsec/guac/pkg/certifier/attestation/license"
 	"github.com/guacsec/guac/pkg/certifier/components/root_package"
 	"github.com/guacsec/guac/pkg/handler/processor"
 	"github.com/guacsec/guac/pkg/logging"
 )
+
+func TestNormalizedSourceLocation(t *testing.T) {
+	revision := "9e3b772b8cabbd8cadc7522ebe3dde3279e79d9e"
+
+	tests := []struct {
+		name          string
+		source        *attestation_license.SourceLocation
+		wantType      string
+		wantNamespace string
+		wantName      string
+	}{
+		{
+			name: "github source URL",
+			source: &attestation_license.SourceLocation{
+				Type:      "git",
+				Provider:  "github",
+				Namespace: "facebook",
+				Name:      "react",
+				Revision:  revision,
+				URL:       "https://github.com/facebook/react/tree/" + revision,
+			},
+			wantType:      "git",
+			wantNamespace: "github.com/facebook",
+			wantName:      "react",
+		},
+		{
+			name: "gitlab source URL",
+			source: &attestation_license.SourceLocation{
+				Type:      "git",
+				Provider:  "gitlab",
+				Namespace: "group",
+				Name:      "project",
+				Revision:  revision,
+				URL:       "https://gitlab.com/group/project/-/tree/" + revision,
+			},
+			wantType:      "git",
+			wantNamespace: "gitlab.com/group",
+			wantName:      "project",
+		},
+		{
+			name: "missing URL preserves existing identity",
+			source: &attestation_license.SourceLocation{
+				Type:      "git",
+				Provider:  "github",
+				Namespace: "facebook",
+				Name:      "react",
+				Revision:  revision,
+			},
+			wantType:      "git",
+			wantNamespace: "facebook",
+			wantName:      "react",
+		},
+		{
+			name: "unsupported URL preserves existing identity",
+			source: &attestation_license.SourceLocation{
+				Type:      "git",
+				Provider:  "unknown",
+				Namespace: "facebook",
+				Name:      "react",
+				Revision:  revision,
+				URL:       "https://example.com/facebook/react/tree/" + revision,
+			},
+			wantType:      "git",
+			wantNamespace: "facebook",
+			wantName:      "react",
+		},
+		{
+			name: "non-git source preserves existing identity",
+			source: &attestation_license.SourceLocation{
+				Type:      "sourcearchive",
+				Provider:  "mavencentral",
+				Namespace: "org.apache.commons",
+				Name:      "commons-text",
+				Revision:  "1.9",
+				URL:       "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.9/commons-text-1.9-sources.jar",
+			},
+			wantType:      "sourcearchive",
+			wantNamespace: "org.apache.commons",
+			wantName:      "commons-text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotNamespace, gotName := normalizedSourceLocation(tt.source)
+			assert.Equal(t, tt.wantType, gotType)
+			assert.Equal(t, tt.wantNamespace, gotNamespace)
+			assert.Equal(t, tt.wantName, gotName)
+		})
+	}
+}
 
 func TestClearlyDefined(t *testing.T) {
 	ctx := logging.WithLogger(context.Background())


### PR DESCRIPTION
# Description of the PR

Fixes #2866.

ClearlyDefined source metadata can identify the same Git repository differently from other GUAC ingestion paths. For example, ClearlyDefined may represent `https://github.com/facebook/react` with namespace `facebook`, while GUAC's existing VCS normalization produces `github.com/facebook`.

This can create duplicate source nodes and fragment relationships such as `HasSourceAt` across the graph.

This change:

- reuses GUAC's existing `VcsToSrc` normalization for ClearlyDefined Git source locations
- strips revision-specific browser paths such as GitHub `/tree/<revision>`, GitLab `/-/tree/<revision>`, and `/src/<revision>`
- preserves the original ClearlyDefined coordinate when querying ClearlyDefined
- falls back to the existing source identity when the URL is missing or cannot be normalized
- adds regression coverage for GitHub, GitLab, missing URLs, unsupported URLs, and non-Git sources

The goal is for different certifiers observing the same Git repository to converge on the same GUAC source identity.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged