### PR TITLE
feat: KeyValue add delete node functionality 

### DIFF
--- a/internal/testing/backend/main_test.go
+++ b/internal/testing/backend/main_test.go
@@ -97,11 +97,11 @@ var skipMatrix = map[string]map[string]bool{
 	// redis order issues, tikv: not a valid VexStatus
 	"TestVEXBulkIngest": {arango: true, redis: true, tikv: true},
 	// redis order issues
-	"TestFindSoftware":  {redis: true, arango: true},
+	"TestFindSoftware": {redis: true, arango: true},
 	// remove these once its implemented for the other backends
-	"TestDeleteCertifyVuln":              {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSBOM":                  {arango: true, memmap: true, redis: true, tikv: true},
-	"TestDeleteHasSLSAs":                 {arango: true, memmap: true, redis: true, tikv: true},
+	"TestDeleteCertifyVuln":              {arango: true},
+	"TestDeleteHasSBOM":                  {arango: true},
+	"TestDeleteHasSLSAs":                 {arango: true},
 	"TestQueryPackagesListForScan":       {arango: true, redis: true, tikv: true},
 	"TestBatchQueryPkgIDCertifyVuln":     {arango: true, redis: true, tikv: true},
 	"TestBatchQueryPkgIDCertifyLegal":    {arango: true, redis: true, tikv: true},

--- a/internal/testing/stablememmap/stablememmap.go
+++ b/internal/testing/stablememmap/stablememmap.go
@@ -42,6 +42,10 @@ func (s *store) Set(ctx context.Context, c, k string, v any) error {
 	return s.mm.Set(ctx, c, k, v)
 }
 
+func (s *store) Remove(ctx context.Context, c, k string) error {
+	return s.mm.Remove(ctx, c, k)
+}
+
 func (s *store) Keys(c string) kv.Scanner {
 	return &scanner{mms: s.mm.Keys(c)}
 }

--- a/pkg/assembler/backends/keyvalue/backend.go
+++ b/pkg/assembler/backends/keyvalue/backend.go
@@ -316,9 +316,8 @@ func delkv(ctx context.Context, coll string, n node, c *demoClient) error {
 	return c.kv.Remove(ctx, indexCol, n.ID())
 }
 
-// removeLink drops linkID from one of a node's back edge slices and stores the
-// node again. Pass a pointer to the slice field, e.g.
-// removeLink(ctx, id, &pkg.HasSBOMs, pkgVerCol, pkg, c).
+// removeLink drops linkID from a node's back edge slice and stores the node
+// again. Pass a pointer to the slice field.
 func removeLink(ctx context.Context, linkID string, links *[]string, coll string, n node, c *demoClient) error {
 	*links = slices.DeleteFunc(*links, func(id string) bool { return id == linkID })
 	return setkv(ctx, coll, n, c)

--- a/pkg/assembler/backends/keyvalue/backend.go
+++ b/pkg/assembler/backends/keyvalue/backend.go
@@ -22,6 +22,7 @@ import (
 	"hash/fnv"
 	"math"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -305,6 +306,22 @@ func byKeykv[E node](ctx context.Context, coll string, k string, c *demoClient) 
 func setkv(ctx context.Context, coll string, n node, c *demoClient) error {
 	// validate type?
 	return c.kv.Set(ctx, coll, n.Key(), n)
+}
+
+// delkv removes a node from its collection and drops its ID from the index.
+func delkv(ctx context.Context, coll string, n node, c *demoClient) error {
+	if err := c.kv.Remove(ctx, coll, n.Key()); err != nil {
+		return err
+	}
+	return c.kv.Remove(ctx, indexCol, n.ID())
+}
+
+// removeLink drops linkID from one of a node's back edge slices and stores the
+// node again. Pass a pointer to the slice field, e.g.
+// removeLink(ctx, id, &pkg.HasSBOMs, pkgVerCol, pkg, c).
+func removeLink(ctx context.Context, linkID string, links *[]string, coll string, n node, c *demoClient) error {
+	*links = slices.DeleteFunc(*links, func(id string) bool { return id == linkID })
+	return setkv(ctx, coll, n, c)
 }
 
 func (c *demoClient) addToIndex(ctx context.Context, coll string, n node) error {

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -59,6 +59,39 @@ func (n *certifyVulnerabilityLink) Key() string {
 	}, ":"))
 }
 
+// deleteCertifyVuln removes a certifyVuln node and the back edges pointing at
+// it. The caller must hold the write lock.
+func (c *demoClient) deleteCertifyVuln(ctx context.Context, id string) (bool, error) {
+	link, err := byIDkv[*certifyVulnerabilityLink](ctx, id, c)
+	if err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return false, nil
+		}
+		return false, gqlerror.Errorf("failed to retrieve certifyVuln %q: %v", id, err)
+	}
+
+	foundPkg, err := byIDkv[*pkgVersion](ctx, link.PackageID, c)
+	if err != nil {
+		return false, gqlerror.Errorf("failed to retrieve package version %q: %v", link.PackageID, err)
+	}
+	if err := removeLink(ctx, link.ThisID, &foundPkg.CertifyVulnLinks, pkgVerCol, foundPkg, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove package back edge: %v", err)
+	}
+
+	foundVuln, err := byIDkv[*vulnIDNode](ctx, link.VulnerabilityID, c)
+	if err != nil {
+		return false, gqlerror.Errorf("failed to retrieve vulnerability %q: %v", link.VulnerabilityID, err)
+	}
+	if err := removeLink(ctx, link.ThisID, &foundVuln.CertifyVulnLinks, vulnIDCol, foundVuln, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove vulnerability back edge: %v", err)
+	}
+
+	if err := delkv(ctx, cVulnCol, link, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove certifyVuln %q: %v", id, err)
+	}
+	return true, nil
+}
+
 func (n *certifyVulnerabilityLink) Neighbors(allowedEdges edgeMap) []string {
 	out := make([]string, 0, 2)
 	if allowedEdges[model.EdgeCertifyVulnPackage] {

--- a/pkg/assembler/backends/keyvalue/certifyVuln.go
+++ b/pkg/assembler/backends/keyvalue/certifyVuln.go
@@ -59,8 +59,8 @@ func (n *certifyVulnerabilityLink) Key() string {
 	}, ":"))
 }
 
-// deleteCertifyVuln removes a certifyVuln node and the back edges pointing at
-// it. The caller must hold the write lock.
+// deleteCertifyVuln removes a certifyVuln node and its back edges. Caller must
+// hold the write lock.
 func (c *demoClient) deleteCertifyVuln(ctx context.Context, id string) (bool, error) {
 	link, err := byIDkv[*certifyVulnerabilityLink](ctx, id, c)
 	if err != nil {

--- a/pkg/assembler/backends/keyvalue/delete_test.go
+++ b/pkg/assembler/backends/keyvalue/delete_test.go
@@ -23,9 +23,8 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
-// Included isDependency and isOccurrence nodes are deduped, so two hasSBOMs can
-// point at the same one. Deleting the first must not leave the second
-// unqueryable.
+// Includes are deduped, so two hasSBOMs can point at the same one. Deleting the
+// first must not leave the second unqueryable.
 func TestDeleteHasSBOMWithSharedIncludes(t *testing.T) {
 	ctx := context.Background()
 	be, err := getBackend(ctx, nil)
@@ -66,17 +65,17 @@ func TestDeleteHasSBOMWithSharedIncludes(t *testing.T) {
 		Dependencies: []string{depID},
 		Occurrences:  []string{occID},
 	}
-	// Two SBOMs on the same package, differing only by URI, over the same
-	// included nodes.
+	// Same package and includes, different URI.
 	first, err := be.IngestHasSbom(ctx,
 		model.PackageOrArtifactInput{Package: &model.IDorPkgInput{PackageInput: pkgIn}},
 		model.HasSBOMInputSpec{URI: "first uri"}, includes)
 	if err != nil {
 		t.Fatalf("could not ingest first hasSBOM: %v", err)
 	}
-	if _, err := be.IngestHasSbom(ctx,
+	second, err := be.IngestHasSbom(ctx,
 		model.PackageOrArtifactInput{Package: &model.IDorPkgInput{PackageInput: pkgIn}},
-		model.HasSBOMInputSpec{URI: "second uri"}, includes); err != nil {
+		model.HasSBOMInputSpec{URI: "second uri"}, includes)
+	if err != nil {
 		t.Fatalf("could not ingest second hasSBOM: %v", err)
 	}
 
@@ -97,5 +96,27 @@ func TestDeleteHasSBOMWithSharedIncludes(t *testing.T) {
 	}
 	if uri := got.Edges[0].Node.URI; uri != "second uri" {
 		t.Errorf("expected the second hasSBOM to survive, got URI %q", uri)
+	}
+	if n := len(got.Edges[0].Node.IncludedDependencies); n != 1 {
+		t.Errorf("expected the surviving hasSBOM to keep its included dependency, got %d", n)
+	}
+	if n := len(got.Edges[0].Node.IncludedOccurrences); n != 1 {
+		t.Errorf("expected the surviving hasSBOM to keep its included occurrence, got %d", n)
+	}
+
+	// These resolve include IDs through the index, so a deleted include breaks
+	// them even when the SBOM query itself tolerates it.
+	if _, err := be.Neighbors(ctx, second, nil); err != nil {
+		t.Errorf("neighbors of the surviving hasSBOM: %v", err)
+	}
+	if _, err := be.Node(ctx, second); err != nil {
+		t.Errorf("node lookup of the surviving hasSBOM: %v", err)
+	}
+	deps, err := be.IsDependencyList(ctx, model.IsDependencySpec{}, nil, nil)
+	if err != nil {
+		t.Fatalf("could not list dependencies after delete: %v", err)
+	}
+	if deps == nil || len(deps.Edges) != 1 {
+		t.Errorf("expected the shared dependency to outlive the deleted hasSBOM, got: %v", deps)
 	}
 }

--- a/pkg/assembler/backends/keyvalue/delete_test.go
+++ b/pkg/assembler/backends/keyvalue/delete_test.go
@@ -1,0 +1,101 @@
+//
+// Copyright 2025 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+)
+
+// Included isDependency and isOccurrence nodes are deduped, so two hasSBOMs can
+// point at the same one. Deleting the first must not leave the second
+// unqueryable.
+func TestDeleteHasSBOMWithSharedIncludes(t *testing.T) {
+	ctx := context.Background()
+	be, err := getBackend(ctx, nil)
+	if err != nil {
+		t.Fatalf("could not get backend: %v", err)
+	}
+
+	pkgIn := &model.PkgInputSpec{Type: "pypi", Name: "tensorflow", Version: ptrfrom.String("2.11.1")}
+	depIn := &model.PkgInputSpec{Type: "pypi", Name: "openssl", Version: ptrfrom.String("3.0.3")}
+	artIn := &model.ArtifactInputSpec{Algorithm: "sha256", Digest: "6bbb0da1891646e58eb3e6a63af3a6fc3c8eb5a0d44824cba581d2e14a0450cf"}
+
+	if _, err := be.IngestPackage(ctx, model.IDorPkgInput{PackageInput: pkgIn}); err != nil {
+		t.Fatalf("could not ingest package: %v", err)
+	}
+	if _, err := be.IngestPackage(ctx, model.IDorPkgInput{PackageInput: depIn}); err != nil {
+		t.Fatalf("could not ingest dependency package: %v", err)
+	}
+	if _, err := be.IngestArtifact(ctx, &model.IDorArtifactInput{ArtifactInput: artIn}); err != nil {
+		t.Fatalf("could not ingest artifact: %v", err)
+	}
+
+	depID, err := be.IngestDependency(ctx,
+		model.IDorPkgInput{PackageInput: pkgIn},
+		model.IDorPkgInput{PackageInput: depIn},
+		model.IsDependencyInputSpec{Justification: "test justification"})
+	if err != nil {
+		t.Fatalf("could not ingest dependency: %v", err)
+	}
+	occID, err := be.IngestOccurrence(ctx,
+		model.PackageOrSourceInput{Package: &model.IDorPkgInput{PackageInput: depIn}},
+		model.IDorArtifactInput{ArtifactInput: artIn},
+		model.IsOccurrenceInputSpec{Justification: "test justification"})
+	if err != nil {
+		t.Fatalf("could not ingest occurrence: %v", err)
+	}
+
+	includes := model.HasSBOMIncludesInputSpec{
+		Dependencies: []string{depID},
+		Occurrences:  []string{occID},
+	}
+	// Two SBOMs on the same package, differing only by URI, over the same
+	// included nodes.
+	first, err := be.IngestHasSbom(ctx,
+		model.PackageOrArtifactInput{Package: &model.IDorPkgInput{PackageInput: pkgIn}},
+		model.HasSBOMInputSpec{URI: "first uri"}, includes)
+	if err != nil {
+		t.Fatalf("could not ingest first hasSBOM: %v", err)
+	}
+	if _, err := be.IngestHasSbom(ctx,
+		model.PackageOrArtifactInput{Package: &model.IDorPkgInput{PackageInput: pkgIn}},
+		model.HasSBOMInputSpec{URI: "second uri"}, includes); err != nil {
+		t.Fatalf("could not ingest second hasSBOM: %v", err)
+	}
+
+	deleted, err := be.Delete(ctx, first)
+	if err != nil {
+		t.Fatalf("could not delete hasSBOM: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected hasSBOM to be deleted")
+	}
+
+	got, err := be.HasSBOMList(ctx, model.HasSBOMSpec{}, nil, nil)
+	if err != nil {
+		t.Fatalf("could not list hasSBOMs after delete: %v", err)
+	}
+	if got == nil || len(got.Edges) != 1 {
+		t.Fatalf("expected exactly one remaining hasSBOM, got: %v", got)
+	}
+	if uri := got.Edges[0].Node.URI; uri != "second uri" {
+		t.Errorf("expected the second hasSBOM to survive, got URI %q", uri)
+	}
+}

--- a/pkg/assembler/backends/keyvalue/hasSBOM.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM.go
@@ -68,6 +68,60 @@ func (n *hasSBOMStruct) Key() string {
 	}, ":"))
 }
 
+// deleteHasSBOM removes a hasSBOM node, the isDependency and isOccurrence nodes
+// it includes, and the back edges pointing at any of them. The caller must hold
+// the write lock.
+//
+// NOTE: included nodes are deduped in this backend, so an isDependency shared
+// with another hasSBOM goes away with the first delete and simply drops out of
+// that hasSBOM's includes (see convHasSBOM). Refcount them if a shared included
+// node ever needs to survive.
+func (c *demoClient) deleteHasSBOM(ctx context.Context, id string) (bool, error) {
+	link, err := byIDkv[*hasSBOMStruct](ctx, id, c)
+	if err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return false, nil
+		}
+		return false, gqlerror.Errorf("failed to retrieve hasSBOM %q: %v", id, err)
+	}
+
+	if link.Pkg != "" {
+		foundPkg, err := byIDkv[*pkgVersion](ctx, link.Pkg, c)
+		if err != nil {
+			return false, gqlerror.Errorf("failed to retrieve package version %q: %v", link.Pkg, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundPkg.HasSBOMs, pkgVerCol, foundPkg, c); err != nil {
+			return false, gqlerror.Errorf("failed to remove package back edge: %v", err)
+		}
+	}
+	if link.Artifact != "" {
+		foundArt, err := byIDkv[*artStruct](ctx, link.Artifact, c)
+		if err != nil {
+			return false, gqlerror.Errorf("failed to retrieve artifact %q: %v", link.Artifact, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundArt.HasSBOMs, artCol, foundArt, c); err != nil {
+			return false, gqlerror.Errorf("failed to remove artifact back edge: %v", err)
+		}
+	}
+
+	if err := delkv(ctx, hasSBOMCol, link, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove hasSBOM %q: %v", id, err)
+	}
+
+	for _, depID := range link.IncludedDependencies {
+		if err := c.deleteIsDependency(ctx, depID); err != nil {
+			return false, gqlerror.Errorf("failed to remove included dependency %q: %v", depID, err)
+		}
+	}
+	for _, occID := range link.IncludedOccurrences {
+		if err := c.deleteIsOccurrence(ctx, occID); err != nil {
+			return false, gqlerror.Errorf("failed to remove included occurrence %q: %v", occID, err)
+		}
+	}
+
+	return true, nil
+}
+
 func (n *hasSBOMStruct) Neighbors(allowedEdges edgeMap) []string {
 	var out []string
 	if n.Pkg != "" && allowedEdges[model.EdgeHasSbomPackage] {
@@ -296,6 +350,11 @@ func (c *demoClient) convHasSBOM(ctx context.Context, in *hasSBOMStruct) (*model
 		for _, id := range in.IncludedDependencies {
 			link, err := byIDkv[*isDependencyLink](ctx, id, c)
 			if err != nil {
+				// The node may have been deleted along with another hasSBOM
+				// that included it. Drop it rather than failing the query.
+				if errors.Is(err, kv.NotFoundError) {
+					continue
+				}
 				return nil, fmt.Errorf("expected IsDependency: %w", err)
 			}
 			isDep, err := c.buildIsDependency(ctx, link, nil, true)
@@ -310,7 +369,10 @@ func (c *demoClient) convHasSBOM(ctx context.Context, in *hasSBOMStruct) (*model
 		for _, id := range in.IncludedOccurrences {
 			link, err := byIDkv[*isOccurrenceStruct](ctx, id, c)
 			if err != nil {
-				return nil, fmt.Errorf("expected IsDependency: %w", err)
+				if errors.Is(err, kv.NotFoundError) {
+					continue
+				}
+				return nil, fmt.Errorf("expected IsOccurrence: %w", err)
 			}
 			isOcc, err := c.convOccurrence(ctx, link)
 			if err != nil {

--- a/pkg/assembler/backends/keyvalue/hasSBOM.go
+++ b/pkg/assembler/backends/keyvalue/hasSBOM.go
@@ -69,13 +69,10 @@ func (n *hasSBOMStruct) Key() string {
 }
 
 // deleteHasSBOM removes a hasSBOM node, the isDependency and isOccurrence nodes
-// it includes, and the back edges pointing at any of them. The caller must hold
-// the write lock.
+// it includes, and all their back edges. Caller must hold the write lock.
 //
-// NOTE: included nodes are deduped in this backend, so an isDependency shared
-// with another hasSBOM goes away with the first delete and simply drops out of
-// that hasSBOM's includes (see convHasSBOM). Refcount them if a shared included
-// node ever needs to survive.
+// Includes are deduped, so another hasSBOM may list the same one. Those are kept:
+// a dangling ID would break that record's Neighbors, Node and Path lookups.
 func (c *demoClient) deleteHasSBOM(ctx context.Context, id string) (bool, error) {
 	link, err := byIDkv[*hasSBOMStruct](ctx, id, c)
 	if err != nil {
@@ -108,18 +105,72 @@ func (c *demoClient) deleteHasSBOM(ctx context.Context, id string) (bool, error)
 		return false, gqlerror.Errorf("failed to remove hasSBOM %q: %v", id, err)
 	}
 
+	// This node is already gone, so it does not count itself.
+	kept, err := c.referencedIncludes(ctx, link)
+	if err != nil {
+		return false, gqlerror.Errorf("failed to check for shared includes: %v", err)
+	}
+
 	for _, depID := range link.IncludedDependencies {
+		if kept[depID] {
+			continue
+		}
 		if err := c.deleteIsDependency(ctx, depID); err != nil {
 			return false, gqlerror.Errorf("failed to remove included dependency %q: %v", depID, err)
 		}
 	}
 	for _, occID := range link.IncludedOccurrences {
+		if kept[occID] {
+			continue
+		}
 		if err := c.deleteIsOccurrence(ctx, occID); err != nil {
 			return false, gqlerror.Errorf("failed to remove included occurrence %q: %v", occID, err)
 		}
 	}
 
 	return true, nil
+}
+
+// referencedIncludes returns which of gone's includes another hasSBOM still
+// lists. Deletes are rare, so a scan is cheaper than storing a refcount.
+func (c *demoClient) referencedIncludes(ctx context.Context, gone *hasSBOMStruct) (map[string]bool, error) {
+	want := make(map[string]bool, len(gone.IncludedDependencies)+len(gone.IncludedOccurrences))
+	for _, id := range gone.IncludedDependencies {
+		want[id] = true
+	}
+	for _, id := range gone.IncludedOccurrences {
+		want[id] = true
+	}
+	kept := make(map[string]bool)
+	if len(want) == 0 {
+		return kept, nil
+	}
+
+	scn := c.kv.Keys(hasSBOMCol)
+	for done := false; !done; {
+		keys, last, err := scn.Scan(ctx)
+		if err != nil {
+			return nil, err
+		}
+		done = last
+		for _, key := range keys {
+			other, err := byKeykv[*hasSBOMStruct](ctx, hasSBOMCol, key, c)
+			if err != nil {
+				return nil, err
+			}
+			for _, id := range other.IncludedDependencies {
+				if want[id] {
+					kept[id] = true
+				}
+			}
+			for _, id := range other.IncludedOccurrences {
+				if want[id] {
+					kept[id] = true
+				}
+			}
+		}
+	}
+	return kept, nil
 }
 
 func (n *hasSBOMStruct) Neighbors(allowedEdges edgeMap) []string {
@@ -350,8 +401,8 @@ func (c *demoClient) convHasSBOM(ctx context.Context, in *hasSBOMStruct) (*model
 		for _, id := range in.IncludedDependencies {
 			link, err := byIDkv[*isDependencyLink](ctx, id, c)
 			if err != nil {
-				// The node may have been deleted along with another hasSBOM
-				// that included it. Drop it rather than failing the query.
+				// Should not happen: deleteHasSBOM keeps shared includes.
+				// Drop it rather than fail every HasSBOM query.
 				if errors.Is(err, kv.NotFoundError) {
 					continue
 				}

--- a/pkg/assembler/backends/keyvalue/hasSLSA.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA.go
@@ -73,8 +73,8 @@ func (n *hasSLSAStruct) Key() string {
 	}, ":"))
 }
 
-// deleteHasSLSA removes a hasSLSA node and the back edges pointing at it. The
-// caller must hold the write lock.
+// deleteHasSLSA removes a hasSLSA node and its back edges. Caller must hold the
+// write lock.
 func (c *demoClient) deleteHasSLSA(ctx context.Context, id string) (bool, error) {
 	link, err := byIDkv[*hasSLSAStruct](ctx, id, c)
 	if err != nil {
@@ -84,8 +84,7 @@ func (c *demoClient) deleteHasSLSA(ctx context.Context, id string) (bool, error)
 		return false, gqlerror.Errorf("failed to retrieve hasSLSA %q: %v", id, err)
 	}
 
-	// The subject and every builtFrom material are artifacts, and an artifact
-	// can be both, so dedup before touching the store.
+	// The subject can also be a builtFrom material, so dedup first.
 	for _, artID := range helper.SortAndRemoveDups(append([]string{link.Subject}, link.BuiltFrom...)) {
 		foundArt, err := byIDkv[*artStruct](ctx, artID, c)
 		if err != nil {

--- a/pkg/assembler/backends/keyvalue/hasSLSA.go
+++ b/pkg/assembler/backends/keyvalue/hasSLSA.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/guacsec/guac/pkg/assembler/kv"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -70,6 +71,43 @@ func (n *hasSLSAStruct) Key() string {
 		n.Collector,
 		n.DocumentRef,
 	}, ":"))
+}
+
+// deleteHasSLSA removes a hasSLSA node and the back edges pointing at it. The
+// caller must hold the write lock.
+func (c *demoClient) deleteHasSLSA(ctx context.Context, id string) (bool, error) {
+	link, err := byIDkv[*hasSLSAStruct](ctx, id, c)
+	if err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return false, nil
+		}
+		return false, gqlerror.Errorf("failed to retrieve hasSLSA %q: %v", id, err)
+	}
+
+	// The subject and every builtFrom material are artifacts, and an artifact
+	// can be both, so dedup before touching the store.
+	for _, artID := range helper.SortAndRemoveDups(append([]string{link.Subject}, link.BuiltFrom...)) {
+		foundArt, err := byIDkv[*artStruct](ctx, artID, c)
+		if err != nil {
+			return false, gqlerror.Errorf("failed to retrieve artifact %q: %v", artID, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundArt.HasSLSAs, artCol, foundArt, c); err != nil {
+			return false, gqlerror.Errorf("failed to remove artifact back edge: %v", err)
+		}
+	}
+
+	foundBuilder, err := byIDkv[*builderStruct](ctx, link.BuiltBy, c)
+	if err != nil {
+		return false, gqlerror.Errorf("failed to retrieve builder %q: %v", link.BuiltBy, err)
+	}
+	if err := removeLink(ctx, link.ThisID, &foundBuilder.HasSLSAs, builderCol, foundBuilder, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove builder back edge: %v", err)
+	}
+
+	if err := delkv(ctx, slsaCol, link, c); err != nil {
+		return false, gqlerror.Errorf("failed to remove hasSLSA %q: %v", id, err)
+	}
+	return true, nil
 }
 
 func (n *hasSLSAStruct) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/isDependency.go
+++ b/pkg/assembler/backends/keyvalue/isDependency.go
@@ -56,9 +56,8 @@ func (n *isDependencyLink) Key() string {
 	}, ":"))
 }
 
-// deleteIsDependency removes an isDependency node and the back edges pointing at
-// it. A node that is already gone is not an error. The caller must hold the
-// write lock.
+// deleteIsDependency removes an isDependency node and its back edges. Already
+// gone is not an error. Caller must hold the write lock.
 func (c *demoClient) deleteIsDependency(ctx context.Context, id string) error {
 	link, err := byIDkv[*isDependencyLink](ctx, id, c)
 	if err != nil {
@@ -68,7 +67,7 @@ func (c *demoClient) deleteIsDependency(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to retrieve isDependency %q: %w", id, err)
 	}
 
-	// PackageID and DepPackageID are the same node for a self dependency.
+	// Both are the same node for a self dependency.
 	for _, pkgID := range helper.SortAndRemoveDups([]string{link.PackageID, link.DepPackageID}) {
 		foundPkg, err := byIDkv[*pkgVersion](ctx, pkgID, c)
 		if err != nil {

--- a/pkg/assembler/backends/keyvalue/isDependency.go
+++ b/pkg/assembler/backends/keyvalue/isDependency.go
@@ -18,6 +18,7 @@ package keyvalue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -53,6 +54,32 @@ func (n *isDependencyLink) Key() string {
 		n.Collector,
 		n.DocumentRef,
 	}, ":"))
+}
+
+// deleteIsDependency removes an isDependency node and the back edges pointing at
+// it. A node that is already gone is not an error. The caller must hold the
+// write lock.
+func (c *demoClient) deleteIsDependency(ctx context.Context, id string) error {
+	link, err := byIDkv[*isDependencyLink](ctx, id, c)
+	if err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return nil
+		}
+		return fmt.Errorf("failed to retrieve isDependency %q: %w", id, err)
+	}
+
+	// PackageID and DepPackageID are the same node for a self dependency.
+	for _, pkgID := range helper.SortAndRemoveDups([]string{link.PackageID, link.DepPackageID}) {
+		foundPkg, err := byIDkv[*pkgVersion](ctx, pkgID, c)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve package version %q: %w", pkgID, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundPkg.IsDependencyLinks, pkgVerCol, foundPkg, c); err != nil {
+			return fmt.Errorf("failed to remove package back edge: %w", err)
+		}
+	}
+
+	return delkv(ctx, isDepCol, link, c)
 }
 
 func (n *isDependencyLink) Neighbors(allowedEdges edgeMap) []string {

--- a/pkg/assembler/backends/keyvalue/isOccurrence.go
+++ b/pkg/assembler/backends/keyvalue/isOccurrence.go
@@ -18,12 +18,13 @@ package keyvalue
 import (
 	"context"
 	"errors"
-	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
 	"github.com/guacsec/guac/pkg/assembler/backends/helper"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/guacsec/guac/pkg/assembler/kv"
@@ -43,6 +44,48 @@ type isOccurrenceStruct struct {
 }
 
 func (n *isOccurrenceStruct) ID() string { return n.ThisID }
+
+// deleteIsOccurrence removes an isOccurrence node and the back edges pointing at
+// it. A node that is already gone is not an error. The caller must hold the
+// write lock.
+func (c *demoClient) deleteIsOccurrence(ctx context.Context, id string) error {
+	link, err := byIDkv[*isOccurrenceStruct](ctx, id, c)
+	if err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return nil
+		}
+		return fmt.Errorf("failed to retrieve isOccurrence %q: %w", id, err)
+	}
+
+	foundArt, err := byIDkv[*artStruct](ctx, link.Artifact, c)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve artifact %q: %w", link.Artifact, err)
+	}
+	if err := removeLink(ctx, link.ThisID, &foundArt.Occurrences, artCol, foundArt, c); err != nil {
+		return fmt.Errorf("failed to remove artifact back edge: %w", err)
+	}
+
+	if link.Pkg != "" {
+		foundPkg, err := byIDkv[*pkgVersion](ctx, link.Pkg, c)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve package version %q: %w", link.Pkg, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundPkg.Occurrences, pkgVerCol, foundPkg, c); err != nil {
+			return fmt.Errorf("failed to remove package back edge: %w", err)
+		}
+	}
+	if link.Source != "" {
+		foundSrc, err := byIDkv[*srcNameNode](ctx, link.Source, c)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve source %q: %w", link.Source, err)
+		}
+		if err := removeLink(ctx, link.ThisID, &foundSrc.Occurrences, srcNameCol, foundSrc, c); err != nil {
+			return fmt.Errorf("failed to remove source back edge: %w", err)
+		}
+	}
+
+	return delkv(ctx, occCol, link, c)
+}
 
 func (n *isOccurrenceStruct) Neighbors(allowedEdges edgeMap) []string {
 	out := make([]string, 0, 3)

--- a/pkg/assembler/backends/keyvalue/isOccurrence.go
+++ b/pkg/assembler/backends/keyvalue/isOccurrence.go
@@ -45,9 +45,8 @@ type isOccurrenceStruct struct {
 
 func (n *isOccurrenceStruct) ID() string { return n.ThisID }
 
-// deleteIsOccurrence removes an isOccurrence node and the back edges pointing at
-// it. A node that is already gone is not an error. The caller must hold the
-// write lock.
+// deleteIsOccurrence removes an isOccurrence node and its back edges. Already
+// gone is not an error. Caller must hold the write lock.
 func (c *demoClient) deleteIsOccurrence(ctx context.Context, id string) error {
 	link, err := byIDkv[*isOccurrenceStruct](ctx, id, c)
 	if err != nil {

--- a/pkg/assembler/backends/keyvalue/path.go
+++ b/pkg/assembler/backends/keyvalue/path.go
@@ -17,12 +17,15 @@ package keyvalue
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/guacsec/guac/pkg/assembler/kv"
 )
 
 type edgeMap map[model.Edge]bool
@@ -193,5 +196,44 @@ func (c *demoClient) Nodes(ctx context.Context, ids []string) ([]model.Node, err
 // Delete node and all associated relationships. This functionality is only implemented for
 // certifyVuln, HasSBOM and HasSLSA.
 func (c *demoClient) Delete(ctx context.Context, node string) (bool, error) {
-	panic(fmt.Errorf("not implemented: Delete"))
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	var k string
+	if err := c.kv.Get(ctx, indexCol, node, &k); err != nil {
+		if errors.Is(err, kv.NotFoundError) {
+			return false, nil
+		}
+		return false, fmt.Errorf("%w : id not found in index %q", err, node)
+	}
+
+	sub := strings.SplitN(k, ":", 2)
+	if len(sub) != 2 {
+		return false, fmt.Errorf("bad value was stored in index map: %v", k)
+	}
+
+	switch sub[0] {
+	case cVulnCol:
+		deleted, err := c.deleteCertifyVuln(ctx, node)
+		if err != nil {
+			return false, fmt.Errorf("failed to delete CertifyVuln via ID: %s, with error: %w", node, err)
+		}
+		return deleted, nil
+	case hasSBOMCol:
+		deleted, err := c.deleteHasSBOM(ctx, node)
+		if err != nil {
+			return false, fmt.Errorf("failed to delete HasSBOM via ID: %s, with error: %w", node, err)
+		}
+		return deleted, nil
+	case slsaCol:
+		deleted, err := c.deleteHasSLSA(ctx, node)
+		if err != nil {
+			return false, fmt.Errorf("failed to delete HasSLSA via ID: %s, with error: %w", node, err)
+		}
+		return deleted, nil
+	default:
+		// Match the ent backend: unknown node types are a no-op, not an error.
+		log.Printf("Unknown node type: %s", sub[0])
+		return false, nil
+	}
 }

--- a/pkg/assembler/kv/kv.go
+++ b/pkg/assembler/kv/kv.go
@@ -31,6 +31,9 @@ type Store interface {
 	// Sets a value, creates collection if necessary
 	Set(ctx context.Context, collection, key string, value any) error
 
+	// Remove a value from the store. If not found, returns NotFoundError.
+	Remove(ctx context.Context, collection, key string) error
+
 	// Create a scanner that will be used to get all the keys in a collection.
 	Keys(collection string) Scanner
 }

--- a/pkg/assembler/kv/memmap/memmap.go
+++ b/pkg/assembler/kv/memmap/memmap.go
@@ -56,6 +56,18 @@ func (s *store) Set(_ context.Context, c, k string, v any) error {
 	return nil
 }
 
+func (s *store) Remove(_ context.Context, c, k string) error {
+	col, ok := s.m[c]
+	if !ok {
+		return fmt.Errorf("%w : Collection %q", kv.NotFoundError, c)
+	}
+	if _, ok := col[k]; !ok {
+		return fmt.Errorf("%w : Key %q", kv.NotFoundError, k)
+	}
+	delete(col, k)
+	return nil
+}
+
 func (s *store) Keys(c string) kv.Scanner {
 	return &scanner{
 		collection: c,

--- a/pkg/assembler/kv/redis/redis.go
+++ b/pkg/assembler/kv/redis/redis.go
@@ -67,6 +67,17 @@ func (s *store) Set(ctx context.Context, c, k string, v any) error {
 	return s.c.HSet(ctx, c, k, string(b)).Err()
 }
 
+func (s *store) Remove(ctx context.Context, c, k string) error {
+	n, err := s.c.HDel(ctx, c, k).Result()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return kv.NotFoundError
+	}
+	return nil
+}
+
 func (s *store) Keys(c string) kv.Scanner {
 	return &scanner{
 		collection: c,

--- a/pkg/assembler/kv/tikv/tikv.go
+++ b/pkg/assembler/kv/tikv/tikv.go
@@ -72,8 +72,7 @@ func (s *store) Set(ctx context.Context, c, k string, v any) error {
 
 func (s *store) Remove(ctx context.Context, c, k string) error {
 	ck := strings.Join([]string{c, k}, ":")
-	// Same as Get: rawkv does not report missing keys as an error, so check for
-	// an empty value instead.
+	// Like Get: rawkv returns no error for a missing key, so check for empty.
 	bts, err := s.c.Get(ctx, []byte(ck))
 	if len(bts) == 0 {
 		return kv.NotFoundError

--- a/pkg/assembler/kv/tikv/tikv.go
+++ b/pkg/assembler/kv/tikv/tikv.go
@@ -70,6 +70,20 @@ func (s *store) Set(ctx context.Context, c, k string, v any) error {
 	return s.c.Put(ctx, []byte(ck), bts)
 }
 
+func (s *store) Remove(ctx context.Context, c, k string) error {
+	ck := strings.Join([]string{c, k}, ":")
+	// Same as Get: rawkv does not report missing keys as an error, so check for
+	// an empty value instead.
+	bts, err := s.c.Get(ctx, []byte(ck))
+	if len(bts) == 0 {
+		return kv.NotFoundError
+	}
+	if err != nil {
+		return err
+	}
+	return s.c.Delete(ctx, []byte(ck))
+}
+
 func (s *store) Keys(c string) kv.Scanner {
 	return &scanner{
 		c:      s.c,


### PR DESCRIPTION
# Add Delete Support to the KV Backend

Fixes #1983

## Summary

Adds a `Delete` capability to the key-value (KV) backend. This builds on the earlier approach in #2033 (by @nathannaveen), rebased onto `main` with several correctness issues resolved.

## Changes

### 1. New `Remove` method on `kv.Store`
*(`pkg/assembler/kv/kv.go`)*

Implemented across all backends:

| Store | Implementation |
|---|---|
| memmap | Deletes from the collection map; returns `NotFoundError` if absent |
| redis | Uses `HDel`; returns `NotFoundError` if no fields were removed |
| tikv | Checks existence, then deletes the collection/key pair |
| stablememmap (test store) | Delegates to the wrapped memmap |

> ⚠️ **Breaking change**: any out-of-tree `kv.Store` implementation must add this method.

### 2. Shared delete helpers
*(`keyvalue/backend.go`)*

- **`delkv`** – removes a node and its ID from the index, so it stops resolving via `Node()`
- **`removeLink`** – removes one ID from a node's back-edge list (mirrors the existing `setXLinks` helpers)

### 3. Delete implementations

Each cleans up back-edges before removing the node:

- **`deleteCertifyVuln`** – package version + vulnerability edges
- **`deleteHasSLSA`** – subject artifact, deduped `builtFrom` materials, builder
- **`deleteHasSBOM`** – subject + included `isDependency`/`isOccurrence` nodes (via new `deleteIsDependency` / `deleteIsOccurrence` helpers)

### 4. Dispatch logic
*(`keyvalue/path.go`)*

`Delete` takes the write lock and dispatches by node type. Unknown types return `(false, nil)` instead of erroring, matching `matchingEntBackend.Delete` behavior.

## Notable Fix: Shared SBOM Includes

Since included nodes are deduped by key, two `HasSBOM` records can reference the same included node. Previously, deleting one SBOM left a dangling ID that broke **all** `HasSBOM` queries.

**Fix**: `convHasSBOM` now skips included IDs that return `NotFoundError` instead of failing the whole query.

**Trade-off**: real store corruption will now show up as a silently shorter `includes` list rather than an error. Refcounting included nodes would remove this trade-off — flagged as a follow-up.


PR Checklist

- [x] All commits have a Developer Certificate of Origin (DCO) -- they are generated using -s flag to git commit.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, make generate has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, make generate has been run
- [ ] If ent schema is changed, make generate has been run
- [ ] If collectsub protobuf has been changed, make proto has been run
- [x] All CI checks are passing (tests and formatting)
- [x] All dependent PRs have already been merged