### PR TITLE
fix: corrects the GCS credentials flag in command examples

### DIFF
--- a/cmd/guaccollect/cmd/gcs.go
+++ b/cmd/guaccollect/cmd/gcs.go
@@ -31,7 +31,7 @@ const gcsCredentialsPathFlag = "gcp-credentials-path"
 var gcsCmd = &cobra.Command{
 	Use:     "gcs [flags] bucket_name",
 	Short:   "takes SBOMs and attestations from a Google Cloud Storage bucket and injects them to GUAC graph. This command talks directly to the graphQL endpoint",
-	Example: "guacone collect gcs my-bucket --gcs-credentials-path /secret/sa.json",
+	Example: "guaccollect gcs my-bucket --gcp-credentials-path /secret/sa.json",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := logging.WithLogger(context.Background())

--- a/cmd/guacone/cmd/gcs.go
+++ b/cmd/guacone/cmd/gcs.go
@@ -51,7 +51,7 @@ const gcsCredentialsPathFlag = "gcp-credentials-path"
 var gcsCmd = &cobra.Command{
 	Use:     "gcs [flags] bucket_name",
 	Short:   "takes SBOMs and attestations from a Google Cloud Storage bucket and injects them to GUAC graph. This command talks directly to the graphQL endpoint",
-	Example: "guacone collect gcs my-bucket --gcs-credentials-path /secret/sa.json",
+	Example: "guacone collect gcs my-bucket --gcp-credentials-path /secret/sa.json",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		opts, err := validateGCSFlags(


### PR DESCRIPTION
Fixes #3193.

The `Example:` strings on both `gcs` commands advertised a
`--gcs-credentials-path` flag. That flag is not registered — `pkg/cli/store.go:130`
registers `gcp-credentials-path` — so copying the example out of `--help` failed
with `unknown flag`. The `gcsCredentialsPathFlag` constant declared two lines
above each example already held the correct value, so this is only the literal
in the example drifting from it.

Two changes:

- `cmd/guaccollect/cmd/gcs.go:34` and `cmd/guacone/cmd/gcs.go:54`:
  `--gcs-credentials-path` -> `--gcp-credentials-path`.
- `cmd/guaccollect/cmd/gcs.go:34` also invoked `guacone collect gcs`.
  `guaccollect` registers `gcs` as a top-level subcommand (`rootCmd.AddCommand(gcsCmd)`,
  line 143) and has no `collect` grouping, so the binary and path are corrected
  to `guaccollect gcs`.

Verified: `go build ./cmd/...`, `go vet` and `go test` on both changed packages
all pass. `cmd/guacone/cmd/gcs_test.go:37` already asserts the correct flag name
in its error text, so the tests agreed with the fix before this change.

The same typo had propagated into the docs; fixed in guacsec/guac-docs#244.
