### PR TITLE
fix(ent): avoid lock-order-inversion deadlocks on occurrence upserts

### DIFF
--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	stdsql "database/sql"
 	"fmt"
+	"sort"
 
 	"entgo.io/contrib/entgql"
 	"entgo.io/ent/dialect/sql"
@@ -167,6 +168,20 @@ func occurrenceConflictColumns() []string {
 	}
 }
 
+// sortableOccurrenceCreates sorts a batch of Occurrence creates by their
+// deterministic ID, keeping ids and creates in lockstep.
+type sortableOccurrenceCreates struct {
+	ids     []string
+	creates []*ent.OccurrenceCreate
+}
+
+func (s sortableOccurrenceCreates) Len() int           { return len(s.creates) }
+func (s sortableOccurrenceCreates) Less(i, j int) bool { return s.ids[i] < s.ids[j] }
+func (s sortableOccurrenceCreates) Swap(i, j int) {
+	s.ids[i], s.ids[j] = s.ids[j], s.ids[i]
+	s.creates[i], s.creates[j] = s.creates[j], s.creates[i]
+}
+
 func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.PackageOrSourceInputs, artifacts []*model.IDorArtifactInput, occurrences []*model.IsOccurrenceInputSpec) (*[]string, error) {
 	ids := make([]string, 0)
 
@@ -196,6 +211,7 @@ func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.Packa
 	index := 0
 	for _, occurs := range batches {
 		creates := make([]*ent.OccurrenceCreate, len(occurs))
+		createIDs := make([]string, len(occurs))
 		for i, occur := range occurs {
 			occur := occur
 			switch {
@@ -206,6 +222,7 @@ func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.Packa
 				if err != nil {
 					return nil, gqlerror.Errorf("generateDependencyCreate :: %s", err)
 				}
+				createIDs[i] = isOccurrenceID.String()
 				ids = append(ids, isOccurrenceID.String())
 
 			case len(subjects.Sources) > 0:
@@ -215,12 +232,21 @@ func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.Packa
 				if err != nil {
 					return nil, gqlerror.Errorf("generateDependencyCreate :: %s", err)
 				}
+				createIDs[i] = isOccurrenceID.String()
 				ids = append(ids, isOccurrenceID.String())
 			default:
 				return nil, gqlerror.Errorf("%v :: %s", "upsertBulkOccurrences", "subject must be either a package or source")
 			}
 			index++
 		}
+
+		// Sort the batch by its deterministic occurrence ID so that concurrent
+		// transactions upserting overlapping occurrences always acquire the
+		// underlying row-exclusive locks in the same order. Building the batch
+		// in unsorted (SBOM) order lets two concurrent transactions lock shared
+		// rows in opposite orders, which Postgres reports as a 40P01 deadlock.
+		// See the equivalent PackageName fix in upsertBulkPackage.
+		sort.Sort(sortableOccurrenceCreates{ids: createIDs, creates: creates})
 
 		err := tx.Occurrence.CreateBulk(creates...).
 			OnConflict(

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -168,8 +168,7 @@ func occurrenceConflictColumns() []string {
 	}
 }
 
-// sortableOccurrenceCreates sorts a batch of Occurrence creates by their
-// deterministic ID, keeping ids and creates in lockstep.
+// sortableOccurrenceCreates sorts a batch of Occurrence creates by deterministic ID, keeping ids and creates paired.
 type sortableOccurrenceCreates struct {
 	ids     []string
 	creates []*ent.OccurrenceCreate
@@ -240,12 +239,7 @@ func upsertBulkOccurrences(ctx context.Context, tx *ent.Tx, subjects model.Packa
 			index++
 		}
 
-		// Sort the batch by its deterministic occurrence ID so that concurrent
-		// transactions upserting overlapping occurrences always acquire the
-		// underlying row-exclusive locks in the same order. Building the batch
-		// in unsorted (SBOM) order lets two concurrent transactions lock shared
-		// rows in opposite orders, which Postgres reports as a 40P01 deadlock.
-		// See the equivalent PackageName fix in upsertBulkPackage.
+		// Sort by deterministic ID so concurrent transactions lock shared rows in the same order, avoiding 40P01 deadlocks.
 		sort.Sort(sortableOccurrenceCreates{ids: createIDs, creates: creates})
 
 		err := tx.Occurrence.CreateBulk(creates...).

--- a/pkg/assembler/backends/ent/backend/occurrence_sort_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_sort_test.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/guacsec/guac/pkg/assembler/backends/ent"
+)
+
+// TestSortableOccurrenceCreates_DeterministicOrder verifies that sorting
+// keeps each Occurrence create paired with its ID, and always produces the
+// same ordering regardless of the input order. This is what prevents two
+// concurrent transactions from locking shared occurrences rows in opposite
+// orders (the lock-order-inversion deadlock described in the issue).
+func TestSortableOccurrenceCreates_DeterministicOrder(t *testing.T) {
+	idA, idB, idC := "aaaaaaaa", "bbbbbbbb", "cccccccc"
+	createA, createB, createC := &ent.OccurrenceCreate{}, &ent.OccurrenceCreate{}, &ent.OccurrenceCreate{}
+
+	orderings := [][]struct {
+		id     string
+		create *ent.OccurrenceCreate
+	}{
+		{{idC, createC}, {idA, createA}, {idB, createB}},
+		{{idB, createB}, {idC, createC}, {idA, createA}},
+		{{idA, createA}, {idB, createB}, {idC, createC}},
+	}
+
+	var results [][]string
+	for _, ordering := range orderings {
+		ids := make([]string, len(ordering))
+		creates := make([]*ent.OccurrenceCreate, len(ordering))
+		for i, entry := range ordering {
+			ids[i] = entry.id
+			creates[i] = entry.create
+		}
+
+		sort.Sort(sortableOccurrenceCreates{ids: ids, creates: creates})
+
+		if !sort.StringsAreSorted(ids) {
+			t.Fatalf("ids not sorted: %v", ids)
+		}
+
+		// Verify ids and creates stayed paired: mapping id -> create must be
+		// consistent with the input mapping (A->createA, B->createB, C->createC).
+		want := map[string]*ent.OccurrenceCreate{idA: createA, idB: createB, idC: createC}
+		for i, id := range ids {
+			if creates[i] != want[id] {
+				t.Fatalf("create for id %q became mispaired after sort", id)
+			}
+		}
+
+		results = append(results, append([]string(nil), ids...))
+	}
+
+	for i := 1; i < len(results); i++ {
+		if len(results[i]) != len(results[0]) {
+			t.Fatalf("result length mismatch: %v vs %v", results[i], results[0])
+		}
+		for j := range results[i] {
+			if results[i][j] != results[0][j] {
+				t.Fatalf("sort order differs across input orderings: %v vs %v", results[i], results[0])
+			}
+		}
+	}
+}

--- a/pkg/assembler/backends/ent/backend/occurrence_sort_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_sort_test.go
@@ -22,11 +22,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent"
 )
 
-// TestSortableOccurrenceCreates_DeterministicOrder verifies that sorting
-// keeps each Occurrence create paired with its ID, and always produces the
-// same ordering regardless of the input order. This is what prevents two
-// concurrent transactions from locking shared occurrences rows in opposite
-// orders (the lock-order-inversion deadlock described in the issue).
 func TestSortableOccurrenceCreates_DeterministicOrder(t *testing.T) {
 	idA, idB, idC := "aaaaaaaa", "bbbbbbbb", "cccccccc"
 	createA, createB, createC := &ent.OccurrenceCreate{}, &ent.OccurrenceCreate{}, &ent.OccurrenceCreate{}
@@ -55,8 +50,6 @@ func TestSortableOccurrenceCreates_DeterministicOrder(t *testing.T) {
 			t.Fatalf("ids not sorted: %v", ids)
 		}
 
-		// Verify ids and creates stayed paired: mapping id -> create must be
-		// consistent with the input mapping (A->createA, B->createB, C->createC).
 		want := map[string]*ent.OccurrenceCreate{idA: createA, idB: createB, idC: createC}
 		for i, id := range ids {
 			if creates[i] != want[id] {


### PR DESCRIPTION
# Description of the PR

Concurrent SBOM ingestion against the Postgres/ent backend can deadlock (SQLSTATE 40P01) in the `isOccurrence` bulk upsert: `upsertBulkOccurrences` built each `CreateBulk` batch in SBOM (unsorted) order, so two concurrent transactions ingesting SBOMs that share packages/artifacts could acquire the same row-exclusive locks in different orders. This is the exact lock-order-inversion shape already fixed for `PackageName` upserts in `upsertBulkPackage` (see PR #3153) — the `isOccurrence` path never got the equivalent treatment.

This PR sorts each Occurrence batch by its deterministic occurrence ID (a hash of subject + artifact + justification/origin/collector/documentRef — the same tuple that identifies the row for conflict purposes) immediately before `CreateBulk`, so concurrent transactions always attempt to lock shared occurrence rows in the same relative order. The function's returned `ids` (used by the caller to map back to GraphQL global IDs) are left in their original, unsorted order — only the local slice passed to `CreateBulk` is reordered.

Deliberately out of scope, matching how PR #3153 scoped the PackageName fix: retrying the outer transaction on 40P01/40001 (this would mean changing the generic `WithinTX` wrapper used by nearly every `Ingest*` function in the backend — a much larger, riskier change), and auditing other bulk-upsert paths for the same pattern. Both are better suited to a separate PR.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [x] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

Fixes #3198