### PR TITLE
fix: resolve staticcheck findings in the keyvalue backend

### DIFF
--- a/pkg/assembler/backends/keyvalue/artifact.go
+++ b/pkg/assembler/backends/keyvalue/artifact.go
@@ -250,12 +250,8 @@ func (c *demoClient) ArtifactsList(ctx context.Context, artifactSpec model.Artif
 
 	edges := make([]*model.ArtifactEdge, 0)
 	count := 0
-	currentPage := false
-
 	// If no cursor present start from the top
-	if after == nil {
-		currentPage = true
-	}
+	currentPage := after == nil
 	hasNextPage := false
 	totalCount := 0
 
@@ -332,15 +328,9 @@ func (c *demoClient) ArtifactsList(ctx context.Context, artifactSpec model.Artif
 }
 
 func createArtifactEdges(algorithm string, a *artStruct, digest string, convArt *model.Artifact) *model.ArtifactEdge {
-	matchAlgorithm := false
-	if algorithm == "" || algorithm == a.Algorithm {
-		matchAlgorithm = true
-	}
+	matchAlgorithm := algorithm == "" || algorithm == a.Algorithm
 
-	matchDigest := false
-	if digest == "" || digest == a.Digest {
-		matchDigest = true
-	}
+	matchDigest := digest == "" || digest == a.Digest
 
 	if matchDigest && matchAlgorithm {
 		return &model.ArtifactEdge{

--- a/pkg/assembler/backends/keyvalue/backend.go
+++ b/pkg/assembler/backends/keyvalue/backend.go
@@ -127,7 +127,7 @@ type node interface {
 }
 
 var errNotFound = errors.New("not found")
-var errTypeNotMatch = errors.New("Stored type does not match")
+var errTypeNotMatch = errors.New("stored type does not match")
 
 // Scorecard scores are in range of 1-10, so a single step at 100 should be
 // plenty big
@@ -289,7 +289,7 @@ func byIDkv[E node](ctx context.Context, id string, c *demoClient) (E, error) {
 	}
 	sub := strings.SplitN(k, ":", 2)
 	if len(sub) != 2 {
-		return nl, fmt.Errorf("Bad value was stored in index map: %v", k)
+		return nl, fmt.Errorf("bad value was stored in index map: %v", k)
 	}
 	return byKeykv[E](ctx, sub[0], sub[1], c)
 }

--- a/pkg/assembler/backends/keyvalue/builder.go
+++ b/pkg/assembler/backends/keyvalue/builder.go
@@ -139,12 +139,8 @@ func (c *demoClient) BuildersList(ctx context.Context, builderSpec model.Builder
 	}
 	edges := make([]*model.BuilderEdge, 0)
 	count := 0
-	currentPage := false
-
 	// If no cursor present start from the top
-	if after == nil {
-		currentPage = true
-	}
+	currentPage := after == nil
 	hasNextPage := false
 	totalCount := 0
 

--- a/pkg/assembler/backends/keyvalue/license.go
+++ b/pkg/assembler/backends/keyvalue/license.go
@@ -191,12 +191,8 @@ func (c *demoClient) LicenseList(ctx context.Context, licenseSpec model.LicenseS
 
 	var done bool
 	scn := c.kv.Keys(licenseCol)
-	currentPage := false
-
 	// If no cursor present start from the top
-	if after == nil {
-		currentPage = true
-	}
+	currentPage := after == nil
 
 	for !done {
 		var lKeys []string

--- a/pkg/assembler/backends/keyvalue/path.go
+++ b/pkg/assembler/backends/keyvalue/path.go
@@ -72,7 +72,7 @@ func (c *demoClient) neighborsFromId(ctx context.Context, id string, allowedEdge
 
 	sub := strings.SplitN(k, ":", 2)
 	if len(sub) != 2 {
-		return nil, fmt.Errorf("Bad value was stored in index map: %v", k)
+		return nil, fmt.Errorf("bad value was stored in index map: %v", k)
 	}
 
 	node := typeColMap(sub[0])
@@ -165,7 +165,7 @@ func (c *demoClient) Node(ctx context.Context, id string) (model.Node, error) {
 
 	sub := strings.SplitN(k, ":", 2)
 	if len(sub) != 2 {
-		return nil, fmt.Errorf("Bad value was stored in index map: %v", k)
+		return nil, fmt.Errorf("bad value was stored in index map: %v", k)
 	}
 
 	node := typeColMap(sub[0])

--- a/pkg/assembler/backends/keyvalue/pkg.go
+++ b/pkg/assembler/backends/keyvalue/pkg.go
@@ -924,7 +924,7 @@ func (c *demoClient) buildPackageResponse(ctx context.Context, id string, filter
 		})
 		currentID = versionNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	pnl := []*model.PackageName{}
@@ -939,7 +939,7 @@ func (c *demoClient) buildPackageResponse(ctx context.Context, id string, filter
 		})
 		currentID = nameNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	pnsl := []*model.PackageNamespace{}
@@ -954,7 +954,7 @@ func (c *demoClient) buildPackageResponse(ctx context.Context, id string, filter
 		})
 		currentID = namespaceNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	typeNode, err := byIDkv[*pkgType](ctx, currentID, c)
@@ -962,7 +962,7 @@ func (c *demoClient) buildPackageResponse(ctx context.Context, id string, filter
 		if errors.Is(err, kv.NotFoundError) || errors.Is(err, errTypeNotMatch) {
 			return nil, fmt.Errorf("%w: ID does not match expected node type for package namespace", errNotFound)
 		} else {
-			return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+			return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 		}
 	}
 	if filter != nil && noMatch(filter.Type, typeNode.Type) {
@@ -1076,7 +1076,7 @@ func noMatchQualifiers(filter *model.PkgSpec, v map[string]string) bool {
 			return true
 		}
 	}
-	if filter.Qualifiers != nil && len(filter.Qualifiers) > 0 {
+	if len(filter.Qualifiers) > 0 {
 		filterQualifiers := getQualifiersFromFilter(filter.Qualifiers)
 		return !reflect.DeepEqual(v, filterQualifiers)
 	}

--- a/pkg/assembler/backends/keyvalue/src.go
+++ b/pkg/assembler/backends/keyvalue/src.go
@@ -667,7 +667,7 @@ func (c *demoClient) buildSourceResponse(ctx context.Context, id string, filter 
 		snl = append(snl, model)
 		currentID = nameNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	snsl := []*model.SourceNamespace{}
@@ -682,7 +682,7 @@ func (c *demoClient) buildSourceResponse(ctx context.Context, id string, filter 
 		})
 		currentID = namespaceNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	typeNode, err := byIDkv[*srcType](ctx, currentID, c)
@@ -690,7 +690,7 @@ func (c *demoClient) buildSourceResponse(ctx context.Context, id string, filter 
 		if errors.Is(err, kv.NotFoundError) || errors.Is(err, errTypeNotMatch) {
 			return nil, fmt.Errorf("%w: ID does not match expected node type for package namespace", errNotFound)
 		} else {
-			return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+			return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 		}
 	}
 	if filter != nil && noMatch(filter.Type, typeNode.Type) {

--- a/pkg/assembler/backends/keyvalue/vulnerability.go
+++ b/pkg/assembler/backends/keyvalue/vulnerability.go
@@ -548,7 +548,7 @@ func (c *demoClient) buildVulnResponse(ctx context.Context, id string, filter *m
 		})
 		currentID = vulnNode.Parent
 	} else if !errors.Is(err, kv.NotFoundError) && !errors.Is(err, errTypeNotMatch) {
-		return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+		return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 	}
 
 	typeStruct, err := byIDkv[*vulnTypeStruct](ctx, currentID, c)
@@ -556,7 +556,7 @@ func (c *demoClient) buildVulnResponse(ctx context.Context, id string, filter *m
 		if errors.Is(err, kv.NotFoundError) || errors.Is(err, errTypeNotMatch) {
 			return nil, fmt.Errorf("%w: ID does not match expected node type for vulnerability", errNotFound)
 		} else {
-			return nil, fmt.Errorf("Error retrieving node for id: %v : %w", currentID, err)
+			return nil, fmt.Errorf("error retrieving node for id: %v : %w", currentID, err)
 		}
 	}
 	if filter != nil && noMatch(toLower(filter.Type), typeStruct.Type) {


### PR DESCRIPTION
Part of #2971

Phase 2 of the lint cleanup: the keyvalue backend, 19 findings, all staticcheck.

- ST1005 (13): lowercased the error strings. Three distinct messages across seven files.
- QF1007 (5): folded boolean flags that were declared false and set in an if into their
  declarations.
- S1009 (1): dropped a nil check ahead of len(), which is defined for nil slices.

Only the error message casing is observable from outside, and nothing in the repo asserts
on those strings. Verified with a scoped lint run: the package goes from 19 findings to 0,
and no files outside it are touched. Build and the package tests pass.
