### PR TITLE
fix: resolve staticcheck findings in guesser, pagination, and slsa parser

### DIFF
--- a/pkg/guacrest/pagination/cursor.go
+++ b/pkg/guacrest/pagination/cursor.go
@@ -33,11 +33,11 @@ var (
 
 func indexFromCursor(cursor string) (uint64, error) {
 	if len(cursor) != 11 {
-		return 0, fmt.Errorf("Encoded cursor %q is not 11 bytes", cursor)
+		return 0, fmt.Errorf("encoded cursor %q is not 11 bytes", cursor)
 	}
 	decodedBytes, err := byteEncoding.DecodeString(cursor)
 	if err != nil {
-		return 0, fmt.Errorf("Cursor could not be decoded as base64: %v", err)
+		return 0, fmt.Errorf("cursor could not be decoded as base64: %v", err)
 	}
 	// decodedBytes must be at least length 8, but this is covered by the
 	// string length check above

--- a/pkg/guacrest/pagination/pagination.go
+++ b/pkg/guacrest/pagination/pagination.go
@@ -55,36 +55,36 @@ func Paginate[T any](ctx context.Context, lst []T, spec *models.PaginationSpec) 
 	models.PaginationInfo, error) {
 	logger := logging.FromContext(ctx)
 
-	var pagesize int = DefaultPageSize
+	var pagesize = DefaultPageSize
 	if spec != nil && spec.PageSize != nil {
 		pagesize = *spec.PageSize
 	}
 	if pagesize < 0 {
 		return nil, models.PaginationInfo{},
-			fmt.Errorf("Pagination error: PageSize is negative.")
+			fmt.Errorf("pagination error: PageSize is negative")
 	}
 
-	var inputLength uint64 = uint64(len(lst))
+	var inputLength = uint64(len(lst))
 	var start uint64 = 0
 
 	if spec != nil && spec.Cursor != nil {
 		if *spec.Cursor == "" {
 			return nil, models.PaginationInfo{},
-				fmt.Errorf("Pagination error: The cursor is the empty string")
+				fmt.Errorf("pagination error: the cursor is the empty string")
 		}
 
 		decoded, err := indexFromCursor(*spec.Cursor)
 		if err != nil {
 			logger.Warnf("Pagination error: %s", err)
 			return nil, models.PaginationInfo{},
-				fmt.Errorf("Pagination error: The cursor is invalid.")
+				fmt.Errorf("pagination error: the cursor is invalid")
 		}
 		if decoded >= inputLength {
 			logger.Warnf("Pagination error: The cursor is out of bounds. This is" +
 				" either due to client manipulation of the cursor or a different slice" +
 				" argument passed to Paginate than when this cursor was generated.")
 			return nil, models.PaginationInfo{},
-				fmt.Errorf("Pagination error: The cursor is invalid")
+				fmt.Errorf("pagination error: the cursor is invalid")
 		}
 		start = decoded
 	}

--- a/pkg/handler/processor/guesser/format_json.go
+++ b/pkg/handler/processor/guesser/format_json.go
@@ -23,7 +23,7 @@ import (
 
 type jsonFormatGuesser struct{}
 
-func (_ *jsonFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
+func (*jsonFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
 	if jsonValidator.Valid(blob) {
 		return processor.FormatJSON
 	}

--- a/pkg/handler/processor/guesser/format_jsonlines.go
+++ b/pkg/handler/processor/guesser/format_jsonlines.go
@@ -24,7 +24,7 @@ import (
 
 type jsonLinesFormatGuesser struct{}
 
-func (_ *jsonLinesFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
+func (*jsonLinesFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
 	lines := strings.Split(strings.TrimSpace(string(blob)), "\n")
 	for _, line := range lines {
 		if !jsonValidator.Valid([]byte(strings.TrimSpace(line))) {

--- a/pkg/handler/processor/guesser/format_xml.go
+++ b/pkg/handler/processor/guesser/format_xml.go
@@ -25,7 +25,7 @@ type xmlFormatGuesser struct{}
 
 // GuessFormat expects at least 1 XML element in a blob to identify it as an XML
 // formatted document
-func (_ *xmlFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
+func (*xmlFormatGuesser) GuessFormat(blob []byte) processor.FormatType {
 	if err := xml.Unmarshal(blob, new(interface{})); err == nil {
 		return processor.FormatXML
 	}

--- a/pkg/handler/processor/guesser/type_csaf.go
+++ b/pkg/handler/processor/guesser/type_csaf.go
@@ -22,7 +22,7 @@ import (
 
 type csafTypeGuesser struct{}
 
-func (_ *csafTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*csafTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	switch format {
 	case processor.FormatJSON:
 		// Decode the BOM

--- a/pkg/handler/processor/guesser/type_cyclonedx.go
+++ b/pkg/handler/processor/guesser/type_cyclonedx.go
@@ -29,7 +29,7 @@ const (
 	cycloneDXFormat = "CycloneDX"
 )
 
-func (_ *cycloneDXTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*cycloneDXTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	reader := bytes.NewReader(blob)
 	switch format {
 	case processor.FormatJSON:

--- a/pkg/handler/processor/guesser/type_deps_dev.go
+++ b/pkg/handler/processor/guesser/type_deps_dev.go
@@ -22,7 +22,7 @@ import (
 
 type depsDevTypeGuesser struct{}
 
-func (_ *depsDevTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*depsDevTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	packageComponent := ddc.PackageComponent{}
 	if json.Unmarshal(blob, &packageComponent) == nil && format == processor.FormatJSON && packageComponent.CurrentPackage != nil {
 		return processor.DocumentDepsDev

--- a/pkg/handler/processor/guesser/type_dsse.go
+++ b/pkg/handler/processor/guesser/type_dsse.go
@@ -22,7 +22,7 @@ import (
 
 type dsseTypeGuesser struct{}
 
-func (_ *dsseTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*dsseTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	var envelope dsse.Envelope
 	if json.Unmarshal(blob, &envelope) == nil && format == processor.FormatJSON {
 		if envelope.Payload != "" && envelope.PayloadType != "" && len(envelope.Signatures) > 0 {

--- a/pkg/handler/processor/guesser/type_ingest_predicates.go
+++ b/pkg/handler/processor/guesser/type_ingest_predicates.go
@@ -24,7 +24,7 @@ import (
 
 type IngestPredicatesGuesser struct{}
 
-func (_ *IngestPredicatesGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*IngestPredicatesGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	switch format {
 	case processor.FormatJSON:
 		var preds assembler.IngestPredicates

--- a/pkg/handler/processor/guesser/type_ite6.go
+++ b/pkg/handler/processor/guesser/type_ite6.go
@@ -29,7 +29,7 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type ite6TypeGuesser struct{}
 
-func (_ *ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*ite6TypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	var statement in_toto.Statement
 	if json.Unmarshal(blob, &statement) == nil && format == processor.FormatJSON {
 		if strings.HasPrefix(statement.Type, "https://in-toto.io/Statement") {

--- a/pkg/handler/processor/guesser/type_open_vex.go
+++ b/pkg/handler/processor/guesser/type_open_vex.go
@@ -23,13 +23,13 @@ import (
 
 type openVexTypeGuesser struct{}
 
-func (_ *openVexTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*openVexTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	switch format {
 	case processor.FormatJSON:
 		// Decode the BOM
 		var decoded vex.VEX
 		err := json.Unmarshal(blob, &decoded)
-		if err == nil && decoded.Metadata.ID != "" {
+		if err == nil && decoded.ID != "" {
 			return processor.DocumentOpenVEX
 		}
 	}

--- a/pkg/handler/processor/guesser/type_scorecard.go
+++ b/pkg/handler/processor/guesser/type_scorecard.go
@@ -22,7 +22,7 @@ import (
 
 type scorecardTypeGuesser struct{}
 
-func (_ *scorecardTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*scorecardTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	var scorecard sc.JSONScorecardResultV2
 	if json.Unmarshal(blob, &scorecard) == nil && format == processor.FormatJSON {
 		if scorecard.Scorecard.Version != "" || scorecard.Scorecard.Commit != "" {

--- a/pkg/handler/processor/guesser/type_spdx.go
+++ b/pkg/handler/processor/guesser/type_spdx.go
@@ -24,7 +24,7 @@ import (
 
 type spdxTypeGuesser struct{}
 
-func (_ *spdxTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+func (*spdxTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
 	switch format {
 	case processor.FormatJSON:
 		spdxDoc, err := jsonReader.Read(bytes.NewReader(blob))

--- a/pkg/ingestor/parser/slsa/parser_slsa.go
+++ b/pkg/ingestor/parser/slsa/parser_slsa.go
@@ -312,12 +312,12 @@ func (s *slsaParser) getSLSA() error {
 	var genericMap map[string]any
 	err = json.Unmarshal(data, &genericMap)
 	if err != nil {
-		return fmt.Errorf("Could not unmarshal SLSA Predicate to map: %w", err)
+		return fmt.Errorf("could not unmarshal SLSA Predicate to map: %w", err)
 	}
 
 	flatMap, err := flatten.Flatten(genericMap, "slsa.", flatten.SeparatorStyle{Middle: "."})
 	if err != nil {
-		return fmt.Errorf("Could not flatten SLSA Predicate map: %w", err)
+		return fmt.Errorf("could not flatten SLSA Predicate map: %w", err)
 	}
 
 	for k, v := range flatMap {
@@ -351,32 +351,32 @@ func (s *slsaParser) getBuilder() error {
 func (s *slsaParser) parseSlsaPredicate(p []byte) error {
 	s.smt = &attestationv1.Statement{}
 	if err := protojson.Unmarshal(p, s.smt); err != nil {
-		return fmt.Errorf("Could not unmarshal SLSA statement: %w", err)
+		return fmt.Errorf("could not unmarshal SLSA statement: %w", err)
 	}
 
 	predBytes, err := json.Marshal(s.smt.Predicate)
 	if err != nil {
-		return fmt.Errorf("Could not marshal SLSA predicate: %w", err)
+		return fmt.Errorf("could not marshal SLSA predicate: %w", err)
 	}
 
 	switch s.smt.PredicateType {
 	case slsa01.PredicateSLSAProvenance:
 		s.pred01 = &slsa01.ProvenancePredicate{}
 		if err := json.Unmarshal(predBytes, s.pred01); err != nil {
-			return fmt.Errorf("Could not unmarshal v0.1 SLSA provenance statement : %w", err)
+			return fmt.Errorf("could not unmarshal v0.1 SLSA provenance statement : %w", err)
 		}
 	case slsa02.PredicateSLSAProvenance:
 		s.pred02 = &slsa02.ProvenancePredicate{}
 		if err := json.Unmarshal(predBytes, s.pred02); err != nil {
-			return fmt.Errorf("Could not unmarshal v0.2 SLSA provenance statement : %w", err)
+			return fmt.Errorf("could not unmarshal v0.2 SLSA provenance statement : %w", err)
 		}
 	case PredicateSLSAProvenancev1:
 		s.pred1 = &slsa1.Provenance{}
 		if err := protojson.Unmarshal(predBytes, s.pred1); err != nil {
-			return fmt.Errorf("Could not unmarshal v1.0 SLSA provenance statement : %w", err)
+			return fmt.Errorf("could not unmarshal v1.0 SLSA provenance statement : %w", err)
 		}
 	default:
-		return fmt.Errorf("Unknown SLSA PredicateType: %q", s.smt.PredicateType)
+		return fmt.Errorf("unknown SLSA PredicateType: %q", s.smt.PredicateType)
 	}
 	return nil
 }


### PR DESCRIPTION
Part of #2971

Phase 3: the guesser, pagination, and slsa parser packages, 29 of their 30 findings.

- ST1006 (12): dropped the underscore receiver names in the guessers.
- ST1005 (14): lowercased error strings and removed trailing punctuation.
- QF1011 + ST1023 (2): let the two pagination var declarations infer their types.
- QF1008 (1): used the promoted ID field directly in the OpenVEX guesser.

The one I left is the SA1019 on in_toto.Statement in the ite6 guesser. Replacing it means
migrating to the protobuf v1 statement, which the function already handles as a separate
path, so that's a behaviour change and not a cleanup. Can file it as its own issue if you
want it tracked.

Same verification as the last two: the three packages go from 30 findings to that 1,
nothing else in the repo asserts on the changed strings, build and package tests pass.

Also still open from the phase 2 thread: whether you want the neo4j findings fixed or
excluded like its existing exclusions, and whether repo-wide ST1005/ST1023 sweeps are
welcome. arangodb and neo4j are two thirds of what remains, so those answers decide the
next phases.
