### PR TITLE
fix: resolve staticcheck and errcheck findings in eight small packages

### DIFF
--- a/cmd/guacone/cmd/annotate_metadata.go
+++ b/cmd/guacone/cmd/annotate_metadata.go
@@ -79,7 +79,8 @@ var annotateMetadata = &cobra.Command{
 		var srcInput *model.SourceInputSpec
 		var artifact *model.ArtifactInputSpec
 
-		if opts.subjectType == "package" {
+		switch opts.subjectType {
+		case "package":
 			pkgInput, err = helpers.PurlToPkg(opts.subject)
 			if err != nil {
 				logger.Fatalf("failed to parse PURL: %v", err)
@@ -93,12 +94,12 @@ var annotateMetadata = &cobra.Command{
 					Pkg: model.PkgMatchTypeSpecificVersion,
 				}
 			}
-		} else if opts.subjectType == "source" {
+		case "source":
 			srcInput, err = helpers.VcsToSrc(opts.subject)
 			if err != nil {
 				logger.Fatalf("failed to parse source: %v", err)
 			}
-		} else {
+		default:
 			split := strings.Split(opts.subject, ":")
 			if len(split) != 2 {
 				logger.Fatalf("failed to parse artifact. Needs to be in algorithm:digest form")

--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -80,7 +80,8 @@ var certifyCmd = &cobra.Command{
 		var srcInput *model.SourceInputSpec
 		var artifact *model.ArtifactInputSpec
 
-		if opts.certifyType == "package" {
+		switch opts.certifyType {
+		case "package":
 			pkgInput, err = helpers.PurlToPkg(opts.subject)
 			if err != nil {
 				logger.Fatalf("failed to parse PURL: %v", err)
@@ -94,12 +95,12 @@ var certifyCmd = &cobra.Command{
 					Pkg: model.PkgMatchTypeSpecificVersion,
 				}
 			}
-		} else if opts.certifyType == "source" {
+		case "source":
 			srcInput, err = helpers.VcsToSrc(opts.subject)
 			if err != nil {
 				logger.Fatalf("failed to parse source: %v", err)
 			}
-		} else {
+		default:
 			split := strings.Split(opts.subject, ":")
 			if len(split) != 2 {
 				logger.Fatalf("failed to parse artifact. Needs to be in algorithm:digest form")

--- a/internal/client/githubclient/githubclient.go
+++ b/internal/client/githubclient/githubclient.go
@@ -212,7 +212,7 @@ func DownloadAndExtractZip(url string, runID int64) ([]*client.WorkflowArtifactC
 	if err != nil {
 		return nil, fmt.Errorf("error getting zip file: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("bad status: %s", resp.Status)
@@ -239,7 +239,7 @@ func DownloadAndExtractZip(url string, runID int64) ([]*client.WorkflowArtifactC
 		if err != nil {
 			return nil, fmt.Errorf("error opening file in zip: %w", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		fileData := make([]byte, zipFile.UncompressedSize64)
 		_, err = io.ReadFull(f, fileData)
@@ -293,7 +293,7 @@ func (gc *githubClient) GetReleaseAsset(asset client.ReleaseAsset) (*client.Rele
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("unable to fetch asset %v, status: %v", asset.URL, resp.Status)

--- a/pkg/assembler/backends/helper/conversion.go
+++ b/pkg/assembler/backends/helper/conversion.go
@@ -22,15 +22,12 @@ import (
 // TODO: maybe use generics for PkgInputSpec and PkgSpec?
 func ConvertPkgInputSpecToPkgSpec(pkgInput *model.PkgInputSpec) *model.PkgSpec {
 	qualifiers := convertQualifierInputToQualifierSpec(pkgInput.Qualifiers)
-	matchEmpty := false
-	if len(qualifiers) == 0 {
-		matchEmpty = true
-	}
-	var version string = ""
+	matchEmpty := len(qualifiers) == 0
+	version := ""
 	if pkgInput.Version != nil {
 		version = *pkgInput.Version
 	}
-	var subpath string = ""
+	subpath := ""
 	if pkgInput.Subpath != nil {
 		subpath = *pkgInput.Subpath
 	}
@@ -60,11 +57,11 @@ func convertQualifierInputToQualifierSpec(qualifiers []*model.PackageQualifierIn
 
 // TODO: maybe use generics for SourceInputSpec and SourceSpec?
 func ConvertSrcInputSpecToSrcSpec(srcInput *model.SourceInputSpec) *model.SourceSpec {
-	var tag string = ""
+	tag := ""
 	if srcInput.Tag != nil {
 		tag = *srcInput.Tag
 	}
-	var commit string = ""
+	commit := ""
 	if srcInput.Commit != nil {
 		commit = *srcInput.Commit
 	}

--- a/pkg/assembler/graphql/resolvers/filterDirective.resolver.go
+++ b/pkg/assembler/graphql/resolvers/filterDirective.resolver.go
@@ -15,7 +15,7 @@ const numWorkers = 5
 const channelBufferSize = 1000
 
 func collectResults(resultChan <-chan reflect.Value, modelType reflect.Type) reflect.Value {
-	matchingItemsInterface := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(modelType)), 0, 0)
+	matchingItemsInterface := reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(modelType)), 0, 0)
 
 	for item := range resultChan {
 		matchingItemsInterface = reflect.Append(matchingItemsInterface, item.Addr())
@@ -70,7 +70,7 @@ func handleSliceField(field reflect.Value, keys []string, value string, operatio
 
 	for j := 0; j < field.Len(); j++ {
 		sliceItem := field.Index(j)
-		if sliceItem.Kind() == reflect.Ptr {
+		if sliceItem.Kind() == reflect.Pointer {
 			sliceItem = sliceItem.Elem()
 		}
 		newItem := reflect.New(sliceItem.Type()).Elem()
@@ -116,7 +116,7 @@ func handleMatchingField(field reflect.Value, keys []string, value string, opera
 }
 
 func isStructOrPointerToStruct(v reflect.Value) (reflect.Value, bool) {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -124,7 +124,7 @@ func isStructOrPointerToStruct(v reflect.Value) (reflect.Value, bool) {
 }
 
 func isStructPtrField(field reflect.Value) bool {
-	return field.Kind() == reflect.Ptr && !field.IsNil() && field.Elem().Kind() == reflect.Struct
+	return field.Kind() == reflect.Pointer && !field.IsNil() && field.Elem().Kind() == reflect.Struct
 }
 
 func isSliceField(field reflect.Value) bool {

--- a/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/hashEqual.resolvers.go
@@ -32,7 +32,7 @@ func (r *mutationResolver) IngestHashEquals(ctx context.Context, artifacts []*mo
 
 // HashEqual is the resolver for the HashEqual field.
 func (r *queryResolver) HashEqual(ctx context.Context, hashEqualSpec model.HashEqualSpec) ([]*model.HashEqual, error) {
-	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
+	if len(hashEqualSpec.Artifacts) > 2 {
 		return nil, gqlerror.Errorf("HashEqual :: Provided spec has too many Artifacts")
 	}
 	return r.Backend.HashEqual(ctx, &hashEqualSpec)
@@ -40,7 +40,7 @@ func (r *queryResolver) HashEqual(ctx context.Context, hashEqualSpec model.HashE
 
 // HashEqualList is the resolver for the HashEqualList field.
 func (r *queryResolver) HashEqualList(ctx context.Context, hashEqualSpec model.HashEqualSpec, after *string, first *int) (*model.HashEqualConnection, error) {
-	if hashEqualSpec.Artifacts != nil && len(hashEqualSpec.Artifacts) > 2 {
+	if len(hashEqualSpec.Artifacts) > 2 {
 		return nil, gqlerror.Errorf("HashEqual :: Provided spec has too many Artifacts")
 	}
 	return r.Backend.HashEqualList(ctx, hashEqualSpec, after, first)

--- a/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
+++ b/pkg/assembler/graphql/resolvers/vulnEqual.resolvers.go
@@ -127,7 +127,7 @@ func (r *mutationResolver) IngestVulnEquals(ctx context.Context, vulnerabilities
 func (r *queryResolver) VulnEqual(ctx context.Context, vulnEqualSpec model.VulnEqualSpec) ([]*model.VulnEqual, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 
-	if vulnEqualSpec.Vulnerabilities != nil && len(vulnEqualSpec.Vulnerabilities) > 2 {
+	if len(vulnEqualSpec.Vulnerabilities) > 2 {
 		return nil, gqlerror.Errorf("VulnEqual :: cannot specify more than 2 vulnerabilities in VulnEqual")
 	}
 
@@ -171,7 +171,7 @@ func (r *queryResolver) VulnEqual(ctx context.Context, vulnEqualSpec model.VulnE
 func (r *queryResolver) VulnEqualList(ctx context.Context, vulnEqualSpec model.VulnEqualSpec, after *string, first *int) (*model.VulnEqualConnection, error) {
 	// vulnerability input (type and vulnerability ID) will be enforced to be lowercase
 
-	if vulnEqualSpec.Vulnerabilities != nil && len(vulnEqualSpec.Vulnerabilities) > 2 {
+	if len(vulnEqualSpec.Vulnerabilities) > 2 {
 		return nil, gqlerror.Errorf("VulnEqual :: cannot specify more than 2 vulnerabilities in VulnEqual")
 	}
 

--- a/pkg/collectsub/datasource/filesource/filesource.go
+++ b/pkg/collectsub/datasource/filesource/filesource.go
@@ -64,7 +64,7 @@ func (d *fileDataSources) GetDataSources(_ context.Context) (*datasource.DataSou
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	b, err := io.ReadAll(f)
 	if err != nil {
@@ -90,12 +90,12 @@ func (d *fileDataSources) DataSourcesUpdate(ctx context.Context) (<-chan error, 
 	}
 	err = watcher.Add(d.filePath)
 	if err != nil {
-		watcher.Close()
+		_ = watcher.Close()
 		return nil, err
 	}
 
 	go func() {
-		defer watcher.Close()
+		defer func() { _ = watcher.Close() }()
 
 		for {
 			select {

--- a/pkg/collectsub/datasource/filesource/filesource_test.go
+++ b/pkg/collectsub/datasource/filesource/filesource_test.go
@@ -38,7 +38,7 @@ func Test_FileSourceGetDataSources(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to create temp dir")
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	path, err := createTestFile(tmpDir, "test1.yaml", simpleConfig)
 	if err != nil {
@@ -78,7 +78,7 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to create temp dir")
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	path, err := createTestFile(tmpDir, "test1.yaml", simpleConfig)
 	if err != nil {
@@ -130,7 +130,7 @@ func Test_FileSourceDataSourcesUpdate(t *testing.T) {
 		if err != nil {
 			t.Errorf("unable to append to file: %v", err)
 		}
-		f.Close()
+		_ = f.Close()
 	}()
 	select {
 	case err = <-upChan:

--- a/pkg/guacanalytics/patchPlanning.go
+++ b/pkg/guacanalytics/patchPlanning.go
@@ -70,7 +70,7 @@ func SearchDependentsFromStartPackage(ctx context.Context, gqlClient graphql.Cli
 	}
 
 	// TODO: add functionality to start with other nodes?
-	if len(nodePkg.AllPkgTree.Namespaces) == 0 {
+	if len(nodePkg.Namespaces) == 0 {
 		return nil, nil, fmt.Errorf("start by inputting a packageName or packageVersion node")
 	}
 
@@ -80,7 +80,7 @@ func SearchDependentsFromStartPackage(ctx context.Context, gqlClient graphql.Cli
 
 	if len(nodePkg.AllPkgTree.Namespaces[0].Names[0].Versions) == 0 {
 		// TODO: handle case where there are circular dependents that introduce more versions to the version list on a node that requires revisiting
-		err := q.addNodesToQueueFromPackageName(ctx, gqlClient, nodePkg.AllPkgTree.Type, nodePkg.AllPkgTree.Namespaces[0].Namespace, nodePkg.AllPkgTree.Namespaces[0].Names[0].Name, startID)
+		err := q.addNodesToQueueFromPackageName(ctx, gqlClient, nodePkg.Type, nodePkg.Namespaces[0].Namespace, nodePkg.Namespaces[0].Names[0].Name, startID)
 
 		if err != nil {
 			return nil, nil, err

--- a/pkg/guacanalytics/patchPlanning_test.go
+++ b/pkg/guacanalytics/patchPlanning_test.go
@@ -1641,7 +1641,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 				}
 
 				// if not present in expected packages or in expected artifacts
-				if !(inExpectedPkgs || inExpectedArtifacts || inExpectedSrcs) {
+				if !inExpectedPkgs && !inExpectedArtifacts && !inExpectedSrcs {
 					t.Errorf("this ID appears in the returned map but is not expected: %s \n", gotID)
 					return
 				}
@@ -1661,7 +1661,7 @@ func Test_SearchSubgraphFromVuln(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		cf()
-		server.Close()
+		_ = server.Close()
 	}
 	cf()
 }

--- a/pkg/ingestor/parser/open_vex/parser_open_vex.go
+++ b/pkg/ingestor/parser/open_vex/parser_open_vex.go
@@ -90,7 +90,7 @@ func (c *openVEXParser) Parse(ctx context.Context, doc *processor.Document) erro
 
 			if s.Status == vex.StatusAffected || s.Status == vex.StatusUnderInvestigation {
 				vulnData := generated.ScanMetadataInput{
-					TimeScanned: *openVex.Metadata.Timestamp,
+					TimeScanned: *openVex.Timestamp,
 				}
 				cv := assembler.CertifyVulnIngest{
 					Pkg:           ingest.Pkg,
@@ -121,8 +121,8 @@ func (c *openVEXParser) generateVexIngest(vulnInput *generated.VulnerabilityInpu
 
 	for _, p := range vexStatement.Products {
 		vd := generated.VexStatementInputSpec{}
-		vd.KnownSince = *openVex.Metadata.Timestamp
-		vd.Origin = openVex.Metadata.ID
+		vd.KnownSince = *openVex.Timestamp
+		vd.Origin = openVex.ID
 
 		ingest := assembler.VexIngest{}
 
@@ -132,9 +132,10 @@ func (c *openVEXParser) generateVexIngest(vulnInput *generated.VulnerabilityInpu
 			return nil, fmt.Errorf("invalid status for openVEX: %s", status)
 		}
 
-		if vd.Status == generated.VexStatusNotAffected {
+		switch vd.Status {
+		case generated.VexStatusNotAffected:
 			vd.Statement = vexStatement.ImpactStatement
-		} else if vd.Status == generated.VexStatusAffected {
+		case generated.VexStatusAffected:
 			vd.Statement = vexStatement.ActionStatement
 		}
 


### PR DESCRIPTION
Part of #2971

Phase 4: eight small packages (guacone cmd, githubclient, backends/helper, graphql
resolvers, filesource, guacanalytics, open_vex parser, sigstore_verifier), 32 of their 37
findings.

- errcheck (10): wrapped the ignored Close and RemoveAll returns, following the same
  convention as the earlier batches.
- QF1008 (5): promoted fields used directly. QF1003 (3): tagged switches. S1009 (4) and
  QF1001 (1): redundant nil checks and a De Morgan rewrite. ST1023 + QF1007 (5): inferred
  declarations. inline (4): reflect.Ptr and reflect.PtrTo moved to their current names.

The five I left are SA1019s: option.WithCredentialsFile in the gcs command and the
in_toto.StatementHeader/Subject fixtures in the sigstore verifier tests. Both are
migrations rather than cleanups, same call as the ite6 one in phase 3.

One heads up: annotate_metadata.go is the only CRLF file in the repo, so I kept its line
endings rather than letting the diff balloon to the whole file.

Same verification as before: these packages go from 37 findings to those 5, and build and
package tests pass.
